### PR TITLE
perf(saves): skip the post-upload confirm_download round-trip when the upload response proves is_current

### DIFF
--- a/docs/adr/0017-client-baseline-detection-authoritative-negotiate-is-transport.md
+++ b/docs/adr/0017-client-baseline-detection-authoritative-negotiate-is-transport.md
@@ -125,3 +125,16 @@ automatic POST path, still live for the version-switch flow),
 [#1013](https://github.com/danielcopper/decky-romm-sync/issues/1013) (byte-identical dedup),
 [#1061](https://github.com/danielcopper/decky-romm-sync/issues/1061) (legacy `slot:null` wire addressing, now
 migration-only).
+
+## Status note — 2026-07-17 (RomM 5.0.0)
+
+Re-verified against RomM 4.9.0 / 4.9.1 / 4.9.2 / 5.0.0. The negotiate session's per-device serialization is now
+bookkeeping-only: opening a session cancels this device's prior session rows, but nothing on the API-mode save paths
+reads session state, and there is no server-side session timeout (an unclosed session lingers until this device's next
+`negotiate` cancels it). Play sessions ship via the standalone `/api/play-sessions` route
+([ADR-0018](0018-native-play-session-tracking-additive-ingest.md)), not through the negotiate envelope. So the
+load-bearing reason the session stays is ecosystem interop with RomM's first-party device-sync clients — not any
+behaviour on our own paths. Decision unchanged: negotiate stays as transport. (Recorded with
+[#1458](https://github.com/danielcopper/decky-romm-sync/issues/1458), which skips the redundant post-upload
+`confirm_download` now that `add_save` / `update_save` are confirmed to upsert the uploader's sync row on every
+supported version.)

--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -134,10 +134,15 @@ migration is pending (#238).
 a POST with `overwrite=false` — see [Upload-time conflicts (the 409 backstop)](#upload-time-conflicts-the-409-backstop)
 below. The old in-place PUT is no longer on the automatic path.
 
-On the automatic path there is no PUT-in-place to bump, so the #748 "drop the PUT-bump" work is **moot** for it;
-`confirm_download` still runs after a successful POST to register this device as `is_current` on the newly created save.
-The version-switch flow (`versions.py`) keeps **both** the PUT-bump and `confirm_download` and is out of scope here —
-see [Version Switch Flow](#version-switch-flow-rollback).
+On the automatic path there is no PUT-in-place to bump, so the #748 "drop the PUT-bump" work is **moot** for it.
+`add_save` (POST) already upserts this device's `device_save_sync` row (`last_synced_at = updated_at`) and serializes it
+into the response's `device_syncs`, so `is_current` is true for us the moment the POST returns — the follow-up
+`confirm_download` ack is redundant and is **skipped** when the response proves us current (`_confirm_upload_sync`,
+#1458). The one path that still needs the ack is `add_save`'s content-dedup early-return: a byte-identical
+`overwrite=false` POST returns the matching save **before** the upsert with `is_current=false`, so the ack is the only
+writer of our sync row there. The version-switch flow (`versions.py`) runs the same `_confirm_upload_sync` after its PUT
+(a redundant idempotent re-ack, since the PUT upserts too) and is out of scope here — see
+[Version Switch Flow](#version-switch-flow-rollback).
 
 ## Save Slots
 
@@ -882,8 +887,8 @@ The façade delegates to `SyncEngine.resolve_sync_conflict`, whose rollback sub-
    - `keep_local` → `_resolve_conflict_keep_local` reads the server save's content hash. If it matches local (rare, but
      possible — both devices ended up at the same content via different paths), the server's id is adopted into state
      without re-uploading. Otherwise the local file is POSTed as a new version with `overwrite=true` — the user's
-     deliberate overwrite bypasses the 409 gate (#1276) — then `confirm_download` registers our device as
-     `is_current=true` on it.
+     deliberate overwrite bypasses the 409 gate (#1276). The POST's own `device_save_sync` upsert leaves us
+     `is_current=true`, so the redundant `confirm_download` ack is skipped (#1458).
    - `use_server` → `_resolve_conflict_use_server` downloads the picked save and writes it to the local path.
 
 The modal only accepts `keep_local` or `use_server`; `cancel` never reaches the backend. A wrong action string is
@@ -1026,13 +1031,13 @@ the actual file/server writes go through `SyncEngine`:
    `tracked_save_id` and `last_sync_hash` to the target version, so even if step 2 fails the local view is consistent
    with the target.
 2. **PUT to bump `updated_at`**: re-upload local content via `_do_upload_save(server_save=target_save)`. This issues a
-   PUT against the target save id with byte-identical content. RomM v4.8.1 fires the SQLAlchemy `onupdate=utc_now` hook
-   on every PUT regardless of whether the content changed, so `save.updated_at` becomes NOW. The target save is now
-   newest in the slot.
-3. **Confirm download**: `_do_upload_save` also calls `confirm_download(target_save_id, device_id)`. RomM v4.8.1's PUT
-   does **not** auto-upsert the calling device's `device_save_sync` row, so without this call our `is_current` would
-   evaluate `false` immediately after our own PUT. The dedicated `/api/saves/{id}/downloaded` endpoint upserts
-   `last_synced_at = save.updated_at` so the computed `is_current` flips back to `true` for us.
+   PUT against the target save id with byte-identical content. RomM fires the SQLAlchemy `onupdate=utc_now` hook on
+   every PUT regardless of whether the content changed, so `save.updated_at` becomes NOW; the same request also upserts
+   our `device_save_sync` row (`last_synced_at = updated_at`). The target save is now newest in the slot and
+   `is_current` is already `true` for us.
+3. **Confirm download (redundant)**: `_do_upload_save` still runs `_confirm_upload_sync`. On every supported RomM
+   version the PUT already upserted our sync row (step 2), so this ack is at most a redundant idempotent re-write of
+   `last_synced_at = save.updated_at`, not the load-bearing step it once was (#1458).
 4. **Update local state**: `_do_upload_save` records `tracked_save_id`, `last_sync_hash`, `last_sync_server_updated_at`,
    and friends from the post-PUT response, leaving local state consistent with the now-newest server save.
 
@@ -1097,17 +1102,23 @@ backstop for its automatic-upload conflict path (see
 [Upload-time conflicts (the 409 backstop)](#upload-time-conflicts-the-409-backstop)); an explicit `keep_local` sets
 `overwrite=true`, which skips the gate entirely.
 
-### PUT bumps `updated_at`, not the calling device's sync row
+### POST and PUT both upsert the calling device's sync row
 
-`PUT /api/saves/{id}` triggers SQLAlchemy's `onupdate=utc_now` hook on every PUT, so `save.updated_at` becomes the
-server's NOW even if the content is byte-identical. **It does not** upsert the calling device's
-`device_save_sync.last_synced_at`. The computed `is_current` flag therefore flips to `false` for the calling device
-immediately after the PUT response is observed (because `save.updated_at > sync.last_synced_at` for everyone, including
-us).
+Re-verified against RomM 4.9.0 / 4.9.1 / 4.9.2 / 5.0.0: both `POST /api/saves` (`add_save`) and `PUT /api/saves/{id}`
+(`update_save`) bump `save.updated_at` to the server's NOW **and** upsert the calling device's
+`device_save_sync.last_synced_at = updated_at`, serializing that row into the response's `device_syncs`. So after our
+own write we read back `is_current = true` (equality counts), without any follow-up call.
 
-To restore `is_current=true` for our device after a PUT, we must explicitly call `POST /api/saves/{id}/downloaded`,
-which upserts `last_synced_at = save.updated_at`. `_do_upload_save` does this unconditionally after every successful
-POST or PUT (best-effort — failures are logged at debug and don't fail the upload).
+This makes the dedicated `POST /api/saves/{id}/downloaded` ack **redundant on the normal upload path** — the sync engine
+skips it when the upload response already shows this device `is_current` (`_confirm_upload_sync`, #1458), saving one
+round-trip per uploaded file. The historical `v4.8.1` note claiming the PUT did **not** upsert the sync row is obsolete
+at the ≥ 4.9.0 floor.
+
+**The one exception — `add_save`'s content-dedup early-return.** A named-slot `overwrite=false` POST whose content hash
+matches an existing save in the slot returns that pre-existing save **before** the `device_save_sync` upsert (a stale
+row, or a synthesized `is_current=false` placeholder). On that path the ack is the only writer of our sync row, so
+`_confirm_upload_sync` fails open (any non-`is_current` response) and still fires. The ack stays best-effort — failures
+are logged at debug and never fail the upload.
 
 ### GET `/content?optimistic=true` auto-upserts the sync row
 
@@ -1121,10 +1132,10 @@ is not used by the sync flow.
 
 ### Implication for the sync algorithm
 
-Because `is_current` is computed and the only ways to make it `true` are PUT/POST followed by `confirm_download`, or a
-`GET /content?optimistic=true`, the algorithm can trust `is_current` as authoritative without further hashing. Row 8 in
-the matrix (no baseline yet, `is_current=true`, local exists) is the canonical adopt-baseline case: we believe the
-server's claim and write `last_sync_hash := local_hash` so future runs can detect drift.
+Because `is_current` is computed and the only ways to make it `true` are a PUT/POST (which upserts the uploader's sync
+row directly), or a `GET /content?optimistic=true`, the algorithm can trust `is_current` as authoritative without
+further hashing. Row 8 in the matrix (no baseline yet, `is_current=true`, local exists) is the canonical adopt-baseline
+case: we believe the server's claim and write `last_sync_hash := local_hash` so future runs can detect drift.
 
 ## Sync Flows
 

--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -140,9 +140,9 @@ into the response's `device_syncs`, so `is_current` is true for us the moment th
 `confirm_download` ack is redundant and is **skipped** when the response proves us current (`_confirm_upload_sync`,
 #1458). The one path that still needs the ack is `add_save`'s content-dedup early-return: a byte-identical
 `overwrite=false` POST returns the matching save **before** the upsert with `is_current=false`, so the ack is the only
-writer of our sync row there. The version-switch flow (`versions.py`) runs the same `_confirm_upload_sync` after its PUT
-(a redundant idempotent re-ack, since the PUT upserts too) and is out of scope here — see
-[Version Switch Flow](#version-switch-flow-rollback).
+writer of our sync row there. The version-switch flow (`versions.py`) routes through the same `_confirm_upload_sync`
+after its PUT — the PUT upserts too, so the ack is at most an idempotent re-ack (and is skipped if the PUT response
+already proves us current) — and is out of scope here — see [Version Switch Flow](#version-switch-flow-rollback).
 
 ## Save Slots
 
@@ -1106,8 +1106,10 @@ backstop for its automatic-upload conflict path (see
 
 Re-verified against RomM 4.9.0 / 4.9.1 / 4.9.2 / 5.0.0: both `POST /api/saves` (`add_save`) and `PUT /api/saves/{id}`
 (`update_save`) bump `save.updated_at` to the server's NOW **and** upsert the calling device's
-`device_save_sync.last_synced_at = updated_at`, serializing that row into the response's `device_syncs`. So after our
-own write we read back `is_current = true` (equality counts), without any follow-up call.
+`device_save_sync.last_synced_at = updated_at`. The POST additionally builds its response **after** that upsert, so the
+body's `device_syncs` shows us `is_current = true` (equality counts) the moment it returns. Whether the PUT response
+body carries `device_syncs` the same way is **unverified** — the skip logic is fail-open either way: a response that
+proves us current skips the ack, anything else (including a bare PUT body) still sends the idempotent ack.
 
 This makes the dedicated `POST /api/saves/{id}/downloaded` ack **redundant on the normal upload path** — the sync engine
 skips it when the upload response already shows this device `is_current` (`_confirm_upload_sync`, #1458), saving one

--- a/py_modules/services/saves/sync_engine/engine.py
+++ b/py_modules/services/saves/sync_engine/engine.py
@@ -612,8 +612,9 @@ class SyncEngine:
         because the local ``compute_sync_action`` matrix is the sole detection
         authority (ADR-0017). Any failure (transport error, or a 200 body missing
         ``session_id``) degrades to ``None``: the sync run proceeds without a
-        session envelope rather than aborting. A session the server never hears
-        completed times out server-side, so a missed close is harmless.
+        session envelope rather than aborting. An unclosed session lingers
+        harmlessly until this device's next ``negotiate`` cancels it, so a missed
+        close is harmless.
         """
         try:
             inventory = await self._loop.run_in_executor(None, self._build_inventory, rom_id)
@@ -630,9 +631,9 @@ class SyncEngine:
         """Close a negotiate session, reporting op counts (non-fatal).
 
         Invoked off-loop like :meth:`_write_save_state` and swallows any failure:
-        a session the server never hears closed times out server-side and is
-        cancelled by this device's next ``negotiate``, so a failed close must
-        never fail the sync run.
+        a session the server never hears closed lingers until it is cancelled by
+        this device's next ``negotiate``, so a failed close must never fail the
+        sync run.
         """
         try:
             await self._loop.run_in_executor(

--- a/py_modules/services/saves/sync_engine/matrix.py
+++ b/py_modules/services/saves/sync_engine/matrix.py
@@ -341,11 +341,26 @@ class MatrixExecutor:
             return None
         return default_slot or "default"
 
-    def _confirm_upload_sync(self, upload_id: int | None, device_id: str | None) -> None:
-        """Ack the uploaded save on the server's DeviceSaveSync row (non-fatal)."""
-        # RomM's upload endpoint updates updated_at but NOT last_synced_at,
-        # so is_current would be False on the next list_saves without this.
+    def _confirm_upload_sync(self, response: dict[str, Any], device_id: str | None) -> None:
+        """Ack the uploaded save on the server's DeviceSaveSync row, unless redundant.
+
+        ``add_save`` (POST) and ``update_save`` (PUT) both upsert this device's
+        DeviceSaveSync row (``synced_at = updated_at``) on every supported RomM
+        version and serialize it into the response's ``device_syncs`` — so the
+        ack is redundant on the normal upload path and is skipped when *response*
+        already shows this device ``is_current`` (one fewer round-trip per
+        uploaded file, #1458). The one path that still needs it is ``add_save``'s
+        content-dedup early-return: a named-slot ``overwrite=false`` POST whose
+        content matches an existing save returns *before* the upsert, reporting
+        ``is_current=false``, so the ack is the only writer of our sync row there.
+        Fail-open — any non-current / missing / unexpected response confirms.
+        Non-fatal: a failed ack is debug-logged and swallowed.
+        """
+        upload_id = response.get("id")
         if not device_id or not upload_id:
+            return
+        if _upload_response_proves_current(response, device_id):
+            self._log_debug(f"confirm_download after upload skipped for save {upload_id} (already current)")
             return
         try:
             self._romm_api.confirm_download(upload_id, device_id)
@@ -417,7 +432,7 @@ class MatrixExecutor:
         if slot:
             save_state.promote_slot_to_server(slot)
 
-        self._confirm_upload_sync(result.get("id"), device_id)
+        self._confirm_upload_sync(result, device_id)
 
         self._log_debug(f"Uploaded save: {filename} (emulator={emulator})")
         return result
@@ -868,6 +883,28 @@ class MatrixExecutor:
             f" synced={synced} errors={len(errors)}"
         )
         return synced, errors, conflicts
+
+
+def _upload_response_proves_current(response: dict[str, Any], device_id: str) -> bool:
+    """Whether *response* proves *device_id* already holds the current save.
+
+    RomM's ``add_save`` / ``update_save`` upsert the uploading device's
+    DeviceSaveSync row (``synced_at = updated_at``) and serialize it into the
+    response's ``device_syncs`` with ``is_current=true`` — except ``add_save``'s
+    content-dedup early-return, which returns the pre-existing save (its stale
+    row, or a synthesized ``is_current=false`` placeholder) *before* the upsert.
+    Reads the same ``device_syncs`` shape ``domain.sync_action`` reads. Fail-open:
+    only an entry for *device_id* whose ``is_current`` is exactly ``True`` counts;
+    any missing / non-list / otherwise-unexpected shape returns ``False`` so the
+    caller still confirms.
+    """
+    device_syncs = response.get("device_syncs")
+    if not isinstance(device_syncs, list):
+        return False
+    return any(
+        isinstance(ds, dict) and ds.get("device_id") == device_id and ds.get("is_current") is True
+        for ds in device_syncs
+    )
 
 
 def _file_state_to_dict(file_state: FileSyncState) -> dict[str, Any]:

--- a/py_modules/services/saves/versions.py
+++ b/py_modules/services/saves/versions.py
@@ -204,14 +204,15 @@ class VersionsService:
         1. Download id=save_id content → overwrite local file.
            ``do_download_save`` updates ``tracked_save_id`` /
            ``last_sync_hash`` to point at the target version locally.
-        2. PUT id=save_id with the same content. RomM v4.8.1 fires the
-           SQLAlchemy ``onupdate=utc_now`` hook, so ``save.updated_at``
-           becomes NOW and id=save_id is now newest in the slot — beating
-           anything else there.
-        3. ``do_upload_save`` calls ``confirm_download(save_id, device_id)``,
-           setting our ``last_synced_at = save.updated_at`` so
-           ``is_current`` evaluates true for us. Required because v4.8.1
-           PUT does NOT auto-upsert sync rows.
+        2. PUT id=save_id with the same content. RomM bumps
+           ``save.updated_at`` to NOW (the ``onupdate=utc_now`` hook) and
+           upserts our DeviceSaveSync row (``synced_at = updated_at``), so
+           id=save_id is now newest in the slot and ``is_current`` already
+           evaluates true for us.
+        3. ``do_upload_save`` acks via ``_confirm_upload_sync``. The PUT
+           already upserted our sync row (RomM's PUT auto-upserts on every
+           supported version), so this ack is at most a redundant idempotent
+           re-write, not the required step it was once described as (#1458).
         4. ``do_upload_save`` refreshes local sync state via
            ``update_file_sync_state`` to match the post-PUT response.
 

--- a/tests/contract/test_saves_confirm_skip.py
+++ b/tests/contract/test_saves_confirm_skip.py
@@ -1,0 +1,93 @@
+"""Contract tests for the post-upload confirm-download skip (#1458).
+
+Driven frontend-shaped through the real ``Plugin`` / ``bootstrap`` harness. A
+normal automatic upload leaves this device ``is_current`` via ``add_save``'s own
+DeviceSaveSync upsert, so the sync engine skips the redundant
+``POST /saves/{id}/downloaded`` ack. The one path that still needs the ack is
+``add_save``'s content-dedup early-return (a byte-identical POST that returns the
+matching save before the upsert, reporting ``is_current=false``).
+
+Both scenarios stay on the legacy ``compute_sync_action`` matrix path
+(``active_slot`` set, ``slot_confirmed`` unset) so the POST is actually
+dispatched, matching the ``test_saves_upload_409`` fixtures.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+
+from domain.rom_save_state import RomSaveState
+
+from ._seed import enable_save_sync, seed_install, seed_save_state, seed_server_save
+
+
+def _write_local_save(harness, *, system: str, content: bytes, filename: str) -> str:
+    """Write a real local save under the resolved saves dir; return its path."""
+    saves_dir = os.path.join(harness.plugin._retrodeck_paths.saves_path(), system)
+    os.makedirs(saves_dir, exist_ok=True)
+    path = os.path.join(saves_dir, filename)
+    with open(path, "wb") as fh:
+        fh.write(content)
+    return path
+
+
+async def test_normal_upload_skips_confirm_download(harness):
+    """A fresh upload into an empty slot: add_save upserts our sync row, so the
+    engine skips the confirm round-trip yet we still read back is_current."""
+    enable_save_sync(harness)
+    seed_install(harness, 42, system="gba", file_name="game.gba")
+    _write_local_save(harness, system="gba", content=b"first save", filename="game.srm")
+    seed_save_state(harness, 42, RomSaveState(active_slot="default", system="gba"))
+
+    result = await harness.plugin.sync_rom_saves(42)
+
+    assert result["success"] is True
+    assert result["synced"] == 1
+    assert result["conflicts"] == []
+    # Exactly one POST, overwrite=false, and NO confirm round-trip after it.
+    upload_calls = [c for c in harness.romm.call_log if c[0] == "upload_save"]
+    assert len(upload_calls) == 1
+    assert upload_calls[0][2]["overwrite"] is False
+    assert not any(c[0] == "confirm_download" for c in harness.romm.call_log)
+    # ...yet the device is genuinely current on the new save (add_save recorded
+    # the DeviceSaveSync row itself, so skipping the ack lost nothing).
+    listed = harness.romm.list_saves(42, device_id="device-1")
+    our_sync = next(ds for ds in listed[0]["device_syncs"] if ds["device_id"] == "device-1")
+    assert our_sync["is_current"] is True
+
+
+async def test_dedup_response_still_confirms_download(harness):
+    """A byte-identical re-upload hits add_save's content-dedup early-return: the
+    response reports is_current=false, so the confirm ack stays load-bearing."""
+    enable_save_sync(harness)
+    seed_install(harness, 42, system="gba", file_name="game.gba")
+    _write_local_save(harness, system="gba", content=b"reverted to older content", filename="game.srm")
+
+    # Head we are current on (branch 4 → Upload) and an older sibling version we
+    # never synced, both in the slot. The local edit diverged from the baseline,
+    # so the matrix POSTs — and the POST dedups against the older version.
+    seed_server_save(
+        harness, save_id=500, rom_id=42, slot="default", file_name="game.srm", updated_at="2026-03-02T00:00:00Z"
+    )
+    harness.romm.stage_device_sync(500, "device-1", "2026-03-02T00:00:00Z")
+    seed_server_save(
+        harness, save_id=400, rom_id=42, slot="default", file_name="game.srm", updated_at="2026-03-01T00:00:00Z"
+    )
+
+    state = RomSaveState(active_slot="default", system="gba")
+    state.adopt_baseline("game.srm", tracked_save_id=500, last_sync_hash=hashlib.md5(b"head content").hexdigest())
+    seed_save_state(harness, 42, state)
+
+    harness.romm.arm_add_save_dedup(400)
+
+    result = await harness.plugin.sync_rom_saves(42)
+
+    assert result["success"] is True
+    assert result["synced"] == 1
+    assert result["conflicts"] == []
+    upload_calls = [c for c in harness.romm.call_log if c[0] == "upload_save"]
+    assert len(upload_calls) == 1
+    # The dedup response was NOT provably current, so the confirm ack fired.
+    confirm_calls = [c for c in harness.romm.call_log if c[0] == "confirm_download"]
+    assert confirm_calls == [("confirm_download", (400, "device-1"), {})]

--- a/tests/fakes/_romm_save_semantics.py
+++ b/tests/fakes/_romm_save_semantics.py
@@ -42,6 +42,20 @@ def compute_is_current(last_synced_at: str | None, save_updated_at: str) -> bool
     return last_synced_at >= save_updated_at
 
 
+def with_absent_device_placeholder(device_syncs: list[dict[str, Any]], device_id: str | None) -> list[dict[str, Any]]:
+    """Ensure *device_id* appears in *device_syncs* as ``is_current=false``.
+
+    Models ``add_save``'s content-dedup early-return response (saves.py:67-76):
+    when the uploading device has no DeviceSaveSync row on the matched save, RomM
+    synthesizes an ``is_current=false`` placeholder for it. Existing rows (a stale
+    prior sync) pass through untouched — either way the uploading device reads as
+    not current, which is the discriminator the post-upload confirm keys on (#1458).
+    """
+    if device_id and not any(ds.get("device_id") == device_id for ds in device_syncs):
+        return [*device_syncs, {"device_id": device_id, "is_current": False, "last_synced_at": None}]
+    return device_syncs
+
+
 def tag_filename(filename: str, ts: str) -> str:
     """Insert a ``[ts]`` marker before the extension (slot POST filename tagging).
 

--- a/tests/fakes/fake_romm_api.py
+++ b/tests/fakes/fake_romm_api.py
@@ -36,7 +36,12 @@ from typing import TYPE_CHECKING, Any
 from models.cover import CoverRevalidation
 
 from domain.cover_refresh import _strip_cover_ts
-from fakes._romm_save_semantics import check_add_save_conflict, compute_is_current, tag_filename
+from fakes._romm_save_semantics import (
+    check_add_save_conflict,
+    compute_is_current,
+    tag_filename,
+    with_absent_device_placeholder,
+)
 from lib.errors import RommUnprocessableEntityError
 from lib.romm_paging import LIST_PAGE_SIZE
 
@@ -102,6 +107,9 @@ class FakeRommApi:
         # each save's ``device_syncs`` (and is_current) from it, and the
         # add_save 409 gate reads it. Seed directly via ``stage_device_sync``.
         self._device_sync_ledger: dict[tuple[str, int], str] = {}
+        # One-shot: arm the next slot POST to model add_save's content-dedup
+        # early-return against this save_id (see ``arm_add_save_dedup``).
+        self._dedup_next_upload_save_id: int | None = None
 
         # Pagination configurable per ROM listing endpoint. Tests can
         # tweak ``items_per_platform`` keyed by ``(platform_id,)``,
@@ -576,11 +584,26 @@ class FakeRommApi:
         filename = file_path[last_sep + 1 :] if last_sep >= 0 else file_path
 
         # PUT path: update the tracked save in place (no new version, no gate).
+        # The bare SaveSchema response carries no ``device_syncs``, so the
+        # post-upload confirm ack fails open and still fires here (#1458).
         if save_id is not None and save_id in self.saves:
             entry = self.saves[save_id]
             entry["updated_at"] = now
             entry["emulator"] = emulator
             return dict(entry)
+
+        # add_save content-dedup early-return (saves.py:253-267): a named-slot
+        # ``overwrite=false`` POST whose content matches an existing slot save
+        # returns that save BEFORE the DeviceSaveSync upsert, so the uploading
+        # device reads is_current=false and the confirm ack stays load-bearing.
+        if self._dedup_next_upload_save_id is not None and slot is not None and not overwrite:
+            dedup_id = self._dedup_next_upload_save_id
+            self._dedup_next_upload_save_id = None
+            existing = self.saves.get(dedup_id)
+            if existing is not None:
+                response = dict(existing)
+                response["device_syncs"] = with_absent_device_placeholder(self._device_syncs_for(existing), device_id)
+                return response
 
         # POST path. On a slot POST the real server refuses (409) to stack onto
         # a slot this device hasn't synced, and tags the stored filename so
@@ -610,7 +633,14 @@ class FakeRommApi:
             "download_path": f"/saves/{stored_filename}",
         }
         self.saves[new_save_id] = entry
-        return dict(entry)
+        # add_save upserts the uploading device's DeviceSaveSync row
+        # (synced_at = updated_at) and serializes device_syncs into the
+        # response — is_current=true for us, so the confirm ack is redundant
+        # here and the sync engine skips it (#1458).
+        self._record_device_sync(new_save_id, device_id)
+        response = dict(entry)
+        response["device_syncs"] = self._device_syncs_for(entry)
+        return response
 
     def download_save(self, save_id: int, dest_path: str) -> None:
         self._log("download_save", (save_id, dest_path))
@@ -751,6 +781,17 @@ class FakeRommApi:
         ``updated_at``; model a *never-synced* device by omitting the call.
         """
         self._device_sync_ledger[(device_id, save_id)] = last_synced_at
+
+    def arm_add_save_dedup(self, save_id: int) -> None:
+        """One-shot: model add_save's content-dedup early-return on the next slot POST.
+
+        The next named-slot ``overwrite=false`` POST returns *save_id* (as if the
+        uploaded content matched it) BEFORE any DeviceSaveSync upsert — no new save
+        row, no ledger write — with the uploading device reported ``is_current=false``.
+        Mirrors saves.py:253-267 so a test can exercise the dedup path where the
+        post-upload confirm ack is the only writer of our sync row (#1458).
+        """
+        self._dedup_next_upload_save_id = save_id
 
     def seed_foreign_save(
         self,

--- a/tests/fakes/fake_save_api.py
+++ b/tests/fakes/fake_save_api.py
@@ -6,7 +6,12 @@ import pathlib
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
-from fakes._romm_save_semantics import check_add_save_conflict, compute_is_current, tag_filename
+from fakes._romm_save_semantics import (
+    check_add_save_conflict,
+    compute_is_current,
+    tag_filename,
+    with_absent_device_placeholder,
+)
 
 if TYPE_CHECKING:
     from models.cover import CoverRevalidation
@@ -51,6 +56,9 @@ class FakeSaveApi:
         # each save's ``device_syncs`` (and is_current) from it, and the
         # add_save 409 gate reads it. Seed directly via ``stage_device_sync``.
         self._device_sync_ledger: dict[tuple[str, int], str] = {}
+        # One-shot: arm the next slot POST to model add_save's content-dedup
+        # early-return against this save_id (see ``arm_add_save_dedup``).
+        self._dedup_next_upload_save_id: int | None = None
         # Native play-session store (ADR-0018): rom_id -> stored session dicts.
         # ``ingest_play_sessions`` appends here and dedupes on
         # ``(device_id, rom_id, start_time)``.
@@ -108,6 +116,17 @@ class FakeSaveApi:
         ``updated_at``; model a *never-synced* device by omitting the call.
         """
         self._device_sync_ledger[(device_id, save_id)] = last_synced_at
+
+    def arm_add_save_dedup(self, save_id: int) -> None:
+        """One-shot: model add_save's content-dedup early-return on the next slot POST.
+
+        The next named-slot ``overwrite=false`` POST returns *save_id* (as if the
+        uploaded content matched it) BEFORE any DeviceSaveSync upsert — no new save
+        row, no ledger write — with the uploading device reported ``is_current=false``.
+        Mirrors saves.py:253-267 so a test can exercise the dedup path where the
+        post-upload confirm ack is the only writer of our sync row (#1458).
+        """
+        self._dedup_next_upload_save_id = save_id
 
     def seed_foreign_save(
         self,
@@ -522,6 +541,8 @@ class FakeSaveApi:
         now = stamp.isoformat()
 
         # PUT path: update the tracked save in place (no new version, no gate).
+        # The bare SaveSchema response carries no ``device_syncs``, so the
+        # post-upload confirm ack fails open and still fires here (#1458).
         if save_id and save_id in self.saves:
             size = self._capture_upload(save_id, file_path)
             entry = self.saves[save_id]
@@ -530,6 +551,19 @@ class FakeSaveApi:
             entry["emulator"] = emulator
             self.uploaded_files[save_id] = file_path
             return dict(entry)
+
+        # add_save content-dedup early-return (saves.py:253-267): a named-slot
+        # ``overwrite=false`` POST whose content matches an existing slot save
+        # returns that save BEFORE the DeviceSaveSync upsert, so the uploading
+        # device reads is_current=false and the confirm ack stays load-bearing.
+        if self._dedup_next_upload_save_id is not None and slot is not None and not overwrite:
+            dedup_id = self._dedup_next_upload_save_id
+            self._dedup_next_upload_save_id = None
+            existing = self.saves.get(dedup_id)
+            if existing is not None:
+                response = dict(existing)
+                response["device_syncs"] = with_absent_device_placeholder(self._device_syncs_for(existing), device_id)
+                return response
 
         # POST path. On a slot POST the real server refuses (409) to stack onto
         # a slot this device hasn't synced, and tags the stored filename so
@@ -578,7 +612,14 @@ class FakeSaveApi:
         }
         self.saves[save_id] = entry
         self.uploaded_files[save_id] = file_path
-        return dict(entry)
+        # add_save upserts the uploading device's DeviceSaveSync row
+        # (synced_at = updated_at) and serializes device_syncs into the
+        # response — is_current=true for us, so the confirm ack is redundant
+        # here and the sync engine skips it (#1458).
+        self._record_device_sync(save_id, device_id)
+        response = dict(entry)
+        response["device_syncs"] = self._device_syncs_for(entry)
+        return response
 
     def download_save(self, save_id: int, dest_path: str) -> None:
         self.call_log.append(("download_save", (save_id, dest_path), {}))

--- a/tests/services/saves/sync_engine/test_matrix.py
+++ b/tests/services/saves/sync_engine/test_matrix.py
@@ -364,19 +364,27 @@ class TestV47SyncFlow:
 
 
 class TestConfirmDownloadAfterSync:
-    """Verify the device's last_synced_at is registered with RomM after each
+    """Verify the device's last_synced_at ends up registered with RomM after each
     upload (PUT/POST) and download.
 
     is_current is computed server-side as
-    ``device_save_sync.last_synced_at >= save.updated_at``. PUT/POST bump
-    ``save.updated_at`` to NOW but do NOT touch the calling device's
-    ``last_synced_at`` in every code path; we explicitly close that gap by
-    calling ``confirm_download``. For downloads, the optimistic query-param on
-    ``download_save_content`` upserts the row server-side before streaming.
+    ``device_save_sync.last_synced_at >= save.updated_at``. ``add_save`` (POST)
+    and ``update_save`` (PUT) both upsert the calling device's
+    ``last_synced_at = updated_at`` on every supported RomM version, so a normal
+    upload leaves us current without a follow-up ack — the POST response proves
+    it and ``_confirm_upload_sync`` skips the redundant round-trip (#1458). The
+    ack stays load-bearing only on ``add_save``'s content-dedup early-return
+    (returns before the upsert, ``is_current=false``). For downloads, the
+    optimistic query-param on ``download_save_content`` upserts the row
+    server-side before streaming.
     """
 
-    def test_do_upload_save_post_calls_confirm_download(self, tmp_path):
-        """POST (no save_id) → confirm_download fires for the new save_id."""
+    def test_do_upload_save_post_skips_confirm_when_response_current(self, tmp_path):
+        """POST whose response proves us current → confirm_download is skipped (#1458).
+
+        The add_save upsert already made us ``is_current`` on the new save, so the
+        redundant ack is elided — but we still end up current on the next read.
+        """
         svc, fake = make_service(tmp_path)
         _set_device_id(svc, "dev-1")
         _install_rom(svc, tmp_path)
@@ -389,9 +397,15 @@ class TestConfirmDownloadAfterSync:
         # FakeSaveApi mints a new save_id starting from 1000 on POST
         new_save_id = next(iter(fake.saves.values()))["id"]
 
+        # The confirm round-trip is skipped — the upload response proved current.
         confirm_calls = [c for c in fake.call_log if c[0] == "confirm_download"]
-        assert len(confirm_calls) == 1
-        assert confirm_calls[0][1] == (new_save_id, "dev-1")
+        assert confirm_calls == []
+        # ...yet the device is genuinely current on the new save (the upload
+        # recorded the DeviceSaveSync row itself, so nothing is lost by skipping).
+        listed = fake.list_saves(42, device_id="dev-1")
+        our_sync = next(ds for ds in listed[0]["device_syncs"] if ds["device_id"] == "dev-1")
+        assert our_sync["is_current"] is True
+        assert new_save_id == listed[0]["id"]
 
     def test_do_upload_save_put_calls_confirm_download(self, tmp_path):
         """PUT (existing save_id) → confirm_download fires for that save_id."""
@@ -428,11 +442,20 @@ class TestConfirmDownloadAfterSync:
         assert confirm_calls == []
 
     def test_do_upload_save_swallows_confirm_download_error(self, tmp_path):
-        """confirm_download failure must NOT bubble — upload is reported successful."""
+        """confirm_download failure must NOT bubble — upload is reported successful.
+
+        Driven down the dedup early-return path (``is_current=false``), where the
+        ack still fires, so the swallow-the-error contract stays exercised (#1458).
+        """
         svc, fake = make_service(tmp_path)
         _set_device_id(svc, "dev-1")
         _install_rom(svc, tmp_path)
         save_path = _create_save(tmp_path)
+
+        # An existing "default"-slot save the POST content dedups against; the
+        # dedup response reports us is_current=false, so the ack still fires.
+        fake.saves[100] = _server_save(save_id=100, rom_id=42, slot="default")
+        fake.arm_add_save_dedup(100)
 
         # Patch confirm_download to raise; the upload itself must still complete.
         original_confirm = fake.confirm_download
@@ -474,6 +497,97 @@ class TestConfirmDownloadAfterSync:
         kwargs = dl_calls[0][2]
         assert kwargs["device_id"] == "dev-1"
         assert kwargs["optimistic"] is True
+
+
+class TestConfirmUploadSyncDiscriminator:
+    """``_confirm_upload_sync`` skips the ack only on a provably-current response.
+
+    The upload response's ``device_syncs`` is the discriminator: skip the
+    confirm round-trip only when THIS device is present with ``is_current=true``.
+    Every other shape — dedup ``is_current=false``, a different device, a missing
+    entry, no ``device_syncs`` at all, or a garbage shape — fails open and
+    confirms (#1458). Each case asserts the presence/absence of the
+    ``confirm_download`` call on the fake, never just that the call returned.
+    """
+
+    @staticmethod
+    def _matrix_and_fake(tmp_path):
+        svc, fake = make_service(tmp_path)
+        return svc._sync_engine._matrix, fake
+
+    @staticmethod
+    def _confirmed(fake) -> bool:
+        return any(c[0] == "confirm_download" for c in fake.call_log)
+
+    def test_skips_confirm_when_this_device_is_current(self, tmp_path):
+        matrix, fake = self._matrix_and_fake(tmp_path)
+        response = {"id": 500, "device_syncs": [{"device_id": "dev-1", "is_current": True}]}
+
+        matrix._confirm_upload_sync(response, "dev-1")
+
+        assert self._confirmed(fake) is False
+
+    def test_confirms_when_this_device_not_current(self, tmp_path):
+        matrix, fake = self._matrix_and_fake(tmp_path)
+        response = {"id": 500, "device_syncs": [{"device_id": "dev-1", "is_current": False}]}
+
+        matrix._confirm_upload_sync(response, "dev-1")
+
+        assert fake.call_log[-1] == ("confirm_download", (500, "dev-1"), {})
+
+    def test_confirms_when_only_a_different_device_is_current(self, tmp_path):
+        matrix, fake = self._matrix_and_fake(tmp_path)
+        response = {"id": 500, "device_syncs": [{"device_id": "other", "is_current": True}]}
+
+        matrix._confirm_upload_sync(response, "dev-1")
+
+        assert self._confirmed(fake) is True
+
+    def test_confirms_when_device_syncs_missing(self, tmp_path):
+        matrix, fake = self._matrix_and_fake(tmp_path)
+
+        matrix._confirm_upload_sync({"id": 500}, "dev-1")
+
+        assert self._confirmed(fake) is True
+
+    def test_confirms_when_device_syncs_empty(self, tmp_path):
+        matrix, fake = self._matrix_and_fake(tmp_path)
+
+        matrix._confirm_upload_sync({"id": 500, "device_syncs": []}, "dev-1")
+
+        assert self._confirmed(fake) is True
+
+    def test_confirms_when_device_syncs_not_a_list(self, tmp_path):
+        matrix, fake = self._matrix_and_fake(tmp_path)
+
+        matrix._confirm_upload_sync({"id": 500, "device_syncs": "garbage"}, "dev-1")
+
+        assert self._confirmed(fake) is True
+
+    def test_confirms_when_is_current_not_strictly_true(self, tmp_path):
+        matrix, fake = self._matrix_and_fake(tmp_path)
+        # A truthy-but-not-True value is "unexpected shape" → fail open, confirm.
+        response = {"id": 500, "device_syncs": [{"device_id": "dev-1", "is_current": "yes"}]}
+
+        matrix._confirm_upload_sync(response, "dev-1")
+
+        assert self._confirmed(fake) is True
+
+    def test_noop_when_no_device_id(self, tmp_path):
+        matrix, fake = self._matrix_and_fake(tmp_path)
+        response = {"id": 500, "device_syncs": [{"device_id": "dev-1", "is_current": False}]}
+
+        matrix._confirm_upload_sync(response, None)
+
+        assert self._confirmed(fake) is False
+
+    def test_noop_when_no_upload_id(self, tmp_path):
+        matrix, fake = self._matrix_and_fake(tmp_path)
+        response = {"device_syncs": [{"device_id": "dev-1", "is_current": False}]}
+
+        matrix._confirm_upload_sync(response, "dev-1")
+
+        assert self._confirmed(fake) is False
 
 
 class TestTrackedSaveIdMatching:


### PR DESCRIPTION
Closes #1458

`add_save` and `update_save` upsert the uploading device's `last_synced_at` on every supported RomM version (verified 4.9.0-5.0.0), so the post-upload `confirm_download` ack is redundant whenever the upload response already proves this device current. The one path that still needs it: `add_save`'s content-dedup early-return returns the existing save **before** the upsert — there the ack is the only writer of the device's sync row.

- `_confirm_upload_sync` now receives the full upload response and skips the ack only when its `device_syncs` shows this device with `is_current` strictly `True` — fail open everywhere else (dedup response, missing entry, unexpected shape): any doubt, confirm as before. Saves one round-trip per uploaded file.
- fakes model `add_save`'s dedup early-return (existing save returned before the upsert, `is_current=false` surface), pinned at unit + contract tier
- corrected the factually wrong rationale comment in `matrix.py`, the obsolete "v4.8.1 PUT does not auto-upsert" docstring in `versions.py`, and the unsupported "session times out server-side" claims in `engine.py` (RomM has no sync-session timeout — an unclosed session lingers until this device's next negotiate cancels it)
- ADR-0017: dated status note — at RomM 5.0.0 the negotiate session's per-device serialization is bookkeeping-only and play sessions ship via the standalone route; ecosystem interop is the load-bearing reason the session stays (decision unchanged)
- docs: `save-file-sync-architecture.md` updated; the PUT **response-body** shape is explicitly marked unverified (the skip is fail-open either way)

Merge gate: on-device — a normal upload shows no `POST /saves/{id}/downloaded` in the RomM access log with `is_current` intact; a dedup-hit upload (byte-identical restore) still fires the ack and the next local change syncs without a spurious conflict; version-switch/rollback unaffected.
