### PR TITLE
fix(ui): render qam active downloads with the bare progress-bar pattern so titles stop clipping

### DIFF
--- a/src/components/DownloadProgressRow.test.tsx
+++ b/src/components/DownloadProgressRow.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+import { DownloadProgressRow } from "./DownloadProgressRow";
+
+// Local @decky/ui mock adds ProgressBar (not in the global stub) and exposes
+// per-prop testids so the bar wiring (nProgress / indeterminate) can be asserted
+// directly. Mirrors the DownloadQueue test mock.
+vi.mock("@decky/ui", async () => {
+  type AnyProps = Record<string, unknown> & { children?: unknown };
+  const { createElement: ce } = await import("react");
+  return {
+    PanelSectionRow: (p: AnyProps) => ce("div", p, p.children as never),
+    ProgressBar: (p: AnyProps & { nProgress?: number; indeterminate?: boolean }) =>
+      ce(
+        "div",
+        { "data-testid": "progress" },
+        ce("span", { "data-testid": "progress-progress" }, String(p.nProgress)),
+        ce("span", { "data-testid": "progress-indeterminate" }, String(p.indeterminate)),
+      ),
+  };
+});
+
+describe("DownloadProgressRow", () => {
+  it("total > 0: nProgress is (bytes/total)*100, indeterminate=false, bytes read 'X / Y'", () => {
+    const { container } = render(<DownloadProgressRow caption="Sonic" bytesDownloaded={256} totalBytes={1024} />);
+    expect(container.querySelector('[data-testid="progress-progress"]')?.textContent).toBe("25");
+    expect(container.querySelector('[data-testid="progress-indeterminate"]')?.textContent).toBe("false");
+    expect(container.querySelector('[data-testid="dl-bytes"]')?.textContent).toBe("256 B / 1.0 KB");
+  });
+
+  it("total === 0: nProgress undefined, indeterminate=true, bytes read the downloaded count alone", () => {
+    const { container } = render(<DownloadProgressRow caption="Sonic" bytesDownloaded={700} totalBytes={0} />);
+    expect(container.querySelector('[data-testid="progress-progress"]')?.textContent).toBe("undefined");
+    expect(container.querySelector('[data-testid="progress-indeterminate"]')?.textContent).toBe("true");
+    expect(container.querySelector('[data-testid="dl-bytes"]')?.textContent).toBe("700 B");
+  });
+
+  it("renders a plain-string caption in the dl-caption span", () => {
+    const { container } = render(<DownloadProgressRow caption="Chrono" bytesDownloaded={0} totalBytes={100} />);
+    expect(container.querySelector('[data-testid="dl-caption"]')?.textContent).toBe("Chrono");
+  });
+
+  it("renders a composed ReactNode caption verbatim (name, platform, status suffix)", () => {
+    const { container } = render(
+      <DownloadProgressRow caption={<>Kirby (Genesis){" — Paused"}</>} bytesDownloaded={0} totalBytes={100} />,
+    );
+    expect(container.querySelector('[data-testid="dl-caption"]')?.textContent).toBe("Kirby (Genesis) — Paused");
+  });
+});

--- a/src/components/DownloadProgressRow.tsx
+++ b/src/components/DownloadProgressRow.tsx
@@ -1,0 +1,55 @@
+import { FC, ReactNode } from "react";
+import { PanelSectionRow, ProgressBar } from "@decky/ui";
+import { formatBytes } from "../utils/formatters";
+import { wrapText } from "../utils/textStyles";
+
+interface DownloadProgressRowProps {
+  /** The row's caption — a bare ROM name on the QAM summary, or a composed
+   *  "name (platform) — Paused" node on the full queue. Whatever the caller
+   *  passes renders inside the `dl-caption` span. */
+  caption: ReactNode;
+  bytesDownloaded: number;
+  totalBytes: number;
+}
+
+/**
+ * One active-download row: a full-width caption + byte-count header above a bare
+ * ProgressBar. Shared by the QAM main-page download summary and the full download
+ * queue so both surfaces render byte-identically.
+ *
+ * The bare ProgressBar (not ProgressBarWithInfo) spans the full panel width:
+ * ProgressBarWithInfo is a Steam Field (label column | bar column) and with the
+ * caption in the label column the empty bar column gets squeezed into the right
+ * half and clips (#751). The caption wraps to as many lines as needed instead of
+ * clipping (shared wrap rule); the bytes column stays pinned top-right. An unknown
+ * total (`totalBytes === 0`) leaves the bar indeterminate and shows the downloaded
+ * bytes alone.
+ */
+export const DownloadProgressRow: FC<DownloadProgressRowProps> = ({ caption, bytesDownloaded, totalBytes }) => (
+  <PanelSectionRow>
+    <div style={{ width: "100%" }}>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "flex-start",
+          fontSize: "12px",
+          marginBottom: "4px",
+        }}
+      >
+        <span data-testid="dl-caption" style={wrapText}>
+          {caption}
+        </span>
+        <span data-testid="dl-bytes" style={{ flexShrink: 0 }}>
+          {totalBytes > 0
+            ? `${formatBytes(bytesDownloaded)} / ${formatBytes(totalBytes)}`
+            : formatBytes(bytesDownloaded)}
+        </span>
+      </div>
+      <ProgressBar
+        indeterminate={totalBytes === 0}
+        {...(totalBytes > 0 ? { nProgress: (bytesDownloaded / totalBytes) * 100 } : {})}
+      />
+    </div>
+  </PanelSectionRow>
+);

--- a/src/components/DownloadQueue.tsx
+++ b/src/components/DownloadQueue.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, FC, Fragment } from "react";
-import { PanelSection, PanelSectionRow, ButtonItem, Field, ProgressBar } from "@decky/ui";
+import { PanelSection, PanelSectionRow, ButtonItem, Field } from "@decky/ui";
 import { toaster } from "@decky/api";
 import {
   getDownloadQueue,
@@ -12,7 +12,7 @@ import { getDownloadState, setDownloads, removeTerminalDownloads } from "../util
 import { formatBytes } from "../utils/formatters";
 import { scrollToTop } from "../utils/scrollHelpers";
 import { detach } from "../utils/detach";
-import { wrapText } from "../utils/textStyles";
+import { DownloadProgressRow } from "./DownloadProgressRow";
 import type { DownloadItem } from "../types";
 
 interface DownloadQueueProps {
@@ -145,42 +145,17 @@ export const DownloadQueue: FC<DownloadQueueProps> = ({ onBack }) => {
         ) : (
           <>
             {active.map((item) => (
-              <PanelSectionRow key={item.rom_id}>
-                {/* Own the caption in a full-width row and use the bare ProgressBar.
-                    ProgressBarWithInfo is a Steam Field (label column | bar column);
-                    with the rom name in sOperationText the empty bar column gets
-                    squeezed into the right half and clips (#751). The bare
-                    ProgressBar is just the bar and spans the full panel width
-                    (mirrors the sync-progress fix in MainPage). */}
-                <div style={{ width: "100%" }}>
-                  <div
-                    style={{
-                      display: "flex",
-                      justifyContent: "space-between",
-                      alignItems: "flex-start",
-                      fontSize: "12px",
-                      marginBottom: "4px",
-                    }}
-                  >
-                    {/* Wrap a long ROM/platform caption to as many lines as
-                        needed instead of clipping it with an ellipsis (shared
-                        wrap rule) — the bytes column stays pinned top-right. */}
-                    <span data-testid="dl-caption" style={wrapText}>
-                      {item.rom_name} ({item.platform_name}){item.status === "paused" ? " — Paused" : ""}
-                      {item.status === "extracting" ? " — Extracting…" : ""}
-                    </span>
-                    <span data-testid="dl-bytes" style={{ flexShrink: 0 }}>
-                      {item.total_bytes > 0
-                        ? `${formatBytes(item.bytes_downloaded)} / ${formatBytes(item.total_bytes)}`
-                        : formatBytes(item.bytes_downloaded)}
-                    </span>
-                  </div>
-                  <ProgressBar
-                    indeterminate={item.total_bytes === 0}
-                    {...(item.total_bytes > 0 ? { nProgress: (item.bytes_downloaded / item.total_bytes) * 100 } : {})}
-                  />
-                </div>
-              </PanelSectionRow>
+              <DownloadProgressRow
+                key={item.rom_id}
+                caption={
+                  <>
+                    {item.rom_name} ({item.platform_name}){item.status === "paused" ? " — Paused" : ""}
+                    {item.status === "extracting" ? " — Extracting…" : ""}
+                  </>
+                }
+                bytesDownloaded={item.bytes_downloaded}
+                totalBytes={item.total_bytes}
+              />
             ))}
             {active.map((item) =>
               // Extraction is not cancellable and can't pause/resume — the

--- a/src/components/MainPage.test.tsx
+++ b/src/components/MainPage.test.tsx
@@ -129,9 +129,9 @@ vi.mock("../utils/syncManager", () => ({
   resetSyncCancel: vi.fn(),
 }));
 
-// Local @decky/ui re-mock — global stub lacks ProgressBarWithInfo (used to
-// render sync + download progress). Mirror the rest with thin pass-throughs
-// + a vi.fn showModal so we can capture ConfirmModal calls.
+// Local @decky/ui re-mock — global stub lacks ProgressBar (used to render sync
+// + download progress). Mirror the rest with thin pass-throughs + a vi.fn
+// showModal so we can capture ConfirmModal calls.
 vi.mock("@decky/ui", async () => {
   type AnyProps = Record<string, unknown> & { children?: unknown };
   const { createElement: ce } = await import("react");
@@ -189,22 +189,6 @@ vi.mock("@decky/ui", async () => {
         onCancel?: () => void;
       },
     ) => ce("div", { "data-testid": "confirm-modal" }, p.children as never),
-    ProgressBarWithInfo: (
-      p: AnyProps & {
-        nProgress?: number;
-        indeterminate?: boolean;
-        sOperationText?: string;
-        sTimeRemaining?: string;
-      },
-    ) =>
-      ce(
-        "div",
-        { "data-testid": "progress" },
-        ce("span", { "data-testid": "progress-op" }, p.sOperationText as never),
-        ce("span", { "data-testid": "progress-remaining" }, p.sTimeRemaining as never),
-        ce("span", { "data-testid": "progress-progress" }, String(p.nProgress)),
-        ce("span", { "data-testid": "progress-indeterminate" }, String(p.indeterminate)),
-      ),
     ProgressBar: (p: AnyProps & { nProgress?: number; indeterminate?: boolean }) =>
       ce(
         "div",
@@ -764,7 +748,7 @@ describe("MainPage", () => {
   // ===========================================================================
   // E. Module helpers — exercised via rendered output
   // ===========================================================================
-  describe("formatBytes (via active download progress remaining text)", () => {
+  describe("formatBytes (via active download bytes caption)", () => {
     async function renderWithActiveDownload(bytes: number, total: number): Promise<HTMLElement> {
       const item: DownloadItem = {
         rom_id: 1,
@@ -803,29 +787,29 @@ describe("MainPage", () => {
 
     it("renders bytes < 1024 as '<n> B'", async () => {
       const c = await renderWithActiveDownload(512, 1024);
-      const remaining = c.querySelector('[data-testid="progress-remaining"]');
-      expect(remaining?.textContent).toContain("512 B");
-      expect(remaining?.textContent).toContain("1.0 KB");
+      const bytes = c.querySelector('[data-testid="dl-bytes"]');
+      expect(bytes?.textContent).toContain("512 B");
+      expect(bytes?.textContent).toContain("1.0 KB");
     });
 
     it("renders bytes in MB range with 1 decimal", async () => {
       const c = await renderWithActiveDownload(2 * 1024 * 1024, 4 * 1024 * 1024);
-      const remaining = c.querySelector('[data-testid="progress-remaining"]');
-      expect(remaining?.textContent).toContain("2.0 MB");
-      expect(remaining?.textContent).toContain("4.0 MB");
+      const bytes = c.querySelector('[data-testid="dl-bytes"]');
+      expect(bytes?.textContent).toContain("2.0 MB");
+      expect(bytes?.textContent).toContain("4.0 MB");
     });
 
     it("renders bytes in GB range with 2 decimals", async () => {
       const c = await renderWithActiveDownload(Math.round(1.5 * 1024 * 1024 * 1024), 2 * 1024 * 1024 * 1024);
-      const remaining = c.querySelector('[data-testid="progress-remaining"]');
-      expect(remaining?.textContent).toContain("1.50 GB");
-      expect(remaining?.textContent).toContain("2.00 GB");
+      const bytes = c.querySelector('[data-testid="dl-bytes"]');
+      expect(bytes?.textContent).toContain("1.50 GB");
+      expect(bytes?.textContent).toContain("2.00 GB");
     });
 
     it("renders only the bytes_downloaded value when total_bytes is 0", async () => {
       const c = await renderWithActiveDownload(700, 0);
-      const remaining = c.querySelector('[data-testid="progress-remaining"]');
-      expect(remaining?.textContent).toBe("700 B");
+      const bytes = c.querySelector('[data-testid="dl-bytes"]');
+      expect(bytes?.textContent).toBe("700 B");
     });
   });
 
@@ -4093,7 +4077,9 @@ describe("MainPage", () => {
       ]);
       const container = await renderAndTick();
       expect(buttonByExactText(container, "View All")).not.toBeNull();
-      expect(container.textContent).toContain("Active");
+      // The rom name lands in the full-width caption (not clipped in a Field
+      // label column) — see the #751 ProgressBarWithInfo fix.
+      expect(container.querySelector('[data-testid="dl-caption"]')?.textContent).toBe("Active");
     });
 
     it("shows '+N more downloading' when more than 2 active downloads", async () => {
@@ -4188,6 +4174,8 @@ describe("MainPage", () => {
       expect(progress?.textContent).toBe("25");
       const indet = container.querySelector('[data-testid="progress-indeterminate"]');
       expect(indet?.textContent).toBe("false");
+      expect(container.querySelector('[data-testid="dl-caption"]')?.textContent).toBe("P");
+      expect(container.querySelector('[data-testid="dl-bytes"]')?.textContent).toBe("256 B / 1.0 KB");
     });
 
     it("active item with total_bytes === 0 renders indeterminate=true", async () => {
@@ -4207,6 +4195,8 @@ describe("MainPage", () => {
       const container = await renderAndTick();
       const indet = container.querySelector('[data-testid="progress-indeterminate"]');
       expect(indet?.textContent).toBe("true");
+      expect(container.querySelector('[data-testid="dl-caption"]')?.textContent).toBe("P");
+      expect(container.querySelector('[data-testid="dl-bytes"]')?.textContent).toBe("0 B");
     });
   });
 

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -30,7 +30,6 @@ import {
   getRetroDeckStatus,
   logError,
 } from "../api/backend";
-import { formatBytes } from "../utils/formatters";
 import { pluralize } from "../utils/pluralize";
 import { estimateApplySeconds, formatDuration } from "../utils/syncEstimate";
 import {
@@ -60,6 +59,7 @@ import { setVersionError } from "../utils/connectionState";
 import { retroDeckBanner, type RetroDeckBanner } from "../utils/retrodeckHealth";
 import { VersionErrorCard, useVersionError } from "./VersionErrorCard";
 import { WarningCard } from "./WarningCard";
+import { DownloadProgressRow } from "./DownloadProgressRow";
 import { MigrationBlockedPage } from "./MigrationBlockedPage";
 import { SettingsResetBanner } from "./SettingsResetBanner";
 import { PlaytimeScopeBanner } from "./PlaytimeScopeBanner";
@@ -1425,41 +1425,12 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
       {hasDownloads && (
         <PanelSection>
           {activeDownloads.slice(0, 2).map((item) => (
-            <PanelSectionRow key={item.rom_id}>
-              {/* Own the caption in a full-width row and use the bare ProgressBar.
-                  ProgressBarWithInfo is a Steam Field (label column | bar column);
-                  with the rom name in sOperationText the empty bar column gets
-                  squeezed into the right half and clips (#751). The bare
-                  ProgressBar spans the full panel width (mirrors the sync-progress
-                  fix above and the DownloadQueue rows). */}
-              <div style={{ width: "100%" }}>
-                <div
-                  style={{
-                    display: "flex",
-                    justifyContent: "space-between",
-                    alignItems: "flex-start",
-                    fontSize: "12px",
-                    marginBottom: "4px",
-                  }}
-                >
-                  {/* Wrap a long ROM caption to as many lines as needed instead
-                      of clipping it (shared wrap rule) — the bytes column stays
-                      pinned top-right. */}
-                  <span data-testid="dl-caption" style={wrapText}>
-                    {item.rom_name}
-                  </span>
-                  <span data-testid="dl-bytes" style={{ flexShrink: 0 }}>
-                    {item.total_bytes > 0
-                      ? `${formatBytes(item.bytes_downloaded)} / ${formatBytes(item.total_bytes)}`
-                      : formatBytes(item.bytes_downloaded)}
-                  </span>
-                </div>
-                <ProgressBar
-                  indeterminate={item.total_bytes === 0}
-                  {...(item.total_bytes > 0 ? { nProgress: (item.bytes_downloaded / item.total_bytes) * 100 } : {})}
-                />
-              </div>
-            </PanelSectionRow>
+            <DownloadProgressRow
+              key={item.rom_id}
+              caption={item.rom_name}
+              bytesDownloaded={item.bytes_downloaded}
+              totalBytes={item.total_bytes}
+            />
           ))}
           {activeDownloads.length > 2 && (
             <PanelSectionRow>

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -6,7 +6,6 @@ import {
   Field,
   Focusable,
   ProgressBar,
-  ProgressBarWithInfo,
   ToggleField,
   Spinner,
   DialogButton,
@@ -1427,16 +1426,39 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
         <PanelSection>
           {activeDownloads.slice(0, 2).map((item) => (
             <PanelSectionRow key={item.rom_id}>
-              <ProgressBarWithInfo
-                {...(item.total_bytes > 0 ? { nProgress: (item.bytes_downloaded / item.total_bytes) * 100 } : {})}
-                indeterminate={item.total_bytes === 0}
-                sOperationText={item.rom_name}
-                sTimeRemaining={
-                  item.total_bytes > 0
-                    ? `${formatBytes(item.bytes_downloaded)} / ${formatBytes(item.total_bytes)}`
-                    : formatBytes(item.bytes_downloaded)
-                }
-              />
+              {/* Own the caption in a full-width row and use the bare ProgressBar.
+                  ProgressBarWithInfo is a Steam Field (label column | bar column);
+                  with the rom name in sOperationText the empty bar column gets
+                  squeezed into the right half and clips (#751). The bare
+                  ProgressBar spans the full panel width (mirrors the sync-progress
+                  fix above and the DownloadQueue rows). */}
+              <div style={{ width: "100%" }}>
+                <div
+                  style={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    alignItems: "flex-start",
+                    fontSize: "12px",
+                    marginBottom: "4px",
+                  }}
+                >
+                  {/* Wrap a long ROM caption to as many lines as needed instead
+                      of clipping it (shared wrap rule) — the bytes column stays
+                      pinned top-right. */}
+                  <span data-testid="dl-caption" style={wrapText}>
+                    {item.rom_name}
+                  </span>
+                  <span data-testid="dl-bytes" style={{ flexShrink: 0 }}>
+                    {item.total_bytes > 0
+                      ? `${formatBytes(item.bytes_downloaded)} / ${formatBytes(item.total_bytes)}`
+                      : formatBytes(item.bytes_downloaded)}
+                  </span>
+                </div>
+                <ProgressBar
+                  indeterminate={item.total_bytes === 0}
+                  {...(item.total_bytes > 0 ? { nProgress: (item.bytes_downloaded / item.total_bytes) * 100 } : {})}
+                />
+              </div>
             </PanelSectionRow>
           ))}
           {activeDownloads.length > 2 && (


### PR DESCRIPTION
Closes #1186.

## Problem

The QAM Downloads summary rendered active-download rows with `ProgressBarWithInfo` (Steam's label-column | bar-column Field layout), which clips the ROM title at QAM width — the exact problem #751 already solved elsewhere.

## Change

Replaced it with the caption-div + bare `<ProgressBar>` pattern, mirroring the two shipped references (the same file's sync-progress bar and `DownloadQueue.tsx`'s converted rows): full-width title caption (wraps instead of clipping) + bytes right-aligned + bare progress bar, indeterminate when `total_bytes === 0`. Progress math and byte formatting are byte-for-byte identical to the old block — pure cosmetic layout swap, no state/logic change.

## Tests

Removed the dead `ProgressBarWithInfo` mock; retargeted the byte-format tests to the new `dl-bytes` element; added non-vacuous caption+bytes assertions on the percentage and indeterminate branches. Full gate green.

docs: N/A — cosmetic swap onto an already-documented pattern, no behavior/flow/architecture change.