### PR TITLE
fix(downloads): keep cleared downloads cleared, and fix cancel-while-paused + lingering cancelled rows

### DIFF
--- a/main.py
+++ b/main.py
@@ -461,6 +461,9 @@ class Plugin:
     async def get_download_queue(self):
         return self._download_service.get_download_queue()
 
+    async def clear_completed_downloads(self):
+        return self._download_service.clear_completed_downloads()
+
     async def get_installed_rom(self, rom_id):
         return self._download_service.get_installed_rom(rom_id)
 

--- a/py_modules/services/downloads.py
+++ b/py_modules/services/downloads.py
@@ -58,7 +58,11 @@ _ZIP_TMP_EXT = ".zip.tmp"
 _TMP_EXT = ".tmp"
 # A download in one of these statuses has run to a terminal end — it is no
 # longer active/queued/paused/extracting. The queue prune trims the oldest of
-# these over the cap, and "Clear Completed" evicts all of them (#149).
+# these over the cap, and "Clear Completed" evicts all of them (#149). In normal
+# flow only completed/failed actually LINGER: a cancel is an explicit discard and
+# evicts its entry on the spot (#149 downloads-round), so "cancelled" stays in
+# this classification defensively (a stray cancelled row is still prune/clearable)
+# and as the transient status the terminal cancel FRAME still carries.
 _TERMINAL_DOWNLOAD_STATUSES = ("completed", "failed", "cancelled")
 
 
@@ -166,11 +170,13 @@ class DownloadService:
         self._download_tasks.clear()
 
     def _prune_download_queue(self):
-        """Remove oldest completed/failed/cancelled items when over the limit.
+        """Remove oldest terminal items when over the limit.
 
-        Keeps all active (downloading) items. Retains up to
-        _DOWNLOAD_QUEUE_MAX_TERMINAL terminal items, removing the oldest
-        (by insertion order) when the count exceeds the limit.
+        Keeps all non-terminal (queued/downloading/paused/extracting) items.
+        Retains up to _DOWNLOAD_QUEUE_MAX_TERMINAL terminal items, removing the
+        oldest (by insertion order) when the count exceeds the limit. In practice
+        the retained terminals are completed/failed — a cancel evicts its own
+        entry immediately (#149 downloads-round), so it rarely reaches the cap.
         """
         terminal_ids = [
             rid for rid, item in self._download_queue.items() if item.get("status") in _TERMINAL_DOWNLOAD_STATUSES
@@ -1064,9 +1070,13 @@ class DownloadService:
                 # PAUSE: keep the partial ``.tmp`` so the transfer can resume from
                 # where it stopped. NOTHING is cleaned up. The entry stays "paused"
                 # in the queue (``_prune_download_queue`` only prunes terminal
-                # completed/failed/cancelled, so "paused" is retained).
+                # completed/failed/cancelled, so "paused" is retained). Record the
+                # target path (internal ``_``-prefixed key, stripped from the wire
+                # by ``get_download_queue``) so a later cancel of this now-task-less
+                # download can delete the partial without re-fetching rom detail.
                 entry = self._download_queue[rom_id]
                 entry["status"] = "paused"
+                entry["_target_path"] = target_path
                 await self._emit(
                     "download_progress",
                     {
@@ -1102,6 +1112,12 @@ class DownloadService:
                         "resumable": entry.get("resumable", False),
                     },
                 )
+                # A cancel is an explicit discard — drop the entry so no
+                # "cancelled" row lingers in the queue view or QAM summary (#149
+                # downloads-round). The terminal frame above already told the
+                # frontend; the store listener drops it there. Emitted BEFORE the
+                # evict so the frame carries the entry's final progress values.
+                self.evict(rom_id)
                 self._logger.info(f"Download cancelled: {rom_name}")
             raise
 
@@ -1233,15 +1249,7 @@ class DownloadService:
         cleanup targets exactly that dir rather than re-deriving it from a stale
         source (unused for single-file ROMs, which own no dir).
         """
-        paths_to_remove = [
-            target_path + _ZIP_TMP_EXT,
-            target_path + _TMP_EXT,
-        ]
-        for path in paths_to_remove:
-            try:
-                self._download_file_store.remove_file(path)
-            except Exception as e:
-                self._logger.warning(f"Cleanup failed for {path}: {e}")
+        self._remove_partial_tmp_files(target_path)
         if has_multiple:
             staging_dir = os.path.join(os.path.dirname(target_path), extract_dir_name)
             dirs_to_remove = {staging_dir}
@@ -1253,16 +1261,87 @@ class DownloadService:
                 except Exception as e:
                     self._logger.warning(f"Cleanup failed for directory {extract_dir}: {e}")
 
+    def _remove_partial_tmp_files(self, target_path: str) -> None:
+        """Remove the ``.zip.tmp`` and ``.tmp`` partials for *target_path*.
+
+        Each removal is independent so one failure doesn't block the other, and a
+        missing partial is not an error. The bare ``target_path`` is NEVER touched
+        — only the transient transfer artifacts. Shared by
+        ``_cleanup_partial_download`` (running-cancel / failure) and the
+        paused-cancel path, which has no live task in scope to name the extension.
+        """
+        for path in (target_path + _ZIP_TMP_EXT, target_path + _TMP_EXT):
+            try:
+                self._download_file_store.remove_file(path)
+            except Exception as e:
+                self._logger.warning(f"Cleanup failed for {path}: {e}")
+
     def cancel_download(self, rom_id):
+        """Cancel a download, whether it is running or paused.
+
+        A running download has a live task: flip its cooperative-cancel token
+        (stops the executor transfer thread, not just the asyncio wrapper — #144)
+        and cancel the task; ``_do_download``'s terminal handler deletes the
+        partial, emits the terminal ``cancelled`` frame, and evicts the entry.
+
+        A **paused** download has NO task — the pause already cancelled it,
+        leaving the entry "paused" and the partial ``.tmp`` kept for resume. A
+        plain task lookup then found nothing and silently no-op'd (the
+        downloads-round finding). Handle it directly here:
+        ``_cancel_paused_download`` deletes the partial, emits the same terminal
+        ``cancelled`` frame, and evicts the entry.
+
+        A cancel that can act on neither (no task AND no paused entry) keeps the
+        canonical failure shape so the frontend can surface it.
+        """
         rom_id = int(rom_id)
         task = self._download_tasks.get(rom_id)
-        if not task:
-            return {"success": False, "reason": "no_active_download", "message": "No active download for this ROM"}
-        token = self._control_tokens.get(rom_id)
-        if token is not None:
-            token.cancelled = True  # stop the executor transfer thread, not just the asyncio wrapper (#144)
-        task.cancel()
-        return {"success": True, "message": "Download cancelled"}
+        if task:
+            token = self._control_tokens.get(rom_id)
+            if token is not None:
+                token.cancelled = True  # stop the executor transfer thread, not just the asyncio wrapper (#144)
+            task.cancel()
+            return {"success": True, "message": "Download cancelled"}
+        entry = self._download_queue.get(rom_id)
+        if entry is not None and entry.get("status") == "paused":
+            self._cancel_paused_download(rom_id, entry)
+            return {"success": True, "message": "Download cancelled"}
+        return {"success": False, "reason": "no_active_download", "message": "No active download for this ROM"}
+
+    def _cancel_paused_download(self, rom_id: int, entry: dict[str, Any]) -> None:
+        """Cancel a paused (task-less) download: delete its partial, notify, evict.
+
+        Does the cleanup the running-cancel terminal branch would have, minus the
+        task: removes the partial ``.tmp``/``.zip.tmp`` (via the ``_target_path``
+        recorded when the entry paused — skipped if absent, the startup sweep
+        still reaps it; a paused transfer is mid-download so it owns no extract
+        dir), emits the same terminal ``download_progress`` ``cancelled`` frame
+        the running-cancel emits (so the button resets and the store drops the
+        row), then evicts the entry — a cancel is an explicit discard that leaves
+        no residue (#149 downloads-round).
+        """
+        target_path = entry.get("_target_path")
+        if target_path:
+            self._remove_partial_tmp_files(target_path)
+        # cancel_download runs on the loop thread; schedule the terminal frame the
+        # same way the progress callbacks do (fire-and-forget on the loop).
+        self._loop.create_task(self._emit("download_progress", self._cancelled_frame(rom_id, entry)))
+        self.evict(rom_id)
+
+    @staticmethod
+    def _cancelled_frame(rom_id: int, entry: dict[str, Any]) -> dict[str, Any]:
+        """Build the terminal ``cancelled`` ``download_progress`` payload from a queue entry."""
+        return {
+            "rom_id": rom_id,
+            "rom_name": entry.get("rom_name", ""),
+            "platform_name": entry.get("platform_name", ""),
+            "file_name": entry.get("file_name", ""),
+            "status": "cancelled",
+            "progress": entry.get("progress", 0),
+            "bytes_downloaded": entry.get("bytes_downloaded", 0),
+            "total_bytes": entry.get("total_bytes", 0),
+            "resumable": entry.get("resumable", False),
+        }
 
     def pause_download(self, rom_id):
         """Pause an in-flight download, keeping the partial ``.tmp`` for resume.
@@ -1339,7 +1418,14 @@ class DownloadService:
             )
 
     def get_download_queue(self):
-        return {"downloads": list(self._download_queue.values())}
+        # Drop internal ``_``-prefixed keys (e.g. ``_target_path``, kept on a
+        # paused entry only for the paused-cancel cleanup) so they never cross
+        # the wire to the frontend ``DownloadItem`` shape.
+        return {
+            "downloads": [
+                {k: v for k, v in entry.items() if not k.startswith("_")} for entry in self._download_queue.values()
+            ]
+        }
 
     def clear_completed_downloads(self) -> dict[str, Any]:
         """Evict every terminal (completed/failed/cancelled) entry from the queue.
@@ -1349,9 +1435,11 @@ class DownloadService:
         is the source ``get_download_queue`` re-seeds the frontend from on every
         mount, so a purely-local hide reappeared on the next reopen. Active,
         queued, paused, and extracting entries are left untouched — only terminal
-        ones are removed. Idempotent: an empty queue or one with no terminal
-        entries clears nothing and reports ``cleared: 0``. A ROM re-downloaded
-        after being cleared re-enters the queue naturally via ``start_download``.
+        ones are removed. In normal flow those are completed/failed only, since a
+        cancel already evicted its own entry (#149 downloads-round); a stray
+        cancelled row would still clear here. Idempotent: an empty queue or one
+        with no terminal entries clears nothing and reports ``cleared: 0``. A ROM
+        re-downloaded after being cleared re-enters the queue via ``start_download``.
         """
         terminal_ids = [
             rid for rid, item in self._download_queue.items() if item.get("status") in _TERMINAL_DOWNLOAD_STATUSES

--- a/py_modules/services/downloads.py
+++ b/py_modules/services/downloads.py
@@ -56,6 +56,10 @@ if TYPE_CHECKING:
 _DOWNLOAD_QUEUE_MAX_TERMINAL = 50
 _ZIP_TMP_EXT = ".zip.tmp"
 _TMP_EXT = ".tmp"
+# A download in one of these statuses has run to a terminal end — it is no
+# longer active/queued/paused/extracting. The queue prune trims the oldest of
+# these over the cap, and "Clear Completed" evicts all of them (#149).
+_TERMINAL_DOWNLOAD_STATUSES = ("completed", "failed", "cancelled")
 
 
 class _DownloadControl:
@@ -169,9 +173,7 @@ class DownloadService:
         (by insertion order) when the count exceeds the limit.
         """
         terminal_ids = [
-            rid
-            for rid, item in self._download_queue.items()
-            if item.get("status") in ("completed", "failed", "cancelled")
+            rid for rid, item in self._download_queue.items() if item.get("status") in _TERMINAL_DOWNLOAD_STATUSES
         ]
         excess = len(terminal_ids) - _DOWNLOAD_QUEUE_MAX_TERMINAL
         if excess <= 0:
@@ -1338,6 +1340,25 @@ class DownloadService:
 
     def get_download_queue(self):
         return {"downloads": list(self._download_queue.values())}
+
+    def clear_completed_downloads(self) -> dict[str, Any]:
+        """Evict every terminal (completed/failed/cancelled) entry from the queue.
+
+        The frontend "Clear Completed" action calls this so a dismissed download
+        stays cleared across a QAM reopen or menu switch (#149): the backend queue
+        is the source ``get_download_queue`` re-seeds the frontend from on every
+        mount, so a purely-local hide reappeared on the next reopen. Active,
+        queued, paused, and extracting entries are left untouched — only terminal
+        ones are removed. Idempotent: an empty queue or one with no terminal
+        entries clears nothing and reports ``cleared: 0``. A ROM re-downloaded
+        after being cleared re-enters the queue naturally via ``start_download``.
+        """
+        terminal_ids = [
+            rid for rid, item in self._download_queue.items() if item.get("status") in _TERMINAL_DOWNLOAD_STATUSES
+        ]
+        for rid in terminal_ids:
+            del self._download_queue[rid]
+        return {"success": True, "cleared": len(terminal_ids)}
 
     def active_download_rom_ids(self) -> set[int]:
         """Snapshot the rom ids with an in-flight or queued download (#1298 F1).

--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -132,6 +132,7 @@ export const cancelDownload = callable<[number], BackendResult>("cancel_download
 export const pauseDownload = callable<[number], BackendResult>("pause_download");
 export const resumeDownload = callable<[number], BackendResult>("resume_download");
 export const getDownloadQueue = callable<[], { downloads: DownloadItem[] }>("get_download_queue");
+export const clearCompletedDownloads = callable<[], { success: boolean; cleared: number }>("clear_completed_downloads");
 export const getInstalledRom = callable<[number], InstalledRom | null>("get_installed_rom");
 export const evaluateLaunch = callable<[number], LaunchVerdict>("evaluate_launch");
 export const checkLocalDrift = callable<[number], { drifted: boolean; rom_id: number }>("check_local_drift");

--- a/src/components/CustomPlayButton.test.tsx
+++ b/src/components/CustomPlayButton.test.tsx
@@ -484,6 +484,46 @@ describe("CustomPlayButton — pause/resume on active download (#1124)", () => {
 
     expect(backend.resumeDownload).toHaveBeenCalledWith(42);
   });
+
+  it("rehydrates a plain downloading (non-paused) download on mount from the queue (#145 / #1126)", async () => {
+    // Sibling of the paused-rehydration case above: a plain "downloading" entry
+    // in the queue at mount must rehydrate the button straight into its active
+    // shape — NOT a fresh "Download" button whose click would restart from byte
+    // 0 (the #145 regression, closed by #1126). No Download click and no live
+    // progress frame — the active state is recovered purely from getDownloadQueue.
+    mockCachedDetail({ rom_id: 42, installed: false });
+    vi.mocked(backend.getDownloadQueue).mockResolvedValue({
+      downloads: [
+        {
+          rom_id: 42,
+          rom_name: "Test ROM",
+          platform_name: "PSX",
+          file_name: "test.chd",
+          status: "downloading",
+          progress: 0.3,
+          bytes_downloaded: 300,
+          total_bytes: 1000,
+          resumable: true,
+        },
+      ],
+    });
+
+    const { findByLabelText, queryByText } = render(<CustomPlayButton appId={100} />);
+
+    // Rehydrated into the active-download shape (the resumable actions dropdown),
+    // reachable without ever falling back to a fresh "Download" button.
+    const dropdownBtn = await findByLabelText("Download actions");
+    expect(queryByText("Download")).toBeNull();
+
+    // The rehydrated state drives the real controls — Pause hits the exact rom_id.
+    const menu = openMenu(dropdownBtn);
+    const pauseItem = await menu.findByText("Pause");
+    await act(async () => {
+      pauseItem.click();
+      await Promise.resolve();
+    });
+    expect(backend.pauseDownload).toHaveBeenCalledWith(42);
+  });
 });
 
 describe("CustomPlayButton — extraction phase on a multi-file download", () => {

--- a/src/components/DownloadQueue.test.tsx
+++ b/src/components/DownloadQueue.test.tsx
@@ -1,5 +1,5 @@
 // CATCH-REJECTION ASSERTION RULE:
-// DownloadQueue has 2 catch sites:
+// DownloadQueue has 3 catch sites:
 //   - useEffect mount: getDownloadQueue().catch → falls back to
 //     setLocalDownloads([...getDownloadState()]). Observable side effect:
 //     pre-seeded store items render. Asserted in "mount: rejection falls back
@@ -10,14 +10,19 @@
 //     catches stay assertion-free; we still exercise the call site by
 //     rejecting cancelDownload and asserting the click did NOT crash + the
 //     component continued to render normally.
+//   - handleClearCompleted's `try/catch { return }`. This catch HAS an
+//     observable side effect: on a failed clear it returns BEFORE
+//     removeTerminalDownloads(), so the finished rows stay visible and the
+//     store is untouched. Asserted in "a failed clear leaves the finished
+//     rows in place".
 //
 // MUTATION CHECKS (by inspection):
 //   1. If clearInterval(pollRef.current) is removed from stopPolling, the
 //      "interval is cleared on unmount" test fails — clearIntervalSpy would
 //      not be called with the captured pollRef id after unmount.
-//   2. If setCleared(unclearRestarted(current)) is removed from pollTick,
-//      the "previously cleared rom restarting un-clears" test fails — a
-//      cleared rom_id that returns to "downloading" would stay hidden.
+//   2. If removeTerminalDownloads() is removed from handleClearCompleted, the
+//      "cleared downloads do not reappear on remount" test fails — the store
+//      keeps the terminal entries, so the poll re-shows them.
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { render, fireEvent, act } from "@testing-library/react";
@@ -108,6 +113,7 @@ describe("DownloadQueue", () => {
     vi.mocked(backend.cancelDownload).mockResolvedValue({ success: true, message: "" });
     vi.mocked(backend.pauseDownload).mockResolvedValue({ success: true, message: "" });
     vi.mocked(backend.resumeDownload).mockResolvedValue({ success: true, message: "" });
+    vi.mocked(backend.clearCompletedDownloads).mockResolvedValue({ success: true, cleared: 0 });
   });
 
   afterEach(() => {
@@ -239,10 +245,15 @@ describe("DownloadQueue", () => {
   });
 
   // ---------------------------------------------------------------------------
-  // unclearRestarted — cleared rom returns to active list
+  // clear + re-download — a cleared rom that re-enters the queue shows again
   // ---------------------------------------------------------------------------
-  describe("unclearRestarted", () => {
-    it("a cleared rom_id whose download restarts (downloading) becomes visible again", async () => {
+  // With backend eviction (#149) there is no client-side "cleared" set: a clear
+  // removes the entries from both the backend queue and the store. A restarted
+  // download re-enters the queue naturally (start_download re-adds it and its
+  // download_progress frame refreshes the store), so it reappears without any
+  // per-component un-clear bookkeeping.
+  describe("clear + re-download", () => {
+    it("a cleared rom whose download restarts (downloading) becomes visible again", async () => {
       const finished = makeItem({
         rom_id: 42,
         rom_name: "Restart",
@@ -259,11 +270,13 @@ describe("DownloadQueue", () => {
 
       // The completed Field is visible.
       expect(container.textContent).toContain("Restart");
-      // Click "Clear Completed" → rom_id 42 enters cleared set.
+      // Click "Clear Completed" → backend evicts, store filtered.
       const clearBtn = buttonByExactText(container, "Clear Completed");
       expect(clearBtn).not.toBeNull();
       await act(async () => {
         fireEvent.click(clearBtn!);
+        await Promise.resolve();
+        await Promise.resolve();
       });
       // After clearing the only item, the empty state shows.
       expect(container.textContent).toContain("No downloads");
@@ -274,13 +287,12 @@ describe("DownloadQueue", () => {
         await vi.advanceTimersByTimeAsync(500);
       });
 
-      // unclearRestarted removed rom_id 42 from `cleared`, so the active
-      // download caption is rendered again.
+      // The re-entered download renders again — nothing keeps it hidden.
       const caption = container.querySelector('[data-testid="dl-caption"]');
       expect(caption?.textContent).toBe("Restart (Genesis)");
     });
 
-    it("a cleared rom_id whose download restarts as 'queued' also becomes visible", async () => {
+    it("a cleared rom whose download restarts as 'queued' also becomes visible", async () => {
       const finished = makeItem({
         rom_id: 13,
         rom_name: "Queued",
@@ -296,6 +308,8 @@ describe("DownloadQueue", () => {
 
       await act(async () => {
         fireEvent.click(buttonByExactText(container, "Clear Completed")!);
+        await Promise.resolve();
+        await Promise.resolve();
       });
       expect(container.textContent).toContain("No downloads");
 
@@ -304,28 +318,6 @@ describe("DownloadQueue", () => {
         await vi.advanceTimersByTimeAsync(500);
       });
       expect(container.querySelector('[data-testid="dl-caption"]')?.textContent).toBe("Queued (Genesis)");
-    });
-
-    it("if no cleared rom_id matches, cleared Set stays the same instance (no needless re-set)", async () => {
-      // Two finished items; clear them; then a tick where NONE of the cleared
-      // ids restart. unclearRestarted's early-return path is exercised.
-      const a = makeItem({ rom_id: 1, status: "completed", bytes_downloaded: 100, total_bytes: 100 });
-      const b = makeItem({ rom_id: 2, rom_name: "Bee", status: "cancelled", bytes_downloaded: 0, total_bytes: 0 });
-      vi.mocked(backend.getDownloadQueue).mockResolvedValue({
-        downloads: [a, b],
-      });
-      const { container } = render(<DownloadQueue onBack={() => {}} />);
-      await flushMount();
-      await act(async () => {
-        fireEvent.click(buttonByExactText(container, "Clear Completed")!);
-      });
-      expect(container.textContent).toContain("No downloads");
-
-      // Tick with the same store contents — no restart → still hidden.
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(500);
-      });
-      expect(container.textContent).toContain("No downloads");
     });
   });
 
@@ -477,7 +469,7 @@ describe("DownloadQueue", () => {
   // handleClearCompleted
   // ---------------------------------------------------------------------------
   describe("handleClearCompleted", () => {
-    it("hides all completed/failed/cancelled items; keeps active items visible", async () => {
+    it("calls clearCompletedDownloads, hides finished items, keeps active items visible", async () => {
       const active = makeItem({ rom_id: 1, rom_name: "Active" });
       const completed = makeItem({
         rom_id: 2,
@@ -500,6 +492,7 @@ describe("DownloadQueue", () => {
       vi.mocked(backend.getDownloadQueue).mockResolvedValue({
         downloads: [active, completed, failed, cancelled],
       });
+      vi.mocked(backend.clearCompletedDownloads).mockResolvedValue({ success: true, cleared: 3 });
       const { container } = render(<DownloadQueue onBack={() => {}} />);
       await flushMount();
 
@@ -511,8 +504,12 @@ describe("DownloadQueue", () => {
 
       await act(async () => {
         fireEvent.click(buttonByExactText(container, "Clear Completed")!);
+        await Promise.resolve();
+        await Promise.resolve();
       });
 
+      // The backend eviction callable was invoked (no args).
+      expect(backend.clearCompletedDownloads).toHaveBeenCalledWith();
       // After clearing: finished Fields are gone; active progress bar remains.
       const labelsAfter = Array.from(container.querySelectorAll('[data-testid="field-label"]')).map(
         (n) => n.textContent,
@@ -523,6 +520,73 @@ describe("DownloadQueue", () => {
       expect(container.querySelector('[data-testid="dl-caption"]')?.textContent).toBe("Active (Genesis)");
       // Clear Completed button is gone (no finished items remain).
       expect(buttonByExactText(container, "Clear Completed")).toBeNull();
+      // The finished entries left the shared store too, so the poll won't re-show
+      // them and a remount fetch (from the evicted backend queue) stays clean.
+      expect(getDownloadState().map((d) => d.rom_id)).toEqual([1]);
+    });
+
+    it("cleared downloads do not reappear on remount (#149)", async () => {
+      // The pre-fix bug: a purely-local hide reset on unmount, and the backend
+      // still returned the terminal entry, so reopening the page re-showed it.
+      // With backend eviction the reopen's getDownloadQueue returns the evicted
+      // queue, so the cleared item stays gone.
+      const completed = makeItem({
+        rom_id: 7,
+        rom_name: "Gone",
+        status: "completed",
+        bytes_downloaded: 100,
+        total_bytes: 100,
+      });
+      vi.mocked(backend.getDownloadQueue).mockResolvedValue({ downloads: [completed] });
+      vi.mocked(backend.clearCompletedDownloads).mockResolvedValue({ success: true, cleared: 1 });
+
+      const first = render(<DownloadQueue onBack={() => {}} />);
+      await flushMount();
+      expect(first.container.textContent).toContain("Gone");
+
+      await act(async () => {
+        fireEvent.click(buttonByExactText(first.container, "Clear Completed")!);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(first.container.textContent).toContain("No downloads");
+      first.unmount();
+
+      // Reopen: the backend now reports the evicted (empty) queue.
+      vi.mocked(backend.getDownloadQueue).mockResolvedValue({ downloads: [] });
+      const second = render(<DownloadQueue onBack={() => {}} />);
+      await flushMount();
+      expect(second.container.textContent).toContain("No downloads");
+      expect(second.container.textContent).not.toContain("Gone");
+    });
+
+    it("a failed clear leaves the finished rows in place (catch returns early)", async () => {
+      // clearCompletedDownloads rejects (bridge/backend error) → the handler
+      // returns before removeTerminalDownloads, so the finished Field stays and
+      // the store is untouched. This is the observable side effect of the catch.
+      const completed = makeItem({
+        rom_id: 9,
+        rom_name: "Keep",
+        status: "completed",
+        bytes_downloaded: 100,
+        total_bytes: 100,
+      });
+      vi.mocked(backend.getDownloadQueue).mockResolvedValue({ downloads: [completed] });
+      vi.mocked(backend.clearCompletedDownloads).mockRejectedValue(new Error("bridge down"));
+
+      const { container } = render(<DownloadQueue onBack={() => {}} />);
+      await flushMount();
+
+      await act(async () => {
+        fireEvent.click(buttonByExactText(container, "Clear Completed")!);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      // The finished row is still there and the store kept the terminal entry.
+      const labels = Array.from(container.querySelectorAll('[data-testid="field-label"]')).map((n) => n.textContent);
+      expect(labels).toContain("Keep");
+      expect(getDownloadState().map((d) => d.rom_id)).toEqual([9]);
     });
   });
 

--- a/src/components/DownloadQueue.test.tsx
+++ b/src/components/DownloadQueue.test.tsx
@@ -4,12 +4,10 @@
 //     setLocalDownloads([...getDownloadState()]). Observable side effect:
 //     pre-seeded store items render. Asserted in "mount: rejection falls back
 //     to store".
-//   - handleCancel inline `.catch(() => {})`. This is the documented
-//     truly-ignored boundary catch — the source comment is "// ignore" and
-//     there is no observable post-catch side effect. Per CLAUDE.md, such
-//     catches stay assertion-free; we still exercise the call site by
-//     rejecting cancelDownload and asserting the click did NOT crash + the
-//     component continued to render normally.
+//   - handleCancel `try/catch`. Both the failure RESULT (success: false) and a
+//     rejection now surface a toast — a cancel is never a silent no-op (#149
+//     downloads-round). Asserted in "a failing cancel result surfaces a toast"
+//     and "a cancelDownload rejection surfaces a toast".
 //   - handleClearCompleted's `try/catch { return }`. This catch HAS an
 //     observable side effect: on a failed clear it returns BEFORE
 //     removeTerminalDownloads(), so the finished rows stay visible and the
@@ -26,9 +24,10 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { render, fireEvent, act } from "@testing-library/react";
+import { toaster } from "@decky/api";
 import { DownloadQueue } from "./DownloadQueue";
 import * as backend from "../api/backend";
-import { setDownloads, getDownloadState } from "../utils/downloadStore";
+import { setDownloads, getDownloadState, removeDownload } from "../utils/downloadStore";
 import type { DownloadItem } from "../types";
 
 // Local @decky/ui mock adds ProgressBar (not in the global stub) and exposes
@@ -114,6 +113,7 @@ describe("DownloadQueue", () => {
     vi.mocked(backend.pauseDownload).mockResolvedValue({ success: true, message: "" });
     vi.mocked(backend.resumeDownload).mockResolvedValue({ success: true, message: "" });
     vi.mocked(backend.clearCompletedDownloads).mockResolvedValue({ success: true, cleared: 0 });
+    vi.mocked(toaster.toast).mockClear();
   });
 
   afterEach(() => {
@@ -336,17 +336,36 @@ describe("DownloadQueue", () => {
       expect(cancel).not.toBeNull();
       await act(async () => {
         fireEvent.click(cancel!);
-        // Let the inline .catch chain settle.
         await Promise.resolve();
       });
       expect(backend.cancelDownload).toHaveBeenCalledWith(77);
+      // A successful cancel is silent — no toast.
+      expect(toaster.toast).not.toHaveBeenCalled();
     });
 
-    it("cancelDownload rejection is silently swallowed (truly-ignored boundary catch)", async () => {
-      // Per CLAUDE.md: the inline `.catch(() => {})` is a truly-ignored
-      // boundary catch — no observable side effect. We still exercise the
-      // call site to keep coverage on the catch arm and ensure the click
-      // does not crash the component.
+    it("a failing cancel result surfaces a toast (never a silent no-op)", async () => {
+      // #149 downloads-round: a cancel that could not act (the entry vanished
+      // between render and click) returns the failure shape; the click must be
+      // surfaced, not swallowed.
+      vi.mocked(backend.cancelDownload).mockResolvedValue({
+        success: false,
+        message: "No active download for this ROM",
+      });
+      vi.mocked(backend.getDownloadQueue).mockResolvedValue({
+        downloads: [makeItem({ rom_id: 5, rom_name: "Cancellable" })],
+      });
+      const { container } = render(<DownloadQueue onBack={() => {}} />);
+      await flushMount();
+
+      await act(async () => {
+        fireEvent.click(buttonByText(container, "Cancel Cancellable")!);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(toaster.toast).toHaveBeenCalledWith(expect.objectContaining({ body: "No active download for this ROM" }));
+    });
+
+    it("a cancelDownload rejection surfaces a toast", async () => {
       vi.mocked(backend.cancelDownload).mockRejectedValue(new Error("nope"));
       vi.mocked(backend.getDownloadQueue).mockResolvedValue({
         downloads: [makeItem({ rom_id: 5, rom_name: "Cancellable" })],
@@ -354,14 +373,39 @@ describe("DownloadQueue", () => {
       const { container } = render(<DownloadQueue onBack={() => {}} />);
       await flushMount();
 
-      const cancel = buttonByText(container, "Cancel Cancellable");
       await act(async () => {
-        fireEvent.click(cancel!);
+        fireEvent.click(buttonByText(container, "Cancel Cancellable")!);
         await Promise.resolve();
         await Promise.resolve();
       });
-      // Component still rendered normally — the catch swallowed cleanly.
+      // The rejection is surfaced (fallback copy), and the component didn't crash.
+      expect(toaster.toast).toHaveBeenCalledWith(expect.objectContaining({ body: "Could not cancel the download" }));
       expect(container.querySelector('[data-testid="dl-caption"]')?.textContent).toBe("Cancellable (Genesis)");
+    });
+
+    it("a paused download cancelled + removed from the store disappears on the next poll (#149 downloads-round)", async () => {
+      // The row drops via the backend's terminal cancelled frame → the index.tsx
+      // store listener's removeDownload (stood in for here) → DownloadQueue's
+      // poll. No client-side 'cancelled' row lingers.
+      const paused = makeItem({ rom_id: 42, rom_name: "Paused", status: "paused", resumable: true });
+      vi.mocked(backend.getDownloadQueue).mockResolvedValue({ downloads: [paused] });
+      const { container } = render(<DownloadQueue onBack={() => {}} />);
+      await flushMount();
+
+      const cancel = buttonByText(container, "Cancel Paused");
+      expect(cancel).not.toBeNull();
+      await act(async () => {
+        fireEvent.click(cancel!);
+        await Promise.resolve();
+      });
+      expect(backend.cancelDownload).toHaveBeenCalledWith(42);
+
+      // Backend evicted + emitted the cancelled frame; the store loses the entry.
+      removeDownload(42);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(500);
+      });
+      expect(container.textContent).toContain("No downloads");
     });
   });
 

--- a/src/components/DownloadQueue.tsx
+++ b/src/components/DownloadQueue.tsx
@@ -1,7 +1,13 @@
 import { useState, useEffect, useRef, FC, Fragment } from "react";
 import { PanelSection, PanelSectionRow, ButtonItem, Field, ProgressBar } from "@decky/ui";
-import { getDownloadQueue, cancelDownload, pauseDownload, resumeDownload } from "../api/backend";
-import { getDownloadState, setDownloads } from "../utils/downloadStore";
+import {
+  getDownloadQueue,
+  cancelDownload,
+  pauseDownload,
+  resumeDownload,
+  clearCompletedDownloads,
+} from "../api/backend";
+import { getDownloadState, setDownloads, removeTerminalDownloads } from "../utils/downloadStore";
 import { formatBytes } from "../utils/formatters";
 import { scrollToTop } from "../utils/scrollHelpers";
 import { detach } from "../utils/detach";
@@ -21,27 +27,8 @@ function formatFinishedDescription(item: DownloadItem): string {
   return "Cancelled";
 }
 
-// Un-clear rom_ids that have new active downloads (re-download case). Pure
-// transform over (current, prev), so it lives at module scope rather than
-// inside the poll effect — module functions don't count toward the component's
-// function-nesting depth and are exempt from the effect's dependency array.
-const unclearRestarted =
-  (current: DownloadItem[]) =>
-  (prev: Set<number>): Set<number> => {
-    const restarted = current.filter(
-      (d) =>
-        (d.status === "downloading" || d.status === "queued" || d.status === "paused" || d.status === "extracting") &&
-        prev.has(d.rom_id),
-    );
-    if (restarted.length === 0) return prev;
-    const next = new Set(prev);
-    for (const d of restarted) next.delete(d.rom_id);
-    return next;
-  };
-
 export const DownloadQueue: FC<DownloadQueueProps> = ({ onBack }) => {
   const [downloads, setLocalDownloads] = useState<DownloadItem[]>([]); // NOSONAR(typescript:S6754) — setter intentionally renamed (local wrapper around global download state).
-  const [cleared, setCleared] = useState<Set<number>>(new Set());
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   useEffect(() => {
@@ -56,9 +43,7 @@ export const DownloadQueue: FC<DownloadQueueProps> = ({ onBack }) => {
     };
 
     const pollTick = () => {
-      const current = getDownloadState();
-      setCleared(unclearRestarted(current));
-      setLocalDownloads([...current]);
+      setLocalDownloads([...getDownloadState()]);
     };
 
     const startPolling = () => {
@@ -104,28 +89,30 @@ export const DownloadQueue: FC<DownloadQueueProps> = ({ onBack }) => {
     }
   };
 
-  const handleClearCompleted = () => {
-    const finishedIds = downloads
-      .filter((d) => d.status === "completed" || d.status === "failed" || d.status === "cancelled")
-      .map((d) => d.rom_id);
-    setCleared((prev) => {
-      const next = new Set(prev);
-      finishedIds.forEach((id) => next.add(id));
-      return next;
-    });
+  const handleClearCompleted = async () => {
+    try {
+      await clearCompletedDownloads();
+    } catch {
+      // Clear failed (bridge/backend error) — leave the finished rows in place
+      // so the list stays honest rather than hiding entries the backend kept.
+      return;
+    }
+    // The backend evicted the terminal entries; drop them from the store too so
+    // the poll and any remount reflect the cleared queue immediately (#149).
+    removeTerminalDownloads();
+    setLocalDownloads([...getDownloadState()]);
   };
 
-  const visible = downloads.filter((d) => !cleared.has(d.rom_id));
   // Paused and extracting downloads stay in the active section — they're not
   // finished. Paused holds the partial transfer for resume; extracting is the
   // post-transfer ZIP unpack (not cancellable, no pause/resume offered).
-  const active = visible.filter(
+  const active = downloads.filter(
     (d) => d.status === "queued" || d.status === "downloading" || d.status === "paused" || d.status === "extracting",
   );
-  const finished = visible.filter((d) => d.status === "completed" || d.status === "failed" || d.status === "cancelled");
-  const hasFinished = downloads.some(
-    (d) => !cleared.has(d.rom_id) && (d.status === "completed" || d.status === "failed" || d.status === "cancelled"),
+  const finished = downloads.filter(
+    (d) => d.status === "completed" || d.status === "failed" || d.status === "cancelled",
   );
+  const hasFinished = finished.length > 0;
 
   return (
     <>
@@ -143,7 +130,7 @@ export const DownloadQueue: FC<DownloadQueueProps> = ({ onBack }) => {
       </PanelSection>
 
       <PanelSection title="Downloads">
-        {visible.length === 0 ? (
+        {downloads.length === 0 ? (
           <PanelSectionRow>
             <Field label="No downloads" />
           </PanelSectionRow>
@@ -239,7 +226,12 @@ export const DownloadQueue: FC<DownloadQueueProps> = ({ onBack }) => {
 
             {hasFinished && (
               <PanelSectionRow>
-                <ButtonItem layout="below" onClick={handleClearCompleted}>
+                <ButtonItem
+                  layout="below"
+                  onClick={() => {
+                    detach(handleClearCompleted());
+                  }}
+                >
                   Clear Completed
                 </ButtonItem>
               </PanelSectionRow>

--- a/src/components/DownloadQueue.tsx
+++ b/src/components/DownloadQueue.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, FC, Fragment } from "react";
 import { PanelSection, PanelSectionRow, ButtonItem, Field, ProgressBar } from "@decky/ui";
+import { toaster } from "@decky/api";
 import {
   getDownloadQueue,
   cancelDownload,
@@ -66,10 +67,17 @@ export const DownloadQueue: FC<DownloadQueueProps> = ({ onBack }) => {
   }, []);
 
   const handleCancel = async (romId: number) => {
+    // A successful cancel (running OR paused) drops the row via the backend's
+    // terminal cancelled frame → store listener. A cancel that could not act
+    // (the entry vanished between render and click) returns the failure shape —
+    // surface it so the click is never a silent no-op (#149 downloads-round).
     try {
-      await cancelDownload(romId);
+      const result = await cancelDownload(romId);
+      if (!result.success) {
+        toaster.toast({ title: "RomM Sync", body: result.message || "Could not cancel the download" });
+      }
     } catch {
-      // ignore
+      toaster.toast({ title: "RomM Sync", body: "Could not cancel the download" });
     }
   };
 

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -23,12 +23,13 @@ import {
   getMetadataCachePage,
 } from "./api/backend";
 import { getSettingsResetState, setSettingsResetState } from "./utils/settingsResetStore";
+import { getDownloadState, setDownloads } from "./utils/downloadStore";
 import { getSyncProgress, setSyncProgress } from "./utils/syncProgress";
 import { estimateApplySeconds } from "./utils/syncEstimate";
 import { resetEta, weightedCoarseFraction } from "./utils/syncEta";
 import { recordSyncCreated, resetSyncDelta } from "./utils/syncDeltaStore";
 import { resetSyncCancel } from "./utils/syncManager";
-import type { DownloadCompleteEvent, SyncPlanData, SyncProgress, SyncStaleData } from "./types";
+import type { DownloadCompleteEvent, DownloadProgressEvent, SyncPlanData, SyncProgress, SyncStaleData } from "./types";
 
 vi.mock("./patches/gameDetailPatch", () => ({
   registerGameDetailPatch: vi.fn(),
@@ -183,6 +184,66 @@ describe("index.tsx — download_complete launch-options sync", () => {
     expect(logError).toHaveBeenCalledWith(
       expect.stringContaining("download_complete: failed to set launch options for rom 42"),
     );
+    plugin.onDismount();
+  });
+});
+
+describe("index.tsx — download_progress cancelled eviction (#149 downloads-round)", () => {
+  it("drops the entry from the store when a cancelled frame arrives", async () => {
+    const plugin = pluginFactory();
+    setDownloads([
+      {
+        rom_id: 42,
+        rom_name: "Paused",
+        platform_name: "N64",
+        file_name: "game.z64",
+        status: "paused",
+        progress: 0.5,
+        bytes_downloaded: 500,
+        total_bytes: 1000,
+        resumable: true,
+      },
+    ]);
+
+    act(() => {
+      emitDeckyEvent<[DownloadProgressEvent]>("download_progress", {
+        rom_id: 42,
+        rom_name: "Paused",
+        platform_name: "N64",
+        file_name: "game.z64",
+        status: "cancelled",
+        progress: 0.5,
+        bytes_downloaded: 500,
+        total_bytes: 1000,
+        resumable: true,
+      });
+    });
+
+    // Explicit discard → no residue in the store (which MainPage's count + the
+    // DownloadQueue view both read).
+    expect(getDownloadState().some((d) => d.rom_id === 42)).toBe(false);
+    plugin.onDismount();
+  });
+
+  it("updates in place (does not drop) for a non-cancelled frame", async () => {
+    const plugin = pluginFactory();
+    setDownloads([]);
+
+    act(() => {
+      emitDeckyEvent<[DownloadProgressEvent]>("download_progress", {
+        rom_id: 7,
+        rom_name: "Live",
+        platform_name: "N64",
+        file_name: "g.z64",
+        status: "downloading",
+        progress: 0.2,
+        bytes_downloaded: 200,
+        total_bytes: 1000,
+        resumable: false,
+      });
+    });
+
+    expect(getDownloadState().find((d) => d.rom_id === 7)?.status).toBe("downloading");
     plugin.onDismount();
   });
 });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,7 +11,7 @@ import { initUnitSyncManager, resetSyncCancel } from "./utils/syncManager";
 import { setSyncProgress, getSyncProgress, updateSyncProgress } from "./utils/syncProgress";
 import { estimateApplySeconds } from "./utils/syncEstimate";
 import { beginEtaRun } from "./utils/syncEta";
-import { updateDownload, getDownloadState } from "./utils/downloadStore";
+import { updateDownload, getDownloadState, removeDownload } from "./utils/downloadStore";
 import { handleGlobalDownloadFailure } from "./utils/downloadFailure";
 import { registerGameDetailPatch, unregisterGameDetailPatch, registerRomMAppId } from "./patches/gameDetailPatch";
 import {
@@ -616,6 +616,15 @@ export default definePlugin(() => {
   const downloadProgressListener = addEventListener<[DownloadProgressEvent]>(
     "download_progress",
     (data: DownloadProgressEvent) => {
+      // A cancel is an explicit discard — drop the entry entirely so no
+      // "Cancelled" row lingers in the queue view or the QAM summary count
+      // (#149 downloads-round). Both the running-cancel and the paused-cancel
+      // backend paths emit this terminal frame, so this is the single place the
+      // store drops a cancelled download. Every other status updates in place.
+      if (data.status === "cancelled") {
+        removeDownload(data.rom_id);
+        return;
+      }
       // Carry the server's resumability verdict from the frame; a frame that
       // omits it (older shape) keeps the prior value instead of clobbering it.
       const prev = getDownloadState().find((d) => d.rom_id === data.rom_id);

--- a/src/utils/downloadStore.ts
+++ b/src/utils/downloadStore.ts
@@ -24,6 +24,13 @@ export function updateDownload(item: DownloadItem): void {
   else _downloads.push(item);
 }
 
+// Drop a single entry by rom_id. The download_progress cancelled listener calls
+// this so a cancelled download — an explicit user discard — leaves no residue in
+// the queue view or QAM summary (#149 downloads-round). Idempotent.
+export function removeDownload(romId: number): void {
+  _downloads = _downloads.filter((d) => d.rom_id !== romId);
+}
+
 export function getDownloadState(): DownloadItem[] {
   return _downloads;
 }

--- a/src/utils/downloadStore.ts
+++ b/src/utils/downloadStore.ts
@@ -27,3 +27,12 @@ export function updateDownload(item: DownloadItem): void {
 export function getDownloadState(): DownloadItem[] {
   return _downloads;
 }
+
+// Drop every terminal (completed/failed/cancelled) entry from the store,
+// mirroring the backend's "Clear Completed" eviction (#149). Active, queued,
+// paused, and extracting entries stay. Called after clear_completed_downloads
+// succeeds so the store matches the freshly-evicted backend queue immediately,
+// rather than waiting for the next mount fetch.
+export function removeTerminalDownloads(): void {
+  _downloads = _downloads.filter((d) => d.status !== "completed" && d.status !== "failed" && d.status !== "cancelled");
+}

--- a/tests/contract/test_download_read.py
+++ b/tests/contract/test_download_read.py
@@ -15,6 +15,8 @@ with that fix.
 
 from __future__ import annotations
 
+import asyncio
+
 from ._seed import seed_install
 
 # ── get_download_queue ───────────────────────────────────────────────────
@@ -84,6 +86,44 @@ async def test_resume_download_not_paused_failure_shape(harness):
         "reason": "not_paused",
         "message": "No paused download for this ROM",
     }
+
+
+async def test_cancel_no_active_download_failure_shape(harness):
+    """Cancelling a ROM with no active or paused download → canonical failure shape."""
+    result = await harness.plugin.cancel_download(999)
+    assert result == {
+        "success": False,
+        "reason": "no_active_download",
+        "message": "No active download for this ROM",
+    }
+
+
+async def test_cancel_paused_download_evicts_and_get_queue_omits_it(harness):
+    """Cancelling a paused download (no live task) evicts its entry, and a
+    following ``get_download_queue`` no longer lists it (#149 downloads-round).
+
+    The pre-fix bug: ``cancel_download`` required a live task, so a paused
+    download's cancel silently no-op'd and its row lingered.
+    """
+    queue = harness.plugin._download_service._download_queue
+    queue[7] = {
+        "rom_id": 7,
+        "rom_name": "Paused",
+        "platform_name": "N64",
+        "file_name": "game.z64",
+        "status": "paused",
+        "progress": 0.5,
+        "bytes_downloaded": 500,
+        "total_bytes": 1000,
+        "resumable": True,
+    }
+
+    result = await harness.plugin.cancel_download(7)
+    await asyncio.sleep(0)  # let the scheduled cancelled-frame emit run + drain
+
+    assert result == {"success": True, "message": "Download cancelled"}
+    after = await harness.plugin.get_download_queue()
+    assert all(d["rom_id"] != 7 for d in after["downloads"])
 
 
 # ── clear_completed_downloads (#149) ─────────────────────────────────────

--- a/tests/contract/test_download_read.py
+++ b/tests/contract/test_download_read.py
@@ -84,3 +84,38 @@ async def test_resume_download_not_paused_failure_shape(harness):
         "reason": "not_paused",
         "message": "No paused download for this ROM",
     }
+
+
+# ── clear_completed_downloads (#149) ─────────────────────────────────────
+
+
+async def test_clear_completed_downloads_empty_queue_shape(harness):
+    """Clearing an empty queue → ``{success: True, cleared: 0}``.
+
+    ``clearCompletedDownloads = callable<[], {success, cleared}>`` — the success
+    payload carries the eviction count.
+    """
+    result = await harness.plugin.clear_completed_downloads()
+    assert result == {"success": True, "cleared": 0}
+
+
+async def test_clear_completed_downloads_evicts_terminal_and_get_queue_omits_them(harness):
+    """Terminal entries evict; a following ``get_download_queue`` no longer lists them.
+
+    This is the #149 contract: the backend queue is what ``get_download_queue``
+    re-seeds the frontend from on every mount, so a cleared entry must be gone
+    from the queue — not merely hidden client-side. Active/queued/paused/
+    extracting entries survive.
+    """
+    queue = harness.plugin._download_service._download_queue
+    queue[1] = {"rom_id": 1, "rom_name": "Done", "status": "completed"}
+    queue[2] = {"rom_id": 2, "rom_name": "Broke", "status": "failed", "error": "boom"}
+    queue[3] = {"rom_id": 3, "rom_name": "Stopped", "status": "cancelled"}
+    queue[4] = {"rom_id": 4, "rom_name": "Live", "status": "downloading"}
+
+    result = await harness.plugin.clear_completed_downloads()
+    assert result == {"success": True, "cleared": 3}
+
+    after = await harness.plugin.get_download_queue()
+    assert [d["rom_id"] for d in after["downloads"]] == [4]
+    assert after["downloads"][0]["status"] == "downloading"

--- a/tests/services/test_downloads.py
+++ b/tests/services/test_downloads.py
@@ -374,6 +374,44 @@ class TestGetDownloadQueue:
         assert statuses == {"downloading", "completed"}
 
 
+class TestClearCompletedDownloads:
+    @pytest.mark.asyncio
+    async def test_evicts_terminal_keeps_active_and_returns_count(self, plugin):
+        # One entry per status: the three terminal ones evict, the four
+        # non-terminal ones (active/queued/paused/extracting) stay.
+        queue = plugin._download_service._download_queue
+        queue[1] = {"rom_id": 1, "status": "completed"}
+        queue[2] = {"rom_id": 2, "status": "failed", "error": "boom"}
+        queue[3] = {"rom_id": 3, "status": "cancelled"}
+        queue[4] = {"rom_id": 4, "status": "downloading"}
+        queue[5] = {"rom_id": 5, "status": "queued"}
+        queue[6] = {"rom_id": 6, "status": "paused"}
+        queue[7] = {"rom_id": 7, "status": "extracting"}
+
+        result = await plugin.clear_completed_downloads()
+
+        assert result == {"success": True, "cleared": 3}
+        assert set(queue.keys()) == {4, 5, 6, 7}
+        assert {item["status"] for item in queue.values()} == {"downloading", "queued", "paused", "extracting"}
+
+    @pytest.mark.asyncio
+    async def test_idempotent_on_empty_queue(self, plugin):
+        result = await plugin.clear_completed_downloads()
+        assert result == {"success": True, "cleared": 0}
+        assert plugin._download_service._download_queue == {}
+
+    @pytest.mark.asyncio
+    async def test_no_terminal_entries_clears_nothing(self, plugin):
+        queue = plugin._download_service._download_queue
+        queue[1] = {"rom_id": 1, "status": "downloading"}
+        queue[2] = {"rom_id": 2, "status": "paused"}
+
+        result = await plugin.clear_completed_downloads()
+
+        assert result == {"success": True, "cleared": 0}
+        assert set(queue.keys()) == {1, 2}
+
+
 class TestGetInstalledRom:
     @pytest.mark.asyncio
     async def test_returns_installed_rom(self, plugin):

--- a/tests/services/test_downloads.py
+++ b/tests/services/test_downloads.py
@@ -334,6 +334,86 @@ class TestCancelDownload:
         assert result["success"] is False
         assert "No active download" in result["message"]
 
+    @pytest.mark.asyncio
+    async def test_cancels_paused_download_deletes_tmp_evicts_and_emits(self, plugin, tmp_path):
+        """A paused download has no live task: cancel deletes the partial .tmp,
+        emits the terminal cancelled frame, and evicts the entry (#149
+        downloads-round finding A/B). Previously this was a silent no-op."""
+        import decky
+
+        decky.emit.reset_mock()
+        plugin._download_service._loop = asyncio.get_event_loop()
+
+        roms_dir = tmp_path / "retrodeck" / "roms" / "n64"
+        roms_dir.mkdir(parents=True)
+        target_path = str(roms_dir / "zelda.z64")
+        tmp_file = target_path + ".tmp"
+        with open(tmp_file, "wb") as f:
+            f.write(b"\x00" * 256)  # the partial the pause kept for resume
+
+        plugin._download_service._download_queue[42] = {
+            "rom_id": 42,
+            "rom_name": "Zelda",
+            "platform_name": "Nintendo 64",
+            "file_name": "zelda.z64",
+            "status": "paused",
+            "progress": 0.3,
+            "bytes_downloaded": 300,
+            "total_bytes": 1000,
+            "resumable": True,
+            "_target_path": target_path,
+        }
+
+        result = await plugin.cancel_download(42)
+        await asyncio.sleep(0)  # let the scheduled cancelled-frame emit run + drain
+
+        assert result == {"success": True, "message": "Download cancelled"}
+        assert 42 not in plugin._download_service._download_queue  # evicted, no residue
+        assert not os.path.exists(tmp_file)  # partial deleted (no resume)
+        cancelled = [
+            c
+            for c in decky.emit.call_args_list
+            if c[0][0] == "download_progress" and c[0][1].get("status") == "cancelled"
+        ]
+        assert len(cancelled) == 1
+        assert cancelled[0][0][1]["rom_id"] == 42
+
+    @pytest.mark.asyncio
+    async def test_cancels_paused_download_without_recorded_target_still_evicts(self, plugin):
+        """A paused entry lacking ``_target_path`` (defensive) still cancels: no
+        tmp removal attempted, entry evicted, success returned. The startup sweep
+        reaps any orphaned .tmp."""
+        import decky
+
+        decky.emit.reset_mock()
+        plugin._download_service._loop = asyncio.get_event_loop()
+        plugin._download_service._download_queue[42] = {
+            "rom_id": 42,
+            "rom_name": "Zelda",
+            "platform_name": "Nintendo 64",
+            "file_name": "zelda.z64",
+            "status": "paused",
+        }
+
+        result = await plugin.cancel_download(42)
+        await asyncio.sleep(0)
+
+        assert result == {"success": True, "message": "Download cancelled"}
+        assert 42 not in plugin._download_service._download_queue
+
+    @pytest.mark.asyncio
+    async def test_cancel_no_task_and_not_paused_returns_failure(self, plugin):
+        """No live task AND the entry isn't paused → canonical failure shape, and
+        the non-paused entry is left untouched (not evicted)."""
+        plugin._download_service._download_queue[42] = {"rom_id": 42, "status": "downloading"}
+        result = await plugin.cancel_download(42)
+        assert result == {
+            "success": False,
+            "reason": "no_active_download",
+            "message": "No active download for this ROM",
+        }
+        assert 42 in plugin._download_service._download_queue
+
 
 class TestGetDownloadQueue:
     @pytest.mark.asyncio
@@ -372,6 +452,21 @@ class TestGetDownloadQueue:
         assert len(result["downloads"]) == 2
         statuses = {d["status"] for d in result["downloads"]}
         assert statuses == {"downloading", "completed"}
+
+    @pytest.mark.asyncio
+    async def test_strips_internal_underscore_keys_from_wire_shape(self, plugin):
+        """Internal ``_``-prefixed keys (e.g. ``_target_path`` on a paused entry,
+        kept only for the paused-cancel cleanup) never cross the wire."""
+        plugin._download_service._download_queue[1] = {
+            "rom_id": 1,
+            "rom_name": "Game A",
+            "status": "paused",
+            "_target_path": "/games/n64/game.z64",
+        }
+        result = await plugin.get_download_queue()
+        assert len(result["downloads"]) == 1
+        assert "_target_path" not in result["downloads"][0]
+        assert result["downloads"][0] == {"rom_id": 1, "rom_name": "Game A", "status": "paused"}
 
 
 class TestClearCompletedDownloads:
@@ -2912,7 +3007,9 @@ class TestDoDownloadCancelled:
         ):
             await plugin._download_service._do_download(42, rom_detail, target_path, "n64", "zelda.z64")
 
-        assert plugin._download_service._download_queue[42]["status"] == "cancelled"
+        # A cancel is an explicit discard: the entry is evicted, not left as a
+        # lingering "cancelled" row (#149 downloads-round).
+        assert 42 not in plugin._download_service._download_queue
         assert not os.path.exists(target_path)
         assert plugin._uow.rom_installs.get(42) is None
 
@@ -4546,7 +4643,9 @@ class TestDoDownloadCancelEmitsEvent:
         assert payload["progress"] == pytest.approx(0.3)
         assert payload["bytes_downloaded"] == 300
         assert payload["total_bytes"] == 1000
-        assert plugin._download_service._download_queue[42]["status"] == "cancelled"
+        # The terminal frame carries the final progress values from the entry,
+        # which is then evicted (#149 downloads-round) — the emit happens first.
+        assert 42 not in plugin._download_service._download_queue
 
 
 class TestConcurrencyReservation:
@@ -4821,7 +4920,9 @@ class TestCooperativeCancel:
         # The loop stopped near tick 3/4 — nowhere near 500. The transfer
         # really halted instead of running to completion.
         assert len(captured) <= 5
-        assert plugin._download_service._download_queue[42]["status"] == "cancelled"
+        # Cancel evicts its entry rather than leaving a "cancelled" row (#149
+        # downloads-round).
+        assert 42 not in plugin._download_service._download_queue
 
     @pytest.mark.asyncio
     async def test_cancel_download_sets_token_and_cancels_task(self, plugin):
@@ -5004,7 +5105,9 @@ class TestPauseResume:
         ):
             await plugin._download_service._do_download(42, rom_detail, target_path, "n64", "zelda.z64", control)
 
-        assert plugin._download_service._download_queue[42]["status"] == "cancelled"
+        # Cancel evicts its entry (#149 downloads-round) and deletes the partial
+        # .tmp — the contrast with pause, which keeps both for resume.
+        assert 42 not in plugin._download_service._download_queue
         assert not os.path.exists(target_path + _TMP_EXT_LITERAL)
 
     @pytest.mark.asyncio

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -745,6 +745,10 @@ _MIGRATION_BLOCKED_WHITELIST: set[str] = {
     "sync_cancel_preview",
     "cancel_download",
     "pause_download",
+    # In-memory download-queue cleanup (#149) — evicts terminal entries from the
+    # queue dict only, never touching SQLite or RetroDECK, so a pending migration
+    # doesn't gate it.
+    "clear_completed_downloads",
     # Frontend logging / diagnostic helpers.
     "frontend_log",
     "debug_log",


### PR DESCRIPTION
Closes #149.

## Problem

"Clear Completed" downloads reappeared on QAM reopen / menu switch: the cleared state lived only in a component-local Set, while the backend `_download_queue` retained terminal entries and re-seeded the frontend store on every mount. Two on-device findings from the verification round rode along in the same file region:

- **Cancel was a silent no-op while paused** — `cancel_download` required an active task, but a paused download has none (pause cancelled it, keeping the partial `.tmp` for resume); it returned a failure the frontend swallowed.
- **A cancelled download lingered** in the finished list as "Cancelled" until manually cleared — an explicit user discard carries no information, unlike completed/failed.

## Change

- **Backend eviction:** new `clear_completed_downloads()` callable pops all terminal-status entries (a shared `_TERMINAL_DOWNLOAD_STATUSES` constant now backs both prune and clear); the frontend calls it then drops terminal entries from the store, so the DownloadQueue view and the QAM count clear consistently and stay cleared across reopen. The component-local `cleared` Set is gone.
- **Cancel-while-paused:** a task-less paused entry now cancels directly — deletes the partial `.tmp` and evicts. A cancel that genuinely can't act keeps the failure shape, and the frontend now surfaces it (toast) instead of swallowing it.
- **Cancelled evicts immediately:** both the running-cancel and paused-cancel paths evict after emitting the terminal frame, so no "Cancelled" row lingers (the cancelled frame is emitted before eviction, so CustomPlayButton's event-driven reset to "Download" still fires). completed/failed retention + Clear Completed are unchanged.

Also folds in a #145 regression test (a plain `downloading` entry rehydrates progress on mount — pinning the #1126 behavior that closed #145).

## Tests

Backend unit (eviction pops terminal / retains active / idempotent; cancel-from-paused deletes tmp + evicts; no-target variant; genuine-failure shape); contract (`clear_completed_downloads` shape + post-cancel `get_download_queue` omits the entry); frontend (cleared survives remount; Cancel-while-paused row disappears; failure toast non-vacuous). Four pre-existing #1017/#144 cancel tests updated from "lingering cancelled row" to "evicted", keeping their tmp/emit assertions. Full gate green.

docs: N/A — `managing-games.md` §Download Queue already describes Clear Completed; the fix makes the described behavior true, the copy stays accurate.