### PR TITLE
feat(ui): busy-disable danger-zone removals with a spinner and progress counter

### DIFF
--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -187,6 +187,11 @@ While a library sync is running (or cancelling), the shortcut and ROM removal ac
 unavailable — the buttons are disabled with a short hint, and the backend refuses the request too. Wait for the sync to
 finish, or cancel it, before removing shortcuts or ROMs. Save-file and BIOS deletions are not affected.
 
+A bulk shortcut removal is paced so it never freezes the interface, so on a large library it can take a few seconds.
+While one is running, all the removal buttons are disabled and a spinner with a live **Removing x of y** counter shows
+the progress; the buttons re-enable and the final count appears once it finishes. You can't start a second removal (or a
+new one from another button) until the current one completes.
+
 ### Remove by Platform
 
 Removes all shortcuts for a specific platform (e.g. all Game Boy Advance games). The associated Steam collection is also

--- a/src/components/DangerZone.test.tsx
+++ b/src/components/DangerZone.test.tsx
@@ -1522,6 +1522,96 @@ describe("DangerZone", () => {
     });
   });
 
+  describe("busy state during removals (#1449)", () => {
+    it("disables every removal button, shows the spinner + counter mid-removal, then re-enables", async () => {
+      const ids = Array.from({ length: 26 }, (_, i) => i + 1);
+      stubCollectionStore(ids);
+      stubAppStore(Object.fromEntries(ids.map((id) => [id, { strDisplayName: `Game ${id}` }])));
+      vi.mocked(backend.getRegistryPlatforms).mockResolvedValue({
+        platforms: [{ slug: "snes", name: "Super Nintendo", count: 2 }],
+      });
+      const { getByText, queryAllByTestId, container } = render(<DangerZone onBack={vi.fn()} />);
+      await flushAsync();
+
+      // Before the removal: no busy spinner, every removal button enabled.
+      expect(queryAllByTestId("spinner").length).toBe(0);
+      expect(getByText("Remove All RomM Shortcuts")).not.toBeDisabled();
+      expect(getByText("Super Nintendo (2)")).not.toBeDisabled();
+
+      fireEvent.click(getByText("Remove 26 Non-Steam Games"));
+      vi.useFakeTimers();
+      try {
+        await act(async () => {
+          fireEvent.click(getByText(/Are you sure\? Remove 26 games/));
+          for (let i = 0; i < 40; i++) await Promise.resolve();
+        });
+        // Mid-removal, parked on the breather after the first 25-item chunk.
+        expect(vi.mocked(removeShortcut)).toHaveBeenCalledTimes(25);
+        // Spinner visible + live counter reflects progress.
+        expect(queryAllByTestId("spinner").length).toBeGreaterThan(0);
+        expect(container.textContent).toContain("Removing 25 of 26...");
+        // Every removal button — across BOTH sections — is disabled: a second
+        // concurrent run is impossible via the UI, not merely harmless.
+        expect(getByText("Remove 26 Non-Steam Games")).toBeDisabled();
+        expect(getByText("Remove All RomM Shortcuts")).toBeDisabled();
+        expect(getByText("Uninstall All Installed ROMs")).toBeDisabled();
+        expect(getByText("Super Nintendo (2)")).toBeDisabled();
+
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(50);
+          for (let i = 0; i < 20; i++) await Promise.resolve();
+          await vi.advanceTimersByTimeAsync(3500); // drain the settle poll
+        });
+        // After completion: last removal ran, spinner gone, buttons re-enabled,
+        // final status text shown.
+        expect(vi.mocked(removeShortcut)).toHaveBeenCalledTimes(26);
+        expect(queryAllByTestId("spinner").length).toBe(0);
+        expect(getByText("Remove 26 Non-Steam Games")).not.toBeDisabled();
+        expect(getByText("Remove All RomM Shortcuts")).not.toBeDisabled();
+        expect(getByText("Super Nintendo (2)")).not.toBeDisabled();
+        expect(container.textContent).toContain("Removed 26 non-steam games");
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("remove-all-RomM drives the counter and clears busy on completion", async () => {
+      const appIds = Array.from({ length: 26 }, (_, i) => i + 1);
+      vi.mocked(backend.removeAllShortcuts).mockResolvedValue({
+        success: true,
+        message: "Removed all",
+        app_ids: appIds,
+        rom_ids: [1],
+      });
+      vi.mocked(getLiveRomMShortcutAppIds).mockResolvedValue([]);
+      const { getByText, container, queryAllByTestId } = render(<DangerZone onBack={vi.fn()} />);
+      await flushAsync();
+      fireEvent.click(getByText("Remove All RomM Shortcuts"));
+      vi.useFakeTimers();
+      try {
+        await act(async () => {
+          fireEvent.click(getByText("Confirm: remove all RomM shortcuts?"));
+          for (let i = 0; i < 40; i++) await Promise.resolve();
+        });
+        expect(vi.mocked(removeShortcut)).toHaveBeenCalledTimes(25);
+        expect(container.textContent).toContain("Removing 25 of 26...");
+        expect(queryAllByTestId("spinner").length).toBeGreaterThan(0);
+        expect(getByText("Remove All RomM Shortcuts")).toBeDisabled();
+
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(50);
+          for (let i = 0; i < 20; i++) await Promise.resolve();
+        });
+        expect(vi.mocked(removeShortcut)).toHaveBeenCalledTimes(26);
+        expect(container.textContent).toContain("Removed all");
+        expect(queryAllByTestId("spinner").length).toBe(0);
+        expect(getByText("Remove All RomM Shortcuts")).not.toBeDisabled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
   describe("WhitelistSection — collapse / expand + spinner", () => {
     it("collapsed by default; click reveals search + toggle list", async () => {
       stubCollectionStore([1]);

--- a/src/components/DangerZone.tsx
+++ b/src/components/DangerZone.tsx
@@ -166,6 +166,17 @@ const PlatformActionModal: FC<{
   );
 };
 
+/** Live progress of an in-flight bulk removal. */
+type RemovalProgress = { removed: number; total: number };
+
+/**
+ * Run a bulk removal wrapped in the DangerZone busy affordance: the removal
+ * buttons disable and the spinner + progress counter show for its duration.
+ * *work* receives an ``onProgress(removed, total)`` reporter to thread into
+ * ``removeShortcutsPaced``; busy + progress are always cleared when it settles.
+ */
+type RunRemoval = (work: (onProgress: (removed: number, total: number) => void) => Promise<void>) => Promise<void>;
+
 interface ShortcutRemovalSectionProps {
   platforms: RegistryPlatform[];
   loading: boolean;
@@ -173,6 +184,8 @@ interface ShortcutRemovalSectionProps {
   loadNonSteamApps: () => void;
   status: string;
   setStatus: (s: string) => void;
+  busy: boolean;
+  runRemoval: RunRemoval;
 }
 
 const ShortcutRemovalSection: FC<ShortcutRemovalSectionProps> = ({
@@ -182,36 +195,40 @@ const ShortcutRemovalSection: FC<ShortcutRemovalSectionProps> = ({
   loadNonSteamApps,
   status,
   setStatus,
+  busy,
+  runRemoval,
 }) => {
   const [actionStatus, setActionStatus] = useState("");
   const [uninstallStatus, setUninstallStatus] = useState("");
   const [confirmRemoveAllRomm, setConfirmRemoveAllRomm] = useState(false);
   const [confirmUninstall, setConfirmUninstall] = useState(false);
   const syncRunning = useSyncRunning();
+  const removalDisabled = busy || syncRunning;
 
-  const handleRemoveShortcuts = async (p: RegistryPlatform) => {
-    setActionStatus(`Removing ${p.name} shortcuts...`);
-    try {
-      const result = await removePlatformShortcuts(p.slug);
-      // The @migration_blocked / @sync_active_blocked gates short-circuit to
-      // { success: false, message, ... } with no app_ids/rom_ids — surface
-      // that message instead of cosmetically reporting a removal.
-      if (!result.success) {
-        setActionStatus(result.message ?? "Failed to remove shortcuts");
-        return;
+  const handleRemoveShortcuts = (p: RegistryPlatform) =>
+    runRemoval(async (onProgress) => {
+      setActionStatus(`Removing ${p.name} shortcuts...`);
+      try {
+        const result = await removePlatformShortcuts(p.slug);
+        // The @migration_blocked / @sync_active_blocked gates short-circuit to
+        // { success: false, message, ... } with no app_ids/rom_ids — surface
+        // that message instead of cosmetically reporting a removal.
+        if (!result.success) {
+          setActionStatus(result.message ?? "Failed to remove shortcuts");
+          return;
+        }
+        await removeShortcutsPaced(result.app_ids ?? [], onProgress);
+        if (result.rom_ids?.length) {
+          await reportRemovalResults(result.rom_ids);
+        }
+        await clearPlatformCollection(result.platform_name || p.name);
+        setActionStatus(`Removed ${p.count} ${p.name} game${p.count === 1 ? "" : "s"}`);
+        await refreshPlatforms();
+        loadNonSteamApps();
+      } catch {
+        setActionStatus("Failed to remove shortcuts");
       }
-      await removeShortcutsPaced(result.app_ids ?? []);
-      if (result.rom_ids?.length) {
-        await reportRemovalResults(result.rom_ids);
-      }
-      await clearPlatformCollection(result.platform_name || p.name);
-      setActionStatus(`Removed ${p.count} ${p.name} game${p.count === 1 ? "" : "s"}`);
-      await refreshPlatforms();
-      loadNonSteamApps();
-    } catch {
-      setActionStatus("Failed to remove shortcuts");
-    }
-  };
+    });
 
   const handleDeleteSaves = (p: RegistryPlatform) => {
     const platformName = p.name || p.slug;
@@ -262,48 +279,54 @@ const ShortcutRemovalSection: FC<ShortcutRemovalSectionProps> = ({
       return;
     }
     setConfirmRemoveAllRomm(false);
-    setStatus("Removing all shortcuts...");
-    let removedCount = 0;
-    try {
-      const result = await removeAllShortcuts();
-      if (!result.success) {
-        // A gate refusal (@sync_active_blocked / @migration_blocked) carries
-        // no app_ids/rom_ids — surface its message and remove nothing.
-        setStatus(result.message ?? "Failed to remove shortcuts");
-      } else {
-        // The backend list is the DB binding map (roms.shortcut_app_id). A
-        // crashed sync run's in-flight chunk can leave RomM-owned shortcuts in
-        // Steam (exe = bin/rom-launcher) that were never committed — no binding,
-        // so the backend never returns them. The live exe-ownership scan sees
-        // them; remove the UNION so no orphan is left behind (#1381).
-        const backendAppIds = result.app_ids ?? [];
-        await removeShortcutsPaced(backendAppIds);
-        const removed = new Set<number>(backendAppIds);
-        const liveAppIds = await getLiveRomMShortcutAppIds();
-        if (liveAppIds === null) {
-          // The scan could not run (Steam's shortcut store was unreadable) —
-          // fall back to the backend-bound list alone rather than skip removal.
-          logWarn("Live RomM shortcut scan unavailable — removed backend-bound shortcuts only.");
+    await runRemoval(async (onProgress) => {
+      setStatus("Removing all shortcuts...");
+      let removedCount = 0;
+      try {
+        const result = await removeAllShortcuts();
+        if (!result.success) {
+          // A gate refusal (@sync_active_blocked / @migration_blocked) carries
+          // no app_ids/rom_ids — surface its message and remove nothing.
+          setStatus(result.message ?? "Failed to remove shortcuts");
         } else {
-          const orphans = liveAppIds.filter((appId) => !removed.has(appId));
-          logInfo(`Remove-all: ${orphans.length} live-scanned RomM shortcut(s) were not in the backend list.`);
-          await removeShortcutsPaced(orphans);
-          for (const appId of orphans) removed.add(appId);
+          // The backend list is the DB binding map (roms.shortcut_app_id). A
+          // crashed sync run's in-flight chunk can leave RomM-owned shortcuts in
+          // Steam (exe = bin/rom-launcher) that were never committed — no binding,
+          // so the backend never returns them. The live exe-ownership scan sees
+          // them; remove the UNION so no orphan is left behind (#1381).
+          const backendAppIds = result.app_ids ?? [];
+          await removeShortcutsPaced(backendAppIds, onProgress);
+          const removed = new Set<number>(backendAppIds);
+          const liveAppIds = await getLiveRomMShortcutAppIds();
+          if (liveAppIds === null) {
+            // The scan could not run (Steam's shortcut store was unreadable) —
+            // fall back to the backend-bound list alone rather than skip removal.
+            logWarn("Live RomM shortcut scan unavailable — removed backend-bound shortcuts only.");
+          } else {
+            const orphans = liveAppIds.filter((appId) => !removed.has(appId));
+            logInfo(`Remove-all: ${orphans.length} live-scanned RomM shortcut(s) were not in the backend list.`);
+            // Continue the counter across the orphan sweep: offset by the backend
+            // count so "removed of total" stays cumulative (orphans are usually none).
+            await removeShortcutsPaced(orphans, (done, orphanTotal) =>
+              onProgress(backendAppIds.length + done, backendAppIds.length + orphanTotal),
+            );
+            for (const appId of orphans) removed.add(appId);
+          }
+          removedCount = removed.size;
+          // rom_ids are backend DB rows — orphans have none, so report only the
+          // backend set exactly as before.
+          if (result.rom_ids?.length) {
+            await reportRemovalResults(result.rom_ids);
+          }
+          await clearAllRomMCollections();
+          setStatus(result.message ?? "All shortcuts removed");
         }
-        removedCount = removed.size;
-        // rom_ids are backend DB rows — orphans have none, so report only the
-        // backend set exactly as before.
-        if (result.rom_ids?.length) {
-          await reportRemovalResults(result.rom_ids);
-        }
-        await clearAllRomMCollections();
-        setStatus(result.message ?? "All shortcuts removed");
+      } catch {
+        setStatus("Failed to remove shortcuts");
       }
-    } catch {
-      setStatus("Failed to remove shortcuts");
-    }
-    await refreshPlatforms();
-    await recountAfterStoreSettles(removedCount, loadNonSteamApps);
+      await refreshPlatforms();
+      await recountAfterStoreSettles(removedCount, loadNonSteamApps);
+    });
   };
 
   const handleUninstallAll = async () => {
@@ -354,6 +377,10 @@ const ShortcutRemovalSection: FC<ShortcutRemovalSectionProps> = ({
       <PanelSectionRow key={p.slug || p.name}>
         <ButtonItem
           layout="below"
+          // Busy-only (not sync): a sync leaves the platform modal openable — its
+          // own Remove Shortcuts button carries the sync gate (#1390). A busy
+          // removal disables opening the modal so no second run can be started.
+          disabled={busy}
           onClick={() => {
             showModal(
               <PlatformActionModal
@@ -384,9 +411,11 @@ const ShortcutRemovalSection: FC<ShortcutRemovalSectionProps> = ({
             onClick={() => {
               detach(handleRemoveAllRomm());
             }}
-            disabled={syncRunning}
+            disabled={removalDisabled}
             // Description ONLY for the disabled-while-syncing case, where it
             // explains why the button can't be pressed (mirrors SessionBudgetBanner).
+            // The in-flight removal has its own affordance (spinner + counter), so
+            // no hint there — the disable reads as "a removal is running".
             description={syncRunning ? SYNC_RUNNING_HINT : undefined}
           >
             {confirmRemoveAllRomm ? (
@@ -419,7 +448,7 @@ const ShortcutRemovalSection: FC<ShortcutRemovalSectionProps> = ({
             onClick={() => {
               detach(handleUninstallAll());
             }}
-            disabled={syncRunning}
+            disabled={removalDisabled}
             description={syncRunning ? SYNC_RUNNING_HINT : undefined}
           >
             {confirmUninstall ? (
@@ -658,6 +687,8 @@ interface RetroDeckSectionProps {
   refreshPlatforms: () => Promise<void>;
   loadNonSteamApps: () => void;
   setStatus: (s: string) => void;
+  busy: boolean;
+  runRemoval: RunRemoval;
 }
 
 const RetroDeckSection: FC<RetroDeckSectionProps> = ({
@@ -670,6 +701,8 @@ const RetroDeckSection: FC<RetroDeckSectionProps> = ({
   refreshPlatforms,
   loadNonSteamApps,
   setStatus,
+  busy,
+  runRemoval,
 }) => {
   const [confirmRemoveAll, setConfirmRemoveAll] = useState(false);
   const [confirmRetrodeck, setConfirmRetrodeck] = useState(false);
@@ -695,14 +728,20 @@ const RetroDeckSection: FC<RetroDeckSectionProps> = ({
     // Disarm the confirm BEFORE the awaited paced removal (mirrors
     // handleRemoveAllRomm) — the removal now yields for seconds on a large library,
     // so a stray tap while it runs must not re-enter and start a second concurrent run.
+    // (The button also busy-disables for the duration; the disarm keeps the label correct.)
     setConfirmRemoveAll(false);
     setConfirmRetrodeck(false);
-    const toRemove = nonSteamApps.filter((a) => !whitelistedIds.has(a.appId));
-    setStatus(`Removing ${toRemove.length} non-steam games...`);
-    await removeShortcutsPaced(toRemove.map((a) => a.appId));
-    setStatus(`Removed ${toRemove.length} non-steam game${toRemove.length === 1 ? "" : "s"}`);
-    refreshPlatforms().catch((e) => logError(`Failed to refresh platforms: ${e}`));
-    await recountAfterStoreSettles(toRemove.length, loadNonSteamApps);
+    await runRemoval(async (onProgress) => {
+      const toRemove = nonSteamApps.filter((a) => !whitelistedIds.has(a.appId));
+      setStatus(`Removing ${toRemove.length} non-steam games...`);
+      await removeShortcutsPaced(
+        toRemove.map((a) => a.appId),
+        onProgress,
+      );
+      setStatus(`Removed ${toRemove.length} non-steam game${toRemove.length === 1 ? "" : "s"}`);
+      refreshPlatforms().catch((e) => logError(`Failed to refresh platforms: ${e}`));
+      await recountAfterStoreSettles(toRemove.length, loadNonSteamApps);
+    });
   };
 
   const removeButtonLabel = () => {
@@ -737,6 +776,7 @@ const RetroDeckSection: FC<RetroDeckSectionProps> = ({
           <PanelSectionRow>
             <ButtonItem
               layout="below"
+              disabled={busy}
               onClick={() => {
                 detach(handleRemoveAll());
               }}
@@ -782,6 +822,22 @@ export const DangerZone: FC<DangerZoneProps> = ({ onBack }) => {
   const [customNames, setCustomNames] = useState<string[]>([]);
   const [settingsLoaded, setSettingsLoaded] = useState(false);
   const [nonSteamApps, setNonSteamApps] = useState<NonSteamApp[]>([]);
+  // In-flight bulk removal: `busy` disables every removal button (no second
+  // concurrent run via the UI), `removalProgress` drives the spinner's live
+  // "removed of total" counter. Shared across both sections so any removal
+  // disables all of them.
+  const [busy, setBusy] = useState(false);
+  const [removalProgress, setRemovalProgress] = useState<RemovalProgress | null>(null);
+
+  const runRemoval: RunRemoval = async (work) => {
+    setBusy(true);
+    try {
+      await work((removed, total) => setRemovalProgress({ removed, total }));
+    } finally {
+      setBusy(false);
+      setRemovalProgress(null);
+    }
+  };
 
   const activeDefaults = useMemo(
     () => DEFAULT_WHITELIST_PATTERNS.filter((p) => !disabledDefaults.includes(p)),
@@ -878,6 +934,16 @@ export const DangerZone: FC<DangerZoneProps> = ({ onBack }) => {
         </PanelSectionRow>
       </PanelSection>
 
+      {busy && (
+        <PanelSection>
+          <LoadingRow
+            label={
+              removalProgress ? `Removing ${removalProgress.removed} of ${removalProgress.total}...` : "Removing..."
+            }
+          />
+        </PanelSection>
+      )}
+
       <ShortcutRemovalSection
         platforms={platforms}
         loading={loading}
@@ -885,6 +951,8 @@ export const DangerZone: FC<DangerZoneProps> = ({ onBack }) => {
         loadNonSteamApps={loadNonSteamApps}
         status={status}
         setStatus={setStatus}
+        busy={busy}
+        runRemoval={runRemoval}
       />
 
       <OrphanedGridCleanupSection />
@@ -899,6 +967,8 @@ export const DangerZone: FC<DangerZoneProps> = ({ onBack }) => {
         refreshPlatforms={refreshPlatforms}
         loadNonSteamApps={loadNonSteamApps}
         setStatus={setStatus}
+        busy={busy}
+        runRemoval={runRemoval}
       />
     </>
   );

--- a/src/utils/pacedOps.test.ts
+++ b/src/utils/pacedOps.test.ts
@@ -180,4 +180,33 @@ describe("pacedOps — pacedForEach", () => {
     const done = await pacedForEach([1, 2, 3], () => {}, { delayMs: 0 });
     expect(done).toBe(true);
   });
+
+  it("onProgress fires once per item with the running count, independent of chunk size", async () => {
+    const seen: number[] = [];
+    await pacedForEach([10, 20, 30, 40], () => {}, { delayMs: 0, chunkSize: 2, onProgress: (c) => seen.push(c) });
+    // One tick per item (1..4), not one per chunk.
+    expect(seen).toEqual([1, 2, 3, 4]);
+  });
+
+  it("onProgress is never called for an empty list", async () => {
+    const onProgress = vi.fn();
+    await pacedForEach([], () => {}, { onProgress });
+    expect(onProgress).not.toHaveBeenCalled();
+  });
+
+  it("onProgress still fires for an item whose fn throws (count reflects items attempted)", async () => {
+    const logSpy = vi.spyOn(backend, "logError").mockImplementation(() => {});
+    const seen: number[] = [];
+    await pacedForEach(
+      [1, 2, 3],
+      (x) => {
+        if (x === 2) throw new Error("boom");
+      },
+      { delayMs: 0, onProgress: (c) => seen.push(c) },
+    );
+    // Item 2 threw (logged + swallowed) but its progress tick still fired.
+    expect(seen).toEqual([1, 2, 3]);
+    expect(logSpy).toHaveBeenCalled();
+    logSpy.mockRestore();
+  });
 });

--- a/src/utils/pacedOps.ts
+++ b/src/utils/pacedOps.ts
@@ -39,6 +39,13 @@ export interface PacedForEachOptions {
    * item. Omit for operations that can't be cancelled (removals).
    */
   isCancelled?: () => boolean;
+  /**
+   * Called after each processed item with the running completed count (1-based),
+   * regardless of chunk size — once per item, never for an empty list, and even
+   * for an item whose *fn* threw (the count reflects items attempted). Additive:
+   * omit it and the loop behaves exactly as before.
+   */
+  onProgress?: (completed: number) => void;
 }
 
 /**
@@ -61,7 +68,7 @@ export async function pacedForEach<T>(
   fn: (item: T, index: number) => void | Promise<void>,
   options: PacedForEachOptions = {},
 ): Promise<boolean> {
-  const { chunkSize = 1, delayMs = 50, heartbeat, heartbeatIntervalMs = 10_000, isCancelled } = options;
+  const { chunkSize = 1, delayMs = 50, heartbeat, heartbeatIntervalMs = 10_000, isCancelled, onProgress } = options;
   let lastHeartbeat = Date.now();
   for (const [i, item] of items.entries()) {
     try {
@@ -70,6 +77,7 @@ export async function pacedForEach<T>(
       logError(`pacedForEach: item ${i} failed: ${e}`);
     }
     const done = i + 1;
+    onProgress?.(done);
     if (done % chunkSize === 0 && done < items.length) {
       await delay(delayMs);
     }

--- a/src/utils/shortcutRemoval.test.ts
+++ b/src/utils/shortcutRemoval.test.ts
@@ -34,4 +34,14 @@ describe("shortcutRemoval — removeShortcutsPaced", () => {
     await removeShortcutsPaced([5, 9, 3]);
     expect(removeShortcut.mock.calls.map((c) => c[0])).toEqual([5, 9, 3]);
   });
+
+  it("reports (removed, total) after each removal when a progress callback is given", async () => {
+    const progress: [number, number][] = [];
+    await removeShortcutsPaced([11, 22, 33], (removed, total) => progress.push([removed, total]));
+    expect(progress).toEqual([
+      [1, 3],
+      [2, 3],
+      [3, 3],
+    ]);
+  });
 });

--- a/src/utils/shortcutRemoval.ts
+++ b/src/utils/shortcutRemoval.ts
@@ -17,10 +17,21 @@ const REMOVAL_CHUNK_DELAY_MS = 50;
  * before their post-removal steps (result reporting, collection clear, re-count).
  * Shared by every bulk-removal path: the DangerZone actions and the sync-run
  * stale-shortcut cleanup (``sync_stale``).
+ *
+ * *onProgress* (optional) is called after each removal with ``(removed, total)``
+ * so a caller can drive a live progress counter; omit it (as ``sync_stale`` does)
+ * for no counter and unchanged behavior.
  */
-export async function removeShortcutsPaced(appIds: number[]): Promise<void> {
+export async function removeShortcutsPaced(
+  appIds: number[],
+  onProgress?: (removed: number, total: number) => void,
+): Promise<void> {
+  const total = appIds.length;
   await pacedForEach(appIds, (appId) => removeShortcut(appId), {
     chunkSize: REMOVAL_CHUNK_SIZE,
     delayMs: REMOVAL_CHUNK_DELAY_MS,
+    // Only thread the hook when a caller wants one (exactOptionalPropertyTypes
+    // forbids passing an explicit ``undefined`` for an optional property).
+    ...(onProgress ? { onProgress: (completed: number) => onProgress(completed, total) } : {}),
   });
 }


### PR DESCRIPTION
Closes #1449

**Problem:** Since #977 the danger-zone bulk removals run paced and take seconds on a large library. The buttons stayed pressable during a run — a second tap started a redundant concurrent run (observed on device) — and the status line was static text with no liveness signal.

**Change:**
- `pacedForEach` gains an optional `onProgress(completed)` hook — once per item, 1-based, fires even for items whose callback threw, never for an empty list; fully additive, so the `sync_stale` cleanup and the sync apply path are unchanged. `removeShortcutsPaced` forwards it as `onProgress(removed, total)`.
- DangerZone gets a shared `busy` flag with a `runRemoval` wrapper: while any removal is in flight, every removal button across both sections is disabled — a second run is impossible via the UI, not merely harmless — and the panel's `LoadingRow` shows a spinner with a live "Removing x of y" counter. State clears in a `finally`, so a throwing handler can't wedge the panel.
- Existing gates preserved: the per-platform modal keeps its sync gate, uninstall-all is busy-disabled but doesn't set busy itself, the RetroDeck remove stays un-sync-gated as before.

**Tests:** +6 — onProgress hook semantics (per-item, empty list, fires-on-throw), `(removed, total)` forwarding, and mid-flight DangerZone assertions (all buttons disabled + spinner + "Removing 25 of 26…" parked on the breather, then re-enable + final status). Full gate green (vitest 1985; pytest 5404).

**Docs:** `docs/user-guide/troubleshooting.md` §Danger Zone — describes the new in-flight feedback.