### PR TITLE
chore(mise): give dev an optional display arg that opens BPM after deploy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,7 +135,8 @@ Latest release and shipped features: see `git tag --sort=-v:refname` and GitHub 
 - **Gate**: `mise run gate` (the full CI battery in one command — mirrors every PR check in `.github/workflows/ci.yml`;
   slow: full pytest + frontend build. Run before pushing.)
 - **Setup**: `mise run setup` (installs JS + Python dependencies)
-- **Dev reload**: `mise run dev` (build + restart plugin_loader)
+- **Dev reload**: `mise run dev [display]` (build + restart plugin_loader; no arg = deploy only, a display like `dp4` /
+  `internal` also opens windowed BPM on it after the deploy)
 - **Frontend live dev**: `mise run dev:watch [display]` (one-time `mise run dev:setup`) — hot-reloads the **frontend**
   into a windowed Big Picture in Desktop Mode on every save, no loader restart. Optional display target picks the
   monitor (`internal` default, or a name like `dp2` / `DP-3`). **Backend** changes don't auto-trigger — push them with

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -114,6 +114,7 @@ Every backend feature or callable where testing makes sense should have unit tes
 
 ```bash
 mise run dev          # build frontend, deploy to the plugin dir, restart plugin_loader
+mise run dev dp2      # ...and also open windowed Big Picture on that display after deploying
 ```
 
 This builds the frontend, copies the plugin files into `~/homebrew/plugins/decky-romm-sync`, and restarts
@@ -122,6 +123,11 @@ root and continuously re-owns the plugin dir back to root within ~1–2s as a ta
 against that re-own and fails with `permission denied`. With the loader stopped, the copy is uncontested; it restarts
 automatically when the task finishes — even if the build or copy fails, so a failure never leaves the plugin dead. For
 backend-only changes, restarting the plugin loader is sufficient without rebuilding.
+
+Passing a display target (`internal`, or an output name like `dp2` / `DP-3` — the same argument
+[`dev:watch`](frontend-dev-loop.md#choosing-the-display) takes) also opens a windowed Big Picture on that display once
+the deploy succeeds, so you can deploy and eyeball the result in one command. With no argument, `dev` stays deploy-only
+and never opens a window. A bad display name is rejected up front, before the loader is stopped.
 
 For frontend iteration there is a much faster loop: after a one-time `mise run dev:setup`,
 `mise run dev:watch [display]` hot-reloads the **frontend** into a windowed Big Picture on the desktop as you save, with

--- a/mise.toml
+++ b/mise.toml
@@ -143,9 +143,23 @@ description = "Build the documentation site (strict mode fails on broken links)"
 run = "mkdocs build --strict"
 
 [tasks.dev]
-description = "Build, deploy, and restart plugin loader"
+description = "Build, deploy, and restart plugin loader; with a display arg also open windowed Big Picture on it"
 raw = true
+# The optional display arg reaches the script as $usage_display (mise exposes
+# usage-spec args as usage_<name> env vars); the complete directive feeds mise's
+# shell tab completion from the real outputs of this machine. Unlike dev:watch there
+# is NO default: omitted → $usage_display empty → dev stays deploy-only, no BPM.
+usage = '''
+arg "[display]" help="Monitor for the Big Picture window: 'internal' or an output name (dp2, DP-3, ...). Omit to deploy only, no BPM."
+complete "display" run="bash scripts/dev_open_bpm.sh --list"
+'''
 run = """
+# A display target given? Fail fast on a typo before sudo / stopping the loader —
+# a bad name shouldn't prompt for sudo or kill the loader for nothing. Omitted →
+# $usage_display empty → this and the BPM open below are skipped (deploy-only).
+if [ -n "${usage_display:-}" ]; then
+  bash scripts/dev_open_bpm.sh --resolve "$usage_display" >/dev/null
+fi
 sudo -v
 DEST="$HOME/homebrew/plugins/decky-romm-sync"
 # plugin_loader runs as root and continuously re-owns the plugin dir + plugin.json
@@ -159,6 +173,12 @@ sudo systemctl stop plugin_loader
 trap 'sudo systemctl start plugin_loader' EXIT
 [ -d "$DEST" ] && sudo chown -R "$(id -un):$(id -gn)" "$DEST"
 mise run deploy
+# With a display target, open windowed Big Picture on it after the deploy — plain
+# bash (not exec) so the EXIT trap still fires and restarts plugin_loader. The
+# helper is non-blocking and places the window on the chosen display.
+if [ -n "${usage_display:-}" ]; then
+  bash scripts/dev_open_bpm.sh "$usage_display"
+fi
 """
 
 [tasks."dev:setup"]


### PR DESCRIPTION
`mise run dev` deploys but doesn't open Big Picture; `mise run dev:bpm` opens BPM but doesn't deploy — so "deploy, then look at it in BPM" was two commands. This adds an optional `[display]` arg to `dev`.

- `mise run dev` → deploy only (**unchanged** — no BPM window)
- `mise run dev dp4` (or `internal`, `DP-3`, …) → deploy **and** open windowed Big Picture on that display

Mirrors the proven `dev:watch` threading (usage arg → `dev_open_bpm.sh`, `--resolve` fail-fast preflight), with one deliberate difference: **no `default=`** on the arg, so omitting it keeps `dev` deploy-only. Both BPM branches are guarded on a non-empty display; the preflight runs before `sudo`/loader-stop so a typo'd target fails fast; BPM opens via plain `bash` (not `exec`) so the loader-restart trap still fires. `dev:bpm` stays the pure no-deploy primitive. Deploy logic byte-identical.

Docs updated in the same PR (CLAUDE.md + `docs/contributing/development.md`).
