### PR TITLE
fix(ui): show cover-refresh progress in the unit line instead of a frozen 0/0

### DIFF
--- a/docs/user-guide/syncing-your-library.md
+++ b/docs/user-guide/syncing-your-library.md
@@ -63,7 +63,8 @@ A few things worth knowing for a large library:
   "Fetching Game Boy Advance (page 12/62)" then "Preparing covers for Game Boy Advance"), and the bar now edges forward
   through the fetch and cover phases as well — not only while shortcuts are being created. A platform whose cost is
   mostly its cover pull no longer shows a bar that sits frozen until the very end, and the bar never jumps backwards as
-  the phases hand over.
+  the phases hand over. When a platform's games are already up to date and only their cover art changed on the server,
+  the line counts those cover updates as they apply — "Game Boy: covers 37/140" — instead of resting at a bare "0/0".
 - **Cover art fills in as the run goes.** Covers appear on your library tiles progressively while the sync creates
   shortcuts, not only at the very end, so you can watch the library fill in. A few tiles may stay gray until the first
   time you open that game's page (or the next time Steam restarts) — that is expected and does not mean the cover is

--- a/src/components/MainPage.test.tsx
+++ b/src/components/MainPage.test.tsx
@@ -2929,6 +2929,50 @@ describe("MainPage", () => {
         logSpy.mockRestore();
       }
     });
+
+    it("does NOT feed the live-rate estimator on a cover-refresh applying frame (#1456)", async () => {
+      const etaSpy = vi.spyOn(syncEta, "observeApplyProgress");
+      try {
+        // Recover an in-flight applying run so the subscriber fires on applying frames.
+        vi.mocked(backend.getSyncStatus).mockResolvedValue({
+          running: true,
+          stage: "applying",
+          step: 2,
+          totalSteps: 8,
+          current: 5,
+          total: 200,
+          message: "PSX: 5/200",
+          runId: "run-cover-eta",
+        });
+        render(<MainPage onNavigate={vi.fn()} />);
+        await flushAsync();
+        etaSpy.mockClear();
+
+        // A normal shortcut-item applying frame DOES feed the estimator.
+        await act(async () => {
+          updateSyncProgress({ running: true, stage: "applying", step: 2, totalSteps: 8, current: 6, total: 200 });
+        });
+        expect(etaSpy).toHaveBeenCalledTimes(1);
+        etaSpy.mockClear();
+
+        // A cover-refresh applying frame carries a cover counter, not item
+        // progress (current is unchanged) — the estimator must NOT be fed, or the
+        // cover phase would distort the rate (#1456).
+        await act(async () => {
+          updateSyncProgress({
+            running: true,
+            stage: "applying",
+            step: 2,
+            totalSteps: 8,
+            message: "PSX: covers 37/140",
+            coverRefresh: true,
+          });
+        });
+        expect(etaSpy).not.toHaveBeenCalled();
+      } finally {
+        etaSpy.mockRestore();
+      }
+    });
   });
 
   describe("sync button label (resume vs fresh)", () => {

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -646,12 +646,19 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
             .then(setBudgetStatus)
             .catch((e) => logError(`Failed to refresh session budget status: ${e}`));
         } else {
-          // Feed the live-rate estimator from applying frames only (fetch frames
-          // carry page/cover counters, not item progress). syncEta re-anchors its
-          // sticky deadline internally; then mirror the current countdown into
-          // state here — the impure now-read must live in this subscriber (an
-          // event handler), never in render, which must stay pure.
-          if (progress.stage === "applying" && progress.step !== undefined && progress.current !== undefined) {
+          // Feed the live-rate estimator from applying frames that carry ITEM
+          // progress only — fetch frames carry page/cover counters, and an
+          // applying-stage cover-refresh frame (``coverRefresh``, #1456) carries a
+          // cover counter, not item progress, so both must be skipped. syncEta
+          // re-anchors its sticky deadline internally; then mirror the current
+          // countdown into state here — the impure now-read must live in this
+          // subscriber (an event handler), never in render, which must stay pure.
+          if (
+            progress.stage === "applying" &&
+            progress.step !== undefined &&
+            progress.current !== undefined &&
+            !progress.coverRefresh
+          ) {
             observeApplyProgress(progress.step, progress.current, Date.now());
           }
           setLiveEtaDisplay(displayedEtaSeconds(Date.now()));

--- a/src/types/sync.ts
+++ b/src/types/sync.ts
@@ -58,6 +58,18 @@ export interface SyncProgress {
    */
   subStage?: string;
   /**
+   * ``true`` on the frontend applying-stage frames that report cover-refresh
+   * progress (``processCoverRefreshes``) rather than shortcut-item progress
+   * (#1456). Frontend-only; the seed clears it at the start of every unit. Its
+   * one job is to keep the live-rate ETA honest: a cover-refresh frame carries a
+   * cover counter, not item progress, so the estimator must skip it exactly as it
+   * skips fetch/cover frames — see the ``observeApplyProgress`` gate in
+   * ``MainPage``. The counter itself surfaces only through ``message``; the bar's
+   * ``current``/``total`` are left untouched (they rest at the unit's apply
+   * position), so this flag has no bar effect.
+   */
+  coverRefresh?: boolean;
+  /**
    * Backend run identity for the in-flight sync, stamped from the backend's
    * ``current_sync_id``. ``""`` when no run is in flight. The authoritative
    * source a Cancel click scopes itself to — the frontend no longer mirrors a

--- a/src/utils/syncManager.test.ts
+++ b/src/utils/syncManager.test.ts
@@ -900,6 +900,84 @@ describe("syncManager — applies cover artwork to created shortcuts via the API
     expect(vi.mocked(backend.reportUnitResults)).toHaveBeenCalledWith({}, "run-cover-only", 1, 0);
   });
 
+  it("cover-only unit: the progress line advances a cover counter, never a frozen 0/0 (#1456)", async () => {
+    getExistingRomMShortcuts.mockResolvedValue(new Map<number, number>());
+    vi.mocked(backend.getArtworkBase64).mockImplementation(async (romId: number) => ({ base64: `COVER-${romId}` }));
+
+    // Capture every progress frame so we can "park" at each cover step and read
+    // the visible text, plus the coverRefresh marker each frame carries.
+    const messages: string[] = [];
+    const coverFlags: (boolean | undefined)[] = [];
+    const unsub = onSyncProgressChange(() => {
+      const p = getSyncProgress();
+      messages.push(p.message ?? "");
+      coverFlags.push(p.coverRefresh);
+    });
+
+    const data = chunkOf([], "run-cover-progress");
+    data.cover_refreshes = [
+      { rom_id: 10, app_id: 7010 },
+      { rom_id: 11, app_id: 7011 },
+      { rom_id: 12, app_id: 7012 },
+    ];
+
+    initUnitSyncManager();
+    await act(async () => {
+      emitDeckyEvent<[SyncApplyUnitData]>("sync_apply_unit", data);
+      await flush(300);
+    });
+    unsub();
+
+    // The line reads the advancing cover counter through the whole phase —
+    // "covers 0/3" the moment covers begin, then 1..3 — never the frozen "0/0".
+    expect(messages).toContain("PSX: covers 0/3");
+    expect(messages).toContain("PSX: covers 1/3");
+    expect(messages).toContain("PSX: covers 2/3");
+    expect(messages).toContain("PSX: covers 3/3");
+    expect(getSyncProgress().message).toBe("PSX: covers 3/3");
+    // The seed's "0/0" is never the last thing shown while busy.
+    expect(messages[messages.length - 1]).not.toBe("PSX: 0/0");
+    // Every cover frame is marked so the live-rate ETA skips it.
+    expect(coverFlags).toContain(true);
+  });
+
+  it("mixed unit: shortcut counter during shortcuts, cover counter during covers (#1456)", async () => {
+    // rom 1,2 are existing shortcuts (update path); the chunk also carries 3
+    // cover refreshes for other roms.
+    getExistingRomMShortcuts.mockResolvedValue(
+      new Map<number, number>([
+        [1, 5001],
+        [2, 5002],
+      ]),
+    );
+    vi.mocked(backend.getArtworkBase64).mockImplementation(async (romId: number) => ({ base64: `COVER-${romId}` }));
+
+    const messages: string[] = [];
+    const unsub = onSyncProgressChange(() => messages.push(getSyncProgress().message ?? ""));
+
+    const data = chunkOf([sc(1), sc(2)], "run-mixed-progress");
+    data.cover_refreshes = [
+      { rom_id: 77, app_id: 5077 },
+      { rom_id: 88, app_id: 5088 },
+      { rom_id: 99, app_id: 5099 },
+    ];
+
+    initUnitSyncManager();
+    await act(async () => {
+      emitDeckyEvent<[SyncApplyUnitData]>("sync_apply_unit", data);
+      await flush(400);
+    });
+    unsub();
+
+    // Shortcut phase: the item counter (against the 2 shortcut items).
+    expect(messages).toContain("PSX: 1/2");
+    expect(messages).toContain("PSX: 2/2");
+    // Cover phase: the cover counter (against the 3 cover refreshes).
+    expect(messages).toContain("PSX: covers 1/3");
+    expect(messages).toContain("PSX: covers 3/3");
+    expect(getSyncProgress().message).toBe("PSX: covers 3/3");
+  });
+
   it("fail-soft: one refresh entry's failure never blocks the rest or the ack (#1386)", async () => {
     getExistingRomMShortcuts.mockResolvedValue(new Map<number, number>());
     vi.mocked(backend.getArtworkBase64).mockResolvedValue({ base64: "COVERPNG" });

--- a/src/utils/syncManager.ts
+++ b/src/utils/syncManager.ts
@@ -268,13 +268,36 @@ async function applyCoverArtwork(appId: number, romId: number): Promise<void> {
  * heartbeats so a long refresh tail never trips the backend's per-unit
  * timeout. Runs BEFORE the chunk ack so the backend's wait covers this work.
  * Fail-soft per item; exits early on cancel.
+ *
+ * The unit progress line reflects the cover work — ``<unit>: covers x/y`` — so a
+ * cover-only unit no longer shows a frozen ``0/0`` for the whole cover phase
+ * (#1456). Each frame carries ``coverRefresh: true`` so the live-rate ETA skips
+ * it (a cover count is not item progress); ``current``/``total`` are left
+ * untouched so the coarse bar rests at the unit's apply position rather than
+ * re-animating off the cover count.
  */
-async function processCoverRefreshes(refreshes: { rom_id: number; app_id: number }[]): Promise<void> {
+async function processCoverRefreshes(data: SyncApplyUnitData): Promise<void> {
+  const refreshes = data.cover_refreshes ?? [];
+  const total = refreshes.length;
+  const showCoverProgress = (done: number): void => {
+    updateSyncProgress({
+      running: true,
+      stage: "applying",
+      message: `${data.unit_name}: covers ${done}/${total}`,
+      step: data.unit_index + 1,
+      totalSteps: data.total_units,
+      coverRefresh: true,
+    });
+  };
+  // Seed the counter before the first cover so the line reads ``covers 0/N`` at
+  // once, never the seed's ``0/0`` even for the first item's duration.
+  showCoverProgress(0);
   const completed = await pacedForEach(refreshes, (entry) => applyCoverArtwork(entry.app_id, entry.rom_id), {
     heartbeat: () => {
       syncHeartbeat().catch(() => {});
     },
     isCancelled: isCancelRequested,
+    onProgress: showCoverProgress,
   });
   if (!completed) logInfo("Per-unit cancel observed during cover refresh");
 }
@@ -460,6 +483,9 @@ export function initUnitSyncManager(): ReturnType<typeof addEventListener> {
         message: `${data.unit_name}: ${data.chunk_offset}/${data.unit_total}`,
         step: data.unit_index + 1,
         totalSteps: data.total_units,
+        // Clear any cover-refresh marker a prior unit left in the store so this
+        // unit's shortcut phase feeds the ETA again (#1456).
+        coverRefresh: false,
       });
 
       const { map: existing, liveAppIds } = await resolveExistingShortcuts(data.run_id);
@@ -470,7 +496,7 @@ export function initUnitSyncManager(): ReturnType<typeof addEventListener> {
       // Processed before the ack so the backend's per-unit wait (heartbeat-fed)
       // covers this work; a cancel observed above skips it entirely.
       if (!isCancelRequested() && data.cover_refreshes?.length) {
-        await processCoverRefreshes(data.cover_refreshes);
+        await processCoverRefreshes(data);
       }
 
       // Do NOT ack a cancelled unit: the backend has already discarded this


### PR DESCRIPTION
Closes #1456

**Problem:** A cover-only apply unit — e.g. after a server rescan that only re-stamps cover timestamps — showed `<platform>: 0/0` with a busy spinner for the whole cover phase (observed live: ~20 s at 140 covers). The unit counter counts shortcut items only; the unit's actual work ran uncounted next to it.

**Change:**
- `processCoverRefreshes` drives the unit progress line through `pacedForEach`'s `onProgress` hook: the line seeds `<unit>: covers 0/N` when the cover phase starts and advances per item. Mixed units keep the shortcut counter during shortcuts and switch to the cover counter during covers; units without cover refreshes render byte-identically to today.
- Cover frames carry a frontend-only `coverRefresh` marker that the ETA gate skips — a cover count is not item progress, so the estimator and the coarse progress bar behave exactly as before (`current`/`total` are never fed cover values, and the marker resets per unit so the next unit's shortcut phase feeds the ETA normally).

**Tests:** +3 — cover-only unit advances `covers 0/N…N/N` and never rests on `0/0` while busy; a mixed unit shows both phases; a `coverRefresh` frame provably bypasses the estimator while a normal item frame feeds it. Existing tests untouched. Full gate green (vitest 1988; pytest 5457).

**Docs:** `docs/user-guide/syncing-your-library.md` — the progress section notes the cover counter.