### PR TITLE
fix(sync): re-apply overview metadata on sync_complete

### DIFF
--- a/docs/architecture/steam-non-steam-shortcuts.md
+++ b/docs/architecture/steam-non-steam-shortcuts.md
@@ -185,7 +185,15 @@ applies the mutations with a **readiness retry** (the same `[0, 1s, 3s, 5s]` lad
 retry the pass runs before `appStore` is populated and silently no-ops on a cold boot, so the badge/rating/categories
 never appear until a later mount (#1203). The mutations are idempotent, so retries are safe.
 
-See: `src/patches/metadataPatches.ts`
+The pass also re-runs on **`sync_complete`**. A sync adds or re-keys ROMs whose metadata the init-time pass never saw,
+so `onSyncComplete` re-fetches the full paged metadata cache + appId map (`fetchMetadataCachePages`, shared with init),
+re-registers via `registerMetadataPatches` with the fresh data, and re-applies — mirroring the playtime re-apply beside
+it. It runs on every `sync_complete`, cancelled runs included (a partial run's committed units still carry fresh
+metadata, and the pass is idempotent), in its own detached block with its own error handling so a re-fetch failure never
+touches the toast, collections, or playtime paths (#1207). The backend commits metadata per unit during the sync (before
+the terminal emit), so this re-fetch always sees the new ROMs.
+
+See: `src/patches/metadataPatches.ts`, `src/utils/metadataCache.ts` (paged fetch), `onSyncComplete` in `src/index.tsx`
 
 ## VDF Format Notes
 

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -29,7 +29,14 @@ import { estimateApplySeconds } from "./utils/syncEstimate";
 import { resetEta, weightedCoarseFraction } from "./utils/syncEta";
 import { recordSyncCreated, resetSyncDelta, getSyncDelta } from "./utils/syncDeltaStore";
 import { resetSyncCancel } from "./utils/syncManager";
-import type { DownloadCompleteEvent, DownloadProgressEvent, SyncPlanData, SyncProgress, SyncStaleData } from "./types";
+import type {
+  DownloadCompleteEvent,
+  DownloadProgressEvent,
+  SyncPlanData,
+  SyncProgress,
+  SyncStaleData,
+  RomMetadata,
+} from "./types";
 
 vi.mock("./patches/gameDetailPatch", () => ({
   registerGameDetailPatch: vi.fn(),
@@ -87,7 +94,7 @@ vi.mock("./api/backend", async () => {
   };
 });
 
-import { applyAllPlaytime } from "./patches/metadataPatches";
+import { applyAllPlaytime, registerMetadataPatches, applyAllMetadata } from "./patches/metadataPatches";
 import { registerRomMAppId } from "./patches/gameDetailPatch";
 import definePluginResult from "./index";
 
@@ -769,6 +776,104 @@ describe("index.tsx — sync_complete stale-collection cleanup (#1040)", () => {
     // The additive create/update path is NOT gated on cancel — the platforms
     // that DID complete still get their collections.
     expect(createOrUpdateCollections).toHaveBeenCalledWith({ "Nintendo 64": [1] });
+    plugin.onDismount();
+  });
+});
+
+describe("index.tsx — sync_complete re-applies overview metadata (#1207)", () => {
+  type SyncCompletePayload = {
+    platform_app_ids: Record<string, number[]>;
+    romm_collection_app_ids?: Record<string, number[]>;
+    total_games: number;
+    cancelled?: boolean;
+  };
+
+  function meta(summary: string): RomMetadata {
+    return {
+      summary,
+      genres: [],
+      companies: [],
+      first_release_date: null,
+      average_rating: null,
+      game_modes: [],
+      player_count: "",
+      cached_at: 0,
+    };
+  }
+
+  beforeEach(() => {
+    vi.mocked(registerMetadataPatches).mockClear();
+    vi.mocked(applyAllMetadata).mockClear();
+    vi.mocked(applyAllMetadata).mockResolvedValue(undefined);
+    vi.mocked(applyAllPlaytime).mockResolvedValue(undefined);
+    vi.mocked(getAllPlaytime).mockResolvedValue({ playtime: {} });
+    // Init's own metadata fetch resolves empty; each test sets distinct fresh
+    // data AFTER init so the sync_complete re-fetch is provably re-fetched.
+    vi.mocked(getMetadataCachePage).mockResolvedValue({ items: {}, total: 0 });
+    vi.mocked(getAppIdRomIdMap).mockResolvedValue({});
+  });
+
+  it("re-fetches the paged cache + map and re-applies on a normal completion", async () => {
+    const plugin = pluginFactory();
+    await flush(); // init done — registerMetadataPatches called once with the empty init cache
+    vi.mocked(registerMetadataPatches).mockClear();
+    vi.mocked(applyAllMetadata).mockClear();
+
+    // The re-fetch after sync must see FRESH data, not the init-time empty cache.
+    vi.mocked(getMetadataCachePage).mockResolvedValue({ items: { "100": meta("Fresh") }, total: 1 });
+    vi.mocked(getAppIdRomIdMap).mockResolvedValue({ "100": 55 });
+
+    act(() => {
+      emitDeckyEvent<[SyncCompletePayload]>("sync_complete", { platform_app_ids: {}, total_games: 1 });
+    });
+    await flush();
+
+    // registerMetadataPatches received the RE-FETCHED cache + map (distinct page content).
+    expect(registerMetadataPatches).toHaveBeenCalledTimes(1);
+    const [cacheArg, mapArg] = vi.mocked(registerMetadataPatches).mock.calls[0]!;
+    expect((cacheArg as Record<string, RomMetadata>)["100"]!.summary).toBe("Fresh");
+    expect(mapArg).toEqual({ "100": 55 });
+    // …and the readiness-gated overview pass re-ran.
+    expect(applyAllMetadata).toHaveBeenCalledTimes(1);
+    plugin.onDismount();
+  });
+
+  it("re-applies overview metadata on a CANCELLED sync too (partial units are still fresh)", async () => {
+    const plugin = pluginFactory();
+    await flush();
+    vi.mocked(registerMetadataPatches).mockClear();
+    vi.mocked(applyAllMetadata).mockClear();
+    vi.mocked(getMetadataCachePage).mockResolvedValue({ items: { "7": meta("Partial") }, total: 1 });
+    vi.mocked(getAppIdRomIdMap).mockResolvedValue({ "7": 9 });
+
+    act(() => {
+      emitDeckyEvent<[SyncCompletePayload]>("sync_complete", { platform_app_ids: {}, total_games: 3, cancelled: true });
+    });
+    await flush();
+
+    expect(registerMetadataPatches).toHaveBeenCalledTimes(1);
+    expect(applyAllMetadata).toHaveBeenCalledTimes(1);
+    plugin.onDismount();
+  });
+
+  it("logs and leaves the other blocks intact when the metadata re-fetch fails", async () => {
+    const plugin = pluginFactory();
+    await flush();
+    vi.mocked(applyAllMetadata).mockClear();
+    vi.mocked(applyAllPlaytime).mockClear();
+    logError.mockClear();
+    // The paged re-fetch throws; the detached block's own catch logs it.
+    vi.mocked(getMetadataCachePage).mockRejectedValue(new Error("boom"));
+
+    act(() => {
+      emitDeckyEvent<[SyncCompletePayload]>("sync_complete", { platform_app_ids: {}, total_games: 1 });
+    });
+    await flush();
+
+    expect(logError).toHaveBeenCalledWith(expect.stringContaining("Failed to re-apply metadata after sync"));
+    expect(applyAllMetadata).not.toHaveBeenCalled();
+    // Non-vacuous: the playtime re-apply is a separate detached block and still ran.
+    expect(applyAllPlaytime).toHaveBeenCalled();
     plugin.onDismount();
   });
 });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -23,7 +23,6 @@ import {
 import { registerLaunchInterceptor, unregisterLaunchInterceptor } from "./utils/launchInterceptor";
 import { hasAnySaveConflict } from "./utils/saveStatus";
 import {
-  getMetadataCachePage,
   getAppIdRomIdMap,
   ensureDeviceRegistered,
   getSaveSyncSettings,
@@ -59,12 +58,12 @@ import type {
   SyncStaleData,
   SyncCollectionsData,
   ServerRetryProgressEvent,
-  RomMetadata,
 } from "./types";
 import { setLaunchOptionsConfirmed } from "./utils/steamShortcuts";
 import { removeShortcutsPaced } from "./utils/shortcutRemoval";
 import { batchConfirmLaunchOptions } from "./utils/launchOptionsReconcile";
 import { withTimeout } from "./utils/withTimeout";
+import { fetchMetadataCachePages } from "./utils/metadataCache";
 
 type Page = "main" | "settings" | "library" | "data" | "downloads" | "system";
 
@@ -202,22 +201,9 @@ export default definePlugin(() => {
     const appIdMap = await withTimeout(getAppIdRomIdMap(), CALLABLE_TIMEOUT);
 
     // Page the metadata cache until every row is collected. A failed page throws
-    // out of the loop (each raced against the same per-callable deadline) and
-    // the outer retry loop restarts init from offset 0. The empty-page guard
-    // stops the loop even if ``total`` overshoots the rows actually returned.
-    const cache: Record<string, RomMetadata> = {};
-    let collected = 0;
-    let total = Number.POSITIVE_INFINITY;
-    let offset = 0;
-    while (collected < total) {
-      const page = await withTimeout(getMetadataCachePage(offset, METADATA_PAGE_SIZE), CALLABLE_TIMEOUT);
-      total = page.total;
-      const keys = Object.keys(page.items);
-      if (keys.length === 0) break;
-      for (const key of keys) cache[key] = page.items[key]!;
-      collected += keys.length;
-      offset += METADATA_PAGE_SIZE;
-    }
+    // out of the shared loop (each raced against the per-callable deadline) and
+    // the outer retry loop restarts init from offset 0.
+    const cache = await fetchMetadataCachePages(METADATA_PAGE_SIZE, CALLABLE_TIMEOUT);
 
     registerMetadataPatches(cache, appIdMap);
 
@@ -504,6 +490,32 @@ export default definePlugin(() => {
           await applyAllPlaytime(playtime, appIdMap);
         } catch (e) {
           logError(`Failed to re-apply playtime after sync: ${e}`);
+        }
+      })(),
+    );
+
+    // Re-apply overview metadata (controller badge / metacritic score / store
+    // categories) to the freshly-synced ROMs. Init runs this pass once on mount,
+    // but onSyncComplete otherwise never re-runs it or refreshes the module-level
+    // metadata cache — so a ROM synced this session misses those overview fields
+    // until the next plugin mount (#1207). Re-fetch the full paged cache + the
+    // appId map, re-register the patches with the fresh data (replacing the
+    // init-time state), and re-apply. Mirrors the playtime re-apply above and
+    // runs on EVERY sync_complete, cancelled included: a partial run's committed
+    // units still have fresh metadata and applyAllMetadata is idempotent.
+    // Detached with its own try/catch so a re-fetch failure never breaks the
+    // toast, collections, or playtime paths.
+    detach(
+      (async () => {
+        try {
+          const [cache, appIdMap] = await Promise.all([
+            fetchMetadataCachePages(METADATA_PAGE_SIZE, CALLABLE_TIMEOUT),
+            getAppIdRomIdMap(),
+          ]);
+          registerMetadataPatches(cache, appIdMap);
+          await applyAllMetadata();
+        } catch (e) {
+          logError(`Failed to re-apply metadata after sync: ${e}`);
         }
       })(),
     );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -505,6 +505,13 @@ export default definePlugin(() => {
     // units still have fresh metadata and applyAllMetadata is idempotent.
     // Detached with its own try/catch so a re-fetch failure never breaks the
     // toast, collections, or playtime paths.
+    //
+    // Known last-writer-wins (deliberately no generation guard): if init is still
+    // on its #1206 retry ladder when a sync completes, a late init registration
+    // can land after this one and overwrite the fresher sync-time cache — a ROM
+    // synced this session then falls back to pre-fix behavior until the next
+    // sync_complete or mount. Self-healing and never below the old baseline, so
+    // it isn't worth the guard.
     detach(
       (async () => {
         try {

--- a/src/utils/metadataCache.test.ts
+++ b/src/utils/metadataCache.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import * as backend from "../api/backend";
+import { fetchMetadataCachePages } from "./metadataCache";
+import type { RomMetadata } from "../types";
+
+function meta(summary: string): RomMetadata {
+  return {
+    summary,
+    genres: [],
+    companies: [],
+    first_release_date: null,
+    average_rating: null,
+    game_modes: [],
+    player_count: "",
+    cached_at: 0,
+  };
+}
+
+describe("metadataCache — fetchMetadataCachePages", () => {
+  beforeEach(() => {
+    vi.mocked(backend.getMetadataCachePage).mockReset();
+  });
+
+  it("assembles multiple pages into one cache, paged by pageSize at ascending offsets", async () => {
+    vi.mocked(backend.getMetadataCachePage)
+      .mockResolvedValueOnce({ items: { "1": meta("A"), "2": meta("B") }, total: 4 })
+      .mockResolvedValueOnce({ items: { "3": meta("C"), "4": meta("D") }, total: 4 });
+
+    const cache = await fetchMetadataCachePages(2, 1000);
+
+    expect(Object.keys(cache).sort()).toEqual(["1", "2", "3", "4"]);
+    // Distinct page content actually reaches the assembled cache.
+    expect(cache["3"]!.summary).toBe("C");
+    expect(vi.mocked(backend.getMetadataCachePage)).toHaveBeenNthCalledWith(1, 0, 2);
+    expect(vi.mocked(backend.getMetadataCachePage)).toHaveBeenNthCalledWith(2, 2, 2);
+    expect(vi.mocked(backend.getMetadataCachePage)).toHaveBeenCalledTimes(2);
+  });
+
+  it("stops on an empty page even when total overshoots the rows returned", async () => {
+    vi.mocked(backend.getMetadataCachePage)
+      .mockResolvedValueOnce({ items: { "1": meta("A") }, total: 100 })
+      .mockResolvedValueOnce({ items: {}, total: 100 });
+
+    const cache = await fetchMetadataCachePages(1, 1000);
+
+    // The empty second page breaks the loop rather than spinning to total=100.
+    expect(Object.keys(cache)).toEqual(["1"]);
+    expect(vi.mocked(backend.getMetadataCachePage)).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns an empty cache when the only page is empty (total 0)", async () => {
+    vi.mocked(backend.getMetadataCachePage).mockResolvedValueOnce({ items: {}, total: 0 });
+
+    const cache = await fetchMetadataCachePages(500, 1000);
+
+    expect(cache).toEqual({});
+    expect(vi.mocked(backend.getMetadataCachePage)).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/utils/metadataCache.ts
+++ b/src/utils/metadataCache.ts
@@ -1,0 +1,35 @@
+import { getMetadataCachePage } from "../api/backend";
+import { withTimeout } from "./withTimeout";
+import type { RomMetadata } from "../types";
+
+/**
+ * Page the backend metadata cache until every row is collected, assembling the
+ * full ``appId → RomMetadata`` map.
+ *
+ * Metadata is paged so a large library never sends a multi-MB dump through the
+ * size-limited WebSocket bridge in a single callable response (#1025). Each page
+ * is raced against ``timeoutMs`` so a hung callable throws out of the loop — init
+ * lets its retry driver restart from offset 0, the sync_complete re-apply logs
+ * and moves on. The empty-page guard stops the loop even if ``total`` overshoots
+ * the rows actually returned. Shared by plugin-load init and the sync_complete
+ * re-apply so the pagination lives in exactly one place (#1207).
+ */
+export async function fetchMetadataCachePages(
+  pageSize: number,
+  timeoutMs: number,
+): Promise<Record<string, RomMetadata>> {
+  const cache: Record<string, RomMetadata> = {};
+  let collected = 0;
+  let total = Number.POSITIVE_INFINITY;
+  let offset = 0;
+  while (collected < total) {
+    const page = await withTimeout(getMetadataCachePage(offset, pageSize), timeoutMs);
+    total = page.total;
+    const keys = Object.keys(page.items);
+    if (keys.length === 0) break;
+    for (const key of keys) cache[key] = page.items[key]!;
+    collected += keys.length;
+    offset += pageSize;
+  }
+  return cache;
+}


### PR DESCRIPTION
Closes #1207

**Problem:** `onSyncComplete` re-applies playtime and re-registers appIds, but never re-runs the overview-metadata pass (Full Controller Support badge, rating, store categories) and never refreshes the module-level metadata cache populated at init — so freshly-synced ROMs miss those overview fields until the next plugin mount.

**Change:**
- The paged metadata-cache loop moved out of init into a shared `fetchMetadataCachePages` (`src/utils/metadataCache.ts`) — init behavior unchanged (same per-page timeout, empty-page guard, error propagation into the #1206 retry driver).
- `onSyncComplete` gains a detached block mirroring the playtime re-apply: re-fetch the paged cache + the appId→romId map, `registerMetadataPatches` with the fresh data, then `applyAllMetadata()` — the existing #1203 readiness-retry and idempotent mutations are reused as-is. Runs on every sync_complete including cancelled/interrupted syncs; a re-fetch failure is logged and leaves toast, collections, launch-options, and playtime untouched.
- Backend metadata is committed per-unit during the sync, before the terminal `sync_complete` emit, so the re-fetch always sees freshly-synced ROMs.

**Tests:** +6 — pagination helper (multi-page assembly, empty-page guard, empty cache) and a new sync_complete suite: the re-fetched cache provably reaches `registerMetadataPatches`, cancelled syncs re-apply too, and a re-fetch failure logs the specific message without breaking the playtime block. Full gate green (vitest 1994; pytest 5457).

**Docs:** `docs/architecture/steam-non-steam-shortcuts.md` §"Overview metadata mutations" — extended with the sync_complete re-apply.