### PR TITLE
fix(artwork): fall back to url_cover when the RomM cover asset returns 404

### DIFF
--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -229,6 +229,21 @@ the apply path as before. The fingerprint is only ever advanced when the cache i
 old fingerprint and the change is retried next sync. A cover-only change never re-applies the shortcut itself (that
 apply path writes launch options under the ADR-0025 invariant — pure churn for a cover).
 
+**`url_cover` fallback on a 404 RomM asset (#1450).** When the RomM-local cover asset returns a definitive HTTP 404 (the
+server's own cover resources are missing while its web UI still renders from `url_cover`), the cover download retries
+**once** against the ROM's `url_cover` — an external metadata-provider CDN (SteamGridDB / IGDB / …) — before giving up.
+The retry lives in `ArtworkService._download_cover_atomic`: only a `RommNotFoundError` (404) with a non-empty
+`url_cover` triggers it, so a transient transport error keeps today's retry-ladder behaviour and never falls back, and
+an empty/absent `url_cover` is exactly today's failure (warning, gray tile). The fallback fetch goes through a
+**separate, bearer-free** adapter seam (`RommRomReader.download_cover_from_url` → `RommHttpAdapter.download_external`):
+the host-bound RomM bearer must never reach a third-party origin, so only the plugin `User-Agent` is attached (the CDN
+behind Cloudflare Bot Fight Mode also 403s the default `Python-urllib` UA). The fingerprint records the source
+**actually applied** — `url_cover` on a fallback, threaded back through the `download_artwork` `applied_sources`
+accumulator (sync path) or the direct persist (`refresh_changed_covers` / `refresh_cover`) — so the compare stays
+truthful: because the fresh RomM `path_cover` string never equals the stored `url_cover`, a later fixed RomM asset (or a
+changed `url_cover`) is always re-checked, at the cost of re-downloading the fallback ROM's cover each sync until the
+RomM asset is repaired.
+
 **Unstamped-platform re-run: the `restamp_platform_count` signal (#1416).** A heartbeat-timeout run's late-ack recovery
 (ADR-0023) leaves a platform **complete but unstamped**: the timed-out apply cleared the stamp at its start and its late
 ack re-binds the chunk without re-writing it (the late-ack path never passes a `platform_stamp`). The wholesale-skip

--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -237,12 +237,15 @@ The retry lives in `ArtworkService._download_cover_atomic`: only a `RommNotFound
 an empty/absent `url_cover` is exactly today's failure (warning, gray tile). The fallback fetch goes through a
 **separate, bearer-free** adapter seam (`RommRomReader.download_cover_from_url` → `RommHttpAdapter.download_external`):
 the host-bound RomM bearer must never reach a third-party origin, so only the plugin `User-Agent` is attached (the CDN
-behind Cloudflare Bot Fight Mode also 403s the default `Python-urllib` UA). The fingerprint records the source
-**actually applied** — `url_cover` on a fallback, threaded back through the `download_artwork` `applied_sources`
-accumulator (sync path) or the direct persist (`refresh_changed_covers` / `refresh_cover`) — so the compare stays
-truthful: because the fresh RomM `path_cover` string never equals the stored `url_cover`, a later fixed RomM asset (or a
-changed `url_cover`) is always re-checked, at the cost of re-downloading the fallback ROM's cover each sync until the
-RomM asset is repaired.
+behind Cloudflare Bot Fight Mode also 403s the default `Python-urllib` UA). Because `url_cover` is untrusted
+server-supplied input, `download_external` scheme-allowlists it to `http`/`https` before any fetch — a
+`file:`/`data:`/`ftp:`/scheme-relative URL is rejected with a `RommApiError` so a `file:///etc/passwd` never reaches
+`urlopen` (the broader bounded-SSRF hardening — post-DNS private/link-local IP blocking and per-redirect-hop
+revalidation — is deferred to #1182). The fingerprint records the source **actually applied** — `url_cover` on a
+fallback, threaded back through the `download_artwork` `applied_sources` accumulator (sync path) or the direct persist
+(`refresh_changed_covers` / `refresh_cover`) — so the compare stays truthful: because the fresh RomM `path_cover` string
+never equals the stored `url_cover`, a later fixed RomM asset (or a changed `url_cover`) is always re-checked, at the
+cost of re-downloading the fallback ROM's cover each sync until the RomM asset is repaired.
 
 **Unstamped-platform re-run: the `restamp_platform_count` signal (#1416).** A heartbeat-timeout run's late-ack recovery
 (ADR-0023) leaves a platform **complete but unstamped**: the timed-out apply cleared the stamp at its start and its late

--- a/py_modules/adapters/romm/http.py
+++ b/py_modules/adapters/romm/http.py
@@ -526,6 +526,17 @@ class RommHttpAdapter:
 
         return self.with_retry(_do_download)
 
+    # Schemes an external ``url_cover`` fetch may use. A server-supplied
+    # ``url_cover`` is untrusted input, so anything else (``file:``, ``ftp:``,
+    # ``data:``, scheme-relative, …) is refused before any request — a
+    # ``file:///etc/passwd`` must never reach ``urlopen`` (#1450). Post-DNS
+    # private/link-local IP blocking and per-redirect-hop revalidation are the
+    # broader bounded-SSRF hardening tracked in #1182 (they also cover the
+    # pre-existing RomM download paths); stdlib's ``HTTPRedirectHandler`` already
+    # refuses redirects to non-http(s) schemes, so this allowlist closes the
+    # ``file:`` primitive on its own.
+    _EXTERNAL_URL_SCHEMES = ("http", "https")
+
     def download_external(self, url: str, dest: str) -> None:
         """Download from an ARBITRARY absolute *url* — ``User-Agent`` only, never the bearer.
 
@@ -534,12 +545,17 @@ class RommHttpAdapter:
         404s (#1450): the host-bound RomM bearer must NEVER reach a third-party
         origin, so only the plugin ``User-Agent`` is attached — no
         ``Authorization`` header is ever built here (the CDN behind Cloudflare
-        Bot Fight Mode also 403s the default ``Python-urllib`` UA). Spaces in
-        *url* are URL-encoded (RomM cover URLs carry them raw). Single-shot
-        streaming — no ``Range``/resume, covers are small; transient errors
-        retry through :meth:`with_retry` like every other download, a 404 raises
-        ``RommNotFoundError`` without retry.
+        Bot Fight Mode also 403s the default ``Python-urllib`` UA). The *url*
+        scheme is validated against :attr:`_EXTERNAL_URL_SCHEMES` first and a
+        non-http(s) scheme is rejected with a :class:`RommApiError` before any
+        request. Spaces in *url* are URL-encoded (RomM cover URLs carry them
+        raw). Single-shot streaming — no ``Range``/resume, covers are small;
+        transient errors retry through :meth:`with_retry` like every other
+        download, a 404 raises ``RommNotFoundError`` without retry.
         """
+        scheme = urllib.parse.urlsplit(url).scheme.lower()
+        if scheme not in self._EXTERNAL_URL_SCHEMES:
+            raise RommApiError(f"Refusing url_cover with non-http(s) scheme {scheme!r}", url=url, method="GET")
         encoded_url = urllib.parse.quote(url, safe="/:?=&@")
         dest_path = Path(dest)
         dest_path.parent.mkdir(parents=True, exist_ok=True)

--- a/py_modules/adapters/romm/http.py
+++ b/py_modules/adapters/romm/http.py
@@ -526,6 +526,46 @@ class RommHttpAdapter:
 
         return self.with_retry(_do_download)
 
+    def download_external(self, url: str, dest: str) -> None:
+        """Download from an ARBITRARY absolute *url* — ``User-Agent`` only, never the bearer.
+
+        For a ROM's ``url_cover`` (an external metadata-provider CDN such as
+        SteamGridDB / IGDB) used as the fallback when the RomM-local cover asset
+        404s (#1450): the host-bound RomM bearer must NEVER reach a third-party
+        origin, so only the plugin ``User-Agent`` is attached — no
+        ``Authorization`` header is ever built here (the CDN behind Cloudflare
+        Bot Fight Mode also 403s the default ``Python-urllib`` UA). Spaces in
+        *url* are URL-encoded (RomM cover URLs carry them raw). Single-shot
+        streaming — no ``Range``/resume, covers are small; transient errors
+        retry through :meth:`with_retry` like every other download, a 404 raises
+        ``RommNotFoundError`` without retry.
+        """
+        encoded_url = urllib.parse.quote(url, safe="/:?=&@")
+        dest_path = Path(dest)
+        dest_path.parent.mkdir(parents=True, exist_ok=True)
+
+        def _do_download():
+            req = urllib.request.Request(encoded_url, method="GET")
+            req.add_header("User-Agent", self._user_agent)
+            try:
+                with urllib.request.urlopen(req, context=self.ssl_context(), timeout=self._CONNECT_TIMEOUT) as resp:
+                    raw_sock = getattr(getattr(getattr(resp, "fp", None), "raw", None), "_sock", None)
+                    if raw_sock is not None:
+                        raw_sock.settimeout(self._READ_TIMEOUT)
+                    total, downloaded = self._stream_to_file(
+                        resp,
+                        dest_path,
+                        block_size=self._DOWNLOAD_BLOCK_SIZE,
+                        url=encoded_url,
+                    )
+                self._validate_download(total, downloaded)
+            except RommApiError:
+                raise
+            except Exception as exc:
+                raise self.translate_http_error(exc, encoded_url, "GET") from exc
+
+        return self.with_retry(_do_download)
+
     def _resume_branch(self, resp, status: int, existing_size: int) -> tuple[str, int, int]:
         """Decide ``(open_mode, seed_bytes, total)`` from the live response.
 

--- a/py_modules/adapters/romm/romm_api.py
+++ b/py_modules/adapters/romm/romm_api.py
@@ -160,6 +160,9 @@ class RommApiAdapter:
     def download_cover(self, cover_url: str, dest: str) -> None:
         self._client.download(cover_url, dest)
 
+    def download_cover_from_url(self, url: str, dest: str) -> None:
+        self._client.download_external(url, dest)
+
     # ── Collections ───────────────────────────────────────────────────
 
     def list_collections(self) -> list[dict[str, Any]]:

--- a/py_modules/services/artwork.py
+++ b/py_modules/services/artwork.py
@@ -14,6 +14,13 @@ came from, and every sync compares it against the fresh fetch (#1386). A
 mismatch re-downloads the cache and republishes the grid copy; a NULL
 fingerprint with an existing cache file is adopted without a download, so the
 fingerprint's introduction never mass re-downloads an existing library.
+
+When the RomM-local cover asset returns a definitive HTTP 404, the download
+retries once against the ROM's external ``url_cover`` (a metadata-provider CDN
+such as SteamGridDB / IGDB) before giving up — the RomM bearer is never sent to
+that third-party host (#1450). The fingerprint records the source *actually*
+applied (``url_cover`` on a fallback), so a later fixed RomM asset or changed
+``url_cover`` is still detected as a change.
 """
 
 from __future__ import annotations
@@ -35,6 +42,7 @@ from domain.artwork_paths import (
 )
 from domain.cover_refresh import scan_cover_refresh_candidates
 from domain.sync_stage import SyncStage
+from lib.errors import RommNotFoundError
 from lib.list_result import ErrorCode
 
 # Emit a cover-download progress frame on the first cover, every Nth cover, and
@@ -126,6 +134,7 @@ class ArtworkService:
         progress_step: int = 4,
         progress_total_steps: int = 6,
         label: str = "",
+        applied_sources: dict[int, str] | None = None,
     ) -> dict[int, str]:
         """Download cover artwork into the per-ROM cache, returning rom_id → cache path.
 
@@ -135,6 +144,15 @@ class ArtworkService:
         landed); else download from RomM. The returned cache path becomes the
         pending-sync ``cover_path`` that ``finalize_cover_path`` publishes onto
         the grid once the Steam app_id is known.
+
+        ``applied_sources`` is an optional accumulator the caller passes to learn
+        which cover source each resolved ROM's bytes actually came from —
+        ``path_cover_large``/``path_cover_small`` for the common case, or the
+        ROM's ``url_cover`` when the RomM asset 404s and the external fallback
+        wins (#1450). It is filled per resolved ROM (fresh download, reuse, or
+        grid seed), so the per-unit commit persists a truthful ``cover_source``
+        fingerprint even for fallback covers — the caller keys its own
+        derivation off it. Absent/unread, ``download_artwork`` behaves as before.
 
         Progress is narrated under the ``fetching`` stage with the ``covers``
         sub-stage (this runs in the per-unit prep phase, before the shortcuts
@@ -178,11 +196,17 @@ class ArtworkService:
             existing = self._resolve_cached_cover(rom_id, cache_path, grid, cover_url)
             if existing:
                 cover_paths[rom_id] = existing
+                if applied_sources is not None:
+                    applied_sources[rom_id] = cover_url
                 continue
 
             try:
-                await self._loop.run_in_executor(None, self._download_cover_atomic, cover_url, cache_path)
+                applied = await self._loop.run_in_executor(
+                    None, self._download_cover_atomic, cover_url, cache_path, rom.get("url_cover")
+                )
                 cover_paths[rom_id] = cache_path
+                if applied_sources is not None:
+                    applied_sources[rom_id] = applied
             except Exception as e:
                 self._logger.warning(f"Failed to download artwork for {rom['name']}: {e}")
 
@@ -297,6 +321,7 @@ class ArtworkService:
 
         self._cover_art_file_store.make_dirs(self._cover_cache_dir)
         grid = self._steam_config.grid_dir()
+        url_covers = {int(rom["id"]): rom.get("url_cover") for rom in all_roms if "id" in rom}
         refresh_target = f"Refreshing covers for {label}" if label else "Refreshing covers"
         refreshed: list[dict[str, int]] = []
         total = len(changed)
@@ -314,7 +339,9 @@ class ArtworkService:
                     total_steps=progress_total_steps,
                     sub_stage="covers",
                 )
-            ok = await self._loop.run_in_executor(None, self._refresh_one_cover_io, rom_id, app_id, cover_url, grid)
+            ok = await self._loop.run_in_executor(
+                None, self._refresh_one_cover_io, rom_id, app_id, cover_url, grid, url_covers.get(rom_id)
+            )
             if ok:
                 refreshed.append({"rom_id": rom_id, "app_id": app_id})
         if refreshed:
@@ -354,25 +381,29 @@ class ArtworkService:
                 rom.adopt_cover_source(source)
                 uow.roms.save(rom)
 
-    def _refresh_one_cover_io(self, rom_id: int, app_id: int, cover_url: str, grid: str | None) -> bool:
+    def _refresh_one_cover_io(
+        self, rom_id: int, app_id: int, cover_url: str, grid: str | None, url_cover: str | None = None
+    ) -> bool:
         """Re-download one changed cover, republish its grid copy, persist the fingerprint.
 
         Ordered so nothing advances on failure: the atomic download either
         replaces the cache in full or leaves the old bytes; only a successful
         download republishes the grid ``{app_id}p.png`` and persists the new
         ``cover_source`` (a missing grid dir skips the publish but still
-        persists — the cache is the source of truth). Returns whether the
+        persists — the cache is the source of truth). The persisted fingerprint
+        is the source actually applied — *url_cover* when the RomM asset 404s
+        and the fallback wins (#1450), else *cover_url*. Returns whether the
         cover was refreshed.
         """
         cache_path = self._cache_path(rom_id)
         try:
-            self._download_cover_atomic(cover_url, cache_path)
+            applied = self._download_cover_atomic(cover_url, cache_path, url_cover)
         except Exception as e:
             self._logger.warning(f"Cover refresh: failed to download cover for rom {rom_id}: {e}")
             return False
         if grid:
             self.finalize_cover_path(grid, cache_path, app_id, str(rom_id))
-        self._persist_cover_source(rom_id, cover_url)
+        self._persist_cover_source(rom_id, applied)
         return True
 
     def _persist_cover_source(self, rom_id: int, source: str) -> None:
@@ -386,8 +417,13 @@ class ArtworkService:
 
     # ── Atomic write helpers ───────────────────────────────────────────────
 
-    def _download_cover_atomic(self, cover_url: str, dest: str) -> None:
-        """Download *cover_url* into ``dest.tmp`` then atomically rename over *dest*.
+    def _download_cover_atomic(self, cover_url: str, dest: str, url_cover: str | None = None) -> str:
+        """Download the cover into ``dest.tmp`` then atomically rename over *dest*.
+
+        Returns the cover source actually applied — *cover_url* for the normal
+        RomM-asset fetch, or *url_cover* when the RomM asset returns a definitive
+        404 and the external ``url_cover`` fallback succeeds (#1450). The caller
+        records that source so the ``cover_source`` fingerprint stays truthful.
 
         A reader of *dest* sees either the old file or the complete new one,
         never a partially-streamed download. The sidecar is removed on any
@@ -395,11 +431,33 @@ class ArtworkService:
         """
         tmp = with_tmp_suffix(dest)
         try:
-            self._romm_api.download_cover(cover_url, tmp)
+            applied = self._fetch_cover_to_tmp(cover_url, tmp, url_cover)
             self._cover_art_file_store.rename(tmp, dest)
+            return applied
         except Exception:
             self._cover_art_file_store.remove_file(tmp)
             raise
+
+    def _fetch_cover_to_tmp(self, cover_url: str, tmp: str, url_cover: str | None) -> str:
+        """Fetch the RomM cover into *tmp*, falling back to *url_cover* on a 404.
+
+        Returns the source actually written (``cover_url`` normally, *url_cover*
+        on a successful fallback). ONLY a definitive RomM 404
+        (:class:`RommNotFoundError`) with a non-empty *url_cover* triggers the
+        external fetch — every other failure (transport, 5xx, auth) propagates
+        unchanged, keeping today's retry-ladder behaviour and no fallback. The
+        external fetch goes out WITHOUT the RomM bearer (host-bound token,
+        #1450) and is logged at INFO with no secret material.
+        """
+        try:
+            self._romm_api.download_cover(cover_url, tmp)
+            return cover_url
+        except RommNotFoundError:
+            if not url_cover:
+                raise
+            self._romm_api.download_cover_from_url(url_cover, tmp)
+            self._logger.info(f"Cover asset 404 ({cover_url}); applied url_cover fallback")
+            return url_cover
 
     def _copy_atomic(self, src: str, dest: str) -> None:
         """Copy *src* into ``dest.tmp`` then atomically rename over *dest*.
@@ -561,7 +619,9 @@ class ArtworkService:
 
         self._cover_art_file_store.make_dirs(self._cover_cache_dir)
         try:
-            await self._loop.run_in_executor(None, self._download_cover_atomic, cover_url, cache_path)
+            await self._loop.run_in_executor(
+                None, self._download_cover_atomic, cover_url, cache_path, rom.get("url_cover")
+            )
         except Exception as e:
             self._logger.warning(f"fetch_cover: failed to download cover for rom {rom_id}: {e}")
             return {"base64": None}
@@ -627,7 +687,9 @@ class ArtworkService:
         cache_path = self._cache_path(rom_id)
         self._cover_art_file_store.make_dirs(self._cover_cache_dir)
         try:
-            await self._loop.run_in_executor(None, self._download_cover_atomic, cover_url, cache_path)
+            applied = await self._loop.run_in_executor(
+                None, self._download_cover_atomic, cover_url, cache_path, rom.get("url_cover")
+            )
         except Exception as e:
             self._logger.warning(f"refresh_cover: failed to download cover for rom {rom_id}: {e}")
             return {
@@ -637,7 +699,7 @@ class ArtworkService:
             }
 
         self.finalize_cover_path(grid, cache_path, app_id, str(rom_id))
-        await self._loop.run_in_executor(None, self._persist_cover_path, rom_id, cache_path, cover_url)
+        await self._loop.run_in_executor(None, self._persist_cover_path, rom_id, cache_path, applied)
 
         return {
             "success": True,

--- a/py_modules/services/library/sync_orchestrator.py
+++ b/py_modules/services/library/sync_orchestrator.py
@@ -1285,25 +1285,31 @@ class SyncOrchestrator:
         (``BIND_ROM_ID_KEY``), whose raw dict is the one present in *unit_roms*.
         A no-op when nothing is emitted.
 
-        Returns the confirmed cover fingerprints — ``rom_id → fresh cover
+        Returns the confirmed cover fingerprints — ``rom_id → applied cover
         source`` for every ROM whose cache the download resolved (fresh
         download, reuse, or grid seed all confirm; a failed download does not) —
-        which the per-unit commit persists as ``roms.cover_source`` (#1386).
+        which the per-unit commit persists as ``roms.cover_source`` (#1386). The
+        source is the one ArtworkService *actually* applied: the fresh
+        ``path_cover`` normally, or the ROM's ``url_cover`` when the RomM asset
+        404s and the external fallback wins (#1450), reported through the
+        ``applied_sources`` accumulator.
         """
         if not emitted:
             return {}
         artwork_ids = {int(e.get(BIND_ROM_ID_KEY, e["rom_id"])) for e in emitted}
         artwork_roms = [rom for rom in unit_roms if rom["id"] in artwork_ids]
+        applied_sources: dict[int, str] = {}
         cover_paths = await self._download_artwork(
             artwork_roms,
             progress_step=unit_index + 1,
             progress_total_steps=total_units,
             label=unit.name,
+            applied_sources=applied_sources,
         )
         for e in emitted:
             e["cover_path"] = cover_paths.get(int(e.get(BIND_ROM_ID_KEY, e["rom_id"])), "")
         return {
-            int(rom["id"]): source
+            int(rom["id"]): applied_sources.get(int(rom["id"])) or source
             for rom in artwork_roms
             if int(rom["id"]) in cover_paths and (source := rom.get("path_cover_large") or rom.get("path_cover_small"))
         }
@@ -1876,11 +1882,16 @@ class SyncOrchestrator:
 
     # ── Artwork delegation ───────────────────────────────────────
 
-    async def _download_artwork(self, all_roms, progress_step=4, progress_total_steps=6, label=""):
+    async def _download_artwork(
+        self, all_roms, progress_step=4, progress_total_steps=6, label="", applied_sources=None
+    ):
         """Delegate artwork download to ArtworkService callback.
 
         ``label`` is the unit's display name, threaded into the cover-download
-        progress frames ("Preparing covers for <label>").
+        progress frames ("Preparing covers for <label>"). ``applied_sources`` is
+        the optional accumulator ArtworkService fills with the cover source
+        actually applied per ROM (``url_cover`` on a 404 fallback, #1450), so the
+        per-unit commit persists a truthful ``cover_source`` fingerprint.
         """
         box = self._sync_state
         return await self._artwork.download_artwork(
@@ -1890,6 +1901,7 @@ class SyncOrchestrator:
             progress_step=progress_step,
             progress_total_steps=progress_total_steps,
             label=label,
+            applied_sources=applied_sources,
         )
 
     async def _refresh_changed_covers(self, unit_roms, registry, progress_step=4, progress_total_steps=6, label=""):

--- a/py_modules/services/protocols/cross_service.py
+++ b/py_modules/services/protocols/cross_service.py
@@ -206,6 +206,7 @@ class ArtworkManager(Protocol):
         progress_step: int = 4,
         progress_total_steps: int = 6,
         label: str = "",
+        applied_sources: dict[int, str] | None = None,
     ) -> dict[Any, Any]: ...
 
     async def refresh_changed_covers(

--- a/py_modules/services/protocols/transport.py
+++ b/py_modules/services/protocols/transport.py
@@ -243,6 +243,17 @@ class RommRomReader(Protocol):
         """
         ...
 
+    def download_cover_from_url(self, url: str, dest: str) -> None:
+        """Download a ROM cover from an external ``url_cover`` CDN to a local path.
+
+        The fallback for a RomM-local cover asset that 404s (#1450): *url* is
+        the ROM's absolute ``url_cover`` (SteamGridDB / IGDB / …). Fetched
+        WITHOUT the RomM bearer — the host-bound token must never reach a
+        third-party origin — with the plugin ``User-Agent`` and spaces
+        URL-encoded.
+        """
+        ...
+
 
 class RommSaveApi(Protocol):
     """RomM saves API surface (list, up/download, confirm, summary, delete)."""

--- a/tests/adapters/romm/test_http.py
+++ b/tests/adapters/romm/test_http.py
@@ -2020,3 +2020,71 @@ class TestDownloadResume:
 
         req = mock_open.call_args[0][0]
         assert req.get_header("Range") is None
+
+
+class TestDownloadExternal:
+    """``download_external`` — the bearer-free fetch for the url_cover fallback (#1450)."""
+
+    def _adapter_with_token(self):
+        import logging
+
+        settings = {
+            "romm_url": "http://romm.local",
+            "romm_api_token": "rmm_secret",
+            "romm_api_token_origin": "http://romm.local",
+        }
+        return RommHttpAdapter(settings, "/fake/plugin_dir", logging.getLogger("test"), "decky-romm-sync/9.9.9")
+
+    def test_omits_authorization_even_with_stored_token(self, tmp_path):
+        """The host-bound RomM bearer must NEVER reach the external url_cover host."""
+        adapter = self._adapter_with_token()
+        dest = str(tmp_path / "cover.png")
+        data = b"cdn art"
+        resp = _make_resp(200, {"Content-Length": str(len(data))}, data)
+
+        with patch("urllib.request.urlopen", return_value=resp) as mock_open:
+            adapter.download_external("https://cdn.example.com/x.png", dest)
+
+        req = mock_open.call_args[0][0]
+        assert req.get_header("Authorization") is None
+        assert req.get_header("User-agent") == "decky-romm-sync/9.9.9"
+        with open(dest, "rb") as f:
+            assert f.read() == data
+
+    def test_uses_absolute_url_verbatim_not_romm_prefixed(self, tmp_path):
+        """The url is absolute — it must NOT be prefixed with romm_url."""
+        adapter = self._adapter_with_token()
+        dest = str(tmp_path / "cover.png")
+        resp = _make_resp(200, {"Content-Length": "1"}, b"x")
+
+        with patch("urllib.request.urlopen", return_value=resp) as mock_open:
+            adapter.download_external("https://cdn.example.com/x.png", dest)
+
+        req = mock_open.call_args[0][0]
+        assert req.full_url == "https://cdn.example.com/x.png"
+
+    def test_encodes_spaces_in_url(self, tmp_path):
+        """RomM cover URLs carry raw spaces — encoded before the request."""
+        adapter = self._adapter_with_token()
+        dest = str(tmp_path / "cover.png")
+        resp = _make_resp(200, {"Content-Length": "1"}, b"x")
+
+        with patch("urllib.request.urlopen", return_value=resp) as mock_open:
+            adapter.download_external("https://cdn.example.com/a b.png", dest)
+
+        req = mock_open.call_args[0][0]
+        assert req.full_url == "https://cdn.example.com/a%20b.png"
+
+    def test_404_raises_not_found_without_retry(self, tmp_path):
+        adapter = self._adapter_with_token()
+        dest = str(tmp_path / "cover.png")
+        exc = urllib.error.HTTPError("https://cdn.example.com/x.png", 404, "Not Found", http.client.HTTPMessage(), None)
+
+        with (
+            patch("urllib.request.urlopen", side_effect=exc) as mock_open,
+            pytest.raises(RommNotFoundError),
+        ):
+            adapter.download_external("https://cdn.example.com/x.png", dest)
+
+        # A definitive 404 is not retryable — a single attempt.
+        assert mock_open.call_count == 1

--- a/tests/adapters/romm/test_http.py
+++ b/tests/adapters/romm/test_http.py
@@ -2088,3 +2088,34 @@ class TestDownloadExternal:
 
         # A definitive 404 is not retryable — a single attempt.
         assert mock_open.call_count == 1
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "file:///etc/passwd",
+            "FILE:///etc/passwd",
+            "ftp://internal.host/secret",
+            "data:text/html,<script>x</script>",
+            "gopher://127.0.0.1:70/",
+            "//cdn.example.com/x.png",  # scheme-relative — no scheme
+            "/relative/path.png",  # not absolute
+        ],
+    )
+    def test_rejects_non_http_scheme_without_requesting(self, tmp_path, url):
+        """A server-supplied non-http(s) url_cover must never reach urlopen (#1450).
+
+        The RomM ``url_cover`` is untrusted input; a ``file:///etc/passwd`` (or
+        any other scheme) is refused with the adapter's normal error type before
+        any request, and nothing is written to disk.
+        """
+        adapter = self._adapter_with_token()
+        dest = tmp_path / "cover.png"
+
+        with (
+            patch("urllib.request.urlopen") as mock_open,
+            pytest.raises(RommApiError),
+        ):
+            adapter.download_external(url, str(dest))
+
+        mock_open.assert_not_called()
+        assert not dest.exists()

--- a/tests/adapters/romm/test_romm_api.py
+++ b/tests/adapters/romm/test_romm_api.py
@@ -581,6 +581,15 @@ class TestDownloadCover:
         client.download.assert_called_once_with("/assets/covers/zelda.jpg", "/tmp/cover.jpg")
 
 
+class TestDownloadCoverFromUrl:
+    def test_delegates_to_client_download_external(self):
+        api, client = _make_api()
+        client.download_external = MagicMock()
+        api.download_cover_from_url("https://cdn.example.com/x.png", "/tmp/cover.png")
+        # The external CDN fetch routes through the bearer-free download_external.
+        client.download_external.assert_called_once_with("https://cdn.example.com/x.png", "/tmp/cover.png")
+
+
 class TestListVirtualCollections:
     def test_returns_list(self):
         api, client = _make_api()

--- a/tests/contract/test_cover_refresh.py
+++ b/tests/contract/test_cover_refresh.py
@@ -22,9 +22,11 @@ import asyncio
 
 from domain.rom import Rom
 from domain.sync_state import SyncState
+from lib.errors import RommNotFoundError
 
 _COVER_OLD = "/assets/romm/resources/roms/10/cover/big.png?ts=2026-01-01 00:00:00"
 _COVER_NEW = "/assets/romm/resources/roms/10/cover/big.png?ts=2026-07-11 12:00:00"
+_URL_COVER = "https://cdn2.steamgriddb.com/grid/abc123.png"
 
 
 def _orchestrator(harness):
@@ -83,6 +85,10 @@ def _apply_unit_events(harness):
 
 def _download_cover_urls(harness):
     return [args[0] for name, args, _kwargs in harness.romm.call_log if name == "download_cover"]
+
+
+def _download_cover_from_url_urls(harness):
+    return [args[0] for name, args, _kwargs in harness.romm.call_log if name == "download_cover_from_url"]
 
 
 async def _run_sync(harness, run_id: str) -> None:
@@ -250,6 +256,32 @@ async def test_cover_only_change_flows_from_preview_to_apply_via_callables(harne
     assert len(events) == 1
     assert events[0]["shortcuts"] == []
     assert events[0]["cover_refreshes"] == [{"rom_id": 10, "app_id": 7777}]
+
+
+async def test_cover_asset_404_falls_back_to_url_cover_and_records_it(harness):
+    """A 404 on the RomM cover asset retries against the ROM's ``url_cover`` and
+    persists the url_cover as the fingerprint across the real reporter commit —
+    the source actually applied, so a later fixed asset is still detected (#1450).
+    """
+    _make_grid_resolvable(harness)
+    _seed_library(harness, cover=_COVER_OLD)
+    harness.romm.roms[10]["url_cover"] = _URL_COVER
+    # The RomM-local cover asset 404s; the external url_cover serves real bytes.
+    harness.romm.download_cover_side_effect = RommNotFoundError("HTTP 404: Not Found")
+    harness.romm.download_payloads[f"cover_url:{_URL_COVER}"] = b"cdn cover bytes"
+    _orchestrator(harness)._wait_for_unit_complete = _ack_with({"10": 7777})
+
+    await _run_sync(harness, "run-fallback-1")
+
+    # The cache holds the external bytes, fetched via the bearer-free fallback path.
+    assert _cache_file(harness).read_bytes() == b"cdn cover bytes"
+    assert _download_cover_from_url_urls(harness) == [_URL_COVER]
+    with harness.uow_factory() as uow:
+        rom = uow.roms.get(10)
+    assert rom is not None
+    assert rom.shortcut_app_id == 7777
+    # The recorded fingerprint is the applied url_cover — NOT the 404'd RomM path.
+    assert rom.cover_source == _URL_COVER
 
 
 async def test_pure_no_changes_preview_keeps_zero_cover_count(harness):

--- a/tests/fakes/fake_romm_api.py
+++ b/tests/fakes/fake_romm_api.py
@@ -134,6 +134,7 @@ class FakeRommApi:
         # Resumability verdict the fake reports via ``on_meta`` (server range support).
         self.download_range_supported: bool = False
         self.download_cover_side_effect: Exception | None = None
+        self.download_cover_from_url_side_effect: Exception | None = None
         self.get_current_user_side_effect: Exception | None = None
         self.ingest_play_sessions_side_effect: Exception | None = None
         self.list_play_sessions_side_effect: Exception | None = None
@@ -362,6 +363,13 @@ class FakeRommApi:
         self._log("download_cover", (cover_url, dest))
         self._check_fail(self.download_cover_side_effect)
         key = f"cover:{cover_url}"
+        payload = self.download_payloads.get(key, b"")
+        self._materialize_download(dest, payload)
+
+    def download_cover_from_url(self, url: str, dest: str) -> None:
+        self._log("download_cover_from_url", (url, dest))
+        self._check_fail(self.download_cover_from_url_side_effect)
+        key = f"cover_url:{url}"
         payload = self.download_payloads.get(key, b"")
         self._materialize_download(dest, payload)
 

--- a/tests/fakes/fake_save_api.py
+++ b/tests/fakes/fake_save_api.py
@@ -288,6 +288,9 @@ class FakeSaveApi:
     def download_cover(self, cover_url: str, dest: str) -> None:
         raise NotImplementedError
 
+    def download_cover_from_url(self, url: str, dest: str) -> None:
+        raise NotImplementedError
+
     def list_firmware(self) -> list[dict[str, Any]]:
         raise NotImplementedError
 

--- a/tests/fakes/library_peers.py
+++ b/tests/fakes/library_peers.py
@@ -52,10 +52,15 @@ class FakeArtworkManager:
         progress_step: int = 4,
         progress_total_steps: int = 6,
         label: str = "",
+        applied_sources: dict[int, str] | None = None,
     ) -> dict[str, Any]:
         self.download_calls.append(
             (list(all_roms), emit_progress, is_cancelling, progress_step, progress_total_steps, label)
         )
+        # The real service fills ``applied_sources`` per resolved ROM (#1450); the
+        # canned fake records only the return dict, so the accumulator is left as
+        # the caller passed it — the orchestrator then derives ``cover_source``
+        # from the rom dict, matching pre-fallback behaviour under test.
         return dict(self.canned_download)
 
     async def refresh_changed_covers(

--- a/tests/services/test_artwork.py
+++ b/tests/services/test_artwork.py
@@ -13,7 +13,9 @@ import pytest
 from fakes.fake_cover_art_file_store import FakeCoverArtFileStore
 from fakes.fake_unit_of_work import FakeUnitOfWork, FakeUnitOfWorkFactory
 
+from domain.cover_refresh import scan_cover_refresh_candidates
 from domain.rom import Rom
+from lib.errors import RommConnectionError, RommNotFoundError
 from services.artwork import ArtworkService, ArtworkServiceConfig
 
 
@@ -472,6 +474,129 @@ class TestDownloadArtwork:
         assert _tmp(cache) not in file_store.files
 
 
+# ── TestUrlCoverFallback ──────────────────────────────────────────────────────
+
+
+class TestUrlCoverFallback:
+    """The url_cover fallback (#1450): a definitive 404 on the RomM cover asset
+    retries once against the ROM's external ``url_cover``.
+
+    The fallback bytes come from ``download_cover_from_url`` — the bearer-free
+    adapter path (the no-bearer guarantee itself is pinned on the HTTP adapter,
+    ``tests/adapters/romm/test_http.py::TestDownloadExternal``). Here we pin the
+    routing (fallback fires only on 404, records the applied source truthfully).
+    """
+
+    _URL_COVER = "https://cdn.example.com/grid/abc.png"
+
+    @pytest.mark.asyncio
+    async def test_404_falls_back_to_url_cover_and_records_applied_source(
+        self, artwork_service, steam_config, file_store, romm_api, cover_cache_dir, tmp_path
+    ):
+        steam_config.grid_dir.return_value = str(tmp_path / "grid")
+        romm_api.download_cover.side_effect = RommNotFoundError("HTTP 404: Not Found")
+        romm_api.download_cover_from_url.side_effect = _writing_download(file_store, b"cdn art")
+
+        applied: dict[int, str] = {}
+        roms = [{"id": 42, "name": "Game", "path_cover_large": "/cover.png", "url_cover": self._URL_COVER}]
+        result = await artwork_service.download_artwork(
+            roms, emit_progress=_noop_emit_progress, is_cancelling=_not_cancelling, applied_sources=applied
+        )
+
+        cache = _cache(cover_cache_dir, 42)
+        assert result[42] == cache
+        assert file_store.files[cache] == b"cdn art"
+        assert _tmp(cache) not in file_store.files
+        # The external url_cover was fetched into the .tmp sidecar (not the RomM path).
+        romm_api.download_cover_from_url.assert_called_once()
+        assert romm_api.download_cover_from_url.call_args[0] == (self._URL_COVER, _tmp(cache))
+        # The applied source is the url_cover, not the 404'd path_cover.
+        assert applied[42] == self._URL_COVER
+
+    @pytest.mark.asyncio
+    async def test_404_without_url_cover_keeps_todays_failure(self, artwork_service, steam_config, romm_api, tmp_path):
+        steam_config.grid_dir.return_value = str(tmp_path / "grid")
+        romm_api.download_cover.side_effect = RommNotFoundError("HTTP 404: Not Found")
+
+        roms = [{"id": 42, "name": "Game", "path_cover_large": "/cover.png"}]  # no url_cover
+        result = await artwork_service.download_artwork(
+            roms, emit_progress=_noop_emit_progress, is_cancelling=_not_cancelling
+        )
+        assert 42 not in result
+        romm_api.download_cover_from_url.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_404_with_empty_url_cover_keeps_todays_failure(
+        self, artwork_service, steam_config, romm_api, tmp_path
+    ):
+        """An empty ``url_cover`` string is falsy — no fallback, today's path."""
+        steam_config.grid_dir.return_value = str(tmp_path / "grid")
+        romm_api.download_cover.side_effect = RommNotFoundError("HTTP 404: Not Found")
+
+        roms = [{"id": 42, "name": "Game", "path_cover_large": "/cover.png", "url_cover": ""}]
+        result = await artwork_service.download_artwork(
+            roms, emit_progress=_noop_emit_progress, is_cancelling=_not_cancelling
+        )
+        assert 42 not in result
+        romm_api.download_cover_from_url.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_404_and_url_cover_also_failing_gives_up_once(
+        self, artwork_service, steam_config, file_store, romm_api, cover_cache_dir, tmp_path
+    ):
+        steam_config.grid_dir.return_value = str(tmp_path / "grid")
+        romm_api.download_cover.side_effect = RommNotFoundError("HTTP 404: Not Found")
+        romm_api.download_cover_from_url.side_effect = RommNotFoundError("HTTP 404: cdn miss")
+
+        roms = [{"id": 42, "name": "Game", "path_cover_large": "/cover.png", "url_cover": self._URL_COVER}]
+        result = await artwork_service.download_artwork(
+            roms, emit_progress=_noop_emit_progress, is_cancelling=_not_cancelling
+        )
+        assert 42 not in result
+        # Exactly one fallback attempt — the ROM is not retried in a loop.
+        romm_api.download_cover_from_url.assert_called_once()
+        # The broken write leaves no sidecar behind.
+        assert _tmp(_cache(cover_cache_dir, 42)) not in file_store.files
+
+    @pytest.mark.asyncio
+    async def test_transport_error_does_not_fall_back(self, artwork_service, steam_config, romm_api, tmp_path):
+        """A transient transport error keeps today's retry-ladder behaviour — the
+        url_cover fallback fires ONLY on a definitive 404."""
+        steam_config.grid_dir.return_value = str(tmp_path / "grid")
+        romm_api.download_cover.side_effect = RommConnectionError("connection refused")
+
+        roms = [{"id": 42, "name": "Game", "path_cover_large": "/cover.png", "url_cover": self._URL_COVER}]
+        result = await artwork_service.download_artwork(
+            roms, emit_progress=_noop_emit_progress, is_cancelling=_not_cancelling
+        )
+        assert 42 not in result
+        romm_api.download_cover_from_url.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_applied_url_cover_lets_refresh_detect_a_later_change(
+        self, artwork_service, steam_config, file_store, romm_api, cover_cache_dir, tmp_path
+    ):
+        """Recording url_cover as the applied source keeps the refresh compare
+        truthful: a later fetch whose fresh source is the (now-fixed) RomM
+        path_cover is detected as a change instead of being silently skipped."""
+        steam_config.grid_dir.return_value = str(tmp_path / "grid")
+        romm_api.download_cover.side_effect = RommNotFoundError("HTTP 404: Not Found")
+        romm_api.download_cover_from_url.side_effect = _writing_download(file_store, b"cdn art")
+
+        applied: dict[int, str] = {}
+        path_cover = "/cover.png?ts=2026-07-11 12:00:00"
+        roms = [{"id": 42, "name": "Game", "path_cover_large": path_cover, "url_cover": self._URL_COVER}]
+        await artwork_service.download_artwork(
+            roms, emit_progress=_noop_emit_progress, is_cancelling=_not_cancelling, applied_sources=applied
+        )
+
+        # The row's cover_source would be the applied url_cover.
+        registry = {"42": {"app_id": 99999, "cover_source": applied[42]}}
+        # A later sync fetches the (fixed) RomM asset — the compare flags it changed.
+        scan = scan_cover_refresh_candidates([{"id": 42, "path_cover_large": path_cover}], registry)
+        assert scan.changed == [(42, 99999, path_cover)]
+
+
 # ── TestRefreshChangedCovers ──────────────────────────────────────────────────
 
 
@@ -508,6 +633,36 @@ class TestRefreshChangedCovers:
         # The fresh fingerprint is persisted — the exact opaque string.
         with uow:
             assert uow.roms.get(42).cover_source == self._NEW
+
+    @pytest.mark.asyncio
+    async def test_404_falls_back_to_url_cover_and_persists_applied_source(
+        self, artwork_service, uow, steam_config, file_store, romm_api, cover_cache_dir, tmp_path
+    ):
+        """A 404 on the changed RomM cover retries against ``url_cover`` and
+        persists the url_cover as the fingerprint (the source actually applied,
+        #1450) — not the 404'd RomM path."""
+        grid_dir = str(tmp_path / "grid")
+        steam_config.grid_dir.return_value = grid_dir
+        cache = _cache(cover_cache_dir, 42)
+        file_store.files[cache] = b"stale"
+        _seed_rom(uow, 42, app_id=99999, cover_source=self._OLD)
+        url_cover = "https://cdn.example.com/grid/abc.png"
+        romm_api.download_cover.side_effect = RommNotFoundError("HTTP 404: Not Found")
+        romm_api.download_cover_from_url.side_effect = _writing_download(file_store, b"cdn art")
+
+        refreshed = await artwork_service.refresh_changed_covers(
+            [{"id": 42, "name": "Game", "path_cover_large": self._NEW, "url_cover": url_cover}],
+            _registry(uow),
+            emit_progress=_noop_emit_progress,
+            is_cancelling=_not_cancelling,
+        )
+
+        assert refreshed == [{"rom_id": 42, "app_id": 99999}]
+        romm_api.download_cover_from_url.assert_called_once()
+        assert file_store.files[cache] == b"cdn art"
+        assert file_store.files[os.path.join(grid_dir, "99999p.png")] == b"cdn art"
+        with uow:
+            assert uow.roms.get(42).cover_source == url_cover
 
     @pytest.mark.asyncio
     async def test_null_fingerprint_with_cache_adopts_without_download(
@@ -1200,6 +1355,21 @@ class TestFetchCoverBase64:
         assert result == {"base64": None}
 
     @pytest.mark.asyncio
+    async def test_404_falls_back_to_url_cover(self, artwork_service, romm_api, file_store, cover_cache_dir):
+        romm_api.get_rom.return_value = {
+            "id": 42,
+            "path_cover_large": "/c.png",
+            "url_cover": "https://cdn.example.com/x.png",
+        }
+        romm_api.download_cover.side_effect = RommNotFoundError("HTTP 404: Not Found")
+        romm_api.download_cover_from_url.side_effect = _writing_download(file_store, b"cdn cover")
+
+        result = await artwork_service.fetch_cover_base64(42)
+        assert base64.b64decode(result["base64"]) == b"cdn cover"
+        romm_api.download_cover_from_url.assert_called_once()
+        assert file_store.files[_cache(cover_cache_dir, 42)] == b"cdn cover"
+
+    @pytest.mark.asyncio
     async def test_cache_hit_read_error_returns_none(self, artwork_service, file_store, romm_api, cover_cache_dir):
         cache = _cache(cover_cache_dir, 42)
         file_store.files[cache] = b"data"
@@ -1386,6 +1556,37 @@ class TestRefreshCover:
         assert romm_api.download_cover.call_args[0][0] == "/small.png"
         with uow:
             assert uow.roms.get(42).cover_path == _cache(cover_cache_dir, 42)
+
+    @pytest.mark.asyncio
+    async def test_404_falls_back_to_url_cover_and_records_it(
+        self,
+        artwork_service,
+        uow,
+        steam_config,
+        file_store,
+        romm_api,
+        cover_cache_dir,
+        tmp_path,
+    ):
+        """A 404 on the RomM cover retries against ``url_cover`` and records the
+        url_cover as the confirmed fingerprint (the applied source, #1450)."""
+        grid = str(tmp_path / "grid")
+        steam_config.grid_dir.return_value = grid
+        _seed_rom(uow, 42, app_id=999, cover_path="")
+        url_cover = "https://cdn.example.com/x.png"
+        romm_api.get_rom.return_value = {"id": 42, "path_cover_large": "/c.png", "url_cover": url_cover}
+        romm_api.download_cover.side_effect = RommNotFoundError("HTTP 404: Not Found")
+        romm_api.download_cover_from_url.side_effect = _writing_download(file_store, b"cdn")
+
+        result = await artwork_service.refresh_cover(42)
+
+        cache = _cache(cover_cache_dir, 42)
+        assert result == {"success": True, "message": "Cover refreshed", "cover_path": cache}
+        romm_api.download_cover_from_url.assert_called_once()
+        assert file_store.files[cache] == b"cdn"
+        with uow:
+            assert uow.roms.get(42).cover_path == cache
+            assert uow.roms.get(42).cover_source == url_cover
 
     @pytest.mark.asyncio
     async def test_download_failure_does_not_mutate_rom(


### PR DESCRIPTION
Closes #1450

**Problem:** RomM's rom payload can point at cover resources whose files are missing server-side (observed live: both size variants 404 while `url_cover` — the external metadata-provider CDN — serves fine; RomM's own UI renders from `url_cover`, so the library looks intact while synced shortcuts stay gray).

**Change:**
- On a definitive 404 of the RomM cover asset, the download retries once with the rom's `url_cover` before giving up. Transport errors keep the existing retry ladder and never trigger the fallback; a missing `url_cover` keeps today's behavior.
- The external fetch is a separate, bearer-free adapter seam (`RommHttpAdapter.download_external`): it sends only the plugin User-Agent — the RomM token can structurally never reach the external host (test-pinned, including a url_cover pointing back at the RomM origin).
- Server-supplied `url_cover` schemes are allowlisted to http/https before any I/O — `file://`/`data:`/scheme-relative URLs are rejected without touching network or disk (test-pinned across seven scheme shapes). Broader SSRF hardening (post-DNS private-range blocking, per-redirect-hop revalidation) stays with #1182.
- `cover_source` records the source actually applied, so the cover-refresh comparison stays truthful: a repaired RomM asset or a changed CDN URL is detected as a change. Known bounded trade-off: a fallback-covered ROM re-fetches its cover once per sync until the server asset is repaired.

**Tests:** +22 backend — fallback-trigger matrix (404-only, transport error, missing url_cover, fallback also failing), no-Authorization + UA pinning, scheme-rejection parametrization, and a contract test proving the real reporter persists `cover_source=url_cover` end-to-end. Full gate green (pytest 5426; vitest 1985).

**Docs:** `docs/architecture/backend-architecture.md` — cover-flow section covers the fallback, the bearer-free seam, the scheme allowlist, and the re-fetch trade-off.