### PR TITLE
fix(saves): surface the classified reason for failed post-exit syncs and stop the panel's false synced state

### DIFF
--- a/docs/user-guide/save-sync.md
+++ b/docs/user-guide/save-sync.md
@@ -70,7 +70,8 @@ Open **Save Sync** from the main QAM page to configure sync behavior.
 
 - **Sync before launch** (default: on) — runs sync when a game starts, whether via the Play button or the launch gate.
   If the server is unreachable, the game launches with whatever local save exists.
-- **Sync after exit** (default: on) — runs sync after closing a game. Shows a toast notification on success.
+- **Sync after exit** (default: on) — runs sync after closing a game. A toast confirms a successful upload; if the sync
+  fails, the toast names the actual cause (see [Offline Behavior](#offline-behavior)) instead of a generic message.
 
 ### When saves conflict
 
@@ -163,8 +164,14 @@ If the RomM server is unreachable when a sync is attempted:
 sync that fails for another reason — for example an expired or revoked login token, or an SSL certificate problem —
 shows that specific reason instead (such as "Authentication failed — check your username and password"), so a working
 server is never mislabelled as offline. This applies to both surfaces: the warning shown before launch and the "after
-exit" toast both name the actual cause rather than a generic "failed to sync" message. If you see an authentication
-message, re-enter your server URL and sign in again in the plugin settings.
+exit" toast both name the actual cause rather than a generic "failed to sync" message. When more than one save file
+fails in the same sync, the toast shows the first file's reason followed by a "(+N more)" count so the message stays
+short. If you see an authentication message, re-enter your server URL and sign in again in the plugin settings.
+
+After a failed sync the game-detail save panel reflects the honest state right away: a file whose upload failed shows a
+yellow **Local changes** badge (not a green "synced"), and its "Last synced" line keeps the time of the last
+_successful_ sync — a green checkmark appears only once a sync actually succeeds. A separate "Checked" line shows when
+the plugin last attempted a sync, so a recent failed attempt and the last good sync are both visible.
 
 ## Playtime Tracking
 

--- a/py_modules/domain/save_status.py
+++ b/py_modules/domain/save_status.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Literal
 
-SaveSyncStatus = Literal["synced", "conflict", "none"]
+SaveSyncStatus = Literal["synced", "pending", "conflict", "none"]
 
 
 @dataclass(frozen=True)
@@ -71,10 +71,17 @@ def compute_save_sync_display(
 ) -> SaveSyncDisplay:
     """Compute save sync display status and label.
 
-    Returns ``SaveSyncDisplay`` with ``status`` ('synced' | 'conflict' |
-    'none'), ``label`` (static text or ``None`` when the frontend formats
-    a time-ago label), and ``last_sync_check_at`` (passthrough for the
-    time-ago case).
+    Returns ``SaveSyncDisplay`` with ``status`` ('synced' | 'pending' |
+    'conflict' | 'none'), ``label`` (static text or ``None`` when the
+    frontend formats a time-ago label), and ``last_sync_check_at``
+    (passthrough for the time-ago case).
+
+    A file the matrix marks ``"upload"`` (local changes to push) or
+    ``"download"`` (server is newer) is NOT synced: the display reports
+    ``status="pending"`` — "Local changes" or "Server newer" — so a failed
+    post-exit upload can no longer masquerade as a green "synced" state
+    (#1334). Only when every local file is at rest ('synced' / 'skip') does
+    the display report ``status="synced"``.
 
     When *server_query_failed* is True the server's save list could not
     be fetched, so the matrix verdict on each file is unreliable. The
@@ -93,6 +100,10 @@ def compute_save_sync_display(
 
     has_local = any(f.get("local_path") or f.get("status") in ("synced", "upload") for f in files)
     if has_local:
+        if any(f.get("status") == "upload" for f in files):
+            return SaveSyncDisplay(status="pending", label="Local changes", last_sync_check_at=None)
+        if any(f.get("status") == "download" for f in files):
+            return SaveSyncDisplay(status="pending", label="Server newer", last_sync_check_at=None)
         if last_sync_check_at:
             return SaveSyncDisplay(status="synced", label=None, last_sync_check_at=last_sync_check_at)
         return SaveSyncDisplay(status="synced", label="Not synced", last_sync_check_at=None)

--- a/py_modules/services/saves/sync_engine/engine.py
+++ b/py_modules/services/saves/sync_engine/engine.py
@@ -95,12 +95,21 @@ def _first_error_reason(errors: list[str]) -> str:
     Per-file dispatch records each failure as ``"<source>: <reason>"`` where
     ``<source>`` is the save filename (or a fixed label like ``"Failed to fetch
     saves"``) and ``<reason>`` is the :func:`lib.errors.classify_error` message.
-    Neither the filename nor the labels ever contain ``": "``, so splitting on the
-    first occurrence isolates the reason — a 403 yields "Access denied — ...",
-    never the filename. Falls back to the whole entry when it carries no ``": "``
-    separator. *errors* must be non-empty.
+    Split on the LAST ``": "`` (``rpartition``): the source can itself contain a
+    colon — a save filename derives from the ROM name, which may include one
+    (e.g. ``"Grand Theft Auto: San Andreas.srm"``) — so splitting on the last
+    separator keeps that colon on the source side and isolates the reason.
+
+    Tradeoff, stated honestly: a ``<reason>`` that itself contained ``": "``
+    would be truncated to its final segment. Every classified ``classify_error``
+    message (auth, forbidden, SSL, timeout, connection, server, not-found,
+    unsupported) uses an em-dash separator and never contains ``": "``, and the
+    fixed dispatch labels don't either — so the common cases are exact; only the
+    rare ``str(exc)`` fallback (UNKNOWN / generic ``RommApiError``) carrying an
+    internal ``": "`` loses its head. Falls back to the whole entry when there is
+    no ``": "`` separator. *errors* must be non-empty.
     """
-    _source, sep, reason = errors[0].partition(": ")
+    _source, sep, reason = errors[0].rpartition(": ")
     return reason if sep and reason else errors[0]
 
 

--- a/py_modules/services/saves/sync_engine/engine.py
+++ b/py_modules/services/saves/sync_engine/engine.py
@@ -89,6 +89,46 @@ if TYPE_CHECKING:
 __all__ = ["MatrixOutcome", "SyncEngine", "SyncEngineConfig"]
 
 
+def _first_error_reason(errors: list[str]) -> str:
+    """Return the classified reason of the first sync error, stripped of its source.
+
+    Per-file dispatch records each failure as ``"<source>: <reason>"`` where
+    ``<source>`` is the save filename (or a fixed label like ``"Failed to fetch
+    saves"``) and ``<reason>`` is the :func:`lib.errors.classify_error` message.
+    Neither the filename nor the labels ever contain ``": "``, so splitting on the
+    first occurrence isolates the reason — a 403 yields "Access denied — ...",
+    never the filename. Falls back to the whole entry when it carries no ``": "``
+    separator. *errors* must be non-empty.
+    """
+    _source, sep, reason = errors[0].partition(": ")
+    return reason if sep and reason else errors[0]
+
+
+def _summarize_sync_result(base: str, *, synced: int, errors: list[str], conflicts: int) -> str:
+    """Compose a sync callable's result ``message``, surfacing the failure reason (#1334).
+
+    A total failure (``synced == 0`` with errors) leads with the first error's
+    classified reason — never the "Uploaded 0 save(s), 1 error(s)" count summary
+    that buries it in ``errors[0]`` — and appends ``"(+N more)"`` when other files
+    also failed. A partial run (some transferred, some failed) keeps the ``base``
+    count summary and appends the first reason after an em-dash. A clean run
+    returns ``base`` unchanged. A surfaced-conflict count is appended after the
+    error clause in every case, preserving the pre-#1334 conflict suffix.
+    """
+    if errors:
+        reason = _first_error_reason(errors)
+        if synced == 0:
+            extra = len(errors) - 1
+            msg = f"{reason} (+{extra} more)" if extra else reason
+        else:
+            msg = f"{base}, {len(errors)} error(s) — {reason}"
+    else:
+        msg = base
+    if conflicts:
+        msg += f", {conflicts} conflict(s)"
+    return msg
+
+
 @dataclass(frozen=True)
 class SyncEngineConfig:
     """Frozen wiring bundle handed to ``SyncEngine.__init__``.
@@ -745,11 +785,9 @@ class SyncEngine:
                     len(conflicts),
                 )
 
-                msg = f"Uploaded {synced} save(s)"
-                if errors:
-                    msg += f", {len(errors)} error(s)"
-                if conflicts:
-                    msg += f", {len(conflicts)} conflict(s)"
+                msg = _summarize_sync_result(
+                    f"Uploaded {synced} save(s)", synced=synced, errors=errors, conflicts=len(conflicts)
+                )
                 return {
                     "success": len(errors) == 0,
                     "message": msg,
@@ -805,11 +843,9 @@ class SyncEngine:
 
                 synced, errors, conflicts = await self._run_rom_sync(rom_id)
 
-                msg = f"Synced {synced} save(s)"
-                if errors:
-                    msg += f", {len(errors)} error(s)"
-                if conflicts:
-                    msg += f", {len(conflicts)} conflict(s)"
+                msg = _summarize_sync_result(
+                    f"Synced {synced} save(s)", synced=synced, errors=errors, conflicts=len(conflicts)
+                )
                 return {
                     "success": len(errors) == 0,
                     "message": msg,
@@ -933,11 +969,12 @@ class SyncEngine:
                         await self._close_negotiate_session(session_id, session_counts[0], session_counts[1])
 
                 conflicts_count = len(all_conflicts)
-                msg = f"Synced {total_synced} save(s) across {rom_count} ROM(s)"
-                if total_errors:
-                    msg += f", {len(total_errors)} error(s)"
-                if conflicts_count:
-                    msg += f", {conflicts_count} conflict(s)"
+                msg = _summarize_sync_result(
+                    f"Synced {total_synced} save(s) across {rom_count} ROM(s)",
+                    synced=total_synced,
+                    errors=total_errors,
+                    conflicts=conflicts_count,
+                )
                 return {
                     "success": len(total_errors) == 0,
                     "message": msg,

--- a/src/components/RomMPlaySection.tsx
+++ b/src/components/RomMPlaySection.tsx
@@ -108,7 +108,7 @@ interface InfoState {
   restoredLastPlayed: string | null;
   playtime: string;
   saveSyncEnabled: boolean;
-  saveSyncStatus: "synced" | "conflict" | "none" | null;
+  saveSyncStatus: "synced" | "pending" | "conflict" | "none" | null;
   saveSyncLabel: string;
   /** RetroArch `savefiles_in_content_dir=true` — saves go next to the ROM and
    *  can't be synced (#239). Derived from a LOCAL retroarch.cfg read, so it is
@@ -154,7 +154,7 @@ async function loadCached(
     romIdRef.current = romId;
 
     // Process save sync from backend-computed display fields
-    let saveSyncStatus: "synced" | "conflict" | "none" | null = null;
+    let saveSyncStatus: "synced" | "pending" | "conflict" | "none" | null = null;
     let saveSyncLabel = "";
     if (cached.save_sync_enabled && cached.save_sync_display) {
       saveSyncStatus = cached.save_sync_display.status;

--- a/src/components/saves/SaveFileRow.test.tsx
+++ b/src/components/saves/SaveFileRow.test.tsx
@@ -135,13 +135,49 @@ describe("renderSaveFileRow", () => {
     expect(container.textContent).toContain("Never");
   });
 
-  it("renders relative time in the last-synced row when last_sync_check_at is set", () => {
+  it("binds 'Last synced' to the success time (last_sync_at), not the attempt time (#1334)", () => {
+    // last_sync_at is 30m ago; the sync CHECK ran 5m ago. "Last synced" must
+    // show the success time, so a later attempt never inflates the displayed
+    // sync recency.
     const { container } = render(
       <div>
-        {renderSaveFileRow(makeFile({ status: "synced", last_sync_at: null }), undefined, "2025-06-15T11:30:00Z")}
+        {renderSaveFileRow(
+          makeFile({ status: "synced", last_sync_at: "2025-06-15T11:30:00Z" }),
+          undefined,
+          "2025-06-15T11:55:00Z",
+        )}
       </div>,
     );
+    expect(container.textContent).toContain("Last synced:");
     expect(container.textContent).toContain("30m ago");
+  });
+
+  it("shows 'Never' with no ✓ for an un-synced file, and surfaces the attempt as 'Checked' (#1334)", () => {
+    // A pending upload with no prior successful sync: no green ✓, "Last synced:
+    // Never", and the recent check shown separately as a "Checked" hint.
+    const { container } = render(
+      <div>
+        {renderSaveFileRow(makeFile({ status: "upload", last_sync_at: null }), undefined, "2025-06-15T11:30:00Z")}
+      </div>,
+    );
+    expect(container.textContent).toContain("Last synced:");
+    expect(container.textContent).toContain("Never");
+    expect(container.textContent).not.toContain("✓");
+    expect(container.textContent).toContain("Checked:");
+    expect(container.textContent).toContain("30m ago");
+  });
+
+  it("omits the 'Checked' hint for a synced file — the ✓ line already conveys currency", () => {
+    const { container } = render(
+      <div>
+        {renderSaveFileRow(
+          makeFile({ status: "synced", last_sync_at: "2025-06-15T11:30:00Z" }),
+          undefined,
+          "2025-06-15T11:55:00Z",
+        )}
+      </div>,
+    );
+    expect(container.textContent).not.toContain("Checked:");
   });
 
   it("renders the last-updated info row when server_updated_at is set", () => {

--- a/src/components/saves/SaveFileRow.tsx
+++ b/src/components/saves/SaveFileRow.tsx
@@ -39,6 +39,25 @@ export function infoRow(
   );
 }
 
+/**
+ * Compose the "Last synced" info-row value: "<time> · <attribution> ✓ · <stale hint>".
+ *
+ * The time binds to the last SUCCESS (`f.last_sync_at`), never the attempt time,
+ * and the ✓ renders only for an at-rest file — a failed post-exit sync shows its
+ * old success time with no ✓ (#1334). Appends the server-attribution segment and,
+ * when the server has moved past us, the "newer version" hint.
+ */
+function buildLastSyncedValue(f: SaveFileStatus, isSynced: boolean): string {
+  const lastSyncer = pickLastSyncer(f.device_syncs);
+  const pieces: string[] = [f.last_sync_at ? formatRelativeTime(f.last_sync_at) || "Never" : "Never"];
+  const attrSegment = formatAttributionSegment(f.uploaded_by_us, lastSyncer?.device_name, isSynced);
+  if (attrSegment !== null) pieces.push(attrSegment);
+  if (f.is_current === false) {
+    pieces.push("Newer version available on server");
+  }
+  return pieces.join(" · ");
+}
+
 export function renderSaveFileRow(
   f: SaveFileStatus,
   conflict: SyncConflict | undefined,
@@ -47,12 +66,8 @@ export function renderSaveFileRow(
   const { color, label } = statusLabel(f.status, f.last_sync_at);
   // "synced"/"skip" are the at-rest states; anything else (upload/download/
   // conflict/unknown) has work pending, so the row must not claim a successful
-  // sync. "Last synced" binds to the last SUCCESS (f.last_sync_at), never the
-  // attempt time — a failed post-exit sync leaves last_sync_at at its old value
-  // and shows no ✓ (#1334).
+  // sync — no ✓, and the "Checked" hint surfaces the attempt time instead (#1334).
   const isSynced = f.status === "synced" || f.status === "skip";
-  const syncTime = f.last_sync_at;
-  const lastSyncer = pickLastSyncer(f.device_syncs);
   const conflictActive = f.status === "conflict" || !!conflict;
   // The slot's most recent sync ATTEMPT — surfaced as a separate "Checked" hint
   // only when this file isn't at rest, so a pending/failed file shows both the
@@ -85,14 +100,8 @@ export function renderSaveFileRow(
     ),
   );
 
-  // Last synced value: "just now · <attribution> ✓" — see formatAttributionSegment
-  const lastSyncedPieces: string[] = [syncTime ? formatRelativeTime(syncTime) || "Never" : "Never"];
-  const attrSegment = formatAttributionSegment(f.uploaded_by_us, lastSyncer?.device_name, isSynced);
-  if (attrSegment !== null) lastSyncedPieces.push(attrSegment);
-  if (f.is_current === false) {
-    lastSyncedPieces.push("Newer version available on server");
-  }
-  const lastSyncedValue = lastSyncedPieces.join(" · ");
+  // Last synced value: "just now · <attribution> ✓" — see buildLastSyncedValue
+  const lastSyncedValue = buildLastSyncedValue(f, isSynced);
 
   // Server save value — two lines: "#18 · retroarch-mgba" / "<server_file_name>"
   const serverValueLines: ReturnType<typeof createElement>[] = [];

--- a/src/components/saves/SaveFileRow.tsx
+++ b/src/components/saves/SaveFileRow.tsx
@@ -45,9 +45,19 @@ export function renderSaveFileRow(
   lastSyncCheckAt: string | null,
 ): ReturnType<typeof createElement> {
   const { color, label } = statusLabel(f.status, f.last_sync_at);
-  const syncTime = lastSyncCheckAt || f.last_sync_at;
+  // "synced"/"skip" are the at-rest states; anything else (upload/download/
+  // conflict/unknown) has work pending, so the row must not claim a successful
+  // sync. "Last synced" binds to the last SUCCESS (f.last_sync_at), never the
+  // attempt time — a failed post-exit sync leaves last_sync_at at its old value
+  // and shows no ✓ (#1334).
+  const isSynced = f.status === "synced" || f.status === "skip";
+  const syncTime = f.last_sync_at;
   const lastSyncer = pickLastSyncer(f.device_syncs);
   const conflictActive = f.status === "conflict" || !!conflict;
+  // The slot's most recent sync ATTEMPT — surfaced as a separate "Checked" hint
+  // only when this file isn't at rest, so a pending/failed file shows both the
+  // last success and the recent check without duplicating the synced ✓ line.
+  const checkedHint = !isSynced && lastSyncCheckAt ? formatRelativeTime(lastSyncCheckAt) : null;
 
   // Header value pieces (right-aligned meta: size + status)
   const headerMeta: (ReturnType<typeof createElement> | null)[] = [];
@@ -77,7 +87,7 @@ export function renderSaveFileRow(
 
   // Last synced value: "just now · <attribution> ✓" — see formatAttributionSegment
   const lastSyncedPieces: string[] = [syncTime ? formatRelativeTime(syncTime) || "Never" : "Never"];
-  const attrSegment = formatAttributionSegment(f.uploaded_by_us, lastSyncer?.device_name);
+  const attrSegment = formatAttributionSegment(f.uploaded_by_us, lastSyncer?.device_name, isSynced);
   if (attrSegment !== null) lastSyncedPieces.push(attrSegment);
   if (f.is_current === false) {
     lastSyncedPieces.push("Newer version available on server");
@@ -179,6 +189,7 @@ export function renderSaveFileRow(
 
     // Info rows
     infoRow("last-synced", "Last synced:", lastSyncedValue),
+    checkedHint ? infoRow("checked", "Checked:", checkedHint, "#8f98a0") : null,
     infoRow(
       "last-updated",
       "Last updated:",

--- a/src/components/saves/helpers.test.ts
+++ b/src/components/saves/helpers.test.ts
@@ -148,6 +148,26 @@ describe("formatAttributionSegment", () => {
     expect(formatAttributionSegment(null, null)).toBe("✓");
     expect(formatAttributionSegment(undefined, undefined)).toBe("✓");
   });
+
+  describe("showCheck=false (a not-yet-synced file must render no ✓, #1334)", () => {
+    it("drops the ✓ from the '(this device)' branch", () => {
+      expect(formatAttributionSegment(true, "deck", false)).toBe("deck (this device)");
+      expect(formatAttributionSegment(true, null, false)).toBe("(this device)");
+    });
+
+    it("drops the ✓ from the '(not this device)' branch", () => {
+      expect(formatAttributionSegment(false, "deck", false)).toBe("(not this device)");
+    });
+
+    it("drops the ✓ from the device-only branch", () => {
+      expect(formatAttributionSegment(null, "deck", false)).toBe("deck");
+    });
+
+    it("returns null when there is nothing but a suppressed ✓", () => {
+      expect(formatAttributionSegment(null, null, false)).toBeNull();
+      expect(formatAttributionSegment(undefined, undefined, false)).toBeNull();
+    });
+  });
 });
 
 describe("statusLabel", () => {
@@ -240,6 +260,21 @@ describe("computeSyncSummary", () => {
     device_id: "dev",
     last_sync_check_at: null,
     ...overrides,
+  });
+
+  const mkFile = (status: SaveStatus["files"][number]["status"]): SaveStatus["files"][number] => ({
+    filename: "save.srm",
+    local_path: "/local/save.srm",
+    local_hash: "abc",
+    local_mtime: "2025-06-15T10:00:00Z",
+    local_size: 100,
+    server_save_id: null,
+    server_file_name: null,
+    server_emulator: null,
+    server_updated_at: null,
+    server_size: null,
+    last_sync_at: null,
+    status,
   });
 
   it("returns null text for inactive slot", () => {
@@ -335,28 +370,41 @@ describe("computeSyncSummary", () => {
     });
   });
 
-  it("returns 'Not synced' when files exist but last_sync_check_at is null", () => {
-    const status = makeStatus({
-      files: [
-        {
-          filename: "save.srm",
-          local_path: "/local/save.srm",
-          local_hash: "abc",
-          local_mtime: "2025-06-15T10:00:00Z",
-          local_size: 100,
-          server_save_id: null,
-          server_file_name: null,
-          server_emulator: null,
-          server_updated_at: null,
-          server_size: null,
-          last_sync_at: null,
-          status: "upload",
-        },
-      ],
-    });
+  it("returns 'Not synced' when files are all synced but last_sync_check_at is null", () => {
+    const status = makeStatus({ files: [mkFile("synced")] });
     expect(computeSyncSummary(true, status, [])).toEqual({
       syncSummaryText: "Not synced",
       syncSummaryColor: "#8f98a0",
+    });
+  });
+
+  it("returns yellow 'Local changes' when any file is pending upload (never a green ✓, #1334)", () => {
+    const status = makeStatus({ last_sync_check_at: new Date().toISOString(), files: [mkFile("upload")] });
+    expect(computeSyncSummary(true, status, [])).toEqual({
+      syncSummaryText: "Local changes",
+      syncSummaryColor: "#d4a72c",
+    });
+  });
+
+  it("'Local changes' wins over an otherwise-synced sibling and a recent check", () => {
+    const status = makeStatus({
+      last_sync_check_at: new Date().toISOString(),
+      files: [mkFile("synced"), mkFile("upload")],
+    });
+    expect(computeSyncSummary(true, status, [])).toEqual({
+      syncSummaryText: "Local changes",
+      syncSummaryColor: "#d4a72c",
+    });
+  });
+
+  it("returns blue 'Server newer' when a file is pending download and none pending upload", () => {
+    const status = makeStatus({
+      last_sync_check_at: new Date().toISOString(),
+      files: [mkFile("synced"), mkFile("download")],
+    });
+    expect(computeSyncSummary(true, status, [])).toEqual({
+      syncSummaryText: "Server newer",
+      syncSummaryColor: "#1a9fff",
     });
   });
 

--- a/src/components/saves/helpers.ts
+++ b/src/components/saves/helpers.ts
@@ -54,24 +54,31 @@ export function attributionLabel(uploadedByUs: boolean | null | undefined): stri
 /**
  * Format the per-save attribution+checkmark segment for the sync-time line.
  *
- * Combines device name, attribution label, and the trailing checkmark into
- * one ready-to-render string, or null when nothing meaningful can be shown.
- * Reused between `renderSaveFileRow` and `renderVersionRow`.
+ * Combines device name, attribution label, and an optional trailing checkmark
+ * into one ready-to-render string, or null when nothing meaningful can be shown.
+ * Reused between `renderSaveFileRow` and `renderVersionRow`. The checkmark marks
+ * an actually-synced file, so `renderSaveFileRow` passes `showCheck=false` for a
+ * file with pending upload/download work — a failed post-exit sync must not
+ * render a ✓ (#1334). Version rows keep the default (`showCheck=true`): the ✓
+ * there is the per-version attribution marker, not a live sync verdict.
  */
 export function formatAttributionSegment(
   uploadedByUs: boolean | null | undefined,
   deviceName: string | null | undefined,
+  showCheck = true,
 ): string | null {
+  const check = showCheck ? " ✓" : "";
   const label = attributionLabel(uploadedByUs);
   if (uploadedByUs === true) {
-    return deviceName ? `${deviceName} ${label} ✓` : `${label} ✓`;
+    return deviceName ? `${deviceName} ${label}${check}` : `${label}${check}`;
   }
   if (uploadedByUs === false) {
     // Intentionally no device name — lastSyncer is our own sync record, not the actual uploader
-    return `${label} ✓`;
+    return `${label}${check}`;
   }
   if (label === null) {
-    return deviceName ? `${deviceName} ✓` : `✓`;
+    if (deviceName) return `${deviceName}${check}`;
+    return showCheck ? "✓" : null;
   }
   return null;
 }
@@ -119,6 +126,13 @@ export function statusLabel(status: string, lastSyncAt: string | null): { color:
  * the backend signals `server_query_failed`, short-circuits with a neutral
  * "Server unreachable" instead of running the matrix-derived classification
  * (which would otherwise read an empty server list as "ready to upload").
+ *
+ * The summary is derived from the per-file matrix statuses so it can never
+ * disagree with the per-file badges (`statusLabel`): any file pending upload
+ * shows yellow "Local changes", any file the server has newer shows blue
+ * "Server newer", and only an all-synced slot shows a green "Synced …". A
+ * failed post-exit upload therefore reads as "Local changes", not a false
+ * green ✓ (#1334).
  */
 export function computeSyncSummary(
   isActive: boolean,
@@ -132,13 +146,19 @@ export function computeSyncSummary(
   }
 
   const hasConflict = conflicts.length > 0;
-  const fileCount = saveStatus.files.length;
+  const files = saveStatus.files;
 
   if (hasConflict) return { syncSummaryText: "Conflict detected", syncSummaryColor: "#d94126" };
-  if (fileCount > 0 && saveStatus.last_sync_check_at) {
+  if (files.length === 0) return { syncSummaryText: "No saves found", syncSummaryColor: MUTED_COLOR };
+  if (files.some((f) => f.status === "upload")) {
+    return { syncSummaryText: "Local changes", syncSummaryColor: "#d4a72c" };
+  }
+  if (files.some((f) => f.status === "download")) {
+    return { syncSummaryText: "Server newer", syncSummaryColor: "#1a9fff" };
+  }
+  if (saveStatus.last_sync_check_at) {
     const rel = formatRelativeTime(saveStatus.last_sync_check_at);
     return { syncSummaryText: rel === "just now" ? "Synced just now" : `Synced ${rel}`, syncSummaryColor: "#5ba32b" };
   }
-  if (fileCount > 0) return { syncSummaryText: "Not synced", syncSummaryColor: MUTED_COLOR };
-  return { syncSummaryText: "No saves found", syncSummaryColor: MUTED_COLOR };
+  return { syncSummaryText: "Not synced", syncSummaryColor: MUTED_COLOR };
 }

--- a/src/types/saves.ts
+++ b/src/types/saves.ts
@@ -66,10 +66,10 @@ interface PlaytimeEntry {
 }
 
 export interface SaveSyncDisplay {
-  status: "synced" | "conflict" | "none";
-  /** Static label, e.g. "No saves" / "Conflict" / "Not synced". `null` for the
-   *  synced+recent-check case, where the frontend formats a time-ago label
-   *  from `last_sync_check_at`. */
+  status: "synced" | "pending" | "conflict" | "none";
+  /** Static label, e.g. "No saves" / "Conflict" / "Not synced" / "Local changes"
+   *  / "Server newer". `null` for the synced+recent-check case, where the
+   *  frontend formats a time-ago label from `last_sync_check_at`. */
   label: string | null;
   /** Raw ISO-8601 timestamp passed through from the backend for time-ago
    *  formatting. `null` whenever `label` carries a fully-formed string. */

--- a/src/utils/playSection.ts
+++ b/src/utils/playSection.ts
@@ -32,7 +32,7 @@ export interface CoreInfoFields {
 }
 
 export interface SaveSyncResolution {
-  status: "synced" | "conflict" | "none";
+  status: "synced" | "pending" | "conflict" | "none";
   label: string;
 }
 

--- a/src/utils/sessionManager.test.ts
+++ b/src/utils/sessionManager.test.ts
@@ -136,6 +136,38 @@ describe("sessionManager lifecycle forwarding", () => {
     expect(backend.recordSessionStart).not.toHaveBeenCalled();
     expect(backend.finalizeGameSession).not.toHaveBeenCalled();
   });
+
+  it("dispatches romm_data_changed on stop even when the post-exit sync failed (#1334)", async () => {
+    // A failed post-exit sync must still refresh open surfaces so the panel
+    // drops any stale green "synced" for a file now pending upload.
+    vi.mocked(backend.finalizeGameSession).mockResolvedValue({
+      total_seconds: null,
+      sync: {
+        offline: false,
+        success: false,
+        synced: 0,
+        conflicts: [],
+        toast_title: "RomM Save Sync",
+        toast_body: "Access denied — your account lacks permissions for this action",
+        conflicts_toast: null,
+      },
+      migration: null,
+    });
+    const dataChanged: unknown[] = [];
+    const listener = (e: Event) => dataChanged.push((e as CustomEvent).detail);
+    globalThis.addEventListener("romm_data_changed", listener);
+    try {
+      await initDrainingAdoptionPoll();
+      const lifetime = captureLifetimeCb();
+
+      await startGame(lifetime);
+      await stopGame(lifetime);
+
+      expect(dataChanged).toContainEqual({ type: "save_sync", rom_id: ROM_ID });
+    } finally {
+      globalThis.removeEventListener("romm_data_changed", listener);
+    }
+  });
 });
 
 describe("sessionManager reload adoption", () => {

--- a/src/utils/sessionManager.ts
+++ b/src/utils/sessionManager.ts
@@ -195,11 +195,11 @@ async function handleGameStop(): Promise<void> {
       toaster.toast({ title: result.sync.toast_title, body: result.sync.toast_body });
     }
 
-    // Save-sync event dispatch — fires for offline OR success (pre-PR parity:
-    // offline branch dispatched, success branch dispatched, failure did not).
-    if (result.sync.offline || result.sync.success) {
-      globalThis.dispatchEvent(new CustomEvent("romm_data_changed", { detail: { type: "save_sync", rom_id: romId } }));
-    }
+    // Save-sync event dispatch — fires unconditionally so open surfaces refresh
+    // to the honest post-sync state. A failed post-exit sync must refresh too
+    // (#1334): the panel would otherwise keep showing a stale green "synced" for
+    // a file that is now pending upload.
+    globalThis.dispatchEvent(new CustomEvent("romm_data_changed", { detail: { type: "save_sync", rom_id: romId } }));
 
     // Additive conflicts toast — backend renders the count string.
     if (result.sync.conflicts_toast) {

--- a/tests/contract/test_saves_read.py
+++ b/tests/contract/test_saves_read.py
@@ -22,10 +22,22 @@ Explicitly OUT of Phase 1 (NOT tested here, named as deferred):
 
 from __future__ import annotations
 
+import os
+
+from domain.rom_save_state import RomSaveState
 from lib.errors import RommConnectionError
 from lib.list_result import ErrorCode
 
-from ._seed import enable_save_sync, seed_confirmed_slot, seed_install, seed_rom, seed_server_save
+from ._seed import enable_save_sync, seed_confirmed_slot, seed_install, seed_rom, seed_save_state, seed_server_save
+
+
+def _write_local_save(harness, *, system: str, filename: str, content: bytes) -> None:
+    """Materialize a local save file under the harness saves tree."""
+    saves_dir = os.path.join(harness.plugin._retrodeck_paths.saves_path(), system)
+    os.makedirs(saves_dir, exist_ok=True)
+    with open(os.path.join(saves_dir, filename), "wb") as fh:
+        fh.write(content)
+
 
 # ── get_save_status ──────────────────────────────────────────────────────
 
@@ -69,6 +81,26 @@ async def test_get_save_status_server_failure_keeps_full_payload(harness):
     assert result["rom_id"] == 42
     assert "files" in result
     assert "save_sync_display" in result
+
+
+async def test_get_save_status_pending_upload_display(harness):
+    """A local file with no server save is pending upload → save_sync_display reports
+    the new pending/'Local changes' value, never a green 'synced' (#1334). The nested
+    shape (status/label/last_sync_check_at) is unchanged; only a new value appears."""
+    enable_save_sync(harness)
+    seed_install(harness, 42, system="gba", file_name="game.gba")
+    _write_local_save(harness, system="gba", filename="game.srm", content=b"local progress")
+    seed_save_state(harness, 42, RomSaveState(active_slot="default", slot_confirmed=True, system="gba"))
+
+    result = await harness.plugin.get_save_status(42)
+
+    files = {f["filename"]: f for f in result["files"]}
+    assert files["game.srm"]["status"] == "upload"
+    assert result["save_sync_display"] == {
+        "status": "pending",
+        "label": "Local changes",
+        "last_sync_check_at": None,
+    }
 
 
 # ── get_save_slots ───────────────────────────────────────────────────────

--- a/tests/domain/test_save_status.py
+++ b/tests/domain/test_save_status.py
@@ -49,10 +49,53 @@ class TestComputeSaveSyncDisplay:
         result = compute_save_sync_display(files, None)
         assert result == SaveSyncDisplay(status="none", label="No local saves", last_sync_check_at=None)
 
-    def test_upload_status_counts_as_local(self):
+    def test_upload_status_is_pending_local_changes(self):
+        """An upload-pending file counts as local but is NOT synced — it reports
+        pending/'Local changes' so a failed post-exit upload can't read as synced (#1334)."""
         files = [{"status": "upload", "local_path": None}]
         result = compute_save_sync_display(files, None)
-        assert result == SaveSyncDisplay(status="synced", label="Not synced", last_sync_check_at=None)
+        assert result == SaveSyncDisplay(status="pending", label="Local changes", last_sync_check_at=None)
+
+    def test_upload_does_not_collapse_to_synced_even_with_recent_check(self):
+        """The pre-#1334 bug: a local file pending upload + a recent sync check
+        collapsed to a green 'synced'. It must now report pending/'Local changes'."""
+        files = [{"status": "upload", "local_path": "/saves/test.srm"}]
+        result = compute_save_sync_display(files, "2026-02-17T10:31:00+00:00")
+        assert result == SaveSyncDisplay(status="pending", label="Local changes", last_sync_check_at=None)
+
+    def test_download_with_local_is_pending_server_newer(self):
+        """A slot with local saves where the server is newer reports pending/'Server newer',
+        not a green 'synced' (#1334)."""
+        files = [
+            {"status": "synced", "local_path": "/saves/a.srm"},
+            {"status": "download", "local_path": "/saves/b.srm"},
+        ]
+        result = compute_save_sync_display(files, "2026-02-17T10:31:00+00:00")
+        assert result == SaveSyncDisplay(status="pending", label="Server newer", last_sync_check_at=None)
+
+    def test_upload_wins_over_download_in_mixed_slot(self):
+        """When both an upload and a download are pending, 'Local changes' takes precedence."""
+        files = [
+            {"status": "upload", "local_path": "/saves/a.srm"},
+            {"status": "download", "local_path": "/saves/b.srm"},
+        ]
+        result = compute_save_sync_display(files, "2026-02-17T10:31:00+00:00")
+        assert result == SaveSyncDisplay(status="pending", label="Local changes", last_sync_check_at=None)
+
+    def test_display_statuses_enumerated(self):
+        """Every display status the frontend must handle, driven from representative inputs."""
+        cases = {
+            "none": compute_save_sync_display([], None),
+            "conflict": compute_save_sync_display([{"status": "conflict", "local_path": "/s/a.srm"}], None),
+            "pending": compute_save_sync_display([{"status": "upload", "local_path": "/s/a.srm"}], None),
+            "synced": compute_save_sync_display([{"status": "synced", "local_path": "/s/a.srm"}], None),
+        }
+        assert {expected: got.status for expected, got in cases.items()} == {
+            "none": "none",
+            "conflict": "conflict",
+            "pending": "pending",
+            "synced": "synced",
+        }
 
     def test_local_path_present_counts_as_local(self):
         files = [{"status": "skip", "local_path": "/saves/test.srm"}]

--- a/tests/services/saves/sync_engine/test_engine.py
+++ b/tests/services/saves/sync_engine/test_engine.py
@@ -15,8 +15,16 @@ import pytest
 
 from domain.rom_save_state import RomSaveState
 from domain.save_layout import ContentDir, InSaveDir
-from lib.errors import RommApiError, RommAuthError, RommConnectionError, RommSSLError, RommTimeoutError
+from lib.errors import (
+    RommApiError,
+    RommAuthError,
+    RommConnectionError,
+    RommForbiddenError,
+    RommSSLError,
+    RommTimeoutError,
+)
 from lib.list_result import ErrorCode
+from services.saves.sync_engine.engine import _first_error_reason, _summarize_sync_result
 from tests.services.saves._helpers import (
     _create_save,
     _do_sync,
@@ -843,12 +851,17 @@ class TestSyncRomSavesDisabledGuard:
 
 
 class TestSyncCallableErrorMessages:
-    """The error-count clause in each public callable's success message
-    (engine.py lines 318 / 380 / 414). Driven by stubbing do_sync_rom_saves
-    to return a non-empty errors list."""
+    """The failure ``message`` each public sync callable builds from the matrix
+    result (``_summarize_sync_result``). A total failure leads with the first
+    error's classified reason (never buried behind "Uploaded 0 save(s)"); a
+    partial run keeps the count summary and appends the reason; pre-launch
+    (download) keeps the plain count clause (#1334). Driven by stubbing
+    do_sync_rom_saves to return a non-empty errors list."""
 
     @pytest.mark.asyncio
     async def test_pre_launch_sync_message_includes_error_count(self, tmp_path):
+        # pre_launch keeps the plain count clause — the reason promotion is
+        # scoped to the upload-side callables (#1334).
         svc, _ = make_service(tmp_path)
         svc._config.settings["save_sync_enabled"] = True
         _set_device_id(svc, "test-device")
@@ -866,7 +879,7 @@ class TestSyncCallableErrorMessages:
         assert "Downloaded" in result["message"]
 
     @pytest.mark.asyncio
-    async def test_post_exit_sync_message_includes_error_count(self, tmp_path):
+    async def test_post_exit_sync_promotes_reason_when_nothing_uploaded(self, tmp_path):
         svc, _ = make_service(tmp_path)
         svc._config.settings["save_sync_enabled"] = True
         _set_device_id(svc, "test-device")
@@ -880,11 +893,44 @@ class TestSyncCallableErrorMessages:
         result = await svc.post_exit_sync(42)
 
         assert result["success"] is False
-        assert "1 error(s)" in result["message"]
-        assert "Uploaded" in result["message"]
+        # A total failure leads with the bare reason, not "Uploaded 0 save(s)".
+        assert result["message"] == "timeout"
 
     @pytest.mark.asyncio
-    async def test_sync_rom_saves_message_includes_error_count(self, tmp_path):
+    async def test_post_exit_sync_partial_keeps_count_and_appends_reason(self, tmp_path):
+        svc, _ = make_service(tmp_path)
+        svc._config.settings["save_sync_enabled"] = True
+        _set_device_id(svc, "test-device")
+        _install_rom(svc, tmp_path)
+
+        def stub_sync(rom_id, *args):
+            return (2, ["pokemon.srm: timeout"], [])
+
+        svc._sync_engine.do_sync_rom_saves = stub_sync  # type: ignore[method-assign]
+
+        result = await svc.post_exit_sync(42)
+
+        assert result["success"] is False
+        assert result["message"] == "Uploaded 2 save(s), 1 error(s) — timeout"
+
+    @pytest.mark.asyncio
+    async def test_post_exit_sync_multiple_errors_count_the_extras(self, tmp_path):
+        svc, _ = make_service(tmp_path)
+        svc._config.settings["save_sync_enabled"] = True
+        _set_device_id(svc, "test-device")
+        _install_rom(svc, tmp_path)
+
+        def stub_sync(rom_id, *args):
+            return (0, ["a.srm: timeout", "b.srm: timeout", "c.srm: timeout"], [])
+
+        svc._sync_engine.do_sync_rom_saves = stub_sync  # type: ignore[method-assign]
+
+        result = await svc.post_exit_sync(42)
+
+        assert result["message"] == "timeout (+2 more)"
+
+    @pytest.mark.asyncio
+    async def test_sync_rom_saves_promotes_reason_when_nothing_synced(self, tmp_path):
         svc, _ = make_service(tmp_path)
         svc._config.settings["save_sync_enabled"] = True
         _set_device_id(svc, "test-device")
@@ -898,7 +944,85 @@ class TestSyncCallableErrorMessages:
         result = await svc.sync_rom_saves(42)
 
         assert result["success"] is False
-        assert "1 error(s)" in result["message"]
+        assert result["message"] == "502 bad gateway"
+
+
+class TestSyncCallablePromotesRealDispatchReason:
+    """The promoted message comes from a REAL classified failure dispatched
+    through the matrix executor — not a fabricated ``message`` — so a 403 on the
+    upload surfaces "Access denied …" in both the post-exit toast and the manual
+    sync result (#1334)."""
+
+    @pytest.mark.asyncio
+    async def test_post_exit_sync_surfaces_dispatched_403(self, tmp_path):
+        svc, fake = make_service(tmp_path)
+        _enable_sync_with_device(svc)
+        svc._config.settings["sync_after_exit"] = True
+        _install_rom(svc, tmp_path)
+        _create_save(tmp_path, content=b"user progress")
+
+        def forbidden_upload(*_a, **_k):
+            raise RommForbiddenError("403")
+
+        fake.upload_save = forbidden_upload  # type: ignore[method-assign]
+
+        result = await svc.post_exit_sync(42)
+
+        assert result["success"] is False
+        assert result["synced"] == 0
+        assert result["message"] == "Access denied — your account lacks permissions for this action"
+        # The raw per-file error still carries the filename for the log surface.
+        assert result["errors"][0].startswith("pokemon.srm:")
+
+    @pytest.mark.asyncio
+    async def test_sync_rom_saves_surfaces_dispatched_403(self, tmp_path):
+        svc, fake = make_service(tmp_path)
+        _enable_sync_with_device(svc)
+        _install_rom(svc, tmp_path)
+        _create_save(tmp_path, content=b"user progress")
+
+        def forbidden_upload(*_a, **_k):
+            raise RommForbiddenError("403")
+
+        fake.upload_save = forbidden_upload  # type: ignore[method-assign]
+
+        result = await svc.sync_rom_saves(42)
+
+        assert result["success"] is False
+        assert result["message"] == "Access denied — your account lacks permissions for this action"
+
+
+class TestSummarizeSyncResult:
+    """Value-exact copy for the pure message composer + reason extractor (engine.py)."""
+
+    def test_clean_run_returns_base_unchanged(self):
+        assert _summarize_sync_result("Uploaded 3 save(s)", synced=3, errors=[], conflicts=0) == "Uploaded 3 save(s)"
+
+    def test_total_failure_leads_with_bare_reason(self):
+        msg = _summarize_sync_result("Uploaded 0 save(s)", synced=0, errors=["a.srm: Access denied"], conflicts=0)
+        assert msg == "Access denied"
+
+    def test_total_failure_counts_the_extra_failures(self):
+        msg = _summarize_sync_result("Uploaded 0 save(s)", synced=0, errors=["a: x", "b: y", "c: z"], conflicts=0)
+        assert msg == "x (+2 more)"
+
+    def test_partial_run_keeps_count_then_appends_reason(self):
+        msg = _summarize_sync_result("Uploaded 2 save(s)", synced=2, errors=["a.srm: timeout"], conflicts=0)
+        assert msg == "Uploaded 2 save(s), 1 error(s) — timeout"
+
+    def test_conflicts_suffix_on_clean_run(self):
+        msg = _summarize_sync_result("Synced 1 save(s)", synced=1, errors=[], conflicts=2)
+        assert msg == "Synced 1 save(s), 2 conflict(s)"
+
+    def test_conflicts_suffix_after_promoted_reason(self):
+        msg = _summarize_sync_result("Uploaded 0 save(s)", synced=0, errors=["a: boom"], conflicts=1)
+        assert msg == "boom, 1 conflict(s)"
+
+    def test_first_error_reason_strips_the_filename_prefix(self):
+        assert _first_error_reason(["pokemon.srm: Access denied — nope"]) == "Access denied — nope"
+
+    def test_first_error_reason_falls_back_without_a_separator(self):
+        assert _first_error_reason(["bare message"]) == "bare message"
 
 
 class TestSyncEngineDelegates:

--- a/tests/services/saves/sync_engine/test_engine.py
+++ b/tests/services/saves/sync_engine/test_engine.py
@@ -1024,6 +1024,25 @@ class TestSummarizeSyncResult:
     def test_first_error_reason_falls_back_without_a_separator(self):
         assert _first_error_reason(["bare message"]) == "bare message"
 
+    def test_first_error_reason_handles_a_colon_in_the_filename(self):
+        # A ROM name may contain a colon ("Grand Theft Auto: San Andreas"), so its
+        # save filename does too; splitting on the LAST ": " keeps that colon on
+        # the source side and the reason must not leak a filename fragment.
+        errors = ["Grand Theft Auto: San Andreas.srm: Access denied — your account lacks permissions for this action"]
+        assert _first_error_reason(errors) == "Access denied — your account lacks permissions for this action"
+
+    def test_first_error_reason_truncates_a_reason_that_contains_a_colon(self):
+        # Documented tradeoff of the last-separator split: a reason carrying an
+        # internal ": " (only the rare str(exc) fallback) loses its head.
+        assert _first_error_reason(["game.srm: weird: colon reason"]) == "colon reason"
+
+    def test_summarize_uses_the_bare_reason_for_a_colon_filename(self):
+        # End-to-end copy: a total failure on a colon-named ROM's save shows the
+        # bare classified reason, never a filename fragment (#1334).
+        errors = ["Game: Subtitle.srm: Access denied — your account lacks permissions for this action"]
+        msg = _summarize_sync_result("Uploaded 0 save(s)", synced=0, errors=errors, conflicts=0)
+        assert msg == "Access denied — your account lacks permissions for this action"
+
 
 class TestSyncEngineDelegates:
     """Cover the thin delegate methods on SyncEngine that forward to MatrixExecutor


### PR DESCRIPTION
Closes #1334.

## Problem

A failed post-exit save sync was invisible: the toast showed only a count summary ("Uploaded 0 save(s), 1 error(s)") while the classified reason stayed buried in the per-file error list, and the Saves-tab panel rendered green "Synced just now ✓" for a failed attempt (attempt-stamped timestamp + per-file status collapse).

## Change

- **Toast (backend):** the engine promotes the first classified per-file reason into the top-level `message` for `post_exit_sync`, `sync_rom_saves`, and `sync_all_saves` — total failure → the bare reason ("… (+N more)" when several), partial → count summary + reason. The #971 toast pipeline carries it unchanged; the manual "Sync Save Files" toast heals through the same engine change. The reason splits the per-file entry on the LAST ": " (colon-containing filenames stay on the source side; a raw-exception reason containing ": " truncates to its tail — documented tradeoff).
- **Panel:** `compute_save_sync_display` no longer collapses per-file upload/download into `synced` (new `pending` display status, labels "Local changes"/"Server newer"); the slot summary derives from per-file statuses (any pending → no green ✓); the per-file row binds "Last synced" to the success time (`last_sync_at`), renders ✓ only for actually-synced files, and shows the last attempt as a "Checked:" hint. `romm_data_changed` fires now also on failure, so the panel updates immediately.
- `mark_sync_evaluated` attempt-stamping unchanged (feeds the "Checked:" hint).

## Tests

Engine-level real-dispatch 403 (through `_dispatch_sync_action`, no fabricated messages) for post-exit and manual sync; value-exact toast copies (total / partial / "+N more" / conflict suffix / colon filenames); domain pending enumeration; contract test pinning the new display value; frontend matrix for summary/✓/time-binding/refresh-on-failure. Full gate battery green (5373 backend / 1946 frontend, rebased onto main).

## On-device

The honest panel states verified live during the test round (conflict badge with "Checked: just now" hint, "Last synced" bound to the real success time, no false ✓); the 403-upload toast path is pinned by the engine-level dispatch tests.