### PR TITLE
fix(ui): pace mass shortcut removals through a shared paced-loop helper

### DIFF
--- a/docs/architecture/steam-non-steam-shortcuts.md
+++ b/docs/architecture/steam-non-steam-shortcuts.md
@@ -357,15 +357,27 @@ Launches fail or open the wrong thing. The plugin gates the `Set*` calls on an o
 [#827](https://github.com/danielcopper/decky-romm-sync/issues/827); see
 [Updating existing shortcuts](#updating-existing-shortcuts)) — the historical "property updates may not persist" warning
 has been narrowed. The remaining hazard is **removal-churn**: adding and removing many shortcuts in one pass can corrupt
-Steam's in-memory shortcut state. A Steam restart clears it. The sync engine processes removals before additions to keep
-churn down, and every launch-options write uses the fire-then-poll `setLaunchOptionsConfirmed` so a silently dropped
-write is observable rather than assumed. Only `exe`/name changes still go through delete + recreate — a fresh
-`AddShortcut`, which yields a new `appId`.
+Steam's in-memory shortcut state. A Steam restart clears it. Two things keep churn down. The sync engine processes
+removals before additions, and every launch-options write uses the fire-then-poll `setLaunchOptionsConfirmed` so a
+silently dropped write is observable rather than assumed. And **mass removals are awaited and chunk-paced** through the
+shared paced loop (`pacedForEach`, [#977](https://github.com/danielcopper/decky-romm-sync/issues/977)): every DangerZone
+removal path (`removeShortcut` per platform, Remove-All-RomM including the live-orphan sweep, and the Remove-Non-Steam
+bulk action) awaits each `removeShortcut` in sequence and yields a 50ms breather every 25 removals, so the CEF renderer
+never blocks and thousands of removals can't stack as fire-and-forget promises. Only `exe`/name changes still go through
+delete + recreate — a fresh `AddShortcut`, which yields a new `appId`.
 
-### AddShortcut timing between shortcuts
+### AddShortcut / RemoveShortcut timing between shortcuts
 
-When creating multiple shortcuts in a loop, a 50ms delay between each `addShortcut()` call prevents corrupting Steam's
-internal shortcut state. Without this delay, some shortcuts may silently fail to register.
+Bulk shortcut loops corrupt Steam's internal store if driven too fast — added shortcuts may silently fail to register,
+and removals churn the in-memory state (above). Both cadences live in one place: the shared paced loop `pacedForEach` in
+`src/utils/pacedOps.ts`, which iterates awaiting each item and yields a breather between chunks (no trailing delay). The
+two callers differ only in chunk size:
+
+- **Add** (`syncManager.ts` — `processUnitShortcuts`, `processCoverRefreshes`) paces **one item at a time**: a 50ms
+  breather after every `addShortcut()` / cover apply, plus the per-unit heartbeat + cancel hooks.
+- **Remove** (`DangerZone.tsx` — `removeShortcutsPaced`) paces in **25-item chunks with a 50ms breather** between them.
+  A removal is a single cheap call, so chunked yielding keeps a 5000-game teardown at ~seconds of overhead instead of
+  the ~4 minutes strict 50ms/item would cost, while still letting the renderer breathe.
 
 ### The apply is chunked; a heartbeat timeout must not discard a chunk's delivered bindings
 

--- a/docs/architecture/steam-non-steam-shortcuts.md
+++ b/docs/architecture/steam-non-steam-shortcuts.md
@@ -360,11 +360,14 @@ has been narrowed. The remaining hazard is **removal-churn**: adding and removin
 Steam's in-memory shortcut state. A Steam restart clears it. Two things keep churn down. The sync engine processes
 removals before additions, and every launch-options write uses the fire-then-poll `setLaunchOptionsConfirmed` so a
 silently dropped write is observable rather than assumed. And **mass removals are awaited and chunk-paced** through the
-shared paced loop (`pacedForEach`, [#977](https://github.com/danielcopper/decky-romm-sync/issues/977)): every DangerZone
-removal path (`removeShortcut` per platform, Remove-All-RomM including the live-orphan sweep, and the Remove-Non-Steam
-bulk action) awaits each `removeShortcut` in sequence and yields a 50ms breather every 25 removals, so the CEF renderer
-never blocks and thousands of removals can't stack as fire-and-forget promises. Only `exe`/name changes still go through
-delete + recreate — a fresh `AddShortcut`, which yields a new `appId`.
+shared `removeShortcutsPaced` helper (`src/utils/shortcutRemoval.ts`, over `pacedForEach`,
+[#977](https://github.com/danielcopper/decky-romm-sync/issues/977)): every bulk removal path — the DangerZone actions
+(per-platform, Remove-All-RomM including the live-orphan sweep, and the Remove-Non-Steam bulk action) **and** the
+sync-run stale-shortcut cleanup (`sync_stale`, fired at run finalize) — awaits each `removeShortcut` in sequence and
+yields a 50ms breather every 25 removals, so the CEF renderer never blocks and thousands of removals can't stack as
+fire-and-forget promises. (The `sync_stale` handler records its "removed" delta for the terminal toast up front, before
+the first breather, so the paced removal can't leave the count partial when `sync_complete` interleaves.) Only
+`exe`/name changes still go through delete + recreate — a fresh `AddShortcut`, which yields a new `appId`.
 
 ### AddShortcut / RemoveShortcut timing between shortcuts
 
@@ -375,9 +378,12 @@ two callers differ only in chunk size:
 
 - **Add** (`syncManager.ts` — `processUnitShortcuts`, `processCoverRefreshes`) paces **one item at a time**: a 50ms
   breather after every `addShortcut()` / cover apply, plus the per-unit heartbeat + cancel hooks.
-- **Remove** (`DangerZone.tsx` — `removeShortcutsPaced`) paces in **25-item chunks with a 50ms breather** between them.
-  A removal is a single cheap call, so chunked yielding keeps a 5000-game teardown at ~seconds of overhead instead of
-  the ~4 minutes strict 50ms/item would cost, while still letting the renderer breathe.
+- **Remove** (`removeShortcutsPaced` in `src/utils/shortcutRemoval.ts`, shared by the DangerZone actions and the
+  `sync_stale` cleanup) paces in **25-item chunks with a 50ms breather** between them. A removal is a single cheap call,
+  so chunked yielding keeps a 5000-game teardown at ~seconds of overhead instead of the ~4 minutes strict 50ms/item
+  would cost, while still letting the renderer breathe. No heartbeat hook: the DangerZone actions run outside any sync,
+  and `sync_stale` fires at run finalize — after every per-unit heartbeat window has already closed and detached from
+  the watchdog (the backend never awaits the frontend's stale removal).
 
 ### The apply is chunked; a heartbeat timeout must not discard a chunk's delivered bindings
 

--- a/src/components/DangerZone.test.tsx
+++ b/src/components/DangerZone.test.tsx
@@ -906,6 +906,126 @@ describe("DangerZone", () => {
     });
   });
 
+  describe("removal paths are chunk-paced (#977)", () => {
+    // 26 shortcuts = one full 25-item chunk + a remainder, so exactly one 50ms
+    // breather must fall between the two chunks.
+    const manyAppIds = Array.from({ length: 26 }, (_, i) => i + 1);
+
+    it("per-platform removal: 25 removals back-to-back, one 50ms breather, then the post-removal steps", async () => {
+      vi.mocked(backend.getRegistryPlatforms).mockResolvedValue({
+        platforms: [{ slug: "snes", name: "Super Nintendo", count: 26 }],
+      });
+      vi.mocked(backend.removePlatformShortcuts).mockResolvedValue({
+        success: true,
+        app_ids: manyAppIds,
+        rom_ids: [1, 2],
+        platform_name: "Super Nintendo",
+      });
+      const { getByText } = render(<DangerZone onBack={vi.fn()} />);
+      await flushAsync();
+      fireEvent.click(getByText("Super Nintendo (26)"));
+      const modalProps = lastShownModalProps<{ onRemoveShortcuts?: () => void }>();
+
+      vi.useFakeTimers();
+      try {
+        await act(async () => {
+          modalProps?.onRemoveShortcuts?.();
+          // Drain: removePlatformShortcuts resolves, then the paced loop runs the
+          // first 25-item chunk back-to-back and blocks on the breather.
+          for (let i = 0; i < 40; i++) await Promise.resolve();
+        });
+        // First chunk done; the 26th removal + the post-removal steps are gated
+        // behind the not-yet-elapsed breather.
+        expect(vi.mocked(removeShortcut)).toHaveBeenCalledTimes(25);
+        expect(vi.mocked(backend.reportRemovalResults)).not.toHaveBeenCalled();
+        expect(vi.mocked(clearPlatformCollection)).not.toHaveBeenCalled();
+
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(50);
+          for (let i = 0; i < 20; i++) await Promise.resolve();
+        });
+        // The breather elapsed → the last removal ran, THEN the post-removal steps.
+        expect(vi.mocked(removeShortcut)).toHaveBeenCalledTimes(26);
+        expect(vi.mocked(backend.reportRemovalResults)).toHaveBeenCalledWith([1, 2]);
+        expect(vi.mocked(clearPlatformCollection)).toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("remove-all: the backend list is chunk-paced before the orphan sweep and reporting run", async () => {
+      vi.mocked(backend.removeAllShortcuts).mockResolvedValue({
+        success: true,
+        message: "Removed all",
+        app_ids: manyAppIds,
+        rom_ids: [7],
+      });
+      // No orphans beyond the backend list — isolate the pacing to the first loop.
+      vi.mocked(getLiveRomMShortcutAppIds).mockResolvedValue([]);
+      const { getByText } = render(<DangerZone onBack={vi.fn()} />);
+      await flushAsync();
+      fireEvent.click(getByText("Remove All RomM Shortcuts"));
+
+      vi.useFakeTimers();
+      try {
+        await act(async () => {
+          fireEvent.click(getByText("Confirm: remove all RomM shortcuts?"));
+          for (let i = 0; i < 40; i++) await Promise.resolve();
+        });
+        // First chunk done; the orphan scan + reporting + collection clear are all
+        // gated behind the breather.
+        expect(vi.mocked(removeShortcut)).toHaveBeenCalledTimes(25);
+        expect(vi.mocked(getLiveRomMShortcutAppIds)).not.toHaveBeenCalled();
+        expect(vi.mocked(backend.reportRemovalResults)).not.toHaveBeenCalled();
+        expect(vi.mocked(clearAllRomMCollections)).not.toHaveBeenCalled();
+
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(50);
+          for (let i = 0; i < 20; i++) await Promise.resolve();
+        });
+        expect(vi.mocked(removeShortcut)).toHaveBeenCalledTimes(26);
+        expect(vi.mocked(getLiveRomMShortcutAppIds)).toHaveBeenCalled();
+        expect(vi.mocked(backend.reportRemovalResults)).toHaveBeenCalledWith([7]);
+        expect(vi.mocked(clearAllRomMCollections)).toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("bulk non-steam removal: 25 back-to-back, one breather, then the 'Removed' status", async () => {
+      stubCollectionStore(manyAppIds);
+      stubAppStore(Object.fromEntries(manyAppIds.map((id) => [id, { strDisplayName: `Game ${id}` }])));
+      const { getByText, container } = render(<DangerZone onBack={vi.fn()} />);
+      await flushAsync();
+      fireEvent.click(getByText("Remove 26 Non-Steam Games"));
+
+      vi.useFakeTimers();
+      try {
+        await act(async () => {
+          fireEvent.click(getByText(/Are you sure\? Remove 26 games/));
+          for (let i = 0; i < 40; i++) await Promise.resolve();
+        });
+        // First 25-item chunk done; the 26th removal + the "Removed" status (a
+        // post-removal step) are gated behind the breather.
+        expect(vi.mocked(removeShortcut)).toHaveBeenCalledTimes(25);
+        expect(container.textContent).toContain("Removing 26 non-steam games...");
+
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(50);
+          for (let i = 0; i < 20; i++) await Promise.resolve();
+          // Drain the post-removal settle poll (store never shrinks — removeShortcut is mocked).
+          await vi.advanceTimersByTimeAsync(3500);
+        });
+        expect(vi.mocked(removeShortcut)).toHaveBeenCalledTimes(26);
+        // Routed through the wrapper, never the direct SteamClient call.
+        expect(vi.mocked(SteamClient.Apps.RemoveShortcut)).not.toHaveBeenCalled();
+        expect(container.textContent).toContain("Removed 26 non-steam games");
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
   describe("ShortcutRemovalSection — handleUninstallAll", () => {
     it("first click arms confirm + shows the warning Field; second click triggers uninstallAllRoms", async () => {
       vi.mocked(backend.uninstallAllRoms).mockResolvedValue({
@@ -1266,7 +1386,7 @@ describe("DangerZone", () => {
   });
 
   describe("RetroDeckSection — handleRemoveAll (no retrodeck risk)", () => {
-    it("first click arms confirm; second click removes via SteamClient.Apps.RemoveShortcut", async () => {
+    it("first click arms confirm; second click removes via the removeShortcut wrapper (#977)", async () => {
       stubCollectionStore([1, 2]);
       stubAppStore({
         1: { strDisplayName: "GameOne" },
@@ -1277,14 +1397,25 @@ describe("DangerZone", () => {
       fireEvent.click(getByText("Remove 2 Non-Steam Games"));
       // After first click — confirm copy without retrodeck warning.
       expect(container.textContent).toContain("Are you sure? Remove 2 games (0 whitelisted)?");
-      expect(vi.mocked(SteamClient.Apps.RemoveShortcut)).not.toHaveBeenCalled();
+      expect(vi.mocked(removeShortcut)).not.toHaveBeenCalled();
 
-      await act(async () => {
-        fireEvent.click(getByText("Are you sure? Remove 2 games (0 whitelisted)?"));
-        await Promise.resolve();
-      });
-      expect(vi.mocked(SteamClient.Apps.RemoveShortcut)).toHaveBeenCalledWith(1);
-      expect(vi.mocked(SteamClient.Apps.RemoveShortcut)).toHaveBeenCalledWith(2);
+      // Loop 3 now routes through the paced removeShortcut wrapper, never the
+      // direct SteamClient.Apps.RemoveShortcut. Drive the paced removal + the
+      // post-removal settle poll under fake timers so nothing waits on a real timer.
+      vi.useFakeTimers();
+      try {
+        await act(async () => {
+          fireEvent.click(getByText("Are you sure? Remove 2 games (0 whitelisted)?"));
+          for (let i = 0; i < 8; i++) await Promise.resolve();
+          await vi.advanceTimersByTimeAsync(3500);
+        });
+      } finally {
+        vi.useRealTimers();
+      }
+      expect(vi.mocked(removeShortcut)).toHaveBeenCalledWith(1);
+      expect(vi.mocked(removeShortcut)).toHaveBeenCalledWith(2);
+      // The direct SteamClient call is gone — removal goes through the wrapper only.
+      expect(vi.mocked(SteamClient.Apps.RemoveShortcut)).not.toHaveBeenCalled();
       // status surfaced.
       expect(container.textContent).toContain("Removed 2 non-steam games");
     });
@@ -1295,10 +1426,16 @@ describe("DangerZone", () => {
       const { getByText, container } = render(<DangerZone onBack={vi.fn()} />);
       await flushAsync();
       fireEvent.click(getByText("Remove 1 Non-Steam Games"));
-      await act(async () => {
-        fireEvent.click(getByText("Are you sure? Remove 1 games (0 whitelisted)?"));
-        await Promise.resolve();
-      });
+      vi.useFakeTimers();
+      try {
+        await act(async () => {
+          fireEvent.click(getByText("Are you sure? Remove 1 games (0 whitelisted)?"));
+          for (let i = 0; i < 8; i++) await Promise.resolve();
+          await vi.advanceTimersByTimeAsync(3500);
+        });
+      } finally {
+        vi.useRealTimers();
+      }
       expect(container.textContent).toContain("Removed 1 non-steam game");
       expect(container.textContent).not.toContain("Removed 1 non-steam games");
     });
@@ -1322,21 +1459,28 @@ describe("DangerZone", () => {
       // First click — generic confirm with retrodeck warning copy.
       fireEvent.click(getByText("Remove 2 Non-Steam Games"));
       expect(container.textContent).toContain("WARNING: RetroDECK not protected! Remove 2 games?");
-      expect(vi.mocked(SteamClient.Apps.RemoveShortcut)).not.toHaveBeenCalled();
+      expect(vi.mocked(removeShortcut)).not.toHaveBeenCalled();
 
       // Second click — RETRODECK warning escalation.
       fireEvent.click(getByText("WARNING: RetroDECK not protected! Remove 2 games?"));
       expect(container.textContent).toContain("!! RETRODECK WILL BE REMOVED !!");
       expect(container.textContent).toContain("RetroDECK is NOT in the whitelist and will be permanently removed!");
-      expect(vi.mocked(SteamClient.Apps.RemoveShortcut)).not.toHaveBeenCalled();
+      expect(vi.mocked(removeShortcut)).not.toHaveBeenCalled();
 
-      // Third click — actually remove.
-      await act(async () => {
-        fireEvent.click(getByText(/!! RETRODECK WILL BE REMOVED !!/));
-        await Promise.resolve();
-      });
-      expect(vi.mocked(SteamClient.Apps.RemoveShortcut)).toHaveBeenCalledWith(1);
-      expect(vi.mocked(SteamClient.Apps.RemoveShortcut)).toHaveBeenCalledWith(2);
+      // Third click — actually remove, through the paced removeShortcut wrapper.
+      vi.useFakeTimers();
+      try {
+        await act(async () => {
+          fireEvent.click(getByText(/!! RETRODECK WILL BE REMOVED !!/));
+          for (let i = 0; i < 8; i++) await Promise.resolve();
+          await vi.advanceTimersByTimeAsync(3500);
+        });
+      } finally {
+        vi.useRealTimers();
+      }
+      expect(vi.mocked(removeShortcut)).toHaveBeenCalledWith(1);
+      expect(vi.mocked(removeShortcut)).toHaveBeenCalledWith(2);
+      expect(vi.mocked(SteamClient.Apps.RemoveShortcut)).not.toHaveBeenCalled();
     });
   });
 

--- a/src/components/DangerZone.test.tsx
+++ b/src/components/DangerZone.test.tsx
@@ -1439,6 +1439,44 @@ describe("DangerZone", () => {
       expect(container.textContent).toContain("Removed 1 non-steam game");
       expect(container.textContent).not.toContain("Removed 1 non-steam games");
     });
+
+    it("disarms the confirm as the paced removal STARTS, not after it finishes (#977 re-entry guard)", async () => {
+      // 26 games → the paced removal parks on a 50ms breather after the first
+      // 25-item chunk. The confirm must already be disarmed at that mid-removal
+      // point (reset moved before the await), so a stray tap can't re-enter and
+      // start a second concurrent run. With the old post-await reset, the button
+      // would still read "Are you sure?" here.
+      const ids = Array.from({ length: 26 }, (_, i) => i + 1);
+      stubCollectionStore(ids);
+      stubAppStore(Object.fromEntries(ids.map((id) => [id, { strDisplayName: `Game ${id}` }])));
+      const { getByText, container } = render(<DangerZone onBack={vi.fn()} />);
+      await flushAsync();
+      fireEvent.click(getByText("Remove 26 Non-Steam Games"));
+      expect(container.textContent).toContain("Are you sure? Remove 26 games (0 whitelisted)?");
+
+      vi.useFakeTimers();
+      try {
+        await act(async () => {
+          fireEvent.click(getByText("Are you sure? Remove 26 games (0 whitelisted)?"));
+          for (let i = 0; i < 40; i++) await Promise.resolve();
+        });
+        // Mid-removal: first chunk removed, loop parked on the breather.
+        expect(vi.mocked(removeShortcut)).toHaveBeenCalledTimes(25);
+        // The confirm is ALREADY disarmed — the armed label is gone, the button
+        // reads its default form again.
+        expect(container.textContent).not.toContain("Are you sure?");
+        expect(container.textContent).toContain("Remove 26 Non-Steam Games");
+
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(50);
+          for (let i = 0; i < 20; i++) await Promise.resolve();
+          await vi.advanceTimersByTimeAsync(3500);
+        });
+        expect(vi.mocked(removeShortcut)).toHaveBeenCalledTimes(26);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
   });
 
   describe("RetroDeckSection — handleRemoveAll (retrodeck at risk)", () => {

--- a/src/components/DangerZone.tsx
+++ b/src/components/DangerZone.tsx
@@ -692,12 +692,15 @@ const RetroDeckSection: FC<RetroDeckSectionProps> = ({
       setConfirmRetrodeck(true);
       return;
     }
+    // Disarm the confirm BEFORE the awaited paced removal (mirrors
+    // handleRemoveAllRomm) — the removal now yields for seconds on a large library,
+    // so a stray tap while it runs must not re-enter and start a second concurrent run.
+    setConfirmRemoveAll(false);
+    setConfirmRetrodeck(false);
     const toRemove = nonSteamApps.filter((a) => !whitelistedIds.has(a.appId));
     setStatus(`Removing ${toRemove.length} non-steam games...`);
     await removeShortcutsPaced(toRemove.map((a) => a.appId));
     setStatus(`Removed ${toRemove.length} non-steam game${toRemove.length === 1 ? "" : "s"}`);
-    setConfirmRemoveAll(false);
-    setConfirmRetrodeck(false);
     refreshPlatforms().catch((e) => logError(`Failed to refresh platforms: ${e}`));
     await recountAfterStoreSettles(toRemove.length, loadNonSteamApps);
   };

--- a/src/components/DangerZone.tsx
+++ b/src/components/DangerZone.tsx
@@ -26,8 +26,8 @@ import {
   getWhitelistSettings,
   updateWhitelistSettings,
 } from "../api/backend";
-import { removeShortcut, getAllNonSteamShortcutAppIds, getLiveRomMShortcutAppIds } from "../utils/steamShortcuts";
-import { pacedForEach } from "../utils/pacedOps";
+import { getAllNonSteamShortcutAppIds, getLiveRomMShortcutAppIds } from "../utils/steamShortcuts";
+import { removeShortcutsPaced } from "../utils/shortcutRemoval";
 import { LoadingRow } from "./LoadingRow";
 import { batchConfirmLaunchOptions } from "../utils/launchOptionsReconcile";
 import { getSyncProgress, onSyncProgressChange } from "../utils/syncProgress";
@@ -114,28 +114,6 @@ async function recountAfterStoreSettles(removedCount: number, loadNonSteamApps: 
     }
   }
   loadNonSteamApps();
-}
-
-// Bulk removals run through the shared paced loop in chunked mode: 25 removals
-// back-to-back, then a 50ms breather so the CEF renderer never blocks and Steam's
-// in-memory shortcut store can't be corrupted by removal churn (#977). Unlike the
-// add path (strict 50ms/item), a removal is a single cheap call, so chunked
-// yielding keeps overhead at ~seconds rather than minutes on a 5000-game library.
-const REMOVAL_CHUNK_SIZE = 25;
-const REMOVAL_CHUNK_DELAY_MS = 50;
-
-/**
- * Remove many Steam shortcuts, chunk-paced. Each ``removeShortcut`` is awaited in
- * sequence (no more fire-and-forget stacking of thousands of pending removals);
- * per-item errors are swallowed by ``removeShortcut``, so one bad appId never
- * aborts the batch. Resolves once every removal has run — callers await this
- * before their post-removal steps (result reporting, collection clear, re-count).
- */
-async function removeShortcutsPaced(appIds: number[]): Promise<void> {
-  await pacedForEach(appIds, (appId) => removeShortcut(appId), {
-    chunkSize: REMOVAL_CHUNK_SIZE,
-    delayMs: REMOVAL_CHUNK_DELAY_MS,
-  });
 }
 
 const PlatformActionModal: FC<{

--- a/src/components/DangerZone.tsx
+++ b/src/components/DangerZone.tsx
@@ -27,6 +27,7 @@ import {
   updateWhitelistSettings,
 } from "../api/backend";
 import { removeShortcut, getAllNonSteamShortcutAppIds, getLiveRomMShortcutAppIds } from "../utils/steamShortcuts";
+import { pacedForEach } from "../utils/pacedOps";
 import { LoadingRow } from "./LoadingRow";
 import { batchConfirmLaunchOptions } from "../utils/launchOptionsReconcile";
 import { getSyncProgress, onSyncProgressChange } from "../utils/syncProgress";
@@ -115,6 +116,28 @@ async function recountAfterStoreSettles(removedCount: number, loadNonSteamApps: 
   loadNonSteamApps();
 }
 
+// Bulk removals run through the shared paced loop in chunked mode: 25 removals
+// back-to-back, then a 50ms breather so the CEF renderer never blocks and Steam's
+// in-memory shortcut store can't be corrupted by removal churn (#977). Unlike the
+// add path (strict 50ms/item), a removal is a single cheap call, so chunked
+// yielding keeps overhead at ~seconds rather than minutes on a 5000-game library.
+const REMOVAL_CHUNK_SIZE = 25;
+const REMOVAL_CHUNK_DELAY_MS = 50;
+
+/**
+ * Remove many Steam shortcuts, chunk-paced. Each ``removeShortcut`` is awaited in
+ * sequence (no more fire-and-forget stacking of thousands of pending removals);
+ * per-item errors are swallowed by ``removeShortcut``, so one bad appId never
+ * aborts the batch. Resolves once every removal has run — callers await this
+ * before their post-removal steps (result reporting, collection clear, re-count).
+ */
+async function removeShortcutsPaced(appIds: number[]): Promise<void> {
+  await pacedForEach(appIds, (appId) => removeShortcut(appId), {
+    chunkSize: REMOVAL_CHUNK_SIZE,
+    delayMs: REMOVAL_CHUNK_DELAY_MS,
+  });
+}
+
 const PlatformActionModal: FC<{
   platform: RegistryPlatform;
   closeModal?: () => void;
@@ -199,9 +222,7 @@ const ShortcutRemovalSection: FC<ShortcutRemovalSectionProps> = ({
         setActionStatus(result.message ?? "Failed to remove shortcuts");
         return;
       }
-      for (const appId of result.app_ids ?? []) {
-        removeShortcut(appId);
-      }
+      await removeShortcutsPaced(result.app_ids ?? []);
       if (result.rom_ids?.length) {
         await reportRemovalResults(result.rom_ids);
       }
@@ -277,11 +298,9 @@ const ShortcutRemovalSection: FC<ShortcutRemovalSectionProps> = ({
         // Steam (exe = bin/rom-launcher) that were never committed — no binding,
         // so the backend never returns them. The live exe-ownership scan sees
         // them; remove the UNION so no orphan is left behind (#1381).
-        const removed = new Set<number>();
-        for (const appId of result.app_ids ?? []) {
-          removeShortcut(appId);
-          removed.add(appId);
-        }
+        const backendAppIds = result.app_ids ?? [];
+        await removeShortcutsPaced(backendAppIds);
+        const removed = new Set<number>(backendAppIds);
         const liveAppIds = await getLiveRomMShortcutAppIds();
         if (liveAppIds === null) {
           // The scan could not run (Steam's shortcut store was unreadable) —
@@ -290,10 +309,8 @@ const ShortcutRemovalSection: FC<ShortcutRemovalSectionProps> = ({
         } else {
           const orphans = liveAppIds.filter((appId) => !removed.has(appId));
           logInfo(`Remove-all: ${orphans.length} live-scanned RomM shortcut(s) were not in the backend list.`);
-          for (const appId of orphans) {
-            removeShortcut(appId);
-            removed.add(appId);
-          }
+          await removeShortcutsPaced(orphans);
+          for (const appId of orphans) removed.add(appId);
         }
         removedCount = removed.size;
         // rom_ids are backend DB rows — orphans have none, so report only the
@@ -699,9 +716,7 @@ const RetroDeckSection: FC<RetroDeckSectionProps> = ({
     }
     const toRemove = nonSteamApps.filter((a) => !whitelistedIds.has(a.appId));
     setStatus(`Removing ${toRemove.length} non-steam games...`);
-    for (const app of toRemove) {
-      SteamClient.Apps.RemoveShortcut(app.appId);
-    }
+    await removeShortcutsPaced(toRemove.map((a) => a.appId));
     setStatus(`Removed ${toRemove.length} non-steam game${toRemove.length === 1 ? "" : "s"}`);
     setConfirmRemoveAll(false);
     setConfirmRetrodeck(false);

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -27,7 +27,7 @@ import { getDownloadState, setDownloads } from "./utils/downloadStore";
 import { getSyncProgress, setSyncProgress } from "./utils/syncProgress";
 import { estimateApplySeconds } from "./utils/syncEstimate";
 import { resetEta, weightedCoarseFraction } from "./utils/syncEta";
-import { recordSyncCreated, resetSyncDelta } from "./utils/syncDeltaStore";
+import { recordSyncCreated, resetSyncDelta, getSyncDelta } from "./utils/syncDeltaStore";
 import { resetSyncCancel } from "./utils/syncManager";
 import type { DownloadCompleteEvent, DownloadProgressEvent, SyncPlanData, SyncProgress, SyncStaleData } from "./types";
 
@@ -285,6 +285,40 @@ describe("index.tsx — sync_stale listener", () => {
     await flush();
 
     expect(removeShortcut).not.toHaveBeenCalled();
+    plugin.onDismount();
+  });
+
+  it("chunk-paces a large stale removal (25 back-to-back, 50ms breather) and records the delta up front (#977)", async () => {
+    const plugin = pluginFactory();
+    await flush();
+    removeShortcut.mockClear();
+    resetSyncDelta();
+
+    // 26 stale shortcuts = one full 25-item chunk + a remainder, so exactly one
+    // 50ms breather must fall between the two chunks.
+    const remove = Array.from({ length: 26 }, (_, i) => ({ rom_id: i + 1, app_id: 1000 + i }));
+
+    vi.useFakeTimers();
+    try {
+      act(() => {
+        emitDeckyEvent<[SyncStaleData]>("sync_stale", { remove });
+      });
+      await act(async () => {
+        for (let i = 0; i < 40; i++) await Promise.resolve();
+      });
+      // First 25-item chunk removed back-to-back; the 26th is gated behind the breather.
+      expect(removeShortcut).toHaveBeenCalledTimes(25);
+      // The removed-delta for ALL 26 is recorded up front, so a sync_complete that
+      // interleaves during the paced breather reads the true count, not a partial one.
+      expect(getSyncDelta().removed).toBe(26);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(50);
+      });
+      expect(removeShortcut).toHaveBeenCalledTimes(26);
+    } finally {
+      vi.useRealTimers();
+    }
     plugin.onDismount();
   });
 });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -61,7 +61,8 @@ import type {
   ServerRetryProgressEvent,
   RomMetadata,
 } from "./types";
-import { removeShortcut, setLaunchOptionsConfirmed } from "./utils/steamShortcuts";
+import { setLaunchOptionsConfirmed } from "./utils/steamShortcuts";
+import { removeShortcutsPaced } from "./utils/shortcutRemoval";
 import { batchConfirmLaunchOptions } from "./utils/launchOptionsReconcile";
 import { withTimeout } from "./utils/withTimeout";
 
@@ -579,16 +580,26 @@ export default definePlugin(() => {
   // shortcut by the ``app_id`` the backend captured BEFORE unbinding the
   // row. Resolving rom_id→app_id here (via getExistingRomMShortcuts) would
   // race the backend unbind and find nothing, orphaning the shortcut.
-  const syncStaleListener = addEventListener<[SyncStaleData]>("sync_stale", (data: SyncStaleData) => {
+  const syncStaleListener = addEventListener<[SyncStaleData]>("sync_stale", async (data: SyncStaleData) => {
     if (!Array.isArray(data.remove) || data.remove.length === 0) return;
+    // Collect the valid app_ids and record the "removed" delta for each UP FRONT —
+    // synchronously, before the first paced breather. recordSyncRemoved is a cheap,
+    // deduped in-memory write; keeping it here rather than paired inside the paced
+    // loop keeps the terminal sync_complete toast accurate. sync_complete reads
+    // getSyncDelta(), and now that the removal yields between chunks it can
+    // interleave during a breather — recording the delta progressively would let it
+    // read a partial "removed" count. Only the Steam removal (the renderer-blocking
+    // part) needs pacing (#977); chunk-paced (25 items / 50ms breather) so a large
+    // platform-deletion / full re-sync teardown never blocks the CEF renderer or
+    // corrupts Steam's in-memory shortcut store via removal churn.
+    const appIds: number[] = [];
     for (const { app_id } of data.remove) {
       if (app_id) {
-        removeShortcut(app_id);
-        // Record the removal as a real "removed" delta. The store dedups across
-        // the per-unit sync_stale emits so a shortcut removed once is counted once.
+        appIds.push(app_id);
         recordSyncRemoved(app_id);
       }
     }
+    await removeShortcutsPaced(appIds);
     logInfo(`sync_stale: removed ${data.remove.length} stale shortcuts`);
   });
 

--- a/src/utils/pacedOps.test.ts
+++ b/src/utils/pacedOps.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import * as backend from "../api/backend";
+import { pacedForEach, delay } from "./pacedOps";
+
+describe("pacedOps — delay", () => {
+  it("resolves after the given number of milliseconds", async () => {
+    vi.useFakeTimers();
+    try {
+      let resolved = false;
+      const p = delay(50).then(() => {
+        resolved = true;
+      });
+      await vi.advanceTimersByTimeAsync(49);
+      expect(resolved).toBe(false);
+      await vi.advanceTimersByTimeAsync(1);
+      await p;
+      expect(resolved).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("pacedOps — pacedForEach", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("per-item mode: a 50ms breather after every item except the last", async () => {
+    vi.useFakeTimers();
+    const calls: number[] = [];
+    const p = pacedForEach([1, 2, 3], (x) => {
+      calls.push(x);
+    });
+    // The first item runs synchronously at entry, then the loop blocks on the breather.
+    expect(calls).toEqual([1]);
+    await vi.advanceTimersByTimeAsync(50);
+    expect(calls).toEqual([1, 2]);
+    await vi.advanceTimersByTimeAsync(50);
+    expect(calls).toEqual([1, 2, 3]);
+    // No trailing delay: the loop resolves without another timer, and none is pending.
+    expect(vi.getTimerCount()).toBe(0);
+    await expect(p).resolves.toBe(true);
+  });
+
+  it("chunked mode: items run back-to-back within a chunk, one breather between chunks, none trailing", async () => {
+    vi.useFakeTimers();
+    const calls: number[] = [];
+    const p = pacedForEach(
+      [1, 2, 3, 4, 5],
+      (x) => {
+        calls.push(x);
+      },
+      { chunkSize: 2, delayMs: 50 },
+    );
+    // Chunk 1 (items 1,2) runs back-to-back with only microtask hops — no timer between them.
+    for (let i = 0; i < 5; i++) await Promise.resolve();
+    expect(calls).toEqual([1, 2]);
+    // Second chunk is gated behind the single breather.
+    await vi.advanceTimersByTimeAsync(50);
+    for (let i = 0; i < 5; i++) await Promise.resolve();
+    expect(calls).toEqual([1, 2, 3, 4]);
+    // Third chunk (just item 5) after the second breather; no trailing delay follows it.
+    await vi.advanceTimersByTimeAsync(50);
+    for (let i = 0; i < 5; i++) await Promise.resolve();
+    expect(calls).toEqual([1, 2, 3, 4, 5]);
+    expect(vi.getTimerCount()).toBe(0);
+    await expect(p).resolves.toBe(true);
+  });
+
+  it("empty list: never calls fn, schedules no timer, resolves true", async () => {
+    vi.useFakeTimers();
+    const fn = vi.fn();
+    const done = await pacedForEach([], fn);
+    expect(fn).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+    expect(done).toBe(true);
+  });
+
+  it("a single item takes no breather at all", async () => {
+    vi.useFakeTimers();
+    const calls: number[] = [];
+    const p = pacedForEach([42], (x) => {
+      calls.push(x);
+    });
+    expect(calls).toEqual([42]);
+    expect(vi.getTimerCount()).toBe(0);
+    await expect(p).resolves.toBe(true);
+  });
+
+  it("logs and continues past an item whose fn throws — one failure never aborts the batch", async () => {
+    const logSpy = vi.spyOn(backend, "logError").mockImplementation(() => {});
+    const seen: number[] = [];
+    // delayMs 0 keeps the test fast; the item at index 1 (value 2) throws.
+    const done = await pacedForEach(
+      [1, 2, 3],
+      (x) => {
+        if (x === 2) throw new Error("boom");
+        seen.push(x);
+      },
+      { delayMs: 0 },
+    );
+    // Item 2 threw but 1 and 3 still ran, and the loop reports completion.
+    expect(seen).toEqual([1, 3]);
+    expect(done).toBe(true);
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("item 1 failed"));
+    logSpy.mockRestore();
+  });
+
+  it("awaits each async fn in sequence (never overlaps the next item)", async () => {
+    const order: string[] = [];
+    let releaseFirst!: () => void;
+    const gate = new Promise<void>((r) => {
+      releaseFirst = r;
+    });
+    const p = pacedForEach(
+      [1, 2],
+      async (x) => {
+        order.push(`start-${x}`);
+        if (x === 1) await gate;
+        order.push(`end-${x}`);
+      },
+      { delayMs: 0 },
+    );
+    await Promise.resolve();
+    // Item 1 is mid-flight; item 2 has NOT started while item 1 is unresolved.
+    expect(order).toEqual(["start-1"]);
+    releaseFirst();
+    await p;
+    expect(order).toEqual(["start-1", "end-1", "start-2", "end-2"]);
+  });
+
+  it("stops before the next item when isCancelled returns true, and returns false", async () => {
+    const seen: number[] = [];
+    const done = await pacedForEach(
+      [1, 2, 3, 4],
+      (x) => {
+        seen.push(x);
+      },
+      { delayMs: 0, isCancelled: () => seen.length >= 2 },
+    );
+    // Cancel observed after item 2 → items 3 and 4 never run; the loop reports early exit.
+    expect(seen).toEqual([1, 2]);
+    expect(done).toBe(false);
+  });
+
+  it("runs the whole list when isCancelled stays false, returning true", async () => {
+    const seen: number[] = [];
+    const done = await pacedForEach(
+      [1, 2, 3],
+      (x) => {
+        seen.push(x);
+      },
+      { delayMs: 0, isCancelled: () => false },
+    );
+    expect(seen).toEqual([1, 2, 3]);
+    expect(done).toBe(true);
+  });
+
+  it("throttles the heartbeat to at most once per interval, not once per item", async () => {
+    vi.useFakeTimers();
+    let beats = 0;
+    const p = pacedForEach([1, 2, 3, 4], () => {}, {
+      delayMs: 50,
+      heartbeat: () => {
+        beats += 1;
+      },
+      heartbeatIntervalMs: 100,
+    });
+    // Four items with 50ms breathers span ~150ms of virtual time; a 100ms throttle
+    // window lets the heartbeat fire at least once but far fewer than four times.
+    await vi.advanceTimersByTimeAsync(400);
+    await p;
+    expect(beats).toBeGreaterThanOrEqual(1);
+    expect(beats).toBeLessThan(4);
+  });
+
+  it("never fires a heartbeat when none is supplied", async () => {
+    // No heartbeat option → no heartbeat path taken (removals pass no watchdog).
+    const done = await pacedForEach([1, 2, 3], () => {}, { delayMs: 0 });
+    expect(done).toBe(true);
+  });
+});

--- a/src/utils/pacedOps.ts
+++ b/src/utils/pacedOps.ts
@@ -1,0 +1,83 @@
+/**
+ * Shared paced iteration for bulk Steam-shortcut operations.
+ *
+ * Steam mutates its in-memory shortcut store on every add/remove; driving those
+ * mutations in a tight synchronous loop blocks the CEF renderer and can corrupt
+ * that store (the documented removal-churn hazard, #977). Every bulk shortcut
+ * loop — the sync add path and the DangerZone removal paths — runs through
+ * {@link pacedForEach} so the pacing is defined in exactly one place and add and
+ * remove can never diverge again. The add path paces one item at a time (the
+ * CEF-safe 50ms cadence); bulk removals pace in larger chunks (a removal is a
+ * single cheap call, so 25 back-to-back then one breather keeps the renderer
+ * responsive at seconds of overhead instead of minutes).
+ */
+
+import { logError } from "../api/backend";
+
+/** Resolve after ``ms`` milliseconds — the one timer primitive shared across the shortcut utils. */
+export const delay = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+export interface PacedForEachOptions {
+  /**
+   * Items processed back-to-back before a breather delay. Default ``1`` — a
+   * breather after every item (the per-item add cadence). Larger values pace in
+   * chunks (bulk removals).
+   */
+  chunkSize?: number;
+  /** Breather duration between chunks, in ms. Default ``50`` (the CEF-safe add cadence). */
+  delayMs?: number;
+  /**
+   * Called after each item so a long run can keep an external watchdog alive
+   * (the sync per-unit heartbeat). Throttled to at most once per
+   * {@link heartbeatIntervalMs}; omit for operations with no watchdog (removals).
+   */
+  heartbeat?: () => void;
+  /** Throttle window for {@link heartbeat}, in ms. Default ``10_000``. */
+  heartbeatIntervalMs?: number;
+  /**
+   * Checked after each item; returning ``true`` stops the loop before the next
+   * item. Omit for operations that can't be cancelled (removals).
+   */
+  isCancelled?: () => boolean;
+}
+
+/**
+ * Iterate *items*, awaiting *fn* for each, pacing the loop so the CEF renderer
+ * stays responsive. After every ``chunkSize`` items — but never after the last —
+ * the loop waits ``delayMs`` (one breather per chunk, no trailing delay).
+ * Returns ``false`` when ``isCancelled`` stopped the loop early, ``true`` when
+ * every item ran.
+ *
+ * Per-item mode (``chunkSize`` 1) is this same body with one item per chunk: a
+ * breather after every item except the last. The add path and bulk removals
+ * share the one body — the only difference is the chunk size.
+ *
+ * Batch resilience: a *fn* that throws is logged and skipped, never aborting the
+ * batch — one bad item can't strand the rest. Consumers that need item-specific
+ * error reporting still catch inside *fn* (this is the last-resort backstop).
+ */
+export async function pacedForEach<T>(
+  items: readonly T[],
+  fn: (item: T, index: number) => void | Promise<void>,
+  options: PacedForEachOptions = {},
+): Promise<boolean> {
+  const { chunkSize = 1, delayMs = 50, heartbeat, heartbeatIntervalMs = 10_000, isCancelled } = options;
+  let lastHeartbeat = Date.now();
+  for (const [i, item] of items.entries()) {
+    try {
+      await fn(item, i);
+    } catch (e) {
+      logError(`pacedForEach: item ${i} failed: ${e}`);
+    }
+    const done = i + 1;
+    if (done % chunkSize === 0 && done < items.length) {
+      await delay(delayMs);
+    }
+    if (heartbeat && Date.now() - lastHeartbeat > heartbeatIntervalMs) {
+      heartbeat();
+      lastHeartbeat = Date.now();
+    }
+    if (isCancelled?.()) return false;
+  }
+  return true;
+}

--- a/src/utils/sessionManager.ts
+++ b/src/utils/sessionManager.ts
@@ -14,8 +14,7 @@ import { setSaveSortMigrationStatus } from "./saveSortMigrationStore";
 import { updatePlaytimeDisplay } from "../patches/metadataPatches";
 import { detach } from "./detach";
 import { readPrimaryRunningApp, readRunningApps, type RunningApp } from "./runningApps";
-
-const delay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+import { delay } from "./pacedOps";
 
 // Active session tracking
 let activeRomId: number | null = null;

--- a/src/utils/shortcutRemoval.test.ts
+++ b/src/utils/shortcutRemoval.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+const removeShortcut = vi.fn();
+vi.mock("./steamShortcuts", () => ({
+  removeShortcut: (...args: unknown[]) => removeShortcut(...args),
+}));
+
+import { removeShortcutsPaced } from "./shortcutRemoval";
+
+describe("shortcutRemoval — removeShortcutsPaced", () => {
+  afterEach(() => {
+    removeShortcut.mockClear();
+    vi.useRealTimers();
+  });
+
+  it("removes in 25-item chunks with a 50ms breather between them", async () => {
+    vi.useFakeTimers();
+    const appIds = Array.from({ length: 26 }, (_, i) => i + 1);
+    const p = removeShortcutsPaced(appIds);
+    for (let i = 0; i < 40; i++) await Promise.resolve();
+    // First 25 removed back-to-back; the 26th is gated behind the breather.
+    expect(removeShortcut).toHaveBeenCalledTimes(25);
+    await vi.advanceTimersByTimeAsync(50);
+    expect(removeShortcut).toHaveBeenCalledTimes(26);
+    await p;
+  });
+
+  it("resolves immediately for an empty list without removing anything", async () => {
+    await removeShortcutsPaced([]);
+    expect(removeShortcut).not.toHaveBeenCalled();
+  });
+
+  it("removes each app_id exactly once, in order", async () => {
+    await removeShortcutsPaced([5, 9, 3]);
+    expect(removeShortcut.mock.calls.map((c) => c[0])).toEqual([5, 9, 3]);
+  });
+});

--- a/src/utils/shortcutRemoval.ts
+++ b/src/utils/shortcutRemoval.ts
@@ -1,0 +1,26 @@
+import { removeShortcut } from "./steamShortcuts";
+import { pacedForEach } from "./pacedOps";
+
+// Bulk removals run through the shared paced loop in chunked mode: 25 removals
+// back-to-back, then a 50ms breather so the CEF renderer never blocks and Steam's
+// in-memory shortcut store can't be corrupted by removal churn (#977). Unlike the
+// add path (strict 50ms/item), a removal is a single cheap call, so chunked
+// yielding keeps overhead at ~seconds rather than minutes on a 5000-game library.
+const REMOVAL_CHUNK_SIZE = 25;
+const REMOVAL_CHUNK_DELAY_MS = 50;
+
+/**
+ * Remove many Steam shortcuts, chunk-paced. Each ``removeShortcut`` is awaited in
+ * sequence (no more fire-and-forget stacking of thousands of pending removals);
+ * per-item errors are swallowed by ``removeShortcut``, so one bad appId never
+ * aborts the batch. Resolves once every removal has run — callers await this
+ * before their post-removal steps (result reporting, collection clear, re-count).
+ * Shared by every bulk-removal path: the DangerZone actions and the sync-run
+ * stale-shortcut cleanup (``sync_stale``).
+ */
+export async function removeShortcutsPaced(appIds: number[]): Promise<void> {
+  await pacedForEach(appIds, (appId) => removeShortcut(appId), {
+    chunkSize: REMOVAL_CHUNK_SIZE,
+    delayMs: REMOVAL_CHUNK_DELAY_MS,
+  });
+}

--- a/src/utils/steamShortcuts.ts
+++ b/src/utils/steamShortcuts.ts
@@ -1,5 +1,6 @@
 import type { SyncAddItem } from "../types";
 import { getAppIdRomIdMap, syncHeartbeat, logError, logInfo } from "../api/backend";
+import { delay } from "./pacedOps";
 
 /**
  * Ownership marker: RomM-managed shortcuts launch through the plugin's
@@ -10,8 +11,6 @@ import { getAppIdRomIdMap, syncHeartbeat, logError, logInfo } from "../api/backe
 const ROM_LAUNCHER_SUFFIX = "/bin/rom-launcher";
 
 const HEARTBEAT_INTERVAL_MS = 10_000;
-
-const delay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
 
 /**
  * Resolve a shortcut's `SteamAppDetails` via the one-shot RegisterForAppDetails

--- a/src/utils/syncManager.ts
+++ b/src/utils/syncManager.ts
@@ -18,9 +18,7 @@ import { updateSyncProgress } from "./syncProgress";
 import { recordSyncCreated } from "./syncDeltaStore";
 import { observeUnitTotal } from "./syncEta";
 import { registerRomMAppId } from "../patches/gameDetailPatch";
-
-const delay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
-const HEARTBEAT_INTERVAL_MS = 10_000;
+import { pacedForEach } from "./pacedOps";
 
 let _cancelRequested = false;
 let _isUnitRunning = false;
@@ -272,19 +270,13 @@ async function applyCoverArtwork(appId: number, romId: number): Promise<void> {
  * Fail-soft per item; exits early on cancel.
  */
 async function processCoverRefreshes(refreshes: { rom_id: number; app_id: number }[]): Promise<void> {
-  let lastHeartbeat = Date.now();
-  for (const entry of refreshes) {
-    if (isCancelRequested()) {
-      logInfo("Per-unit cancel observed during cover refresh");
-      break;
-    }
-    await applyCoverArtwork(entry.app_id, entry.rom_id);
-    await delay(50);
-    if (Date.now() - lastHeartbeat > HEARTBEAT_INTERVAL_MS) {
+  const completed = await pacedForEach(refreshes, (entry) => applyCoverArtwork(entry.app_id, entry.rom_id), {
+    heartbeat: () => {
       syncHeartbeat().catch(() => {});
-      lastHeartbeat = Date.now();
-    }
-  }
+    },
+    isCancelled: isCancelRequested,
+  });
+  if (!completed) logInfo("Per-unit cancel observed during cover refresh");
 }
 
 /**
@@ -310,57 +302,56 @@ async function processUnitShortcuts(
   liveAppIds: number[] | null,
   romIdToAppId: Record<string, number>,
 ): Promise<void> {
-  let lastHeartbeat = Date.now();
-  for (const [i, item] of data.shortcuts.entries()) {
-    const unitCurrent = data.chunk_offset + i + 1;
-    try {
-      // Carry the chunk-constant fields on every per-item update, not just the
-      // fine current/message. The chunk-init emit (initUnitSyncManager) seeds
-      // these once, but a QAM remount mid-chunk can replace the module store
-      // with the backend's coarse snapshot; re-asserting the full field set here
-      // lets the store self-heal on the next item (≤0.55s), so the fine line +
-      // step counter reappear without waiting for the next chunk boundary.
-      updateSyncProgress({
-        running: true,
-        stage: "applying",
-        current: unitCurrent,
-        total: data.unit_total,
-        message: `${data.unit_name}: ${unitCurrent}/${data.unit_total}`,
-        step: data.unit_index + 1,
-        totalSteps: data.total_units,
-      });
-      const { appId, created } = await resolveShortcutAppId(item, existing, data.run_id, liveAppIds);
-      if (appId) {
-        romIdToAppId[String(item.rom_id)] = appId;
-        // Register the appId as RomM-owned the moment the mapping exists — the
-        // earliest point the game-detail patch and launch interceptor can gate
-        // on it. Registering only at sync_complete leaves a newly created
-        // shortcut's detail page rendering native Steam UI for the whole run's
-        // artwork/collection tail, and a collection-only sync's appIds may never
-        // reach platform_app_ids at all (#1205). Idempotent (Set.add); covers
-        // created, updated, and rebind entries alike.
-        registerRomMAppId(appId);
-        // Apply cover artwork to newly-managed shortcuts — a fresh create or an
-        // adopted orphan (#1366; ``created`` covers both). An updated/rebound
-        // shortcut keeps its existing grid file (cover refresh on change is
-        // #1386). Awaited so covers stay one-per-item under the 50ms pacing;
-        // fail-soft.
-        if (created) await applyCoverArtwork(appId, item.rom_id);
+  const completed = await pacedForEach(
+    data.shortcuts,
+    async (item, i) => {
+      const unitCurrent = data.chunk_offset + i + 1;
+      try {
+        // Carry the chunk-constant fields on every per-item update, not just the
+        // fine current/message. The chunk-init emit (initUnitSyncManager) seeds
+        // these once, but a QAM remount mid-chunk can replace the module store
+        // with the backend's coarse snapshot; re-asserting the full field set here
+        // lets the store self-heal on the next item (≤0.55s), so the fine line +
+        // step counter reappear without waiting for the next chunk boundary.
+        updateSyncProgress({
+          running: true,
+          stage: "applying",
+          current: unitCurrent,
+          total: data.unit_total,
+          message: `${data.unit_name}: ${unitCurrent}/${data.unit_total}`,
+          step: data.unit_index + 1,
+          totalSteps: data.total_units,
+        });
+        const { appId, created } = await resolveShortcutAppId(item, existing, data.run_id, liveAppIds);
+        if (appId) {
+          romIdToAppId[String(item.rom_id)] = appId;
+          // Register the appId as RomM-owned the moment the mapping exists — the
+          // earliest point the game-detail patch and launch interceptor can gate
+          // on it. Registering only at sync_complete leaves a newly created
+          // shortcut's detail page rendering native Steam UI for the whole run's
+          // artwork/collection tail, and a collection-only sync's appIds may never
+          // reach platform_app_ids at all (#1205). Idempotent (Set.add); covers
+          // created, updated, and rebind entries alike.
+          registerRomMAppId(appId);
+          // Apply cover artwork to newly-managed shortcuts — a fresh create or an
+          // adopted orphan (#1366; ``created`` covers both). An updated/rebound
+          // shortcut keeps its existing grid file (cover refresh on change is
+          // #1386). Awaited so covers stay one-per-item under the 50ms pacing;
+          // fail-soft.
+          if (created) await applyCoverArtwork(appId, item.rom_id);
+        }
+      } catch (e) {
+        logError(`Per-unit: failed to process shortcut for rom ${item.rom_id}: ${e}`);
       }
-    } catch (e) {
-      logError(`Per-unit: failed to process shortcut for rom ${item.rom_id}: ${e}`);
-    }
-    await delay(50);
-
-    if (Date.now() - lastHeartbeat > HEARTBEAT_INTERVAL_MS) {
-      syncHeartbeat().catch(() => {});
-      lastHeartbeat = Date.now();
-    }
-    if (isCancelRequested()) {
-      logInfo(`Per-unit cancel observed during ${data.unit_name}`);
-      break;
-    }
-  }
+    },
+    {
+      heartbeat: () => {
+        syncHeartbeat().catch(() => {});
+      },
+      isCancelled: isCancelRequested,
+    },
+  );
+  if (!completed) logInfo(`Per-unit cancel observed during ${data.unit_name}`);
 }
 
 /**


### PR DESCRIPTION
Closes #977

**Problem:** The add path enforces a CEF-safe 50ms cadence, but every mass-removal path removed shortcuts in tight synchronous fire-and-forget loops — DangerZone's three bulk handlers and the `sync_stale` listener. Removal churn is the documented hazard that can corrupt Steam's in-memory shortcut state, and the unpaced loops also stacked thousands of pending promises while blocking the CEF event loop.

**Change:**
- New `src/utils/pacedOps.ts`: `pacedForEach(items, fn, opts)` — one loop body for all paced shortcut operations. Chunked mode (N items back-to-back, then a breather); per-item mode is chunk size 1. Optional throttled-heartbeat and cancel hooks. Owns the shared `delay` (previously triplicated across three files).
- All removal paths route through `removeShortcutsPaced` (`src/utils/shortcutRemoval.ts`): 25-item chunks, 50ms breather, every `removeShortcut` awaited. Removals stay paced without becoming slow — ~10s of pacing overhead at 5000 shortcuts instead of minutes at a naive 50ms/item — and the renderer keeps breathing. The RetroDeck bulk handler no longer calls `SteamClient.Apps.RemoveShortcut` directly; the wrapper is the single call site.
- The sync apply path (`processUnitShortcuts`, `processCoverRefreshes`) drives its existing 50ms/item cadence, heartbeat, and cancel checks through the same helper — add and remove can't diverge again. `syncManager.test.ts` is untouched and green as the behavior-parity net.
- `sync_stale` removals record their sync-delta counts up front: the paced loop now yields between chunks, so `sync_complete` could otherwise interleave and show a partial "removed" count in the terminal toast. The paced removal runs after all per-unit heartbeat windows have closed, so no watchdog interaction.

**Tests:** new unit tests for `pacedForEach` and `removeShortcutsPaced`, chunk-pacing assertions for all three DangerZone paths and the `sync_stale` path (fake timers, `emitDeckyEvent` harness). Full gate green (vitest 1978 across 86 files; pytest 5404; lint/typecheck/build clean).

**Docs:** `docs/architecture/steam-non-steam-shortcuts.md` — removal-churn section now describes the awaited chunk-paced removals; the timing section covers both cadences and points at the shared helper.