### PR TITLE
feat(saves): store the server content_hash as the sync baseline; scheme parity becomes the no-history fallback

### DIFF
--- a/docs/architecture/database-design.md
+++ b/docs/architecture/database-design.md
@@ -508,6 +508,18 @@ persists without a re-download, so the upgrade never mass re-downloads a library
 before. Unlike the pin columns it rides the sync UPSERT, but the commit always writes the confirmed-else-preserved merge
 — a fingerprint advances only when the cache was actually confirmed against the server.
 
+`017_add_last_sync_server_hash.sql` (`user_version = 17`) adds the nullable `last_sync_server_hash TEXT` column to
+`rom_save_files` — the first schema change to a `FileSyncState` child
+([#1468](https://github.com/danielcopper/decky-romm-sync/issues/1468)) — a single
+`ALTER TABLE rom_save_files ADD COLUMN last_sync_server_hash TEXT;` with no backfill. It records the server's own
+`content_hash` for the save synced at the last baseline, so the save-sync identity check
+(`domain.sync_action._local_matches_server`) can compare two server-produced hashes (the stored one against the live
+`server.content_hash`) instead of relying on the client's local reimplementation of RomM's hashing — the **provenance**
+route, now primary. `NULL` means "no stored server hash": a pre-migration baseline (or a hash-only skip-adopt) uses the
+**parity** fallback (`local_hash == server.content_hash`, #1457) until the next full sync stamps a value. Written only
+alongside `last_sync_hash` at the recorded-baseline writer sites (`adopt_baseline`), so a stored server hash always
+truthfully pairs with its `last_sync_hash`.
+
 ## The runtime Unit of Work
 
 The schema is read and written at runtime through a **Unit of Work** (UoW) — the atomic transaction boundary one

--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -85,7 +85,10 @@ disjunction used at matrix rows 6d / 11a and the `resolve_upload_conflict` 409 b
 - **Parity (fallback).** A file with **no sync history on this device** (fresh reinstall, copied SD card, second device)
   has no stored server hash, so identity falls back to the direct `local_hash == server.content_hash` comparison — kept
   correct by the hash reproduction above (#1457). Branch 5's no-baseline slice and true fresh installs can only ever use
-  this route, by design.
+  this route, by design. Watch item: RomM's zip scheme is undocumented internal behavior and its author has publicly
+  sketched a metadata-based variant that does not match the shipped code — re-verify the zip branch of this fallback
+  against the RomM source on server version bumps. If it ever drifts, the fallback degrades to spurious conflict prompts
+  (never data loss); the stored-server-hash primary route is unaffected.
 
 The baseline pair is written together at the recorded-baseline writer sites (`update_file_sync_state` on upload/download
 and the keep_local adopt-without-upload path) with honest provenance per flow — the upload response's `content_hash`

--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -66,13 +66,35 @@ the negotiate inventory param. See
 The plugin reproduces this `content_hash` byte-for-byte so a save's local and server hashes agree and sync converges:
 single-file MD5 via `SaveFileStore.checksum_md5`, and the zip per-entry scheme via `SaveFileStore.content_hash` →
 `domain.save_hash.combine_zip_entry_hashes` (sorted `name:md5(entry)` lines joined by `\n`, then MD5'd; dispatch is by
-`zipfile.is_zipfile`, a content sniff, not the extension). This hash parity is the foundation the sync decision needs
+`zipfile.is_zipfile`, a content sniff, not the extension). This hash reproduction is what the sync decision needs
 ([ADR-0016](../adr/0016-save-sync-hands-detection-to-romm-negotiate.md) /
 [ADR-0017](../adr/0017-client-baseline-detection-authoritative-negotiate-is-transport.md) / #1234): the client's
-`compute_sync_action` compares each save's local `content_hash` against the server's `content_hash` (matrix rows 6d /
-11a and the `resolve_upload_conflict` 409 backstop) to decide `upload` / `download` / `conflict` / `no_op` without a
-download-and-rehash. The decision matrix runs for every ROM — including legacy `slot:null` saves, which RomM cannot
-address through the negotiate inventory param.
+`compute_sync_action` decides `upload` / `download` / `conflict` / `no_op` without a download-and-rehash, for every ROM
+— including legacy `slot:null` saves, which RomM cannot address through the negotiate inventory param.
+
+**Server-hash baseline; parity as the no-history fallback (#1468).** The identity question — "is my local file
+byte-identical to that server save?" — is answered by `domain.sync_action._local_matches_server`, a two-route
+disjunction used at matrix rows 6d / 11a and the `resolve_upload_conflict` 409 backstop:
+
+- **Provenance (primary).** At each sync boundary the plugin stores the server's own `content_hash` alongside the local
+  baseline, in `FileSyncState.last_sync_server_hash` (the `rom_save_files.last_sync_server_hash` column, added by
+  migration 017). While the local file is unchanged since that baseline (`local_hash == last_sync_hash`), identity is
+  proven by `last_sync_server_hash == server.content_hash` — two hashes RomM itself produced, so this route holds even
+  if the plugin's local hashing ever drifts from the server's. This is the robustness the issue buys: identity no longer
+  depends on the plugin's reimplementation staying byte-for-byte identical to RomM's scheme.
+- **Parity (fallback).** A file with **no sync history on this device** (fresh reinstall, copied SD card, second device)
+  has no stored server hash, so identity falls back to the direct `local_hash == server.content_hash` comparison — kept
+  correct by the hash reproduction above (#1457). Branch 5's no-baseline slice and true fresh installs can only ever use
+  this route, by design.
+
+The baseline pair is written together at the recorded-baseline writer sites (`update_file_sync_state` on upload/download
+and the keep_local adopt-without-upload path) with honest provenance per flow — the upload response's `content_hash`
+(RomM hashed the bytes it received), the adopted server save's `content_hash` on download — recording `None` when a
+response/save carries none rather than fabricating one from a local recomputation. The hash-only skip-adopt path
+(`update_baseline_hash`) keeps the stored server hash only while the local hash is unchanged and clears it when the hash
+changes, so a stored server hash always truthfully pairs with its `last_sync_hash`. The negotiate inventory
+(`build_save_inventory`) still sends the locally-computed `content_hash`: echoing the stored hash buys nothing while the
+computed hash already is RomM's scheme (#1457), and it stays the client's own statement of local content.
 
 Every local hash that reaches this comparison — the matrix's `local_hash`, the post-op baseline (`last_sync_hash`), the
 drift check, the slot-switch pending-changes check, and the keep_local adopt-without-upload probe — is computed with
@@ -342,12 +364,16 @@ unit-tested.
 - **`server_saves_in_slot`** — RomM save dicts already filtered to the active slot.
 - **`files_state`** — the per-filename baseline from the ROM's save state — the `FileSyncState` value object on the
   `RomSaveState` aggregate (persisted in the `rom_save_files` table), may be empty for a never-synced file. Carries
-  `tracked_save_id`, `last_sync_hash`, `last_sync_server_updated_at`, `last_sync_local_mtime`, etc.
+  `tracked_save_id`, `last_sync_hash` (our own hash of the local file at the last sync — the drift baseline),
+  `last_sync_server_hash` (the server's own `content_hash` for that same sync — the provenance anchor for the identity
+  check, `None` before this field existed or for a hash-only skip-adopt), `last_sync_server_updated_at`,
+  `last_sync_local_mtime`, etc.
 - **`device_id`** — this device's RomM-server ID (used to find our entry in `server_save.device_syncs`).
 - **`local_hash`** — pre-computed RomM-parity `content_hash` of `local_file` (zip-aware: a plain MD5 for a single-file
   save, the per-entry combined hash for a zipped multi-file save — `SaveFileStore.content_hash`, never the whole-archive
-  `checksum_md5`), or `None`. It **must** be the same scheme the server stamps so the byte-identity checks against
-  `server.content_hash` (rows 6d / 11a) can match for zip saves too (#1457).
+  `checksum_md5`), or `None`. It **must** be the same scheme the server stamps so the parity-route byte-identity checks
+  against `server.content_hash` (rows 6d / 11a) can match for zip saves too (#1457); the provenance route instead
+  compares the stored `last_sync_server_hash` against `server.content_hash` and needs no such agreement (#1468).
 
 ### Pick rule and discriminators
 
@@ -417,28 +443,30 @@ Dimensions:
 - **Local vs `last_sync_hash`** — _unchanged_, _changed_, or _no baseline_ (key missing in state).
 - **Local mtime vs server `updated_at`** — only consulted in the `never touched` branch where the algorithm has no other
   ordering signal.
-- **Content identity** — in the `never touched` branch, the server save's RomM-provided `content_hash` is compared to
-  the local content hash first; a match short-circuits to row 6d before mtime/baseline are consulted.
+- **Content identity** — in the `never touched` branch, byte-identity between the local file and the server head is
+  checked first (`_local_matches_server`: the stored `last_sync_server_hash` vs `server.content_hash` while local is
+  unchanged, else parity `local_hash == server.content_hash`); a match short-circuits to row 6d before mtime/baseline
+  are consulted (#1468).
 
-| #   | local file | server in slot | our entry     | local vs baseline | mtime vs server      | decision                            | reason                                                                                                                          |
-| --- | ---------- | -------------- | ------------- | ----------------- | -------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| 1   | no         | none           | n/a           | n/a               | n/a                  | `Skip(nothing_to_sync)`             | nothing local, nothing server                                                                                                   |
-| 2   | yes        | none           | n/a           | n/a               | n/a                  | `Upload(POST)`                      | first push for this save (or recovery after server-side wipe)                                                                   |
-| 3   | no         | ≥1             | never touched | n/a               | n/a                  | `Download(picked)`                  | no relation, pull newest                                                                                                        |
-| 4   | no         | ≥1             | current=true  | n/a               | n/a                  | `Download(picked)`                  | recovery — server still tracks our last version, local is gone                                                                  |
-| 5   | no         | ≥1             | current=false | n/a               | n/a                  | `Download(picked)`                  | server moved forward, nothing local to protect                                                                                  |
-| 6a  | yes        | ≥1             | never touched | no baseline       | local mtime ≥ server | `Upload(POST)`                      | post our local as a new save in the slot — no overwrite risk                                                                    |
-| 6b  | yes        | ≥1             | never touched | no baseline       | local mtime < server | `Download(picked)`                  | server is newer than our untracked local                                                                                        |
-| 6c  | yes        | ≥1             | never touched | changed           | n/a                  | **`Conflict(picked)`**              | baseline held from a prior sync but the picked head is a save we never synced — both sides moved (#1059)                        |
-| 6d  | yes        | ≥1             | never touched | any               | any                  | `Skip(synced, adopt_baseline=true)` | `server.content_hash == local_hash` — byte-identical to an existing server save; adopt it, never POST a duplicate (#1013)       |
-| 7   | yes        | ≥1             | current=true  | unchanged         | n/a                  | `Skip(synced)`                      | steady state                                                                                                                    |
-| 8   | yes        | ≥1             | current=true  | no baseline       | n/a                  | `Skip(synced, adopt_baseline=true)` | trust server's `is_current=true`, write `last_sync_hash := local_hash` so future drift can be detected                          |
-| 9   | yes        | ≥1             | current=true  | changed           | n/a                  | `Upload(supersede picked.id)`       | offline edit (plausible size) — POST our changes as a new version that supersedes the save the server still considers ours      |
-| 9b  | yes        | ≥1             | current=true  | changed           | n/a                  | **`Conflict(picked)`**              | diverged local is 0-byte or shrunk past the baseline (crash / full disk) — refuse the in-place PUT, let the user decide (#1062) |
-| 10  | yes        | ≥1             | current=false | unchanged         | n/a                  | `Download(picked)`                  | another device synced; we did nothing — adopt their version                                                                     |
-| 11a | yes        | ≥1             | current=false | no baseline       | n/a                  | `Download(picked)`                  | no baseline, but `server.content_hash == local_hash` — byte-identical, adopt the server head safely                             |
-| 11b | yes        | ≥1             | current=false | no baseline       | n/a                  | **`Conflict(picked)`**              | no baseline and content differs from the server head — cannot prove which side is newer; refuse the silent overwrite (#1276)    |
-| 12  | yes        | ≥1             | current=false | changed           | n/a                  | **`Conflict(picked)`**              | both sides changed independently — only true conflict                                                                           |
+| #   | local file | server in slot | our entry     | local vs baseline | mtime vs server      | decision                            | reason                                                                                                                                                                  |
+| --- | ---------- | -------------- | ------------- | ----------------- | -------------------- | ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | no         | none           | n/a           | n/a               | n/a                  | `Skip(nothing_to_sync)`             | nothing local, nothing server                                                                                                                                           |
+| 2   | yes        | none           | n/a           | n/a               | n/a                  | `Upload(POST)`                      | first push for this save (or recovery after server-side wipe)                                                                                                           |
+| 3   | no         | ≥1             | never touched | n/a               | n/a                  | `Download(picked)`                  | no relation, pull newest                                                                                                                                                |
+| 4   | no         | ≥1             | current=true  | n/a               | n/a                  | `Download(picked)`                  | recovery — server still tracks our last version, local is gone                                                                                                          |
+| 5   | no         | ≥1             | current=false | n/a               | n/a                  | `Download(picked)`                  | server moved forward, nothing local to protect                                                                                                                          |
+| 6a  | yes        | ≥1             | never touched | no baseline       | local mtime ≥ server | `Upload(POST)`                      | post our local as a new save in the slot — no overwrite risk                                                                                                            |
+| 6b  | yes        | ≥1             | never touched | no baseline       | local mtime < server | `Download(picked)`                  | server is newer than our untracked local                                                                                                                                |
+| 6c  | yes        | ≥1             | never touched | changed           | n/a                  | **`Conflict(picked)`**              | baseline held from a prior sync but the picked head is a save we never synced — both sides moved (#1059)                                                                |
+| 6d  | yes        | ≥1             | never touched | any               | any                  | `Skip(synced, adopt_baseline=true)` | byte-identical to an existing server save (stored server hash — provenance, or `content_hash == local_hash` — parity); adopt it, never POST a duplicate (#1013 / #1468) |
+| 7   | yes        | ≥1             | current=true  | unchanged         | n/a                  | `Skip(synced)`                      | steady state                                                                                                                                                            |
+| 8   | yes        | ≥1             | current=true  | no baseline       | n/a                  | `Skip(synced, adopt_baseline=true)` | trust server's `is_current=true`, write `last_sync_hash := local_hash` so future drift can be detected                                                                  |
+| 9   | yes        | ≥1             | current=true  | changed           | n/a                  | `Upload(supersede picked.id)`       | offline edit (plausible size) — POST our changes as a new version that supersedes the save the server still considers ours                                              |
+| 9b  | yes        | ≥1             | current=true  | changed           | n/a                  | **`Conflict(picked)`**              | diverged local is 0-byte or shrunk past the baseline (crash / full disk) — refuse the in-place PUT, let the user decide (#1062)                                         |
+| 10  | yes        | ≥1             | current=false | unchanged         | n/a                  | `Download(picked)`                  | another device synced; we did nothing — adopt their version                                                                                                             |
+| 11a | yes        | ≥1             | current=false | no baseline       | n/a                  | `Download(picked)`                  | no baseline (so parity only, #1468), but `server.content_hash == local_hash` — byte-identical, adopt the server head safely                                             |
+| 11b | yes        | ≥1             | current=false | no baseline       | n/a                  | **`Conflict(picked)`**              | no baseline and content differs from the server head — cannot prove which side is newer; refuse the silent overwrite (#1276)                                            |
+| 12  | yes        | ≥1             | current=false | changed           | n/a                  | **`Conflict(picked)`**              | both sides changed independently — only true conflict                                                                                                                   |
 
 Conflict happens in four rows — #12 (we already hold an entry on the picked save and our local diverged from the
 baseline), #6c (we hold a baseline from a prior sync but no entry on the picked head), #11b (we hold an

--- a/py_modules/adapters/repositories/rom_save_state.py
+++ b/py_modules/adapters/repositories/rom_save_state.py
@@ -29,7 +29,7 @@ _STATE_COLUMNS = (
     "rom_id, active_slot, slot_confirmed, emulator, system, last_synced_core, own_upload_ids, slots, last_sync_check_at"
 )
 _FILE_COLUMNS = (
-    "rom_id, filename, tracked_save_id, last_sync_hash, last_sync_at, "
+    "rom_id, filename, tracked_save_id, last_sync_hash, last_sync_server_hash, last_sync_at, "
     "last_sync_server_updated_at, last_sync_server_save_id, last_sync_server_size, "
     "last_sync_local_mtime, last_sync_local_size"
 )
@@ -39,6 +39,7 @@ def _row_to_file(row: sqlite3.Row) -> FileSyncState:
     return FileSyncState(
         tracked_save_id=row["tracked_save_id"],
         last_sync_hash=row["last_sync_hash"],
+        last_sync_server_hash=row["last_sync_server_hash"],
         last_sync_at=row["last_sync_at"],
         last_sync_server_updated_at=row["last_sync_server_updated_at"],
         last_sync_server_save_id=row["last_sync_server_save_id"],
@@ -97,13 +98,14 @@ class SqliteRomSaveStateRepository(BaseRepository):
         )
         self._conn.execute("DELETE FROM rom_save_files WHERE rom_id = ?", (rom_id,))
         self._conn.executemany(
-            f"INSERT INTO rom_save_files ({_FILE_COLUMNS}) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            f"INSERT INTO rom_save_files ({_FILE_COLUMNS}) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             [
                 (
                     rom_id,
                     filename,
                     file.tracked_save_id,
                     file.last_sync_hash,
+                    file.last_sync_server_hash,
                     file.last_sync_at,
                     file.last_sync_server_updated_at,
                     file.last_sync_server_save_id,

--- a/py_modules/db/migrations/017_add_last_sync_server_hash.sql
+++ b/py_modules/db/migrations/017_add_last_sync_server_hash.sql
@@ -1,0 +1,29 @@
+-- =============================================================================
+-- 017_add_last_sync_server_hash.sql — server-provided baseline hash on FileSyncState
+-- #1468 (server-hash baseline; parity demoted to the no-history fallback)
+-- =============================================================================
+--
+-- Adds a nullable column recording the server's own ``content_hash`` for the
+-- save synced at the last baseline. The identity check ("is my local file
+-- byte-identical to that server save?") now prefers comparing this stored,
+-- server-produced hash against the save's live ``content_hash`` (the provenance
+-- route, immune to a future drift between our local hashing and RomM's) and
+-- falls back to the parity recomputation (``local_hash == content_hash``, #1457)
+-- only for files with no sync history on this device.
+--
+-- NULL = no stored server hash. A pre-migration baseline (and every hash-only
+-- skip-adopt) reads NULL, so the identity check simply uses the parity fallback
+-- until the next full sync stamps a value — no data is invented from the
+-- migration, and no backfill is possible or needed.
+--
+-- Written only alongside ``last_sync_hash`` at the recorded-baseline writer
+-- sites (``adopt_baseline`` via ``update_file_sync_state`` on upload/download
+-- and the keep_local adopt-without-upload path); the hash-only
+-- ``update_baseline_hash`` clears it, so a stored server hash always truthfully
+-- pairs with its ``last_sync_hash``. Anchored on ``rom_save_files`` (the
+-- FileSyncState child of the RomSaveState aggregate).
+--
+-- Transaction-safe DDL only — the runner (adapters/sqlite_migrations.py) wraps
+-- BEGIN/COMMIT and stamps PRAGMA user_version = 17.
+-- -----------------------------------------------------------------------------
+ALTER TABLE rom_save_files ADD COLUMN last_sync_server_hash TEXT;  -- server's content_hash at last sync; NULL = none stored (parity fallback)

--- a/py_modules/domain/rom_save_state.py
+++ b/py_modules/domain/rom_save_state.py
@@ -32,15 +32,27 @@ from domain._aggregate import cosmic_aggregate
 
 @dataclass(frozen=True, slots=True)
 class FileSyncState:
-    """Per-file sync baseline — last-observed hash, sizes, and timestamps.
+    """Per-file sync baseline — last-observed hashes, sizes, and timestamps.
 
     Immutable value object owned by :class:`RomSaveState`; the aggregate builds
     one whole on :meth:`RomSaveState.adopt_baseline` so the newest-wins matrix
     can detect drift against it on the next sync.
+
+    ``last_sync_hash`` is our own content hash of the local file at the last
+    sync (the drift baseline). ``last_sync_server_hash`` is the server-provided
+    ``content_hash`` of that same sync — RomM's own digest of the bytes, stored
+    so an identity-vs-server check can compare two server-produced hashes
+    instead of relying on our local reimplementation staying byte-for-byte
+    identical to RomM's scheme (#1468). It is ``None`` for a baseline recorded
+    before this field existed or for a hash-only skip-adopt; the identity check
+    falls back to parity there. The two hashes are always recorded together at a
+    single sync event — never re-paired independently — so a stored server hash
+    truthfully corresponds to its ``last_sync_hash``.
     """
 
     tracked_save_id: int | None = None
     last_sync_hash: str | None = None
+    last_sync_server_hash: str | None = None
     last_sync_at: str = ""
     last_sync_server_updated_at: str = ""
     last_sync_server_save_id: int | None = None
@@ -73,6 +85,7 @@ class RomSaveState:
         *,
         tracked_save_id: int,
         last_sync_hash: str,
+        last_sync_server_hash: str | None = None,
         last_sync_at: str = "",
         last_sync_server_updated_at: str = "",
         last_sync_server_save_id: int | None = None,
@@ -85,8 +98,12 @@ class RomSaveState:
         The only way to add a file to ``files`` — enforces that every tracked
         file carries both a server save id and a hash baseline (invariant 1).
         Re-calling with an existing filename re-adopts the baseline under the
-        known ``tracked_save_id``. Raises ``ValueError`` if the id is not
-        positive or the hash is empty.
+        known ``tracked_save_id``. ``last_sync_server_hash`` is the server's own
+        ``content_hash`` for this sync (``None`` when the response/save carried
+        none — the identity check then falls back to parity, #1468); it is paired
+        with ``last_sync_hash`` here so the two always describe the same sync
+        event. Raises ``ValueError`` if the id is not positive or the hash is
+        empty.
         """
         if tracked_save_id <= 0:
             raise ValueError("tracked_save_id must be positive")
@@ -95,6 +112,7 @@ class RomSaveState:
         self.files[filename] = FileSyncState(
             tracked_save_id=tracked_save_id,
             last_sync_hash=last_sync_hash,
+            last_sync_server_hash=last_sync_server_hash,
             last_sync_at=last_sync_at,
             last_sync_server_updated_at=last_sync_server_updated_at,
             last_sync_server_save_id=last_sync_server_save_id,
@@ -111,16 +129,24 @@ class RomSaveState:
         save id to anchor a full baseline, but still wants to record the hash so
         a later run can detect offline-edit drift. Updates the hash in place when
         ``filename`` is already tracked (preserving its other anchors), else
-        creates a minimal :class:`FileSyncState` carrying just the hash. Raises
-        ``ValueError`` if the hash is empty.
+        creates a minimal :class:`FileSyncState` carrying just the hash.
+
+        ``last_sync_server_hash`` is kept only while the local hash is unchanged
+        (a re-adopt of the same content — the stored server hash still pairs with
+        it, so provenance survives repeated syncs and status reads); it is dropped
+        when the local hash actually changes, since this path has no server hash
+        for the new content and a stale one would pair a fresh ``last_sync_hash``
+        with a server hash from an unrelated sync — a false provenance match
+        (#1468). Raises ``ValueError`` if the hash is empty.
         """
         if not last_sync_hash:
             raise ValueError("last_sync_hash is required")
         existing = self.files.get(filename)
         if existing is None:
             self.files[filename] = FileSyncState(last_sync_hash=last_sync_hash)
-        else:
-            self.files[filename] = replace(existing, last_sync_hash=last_sync_hash)
+            return
+        server_hash = existing.last_sync_server_hash if existing.last_sync_hash == last_sync_hash else None
+        self.files[filename] = replace(existing, last_sync_hash=last_sync_hash, last_sync_server_hash=server_hash)
 
     def track_own_upload(self, save_id: int) -> None:
         """Attribute ``save_id`` to an upload we made (idempotent).

--- a/py_modules/domain/sync_action.py
+++ b/py_modules/domain/sync_action.py
@@ -37,15 +37,25 @@ Recovery: ``is_current=true`` + no local file means our last upload is
 still tracked on the server but the local copy disappeared. We download to
 recover the canonical content.
 
+Identity — "is my local file byte-identical to that server save?" — is decided
+by ``_local_matches_server`` (used at branches 5, 6, and the 409 backstop): the
+**primary** route compares the server hash we stored at the last sync
+(``last_sync_server_hash``) against the save's live ``content_hash`` while local
+is unchanged since baseline — both operands are hashes RomM produced, so it
+survives a future drift between our local hashing and the server's; the
+**fallback** route is the direct parity check ``local_hash == content_hash``,
+the only one available to a file with no sync history on this device (fresh
+reinstall, copied SD card, second device — branch 5's no-baseline slice and true
+fresh installs can *only* ever use it, by design). The stored server hash makes
+identity robust; parity stays correct (#1457) as the no-history fallback (#1468).
+
 When our device has never touched the picked save (no entry in
 ``device_syncs``) and the local file is present: first, if the local content is
-byte-identical to that server save — RomM stamps each save with a
-``content_hash``, so ``server.content_hash == local_hash`` proves identity
-without any I/O — we adopt it as the baseline (``Skip(adopt_baseline=True)``)
-rather than POSTing a duplicate of bytes the server already holds (copied SD
-card, restored backup, fresh reinstall). Otherwise, if we hold a baseline
-(``last_sync_hash``) and local has diverged from it, both sides moved — the
-chosen head is a save we never synced — so that is a ``Conflict``, the same as
+byte-identical to that server save (``_local_matches_server`` — provenance or
+parity), we adopt it as the baseline (``Skip(adopt_baseline=True)``) rather than
+POSTing a duplicate of bytes the server already holds. Otherwise, if we hold a
+baseline (``last_sync_hash``) and local has diverged from it, both sides moved —
+the chosen head is a save we never synced — so that is a ``Conflict``, the same as
 branch 5. And if we hold no baseline at all but the present local is not
 byte-identical to that head, its provenance is unknown and it collides with a
 save we never synced — likewise the "user decides" case, a ``Conflict`` in both
@@ -133,6 +143,46 @@ SyncAction = Skip | Upload | Download | Conflict
 # ---------------------------------------------------------------------------
 
 
+def _local_matches_server(
+    local_hash: str | None,
+    server_content_hash: str | None,
+    last_sync_hash: str | None,
+    last_sync_server_hash: str | None,
+) -> bool:
+    """Whether the present local file is byte-identical to a server save.
+
+    The single identity question the kernel asks wherever it must decide "are
+    these the same bytes?" — answered by a disjunction so a future divergence
+    between our local content-hash reimplementation and RomM's own hashing never
+    silently breaks it (#1468):
+
+    - **Provenance** (primary): the local file is unchanged since our recorded
+      baseline (``local_hash == last_sync_hash``) AND that baseline was synced
+      against this exact server content (``last_sync_server_hash ==
+      server_content_hash``). Every value in the two comparisons must be truthy —
+      an empty string proves nothing. Both operands are hashes RomM itself
+      produced (the stored one against the live one), so this route holds even if
+      our local hashing scheme drifts from the server's.
+    - **Parity** (fallback): the local content hash equals the server content
+      hash directly (``local_hash == server_content_hash``, both truthy). The
+      only route available to a file with no sync history on this device (fresh
+      reinstall, copied SD card, second device) — it has no stored server hash to
+      anchor provenance. Correct only while our ``content_hash`` reproduces
+      RomM's scheme (#1457), which is why it is the fallback, not the primary.
+
+    Truthiness guards mirror the kernel's ``not last_sync_hash`` convention:
+    uncertainty (a missing or empty hash on either side) never reads as a match.
+    """
+    if (
+        local_hash
+        and local_hash == last_sync_hash
+        and last_sync_server_hash
+        and last_sync_server_hash == server_content_hash
+    ):
+        return True
+    return bool(local_hash) and local_hash == server_content_hash
+
+
 def _local_mtime_ge_server_updated_at(local_file: dict[str, Any], server: dict[str, Any]) -> bool:
     """Return True iff local mtime is at-or-after the server save's updated_at.
 
@@ -185,7 +235,11 @@ def _decide_when_is_current(
 
 
 def _decide_when_not_current(
-    server: dict[str, Any], local_file: dict[str, Any] | None, local_hash: str | None, last_sync_hash: str | None
+    server: dict[str, Any],
+    local_file: dict[str, Any] | None,
+    local_hash: str | None,
+    last_sync_hash: str | None,
+    last_sync_server_hash: str | None,
 ) -> SyncAction:
     """Branch 5: ``our_entry`` exists but ``is_current=False`` (server moved past us)."""
     if local_file is None:
@@ -193,13 +247,13 @@ def _decide_when_not_current(
         return Download(server_save=server)
     if not last_sync_hash:
         # Local present but no baseline to prove it's unchanged. If it is
-        # byte-identical to this server save (RomM content_hash), adopting via
-        # download is harmless and re-establishes the baseline + is_current.
-        # Otherwise a present local of unknown provenance colliding with a
-        # moved-past head is the "no assumptions, user decides" case (#1276) —
-        # not a safe silent download.
-        server_hash = server.get("content_hash")
-        if server_hash and local_hash and server_hash == local_hash:
+        # byte-identical to this server save, adopting via download is harmless
+        # and re-establishes the baseline + is_current. With no baseline the
+        # identity check can only take the parity route (#1468) — there is no
+        # stored server hash to anchor provenance. Otherwise a present local of
+        # unknown provenance colliding with a moved-past head is the "no
+        # assumptions, user decides" case (#1276) — not a safe silent download.
+        if _local_matches_server(local_hash, server.get("content_hash"), last_sync_hash, last_sync_server_hash):
             return Download(server_save=server)
         return Conflict(server_save=server)
     if local_hash and local_hash != last_sync_hash:
@@ -209,15 +263,20 @@ def _decide_when_not_current(
 
 
 def _decide_when_no_entry(
-    server: dict[str, Any], local_file: dict[str, Any] | None, local_hash: str | None, last_sync_hash: str | None
+    server: dict[str, Any],
+    local_file: dict[str, Any] | None,
+    local_hash: str | None,
+    last_sync_hash: str | None,
+    last_sync_server_hash: str | None,
 ) -> SyncAction:
     """Branch 6: no ``device_syncs`` entry for our device on the chosen save."""
     if local_file is None:
         return Download(server_save=server)
-    # #1013: local content is byte-identical to this server save (RomM-provided
-    # content_hash) → adopt it as the baseline instead of POSTing a duplicate.
-    server_hash = server.get("content_hash")
-    if server_hash and local_hash and server_hash == local_hash:
+    # #1013 / #1468: local content is byte-identical to this server save → adopt
+    # it as the baseline instead of POSTing a duplicate. Identity is proven by
+    # the stored server hash when we hold one (provenance, immune to scheme
+    # drift) and by RomM's ``content_hash`` otherwise (parity fallback).
+    if _local_matches_server(local_hash, server.get("content_hash"), last_sync_hash, last_sync_server_hash):
         return Skip(reason="synced", adopt_baseline=True)
     if last_sync_hash and local_hash and local_hash != last_sync_hash:
         # Both sides moved — the chosen head is a save we never synced while
@@ -250,13 +309,18 @@ def compute_sync_action(
     - `local_file`: {"filename", "path", "size", "mtime"} or None
     - `server_saves_in_slot`: list of RomM API server-save dicts, already
       filtered by the caller to the relevant slot
-    - `files_state`: the per-filename slice of saved sync state (may be empty)
+    - `files_state`: the per-filename slice of saved sync state (may be empty).
+      ``last_sync_hash`` is our own content hash of the local file at the last
+      sync (the drift baseline); ``last_sync_server_hash`` is the server's own
+      ``content_hash`` for that same sync (``None`` before this field existed or
+      for a hash-only skip-adopt), the primary anchor for the identity check via
+      ``_local_matches_server``; ``last_sync_local_size`` backs the shrink guard.
     - `device_id`: this device's id (string)
     - `local_hash`: pre-computed RomM-parity content hash of local_file
       (zip-aware; a plain MD5 for a single-file save, the per-entry combined
       hash for a zip), or None when unknown. Must be computed the same way as
-      the server's ``content_hash`` so the byte-identity checks against it can
-      match for zip saves too.
+      the server's ``content_hash`` so the parity-route byte-identity checks
+      against it can match for zip saves too.
     """
     # 1. No server saves in slot.
     if not server_saves_in_slot:
@@ -275,19 +339,21 @@ def compute_sync_action(
     device_syncs = server.get("device_syncs") or []
     our_entry = next((ds for ds in device_syncs if ds.get("device_id") == device_id), None)
     last_sync_hash = files_state.get("last_sync_hash")
+    last_sync_server_hash = files_state.get("last_sync_server_hash")
     last_sync_local_size = files_state.get("last_sync_local_size")
 
     if our_entry and our_entry.get("is_current"):
         return _decide_when_is_current(server, local_file, local_hash, last_sync_hash, last_sync_local_size)
     if our_entry is not None:
-        return _decide_when_not_current(server, local_file, local_hash, last_sync_hash)
-    return _decide_when_no_entry(server, local_file, local_hash, last_sync_hash)
+        return _decide_when_not_current(server, local_file, local_hash, last_sync_hash, last_sync_server_hash)
+    return _decide_when_no_entry(server, local_file, local_hash, last_sync_hash, last_sync_server_hash)
 
 
 def resolve_upload_conflict(
     local_hash: str | None,
     last_sync_hash: str | None,
     server_content_hash: str | None = None,
+    last_sync_server_hash: str | None = None,
 ) -> Literal["download", "conflict"]:
     """Decide the fallback when an upload POST is rejected by RomM's 409.
 
@@ -297,9 +363,14 @@ def resolve_upload_conflict(
     Two provably-safe outcomes, else a user decision:
 
     - local is unchanged since our own recorded baseline
-      (``local_hash == last_sync_hash``), or byte-identical to what the server
-      now holds (``local_hash == server_content_hash``) → nothing of ours to
-      protect; adopt the server save via ``"download"``.
+      (``local_hash == last_sync_hash``), so we hold no un-synced work — nothing
+      of ours to protect; adopt the server save via ``"download"``.
+    - local is byte-identical to what the server now holds
+      (:func:`_local_matches_server`, provenance-first with a parity fallback) →
+      also ``"download"``. When local is unchanged since baseline this route is
+      already covered by the first check, so here it is the parity fallback that
+      earns its keep — a local that *diverged* from baseline yet reproduces the
+      server head byte-for-byte.
     - otherwise local carries changes AND the server independently moved (which
       is exactly what the 409 proves) → genuine two-sided divergence →
       ``"conflict"`` for the user to resolve.
@@ -312,6 +383,6 @@ def resolve_upload_conflict(
     """
     if local_hash and last_sync_hash and local_hash == last_sync_hash:
         return "download"
-    if local_hash and server_content_hash and local_hash == server_content_hash:
+    if _local_matches_server(local_hash, server_content_hash, last_sync_hash, last_sync_server_hash):
         return "download"
     return "conflict"

--- a/py_modules/services/saves/sync_engine/matrix.py
+++ b/py_modules/services/saves/sync_engine/matrix.py
@@ -206,7 +206,11 @@ class MatrixExecutor:
         active slot from *default_slot* so the first sync lands in the
         configured slot. The per-file baseline is recorded via
         :meth:`RomSaveState.adopt_baseline` — the server response always
-        carries the tracked save id.
+        carries the tracked save id. Its ``content_hash`` (RomM's own digest of
+        the bytes: the save it holds after a download, the bytes it received
+        after an upload) is stored as ``last_sync_server_hash`` so the next sync's
+        identity check can compare server-produced hashes; a response without one
+        records ``None`` and the identity check falls back to parity (#1468).
         """
         if not save_state.system and system:
             save_state.adopt_system(system)
@@ -239,6 +243,7 @@ class MatrixExecutor:
             filename,
             tracked_save_id=int(server_save_id),
             last_sync_hash=local_hash,
+            last_sync_server_hash=server_response.get("content_hash"),
             last_sync_at=now,
             last_sync_server_updated_at=server_response.get("updated_at", now) or now,
             last_sync_server_save_id=server_save_id,
@@ -536,6 +541,7 @@ class MatrixExecutor:
         local_path: str | None,
         local_hash: str | None,
         last_sync_hash: str | None,
+        last_sync_server_hash: str | None,
         options: SyncRunOptions,
         sink: DispatchSink,
     ) -> bool:
@@ -582,6 +588,7 @@ class MatrixExecutor:
                 local_path=local_path,
                 local_hash=local_hash,
                 last_sync_hash=last_sync_hash,
+                last_sync_server_hash=last_sync_server_hash,
                 options=options,
                 sink=sink,
             )
@@ -594,6 +601,7 @@ class MatrixExecutor:
         local_path: str,
         local_hash: str | None,
         last_sync_hash: str | None,
+        last_sync_server_hash: str | None,
         options: SyncRunOptions,
         sink: DispatchSink,
     ) -> bool:
@@ -618,7 +626,10 @@ class MatrixExecutor:
             sink.errors.append(f"{filename}: upload rejected by server and no server save found to reconcile")
             return False
         fresh = max(group, key=lambda s: parse_iso_to_epoch(s.get("updated_at")) or 0.0)
-        if resolve_upload_conflict(local_hash, last_sync_hash, fresh.get("content_hash")) == "download":
+        if (
+            resolve_upload_conflict(local_hash, last_sync_hash, fresh.get("content_hash"), last_sync_server_hash)
+            == "download"
+        ):
             self.do_download_save(
                 fresh, ctx.saves_dir, filename, ctx.save_state, ctx.device_id, ctx.system, options.default_slot
             )
@@ -635,6 +646,7 @@ class MatrixExecutor:
         local_path: str | None,
         local_hash: str | None,
         last_sync_hash: str | None,
+        last_sync_server_hash: str | None,
         options: SyncRunOptions,
         sink: DispatchSink,
     ) -> bool:
@@ -643,9 +655,9 @@ class MatrixExecutor:
         Centralises the I/O dispatch so ``sync_rom_saves`` stays declarative.
         Errors are caught and pushed onto ``sink.errors`` so a single failure
         can't abort the whole rom-level sync; conflicts land on
-        ``sink.conflicts``. ``ctx.rom_name`` + ``last_sync_hash`` are threaded
-        through for the upload 409 backstop (canonical-target regroup + hash
-        re-decision).
+        ``sink.conflicts``. ``ctx.rom_name`` + the stored baseline pair
+        (``last_sync_hash`` / ``last_sync_server_hash``) are threaded through for
+        the upload 409 backstop (canonical-target regroup + hash re-decision).
         """
         try:
             if isinstance(action, Skip):
@@ -664,6 +676,7 @@ class MatrixExecutor:
                     local_path=local_path,
                     local_hash=local_hash,
                     last_sync_hash=last_sync_hash,
+                    last_sync_server_hash=last_sync_server_hash,
                     options=options,
                     sink=sink,
                 )
@@ -880,6 +893,7 @@ class MatrixExecutor:
                 local_path=outcome.local_path,
                 local_hash=outcome.local_hash,
                 last_sync_hash=outcome.file_state.last_sync_hash,
+                last_sync_server_hash=outcome.file_state.last_sync_server_hash,
                 options=options,
                 sink=sink,
             ):
@@ -923,6 +937,7 @@ def _file_state_to_dict(file_state: FileSyncState) -> dict[str, Any]:
     return {
         "tracked_save_id": file_state.tracked_save_id,
         "last_sync_hash": file_state.last_sync_hash,
+        "last_sync_server_hash": file_state.last_sync_server_hash,
         "last_sync_at": file_state.last_sync_at,
         "last_sync_server_updated_at": file_state.last_sync_server_updated_at,
         "last_sync_server_save_id": file_state.last_sync_server_save_id,

--- a/py_modules/services/saves/sync_engine/rollback.py
+++ b/py_modules/services/saves/sync_engine/rollback.py
@@ -296,7 +296,13 @@ class RollbackOrchestrator:
 
         server_id = server.get("id")
         if server_hash and local_hash == server_hash and server_id is not None:
-            # Hashes match — adopt server's id without re-uploading.
+            # Hashes match — adopt server's id without re-uploading. Store the
+            # server's own ``content_hash`` (never our downloaded-and-recomputed
+            # ``server_hash``, which is parity-derived) as ``last_sync_server_hash``
+            # so a later identity check can take the provenance route; ``None``
+            # when the listed save carried no ``content_hash`` (the reason
+            # ``get_server_save_hash`` had to download to compare), falling back to
+            # parity (#1468).
             self._log_debug(
                 f"keep_local: hash matches server, adopting without upload (rom={rom_id} filename={target})"
             )
@@ -304,6 +310,7 @@ class RollbackOrchestrator:
                 target,
                 tracked_save_id=int(server_id),
                 last_sync_hash=local_hash,
+                last_sync_server_hash=server.get("content_hash"),
                 last_sync_at=self._clock.now().isoformat(),
                 last_sync_server_updated_at=server.get("updated_at", "") or "",
                 last_sync_server_save_id=server_id,

--- a/tests/adapters/repositories/test_rom_save_state.py
+++ b/tests/adapters/repositories/test_rom_save_state.py
@@ -60,6 +60,23 @@ class TestRoundTrip:
         assert loaded == state
         assert set(loaded.files) == {"save.srm", "save.state"}
 
+    def test_last_sync_server_hash_round_trips_value_and_none(self, uow: SqliteUnitOfWork):
+        # #1468 — the provenance anchor persists as a value and as NULL (parity
+        # fallback) across the rom_save_files column.
+        _seed_rom(uow, 5)
+        state = RomSaveState(
+            files={
+                "with.srm": FileSyncState(tracked_save_id=1, last_sync_hash="h1", last_sync_server_hash="srv-h1"),
+                "without.srm": FileSyncState(tracked_save_id=2, last_sync_hash="h2"),  # no stored server hash
+            },
+        )
+        uow.rom_save_states.save(5, state)
+
+        loaded = uow.rom_save_states.get(5)
+        assert loaded is not None
+        assert loaded.files["with.srm"].last_sync_server_hash == "srv-h1"
+        assert loaded.files["without.srm"].last_sync_server_hash is None
+
     def test_slot_confirmed_bool_round_trips(self, uow: SqliteUnitOfWork):
         _seed_rom(uow, 5)
         uow.rom_save_states.save(5, RomSaveState(slot_confirmed=False))

--- a/tests/adapters/test_sqlite_migrations.py
+++ b/tests/adapters/test_sqlite_migrations.py
@@ -76,8 +76,9 @@ def _set_user_version(db_path: str, version: int) -> None:
 # + 009_add_last_session_start_monotonic + 010_add_sibling_group_key_index
 # + 011_rekey_sibling_group_key + 012_add_platform_sync_state
 # + 013_add_interrupted_sync_run_status + 014_add_paused_sync_run_status
-# + 015_add_applied_launch_options + 016_add_cover_source).
-_SHIPPED_VERSION = 16
+# + 015_add_applied_launch_options + 016_add_cover_source
+# + 017_add_last_sync_server_hash).
+_SHIPPED_VERSION = 17
 
 # Tables after every shipped migration: the v1 set plus 006's play-session outbox
 # and 012's per-platform completion stamp.
@@ -1051,6 +1052,57 @@ class Test016CoverSource:
         db_path = str(tmp_path / "romm_sync.db")
         apply_migrations(db_path, str(_only_migrations_through(tmp_path, 15)))
         assert "cover_source" not in _columns(db_path, "roms")
+
+
+class Test017LastSyncServerHash:
+    """017 — adds the nullable last_sync_server_hash column to rom_save_files only (#1468)."""
+
+    def test_adds_last_sync_server_hash_to_rom_save_files_only(self, tmp_path: Path):
+        # 017 ALTERs only rom_save_files; rom_save_states (and every other table) is untouched.
+        db_path = str(tmp_path / "romm_sync.db")
+
+        apply_migrations(db_path)
+
+        assert _user_version(db_path) == _SHIPPED_VERSION
+        assert "last_sync_server_hash" in _columns(db_path, "rom_save_files")
+        assert "last_sync_server_hash" not in _columns(db_path, "rom_save_states")
+
+    def test_existing_row_reads_null_across_the_migration(self, tmp_path: Path):
+        # A file baseline seeded before 017 reads NULL for the new column (no
+        # stored server hash → the identity check's parity fallback), the "no
+        # data invented" contract: a server hash is never fabricated by the
+        # migration, only stamped by a later real sync.
+        db_path = str(tmp_path / "romm_sync.db")
+        apply_migrations(db_path, str(_only_migrations_through(tmp_path, 16)))
+        conn = sqlite3.connect(db_path, isolation_level=None)
+        try:
+            conn.execute(
+                "INSERT INTO roms (rom_id, platform_slug, name, fs_name, last_synced_at) "
+                "VALUES (1, 'gba', 'Game', 'game.gba', '2026-07-11T10:00:00')"
+            )
+            conn.execute("INSERT INTO rom_save_states (rom_id) VALUES (1)")
+            conn.execute(
+                "INSERT INTO rom_save_files (rom_id, filename, last_sync_hash) VALUES (1, 'game.srm', 'deadbeef')"
+            )
+        finally:
+            conn.close()
+
+        assert apply_migrations(db_path) == _SHIPPED_VERSION
+
+        conn = sqlite3.connect(db_path)
+        try:
+            value = conn.execute(
+                "SELECT last_sync_server_hash FROM rom_save_files WHERE rom_id = 1 AND filename = 'game.srm'"
+            ).fetchone()[0]
+        finally:
+            conn.close()
+        assert value is None
+
+    def test_last_sync_server_hash_absent_before_017(self, tmp_path: Path):
+        # At v16 the column does not yet exist.
+        db_path = str(tmp_path / "romm_sync.db")
+        apply_migrations(db_path, str(_only_migrations_through(tmp_path, 16)))
+        assert "last_sync_server_hash" not in _columns(db_path, "rom_save_files")
 
 
 def test_shipped_migrations_dir_resolves_to_real_schema():

--- a/tests/contract/test_saves_server_hash_baseline.py
+++ b/tests/contract/test_saves_server_hash_baseline.py
@@ -1,0 +1,116 @@
+"""Contract tests for the server-hash baseline identity check (#1468).
+
+Drives the real ``Plugin`` over the real ``bootstrap`` to prove the two identity
+routes at the wire:
+
+- **Provenance** (primary): a file with sync history whose stored server hash
+  (``last_sync_server_hash``) matches the server head's ``content_hash`` syncs
+  cleanly even when the LOCALLY-recomputed parity hash no longer matches the
+  server's — the scheme-drift robustness the issue is about. No parity
+  agreement is consulted.
+- **Parity** (fallback): a fresh-install / copied-SD-card file with NO sync
+  history (no stored server hash) whose bytes are byte-identical to the server
+  head is still adopted via the direct ``local_hash == content_hash`` check.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+
+from domain.rom_save_state import FileSyncState, RomSaveState
+
+from ._seed import enable_save_sync, seed_install, seed_save_state, seed_server_save
+
+
+def _write_local_save(harness, *, system: str, content: bytes, filename: str) -> None:
+    saves_dir = os.path.join(harness.plugin._retrodeck_paths.saves_path(), system)
+    os.makedirs(saves_dir, exist_ok=True)
+    with open(os.path.join(saves_dir, filename), "wb") as fh:
+        fh.write(content)
+
+
+async def test_provenance_syncs_cleanly_under_scheme_drift(harness):
+    """A synced file whose local parity recomputation is forced to mismatch the
+    server's ``content_hash`` still syncs cleanly via the stored server hash.
+
+    The server head carries a ``content_hash`` (``drifted-server-hash``) that
+    does NOT equal the local file's real content hash — the exact situation a
+    change in RomM's hashing would produce. Because we stored that server hash at
+    the last sync AND the local file is unchanged since then, the provenance
+    route proves byte-identity without any parity agreement: the kernel adopts
+    (``Skip(adopt_baseline=True)``), so the sync transfers nothing and raises no
+    conflict.
+    """
+    enable_save_sync(harness)
+    seed_install(harness, 42, system="gba", file_name="game.gba")
+    content = b"unchanged local save bytes"
+    _write_local_save(harness, system="gba", content=content, filename="game.srm")
+    local_hash = hashlib.md5(content).hexdigest()
+
+    drifted_server_hash = "drifted-server-hash"
+    assert drifted_server_hash != local_hash  # parity would fail
+
+    # Sync history: our baseline matches the current local (unchanged) and stores
+    # the server's own hash from that sync.
+    state = RomSaveState(
+        active_slot="default",
+        slot_confirmed=True,
+        system="gba",
+        files={
+            "game.srm": FileSyncState(
+                tracked_save_id=100,
+                last_sync_hash=local_hash,
+                last_sync_server_hash=drifted_server_hash,
+            )
+        },
+    )
+    seed_save_state(harness, 42, state)
+
+    # The server head: same slot, no device_syncs row for us (branch 6), and a
+    # content_hash equal to our stored server hash but NOT the local parity hash.
+    entry = seed_server_save(harness, save_id=100, rom_id=42, slot="default", file_name="game.srm")
+    entry["content_hash"] = drifted_server_hash
+
+    status = await harness.plugin.get_save_status(42)
+    files = {f["filename"]: f for f in status["files"]}
+    assert files["game.srm"]["status"] == "synced"
+    assert status["conflicts"] == []
+
+    result = await harness.plugin.sync_rom_saves(42)
+    assert result["success"] is True
+    assert result["synced"] == 0
+    assert result["conflicts"] == []
+    assert result["errors"] == []
+
+    # Provenance carried it: no transfer despite the parity mismatch.
+    assert not any(c[0] == "upload_save" for c in harness.romm.call_log)
+    assert not any(c[0] == "download_save_content" for c in harness.romm.call_log)
+
+
+async def test_parity_fallback_adopts_fresh_install(harness):
+    """A fresh-install byte-identical file with NO sync history adopts via parity.
+
+    No baseline, so no stored server hash — the only route is the direct
+    ``local_hash == server.content_hash`` parity check. The byte-identical head
+    is adopted (``Skip(adopt_baseline=True)``), never re-POSTed as a duplicate.
+    """
+    enable_save_sync(harness)
+    seed_install(harness, 42, system="gba", file_name="game.gba")
+    content = b"fresh install identical bytes"
+    _write_local_save(harness, system="gba", content=content, filename="game.srm")
+    local_hash = hashlib.md5(content).hexdigest()
+
+    # Confirmed slot, but no per-file baseline (never synced this device).
+    seed_save_state(harness, 42, RomSaveState(active_slot="default", slot_confirmed=True, system="gba"))
+
+    entry = seed_server_save(harness, save_id=100, rom_id=42, slot="default", file_name="game.srm")
+    entry["content_hash"] = local_hash  # byte-identical → parity route
+
+    result = await harness.plugin.sync_rom_saves(42)
+    assert result["success"] is True
+    assert result["synced"] == 0
+    assert result["conflicts"] == []
+    assert result["errors"] == []
+    assert not any(c[0] == "upload_save" for c in harness.romm.call_log)
+    assert not any(c[0] == "download_save_content" for c in harness.romm.call_log)

--- a/tests/contract/test_saves_setup_migration_005_reconfirms_legacy_rom.py
+++ b/tests/contract/test_saves_setup_migration_005_reconfirms_legacy_rom.py
@@ -28,13 +28,14 @@ def _rewind_to_v4(db_path: str) -> None:
 
     Bootstrap stamps the DB at the latest version with the full schema. To replay
     the real 005 upgrade path the runner must see a genuine v4 database: the
-    version stamp AND the pre-006/007/008/009/010/011/015/016 schema (006's
+    version stamp AND the pre-006/007/008/009/010/011/015/016/017 schema (006's
     play-session outbox table absent and ``note_id`` present, 007's
     ``last_played`` column absent, 008's version-metadata columns absent, 009's
     ``last_session_start_monotonic`` column absent, 010's sibling_group_key index
     absent, 011's platform_sync_state table absent, 015's
-    ``applied_launch_options`` column absent, and 016's ``cover_source`` column
-    absent) so the sequential 005→…→016 re-run applies cleanly.
+    ``applied_launch_options`` column absent, 016's ``cover_source`` column
+    absent, and 017's ``last_sync_server_hash`` column absent) so the sequential
+    005→…→017 re-run applies cleanly.
     """
     conn = sqlite3.connect(db_path, isolation_level=None)
     try:
@@ -55,6 +56,8 @@ def _rewind_to_v4(db_path: str) -> None:
         conn.execute("ALTER TABLE roms DROP COLUMN applied_launch_options")
         # Reverse 016 so its ADD COLUMN re-applies instead of duplicating.
         conn.execute("ALTER TABLE roms DROP COLUMN cover_source")
+        # Reverse 017 so its ADD COLUMN re-applies instead of duplicating.
+        conn.execute("ALTER TABLE rom_save_files DROP COLUMN last_sync_server_hash")
         conn.execute("PRAGMA user_version = 4")
     finally:
         conn.close()

--- a/tests/domain/test_rom_save_state.py
+++ b/tests/domain/test_rom_save_state.py
@@ -34,6 +34,7 @@ class TestFileSyncState:
         fs = FileSyncState()
         assert fs.tracked_save_id is None
         assert fs.last_sync_hash is None
+        assert fs.last_sync_server_hash is None
         assert fs.last_sync_at == ""
         assert fs.last_sync_server_updated_at == ""
         assert fs.last_sync_server_save_id is None
@@ -55,6 +56,7 @@ class TestAdoptBaseline:
         assert fs.tracked_save_id == 11
         assert fs.last_sync_hash == "deadbeef"
         # Untouched optionals fall back to FileSyncState defaults.
+        assert fs.last_sync_server_hash is None
         assert fs.last_sync_at == ""
         assert fs.last_sync_server_updated_at == ""
         assert fs.last_sync_server_save_id is None
@@ -68,6 +70,7 @@ class TestAdoptBaseline:
             "game.srm",
             tracked_save_id=11,
             last_sync_hash="deadbeef",
+            last_sync_server_hash="srv-deadbeef",
             last_sync_at="2026-05-28T10:00:00",
             last_sync_server_updated_at="2026-05-28T09:00:00",
             last_sync_server_save_id=99,
@@ -78,6 +81,7 @@ class TestAdoptBaseline:
         fs = state.files["game.srm"]
         assert fs.tracked_save_id == 11
         assert fs.last_sync_hash == "deadbeef"
+        assert fs.last_sync_server_hash == "srv-deadbeef"
         assert fs.last_sync_at == "2026-05-28T10:00:00"
         assert fs.last_sync_server_updated_at == "2026-05-28T09:00:00"
         assert fs.last_sync_server_save_id == 99
@@ -142,6 +146,44 @@ class TestUpdateBaselineHash:
         assert fs.last_sync_at == "2026-05-28T10:00:00"
         assert fs.last_sync_server_save_id == 99
         assert fs.last_sync_server_size == 2048
+
+    def test_clears_stale_server_hash_when_hash_changes(self):
+        # A changed local hash has no server hash for the new content; a kept
+        # stale one would pair a fresh last_sync_hash with an unrelated server
+        # hash, which the provenance identity check would misread (#1468).
+        state = RomSaveState()
+        state.adopt_baseline(
+            "game.srm",
+            tracked_save_id=11,
+            last_sync_hash="old",
+            last_sync_server_hash="srv-old",
+        )
+        state.update_baseline_hash("game.srm", "new")
+        fs = state.files["game.srm"]
+        assert fs.last_sync_hash == "new"
+        assert fs.last_sync_server_hash is None
+
+    def test_keeps_server_hash_when_hash_unchanged(self):
+        # A re-adopt of the SAME content (e.g. a status read or repeat sync of an
+        # unchanged file) keeps the stored server hash — it still pairs with the
+        # unchanged last_sync_hash, so provenance survives repeated evaluation
+        # (#1468).
+        state = RomSaveState()
+        state.adopt_baseline(
+            "game.srm",
+            tracked_save_id=11,
+            last_sync_hash="same",
+            last_sync_server_hash="srv-same",
+        )
+        state.update_baseline_hash("game.srm", "same")
+        fs = state.files["game.srm"]
+        assert fs.last_sync_hash == "same"
+        assert fs.last_sync_server_hash == "srv-same"
+
+    def test_minimal_entry_has_no_server_hash(self):
+        state = RomSaveState()
+        state.update_baseline_hash("game.srm", "abc123")
+        assert state.files["game.srm"].last_sync_server_hash is None
 
     def test_does_not_add_a_second_entry_on_update(self):
         state = RomSaveState()

--- a/tests/domain/test_sync_action.py
+++ b/tests/domain/test_sync_action.py
@@ -690,6 +690,115 @@ def test_no_device_entry_diverged_baseline_with_different_content_hash_returns_c
     assert result == Conflict(server_save=server)
 
 
+# ---------------------------------------------------------------------------
+# #1468 — provenance-first identity (stored server hash), parity fallback
+# ---------------------------------------------------------------------------
+
+
+def test_no_device_entry_provenance_adopts_despite_scheme_drift():
+    """Branch 6 / #1468 — the whole point of the issue. We hold a baseline the
+    local still matches (``local_hash == last_sync_hash``) and a stored server
+    hash equal to the picked head's ``content_hash``, but the computed
+    ``local_hash`` DIFFERS from ``server.content_hash`` (a future drift between
+    our local hashing and RomM's). The parity route would miss the identity;
+    provenance — two server-produced hashes — proves it, so the head is adopted
+    (``Skip(adopt_baseline=True)``), never re-POSTed as a duplicate.
+    """
+    server = _server_save(
+        content_hash="server-scheme-hash",
+        device_syncs=[_device_sync(OTHER_DEVICE_ID, is_current=True)],
+    )
+    result = compute_sync_action(
+        local_file=_local(),
+        server_saves_in_slot=[server],
+        files_state={"last_sync_hash": "local-scheme-hash", "last_sync_server_hash": "server-scheme-hash"},
+        device_id=DEVICE_ID,
+        local_hash="local-scheme-hash",  # unchanged since baseline, but != server.content_hash
+    )
+    assert result == Skip(reason="synced", adopt_baseline=True)
+
+
+def test_not_current_provenance_does_not_apply_without_baseline():
+    """Branch 5 / #1468 — the no-baseline slice can only ever use parity, by
+    design. A stored server hash is impossible here (no baseline), so a scheme
+    drift where ``local_hash != server.content_hash`` cannot be rescued by
+    provenance → ``Conflict``, exactly as before this issue.
+    """
+    server = _server_save(
+        content_hash="server-scheme-hash",
+        device_syncs=[_device_sync(DEVICE_ID, is_current=False)],
+    )
+    result = compute_sync_action(
+        local_file=_local(),
+        server_saves_in_slot=[server],
+        files_state={},  # no baseline → no stored server hash
+        device_id=DEVICE_ID,
+        local_hash="local-scheme-hash",
+    )
+    assert result == Conflict(server_save=server)
+
+
+def test_no_device_entry_parity_adopts_fresh_install_no_stored_hash():
+    """Branch 6 / #1468 fallback — a fresh install / copied SD card has a local
+    file byte-identical to the server head but NO sync history (no baseline, no
+    stored server hash). Parity (``local_hash == server.content_hash``) is the
+    only route and still adopts (``Skip(adopt_baseline=True)``).
+    """
+    server = _server_save(
+        content_hash="same-hash",
+        device_syncs=[_device_sync(OTHER_DEVICE_ID, is_current=True)],
+    )
+    result = compute_sync_action(
+        local_file=_local(),
+        server_saves_in_slot=[server],
+        files_state={},  # no baseline, no last_sync_server_hash
+        device_id=DEVICE_ID,
+        local_hash="same-hash",
+    )
+    assert result == Skip(reason="synced", adopt_baseline=True)
+
+
+def test_no_device_entry_provenance_not_taken_when_local_changed():
+    """Branch 6 / #1468 poisoned input — a stored server hash equal to the head's
+    ``content_hash`` must NOT rescue a local that DIVERGED from the baseline. The
+    provenance route requires ``local_hash == last_sync_hash``; here local drifted
+    and is not byte-identical to the head, so identity fails → ``Conflict``. The
+    stored hash never fabricates a false match for changed local content.
+    """
+    server = _server_save(
+        content_hash="server-content",
+        device_syncs=[_device_sync(OTHER_DEVICE_ID, is_current=True)],
+    )
+    result = compute_sync_action(
+        local_file=_local(),
+        server_saves_in_slot=[server],
+        files_state={"last_sync_hash": "baseline", "last_sync_server_hash": "server-content"},
+        device_id=DEVICE_ID,
+        local_hash="CHANGED",  # != baseline AND != server.content_hash
+    )
+    assert result == Conflict(server_save=server)
+
+
+def test_no_device_entry_empty_stored_server_hash_falls_back_to_parity():
+    """Branch 6 / #1468 poisoned input — an empty-string ``last_sync_server_hash``
+    proves nothing (truthiness guard), so provenance cannot fire. With the head's
+    ``content_hash`` also differing from ``local_hash``, parity fails too → the
+    diverged-baseline path decides ``Conflict``, never a false provenance adopt.
+    """
+    server = _server_save(
+        content_hash="server-content",
+        device_syncs=[_device_sync(OTHER_DEVICE_ID, is_current=True)],
+    )
+    result = compute_sync_action(
+        local_file=_local(),
+        server_saves_in_slot=[server],
+        files_state={"last_sync_hash": "baseline", "last_sync_server_hash": ""},
+        device_id=DEVICE_ID,
+        local_hash="CHANGED",
+    )
+    assert result == Conflict(server_save=server)
+
+
 def test_no_device_entry_garbled_server_updated_at_returns_download():
     """Parse-failure path: unparseable server `updated_at` → server effectively
     wins (Download), per the conservative-fallthrough contract.
@@ -808,3 +917,30 @@ def test_resolve_upload_conflict_empty_local_and_server_content_conflicts():
     coincidentally match — the truthiness guard keeps it ``"conflict"``.
     """
     assert resolve_upload_conflict("", None, "") == "conflict"
+
+
+def test_resolve_upload_conflict_downloads_despite_scheme_drift():
+    """#1468 shape (a) — local is unchanged since our baseline and the server
+    still holds what we synced (``last_sync_server_hash == server_content_hash``),
+    but the computed ``local_hash`` differs from ``server_content_hash`` (scheme
+    drift). We still ``"download"``: our own baseline proves the local carries no
+    un-synced work, so parity is not required to decide it is safe to adopt.
+    """
+    assert resolve_upload_conflict("local-scheme", "local-scheme", "server-scheme", "server-scheme") == "download"
+
+
+def test_resolve_upload_conflict_parity_downloads_without_stored_hash():
+    """#1468 shape (b) — a diverged local (``!= last_sync_hash``) that is
+    byte-identical to the fresh server head still downloads via the parity
+    fallback, even with no ``last_sync_server_hash`` stored (fresh-install shape).
+    """
+    assert resolve_upload_conflict("abc", "old-baseline", "abc", None) == "download"
+
+
+def test_resolve_upload_conflict_stored_hash_alone_does_not_download():
+    """#1468 shape (c) — a stored server hash matching the head is NOT enough on
+    its own: with local diverged from baseline (``local_hash != last_sync_hash``)
+    and not byte-identical to the head (``local_hash != server_content_hash``),
+    the stored hash never fabricates a provenance match → ``"conflict"``.
+    """
+    assert resolve_upload_conflict("CHANGED", "baseline", "server-content", "server-content") == "conflict"

--- a/tests/domain/test_sync_action_property.py
+++ b/tests/domain/test_sync_action_property.py
@@ -46,6 +46,12 @@ Invariants encoded here:
   ``Download`` / ``Upload`` of an unbacked local edit; a byte-identical local is
   adopted (``Skip(adopt_baseline=True)``), never a duplicate POST. Branch-5
   parity.
+- Inv10 (#1468): branch-6 adopts the baseline (``Skip(adopt_baseline=True)``)
+  ONLY when the local is proven byte-identical to the head — either the stored
+  server hash matches while local is unchanged since baseline (provenance) or the
+  live parity hash matches (fallback). The provenance route never fires when
+  local has diverged from the baseline, so a stored server hash can never
+  fabricate a false identity for changed local content.
 """
 
 from __future__ import annotations
@@ -140,7 +146,10 @@ def _server_saves(draw: st.DrawFn) -> dict[str, Any]:
 
 _server_lists = st.lists(_server_saves(), min_size=0, max_size=5)
 _sizes = st.integers(min_value=0, max_value=1_048_576)
-_files_states = st.fixed_dictionaries({}, optional={"last_sync_hash": _hashes, "last_sync_local_size": _sizes})
+_files_states = st.fixed_dictionaries(
+    {},
+    optional={"last_sync_hash": _hashes, "last_sync_server_hash": _hashes, "last_sync_local_size": _sizes},
+)
 
 
 def _action(
@@ -511,20 +520,24 @@ def test_not_current_no_baseline_downloads_only_when_content_identical(
     local_hash=_opt_hashes,
     last_sync_hash=_opt_hashes,
     server_content_hash=_opt_hashes,
+    last_sync_server_hash=_opt_hashes,
 )
 def test_resolve_upload_conflict_never_downloads_unless_provably_unchanged(
     local_hash: str | None,
     last_sync_hash: str | None,
     server_content_hash: str | None,
+    last_sync_server_hash: str | None,
 ) -> None:
-    """Branch 409 / #1276 — ``resolve_upload_conflict`` maps a write-time 409 to
-    an action. It returns ``"download"`` (adopt the server) ONLY when
+    """Branch 409 / #1276 + #1468 — ``resolve_upload_conflict`` maps a write-time
+    409 to an action. It returns ``"download"`` (adopt the server) ONLY when
     ``local_hash`` is non-None and equals either our recorded baseline
     (``last_sync_hash``) or the server's current content (``server_content_hash``);
-    a missing ``local_hash`` always yields ``"conflict"``. Missing evidence never
-    downgrades to a data-losing download.
+    a missing ``local_hash`` always yields ``"conflict"``. A stored server hash
+    (the #1468 provenance input) never enables a download outside those two
+    equalities — provenance requires ``local_hash == last_sync_hash``, already
+    covered. Missing evidence never downgrades to a data-losing download.
     """
-    result = resolve_upload_conflict(local_hash, last_sync_hash, server_content_hash)
+    result = resolve_upload_conflict(local_hash, last_sync_hash, server_content_hash, last_sync_server_hash)
     assert result in ("download", "conflict")
 
     if local_hash is None:
@@ -590,3 +603,58 @@ def test_no_entry_no_baseline_differing_local_is_conflict(
         assert result == Skip(reason="synced", adopt_baseline=True)
     else:
         assert result == Conflict(server_save=server)
+
+
+# ---------------------------------------------------------------------------
+# Invariant 10 (#1468): branch-6 adopts only on proven identity; provenance
+# never fires on a diverged local.
+# ---------------------------------------------------------------------------
+
+
+@given(
+    local_file=_local_files(),
+    server=_head_no_entry(),
+    local_hash=_hashes,
+    baseline=_opt_hashes,
+    stored_server_hash=_opt_hashes,
+)
+def test_no_entry_adopts_baseline_only_on_proven_identity(
+    local_file: dict[str, Any],
+    server: dict[str, Any],
+    local_hash: str,
+    baseline: str | None,
+    stored_server_hash: str | None,
+) -> None:
+    """Branch 6 / #1468 — with a present local and NO ``device_syncs`` entry for
+    our device, the kernel adopts the head as the baseline
+    (``Skip(adopt_baseline=True)``) ONLY when the local is proven byte-identical
+    to it: either the stored server hash matches the head's ``content_hash`` while
+    local is unchanged since our baseline (provenance) OR the live parity hash
+    matches (``local_hash == server.content_hash``). Crucially, the provenance
+    route never fires on a local that has diverged from the baseline
+    (``local_hash != last_sync_hash``) — a stored server hash can never fabricate
+    a false identity for changed local content.
+    """
+    files_state: dict[str, Any] = {}
+    if baseline is not None:
+        files_state["last_sync_hash"] = baseline
+    if stored_server_hash is not None:
+        files_state["last_sync_server_hash"] = stored_server_hash
+
+    result = _action(local_file, [server], files_state, local_hash)
+
+    server_hash = server.get("content_hash")
+    parity = server_hash is not None and local_hash == server_hash
+    provenance = (
+        baseline is not None
+        and local_hash == baseline
+        and bool(stored_server_hash)
+        and stored_server_hash == server_hash
+    )
+
+    if isinstance(result, Skip) and result.adopt_baseline:
+        assert parity or provenance
+
+    # The literal safety statement: provenance can never rescue a diverged local.
+    if baseline is not None and local_hash != baseline and not parity:
+        assert not (isinstance(result, Skip) and result.adopt_baseline)

--- a/tests/fakes/fake_save_api.py
+++ b/tests/fakes/fake_save_api.py
@@ -214,6 +214,20 @@ class FakeSaveApi:
         last_sep = max(path.rfind("/"), path.rfind("\\"))
         return path[last_sep + 1 :] if last_sep >= 0 else path
 
+    def _server_content_hash(self, file_path: str) -> str | None:
+        """RomM's own ``content_hash`` of the uploaded bytes, or None with no adapter.
+
+        Models the server computing and returning ``content_hash`` on the upload
+        SaveSchema response. Computed with the injected store's zip-aware parity
+        hash — the same scheme the real server uses today — so the fake's response
+        hash agrees with what the client would compute for a non-drifted server.
+        Added to the response only (never to the stored save), so ``list_saves``
+        behaviour is unchanged.
+        """
+        if self.save_file_store is None or not self.save_file_store.is_file(file_path):
+            return None
+        return self.save_file_store.content_hash(file_path)
+
     def _capture_upload(self, save_id: int, file_path: str) -> int:
         """Read bytes from *file_path* via the injected adapter and return size.
 
@@ -550,7 +564,9 @@ class FakeSaveApi:
             entry["file_size_bytes"] = size
             entry["emulator"] = emulator
             self.uploaded_files[save_id] = file_path
-            return dict(entry)
+            response = dict(entry)
+            response["content_hash"] = self._server_content_hash(file_path)
+            return response
 
         # add_save content-dedup early-return (saves.py:253-267): a named-slot
         # ``overwrite=false`` POST whose content matches an existing slot save
@@ -595,7 +611,9 @@ class FakeSaveApi:
                 existing["file_size_bytes"] = size
                 existing["emulator"] = emulator
                 self.uploaded_files[save_id] = file_path
-                return dict(existing)
+                response = dict(existing)
+                response["content_hash"] = self._server_content_hash(file_path)
+                return response
 
         save_id = self._next_save_id
         self._next_save_id += 1
@@ -619,6 +637,7 @@ class FakeSaveApi:
         self._record_device_sync(save_id, device_id)
         response = dict(entry)
         response["device_syncs"] = self._device_syncs_for(entry)
+        response["content_hash"] = self._server_content_hash(file_path)
         return response
 
     def download_save(self, save_id: int, dest_path: str) -> None:

--- a/tests/services/saves/_helpers.py
+++ b/tests/services/saves/_helpers.py
@@ -127,6 +127,7 @@ def rom_save_state_from_dict(data: dict[str, Any]) -> RomSaveState:
     _FILE_FIELDS = {
         "tracked_save_id",
         "last_sync_hash",
+        "last_sync_server_hash",
         "last_sync_at",
         "last_sync_server_updated_at",
         "last_sync_server_save_id",

--- a/tests/services/saves/sync_engine/test_matrix.py
+++ b/tests/services/saves/sync_engine/test_matrix.py
@@ -68,6 +68,30 @@ class TestUpdateFileSyncState:
         assert entry.last_sync_at is not None
         assert entry.last_sync_server_save_id == 200
 
+    def test_records_server_content_hash_from_response(self, tmp_path):
+        """#1468 — the server response's ``content_hash`` (RomM's own digest of the
+        bytes) is stored as ``last_sync_server_hash``, the provenance anchor."""
+        svc, _ = make_service(tmp_path)
+        save_file = _create_save(tmp_path)
+        server_resp = {"id": 200, "updated_at": "2026-02-17T15:00:00Z", "content_hash": "srv-abc123"}
+
+        state = RomSaveState()
+        svc._sync_engine._matrix.update_file_sync_state(state, "pokemon.srm", server_resp, str(save_file), "gba")
+
+        assert state.files["pokemon.srm"].last_sync_server_hash == "srv-abc123"
+
+    def test_records_none_server_hash_when_response_lacks_content_hash(self, tmp_path):
+        """#1468 — a response without ``content_hash`` records ``None`` (never a
+        fabricated or locally-computed value); the identity check falls back to parity."""
+        svc, _ = make_service(tmp_path)
+        save_file = _create_save(tmp_path)
+        server_resp = {"id": 200, "updated_at": "2026-02-17T15:00:00Z"}  # no content_hash
+
+        state = RomSaveState()
+        svc._sync_engine._matrix.update_file_sync_state(state, "pokemon.srm", server_resp, str(save_file), "gba")
+
+        assert state.files["pokemon.srm"].last_sync_server_hash is None
+
     def test_creates_entry_with_new_fields(self, tmp_path):
         svc, _ = make_service(tmp_path)
         save_file = _create_save(tmp_path)
@@ -184,6 +208,52 @@ class TestUpdateFileSyncState:
 
         # No baseline is recorded — the aggregate rejects a hash-less file entry.
         assert "missing.srm" not in state.files
+
+
+class TestServerHashBaselineWriterFlows:
+    """#1468 — each transfer flow records the SERVER's content_hash as the provenance
+    anchor, with honest provenance per flow (upload response vs adopted server save)."""
+
+    def test_upload_flow_records_server_content_hash_from_response(self, tmp_path):
+        """The upload flow records the upload RESPONSE's ``content_hash`` (RomM's
+        digest of the bytes it received), not a locally-recomputed value."""
+        svc, _ = make_service(tmp_path)
+        _enable_sync_with_device(svc)
+        _install_rom(svc, tmp_path)
+        save_file = _create_save(tmp_path)
+
+        state = _do_upload(svc, 42, str(save_file), "pokemon.srm", "gba")
+
+        # The fake server returns content_hash = its own hash of the received bytes.
+        expected = svc._save_file_store.content_hash(str(save_file))
+        assert state.files["pokemon.srm"].last_sync_server_hash == expected
+
+    def test_download_flow_records_adopted_server_save_content_hash(self, tmp_path):
+        """The download flow records the ADOPTED server save's ``content_hash``."""
+        svc, _ = make_service(tmp_path)
+        _enable_sync_with_device(svc)
+        _install_rom(svc, tmp_path)
+        saves_dir = str(tmp_path / "saves" / "gba")
+        server_save = _server_save(save_id=100)
+        server_save["content_hash"] = "srv-download-hash"
+
+        state = RomSaveState()
+        svc._sync_engine._matrix.do_download_save(server_save, saves_dir, "pokemon.srm", state, "device-1", "gba")
+
+        assert state.files["pokemon.srm"].last_sync_server_hash == "srv-download-hash"
+
+    def test_download_flow_records_none_when_server_save_lacks_content_hash(self, tmp_path):
+        """A server save with no ``content_hash`` records ``None`` (parity fallback)."""
+        svc, _ = make_service(tmp_path)
+        _enable_sync_with_device(svc)
+        _install_rom(svc, tmp_path)
+        saves_dir = str(tmp_path / "saves" / "gba")
+        server_save = _server_save(save_id=100)  # no content_hash
+
+        state = RomSaveState()
+        svc._sync_engine._matrix.do_download_save(server_save, saves_dir, "pokemon.srm", state, "device-1", "gba")
+
+        assert state.files["pokemon.srm"].last_sync_server_hash is None
 
 
 class TestV47SyncFlow:
@@ -1841,6 +1911,7 @@ class TestSyncRomSavesDispatch:
             local_path=str(save_path),
             local_hash=_file_md5(str(save_path)),
             last_sync_hash=None,
+            last_sync_server_hash=None,
             options=SyncRunOptions(default_slot="default"),
             sink=DispatchSink(errors=errors, conflicts=conflicts),
         )
@@ -1943,6 +2014,7 @@ class TestHandleUnexpectedError:
             local_path=None,
             local_hash=None,
             last_sync_hash=None,
+            last_sync_server_hash=None,
             options=SyncRunOptions(),
             sink=DispatchSink(errors=errors, conflicts=conflicts),
         )
@@ -1993,6 +2065,7 @@ class TestDispatchSyncActionErrorBranches:
             local_path=None,
             local_hash=None,
             last_sync_hash=None,
+            last_sync_server_hash=None,
             options=SyncRunOptions(),
             sink=DispatchSink(errors=errors, conflicts=conflicts),
         )
@@ -2038,6 +2111,7 @@ class TestDispatchUploadDefensiveBranches:
             local_path=None,
             local_hash=None,
             last_sync_hash=None,
+            last_sync_server_hash=None,
             options=SyncRunOptions(),
             sink=DispatchSink(errors=errors, conflicts=conflicts),
         )

--- a/tests/services/saves/sync_engine/test_rollback.py
+++ b/tests/services/saves/sync_engine/test_rollback.py
@@ -60,6 +60,60 @@ class TestResolveSyncConflict:
         assert file_state.last_sync_hash == local_hash
 
     @pytest.mark.asyncio
+    async def test_resolve_keep_local_adopt_records_server_content_hash_honestly(self, tmp_path):
+        """#1468 — the keep_local adopt-without-upload branch stores the server's
+        OWN ``content_hash`` as ``last_sync_server_hash``, never the
+        downloaded-and-recomputed ``server_hash`` (which is parity-derived). Here
+        the server save advertises a distinct ``content_hash`` while the download
+        still hashes equal to local (so the adopt fires); the recorded provenance
+        anchor must be the advertised server value.
+        """
+        svc, fake = make_service(tmp_path)
+        _enable_sync_with_device(svc)
+        _install_rom(svc, tmp_path)
+        save_path = _create_save(tmp_path, content=b"identical content")
+        local_hash = _file_md5(str(save_path))
+
+        ss = _server_save_with_syncs(device_syncs=[{"device_id": "device-1", "is_current": False}])
+        ss["content_hash"] = "distinct-server-hash"  # honest server value, != local_hash
+        fake.saves[100] = ss
+        fake.uploaded_files[100] = str(save_path)  # download hashes equal → adopt fires
+
+        result = await svc.resolve_sync_conflict(
+            rom_id=42, filename="pokemon.srm", server_save_id=100, action="keep_local"
+        )
+
+        assert result["success"] is True
+        assert not any(c[0] == "upload_save" for c in fake.call_log)
+        file_state = _require_save_state(svc, 42).files["pokemon.srm"]
+        assert file_state.last_sync_hash == local_hash
+        assert file_state.last_sync_server_hash == "distinct-server-hash"
+
+    @pytest.mark.asyncio
+    async def test_resolve_keep_local_adopt_records_none_when_no_content_hash(self, tmp_path):
+        """#1468 — a keep_local adopt against a server save with no ``content_hash``
+        records ``None`` (never the computed hash); the identity check falls back to
+        parity."""
+        svc, fake = make_service(tmp_path)
+        _enable_sync_with_device(svc)
+        _install_rom(svc, tmp_path)
+        save_path = _create_save(tmp_path, content=b"identical content")
+
+        ss = _server_save_with_syncs(device_syncs=[{"device_id": "device-1", "is_current": False}])
+        # No content_hash advertised by the server save.
+        fake.saves[100] = ss
+        fake.uploaded_files[100] = str(save_path)
+
+        result = await svc.resolve_sync_conflict(
+            rom_id=42, filename="pokemon.srm", server_save_id=100, action="keep_local"
+        )
+
+        assert result["success"] is True
+        assert not any(c[0] == "upload_save" for c in fake.call_log)
+        file_state = _require_save_state(svc, 42).files["pokemon.srm"]
+        assert file_state.last_sync_server_hash is None
+
+    @pytest.mark.asyncio
     async def test_resolve_keep_local_hash_mismatch_reposts_with_overwrite(self, tmp_path):
         """Local differs from server content → POST a new save with overwrite=true."""
         svc, fake = make_service(tmp_path)


### PR DESCRIPTION
Closes #1468

> **Stacked PR — draft until #1460 and #1463 merge.** This branch is based on the integration of both; the diff below includes their changes until they land on main, after which this rebases onto main and shows only its own two commits (`f2019fa8`, `dec52f5d`).

Every identity check against the server previously relied on recomputing RomM's content-hash scheme locally (scheme parity — #1457 fixed its broken zip half). That stays correct but fragile: it silently breaks whenever RomM's hashing process changes. This PR makes the **server-provided hash the primary identity mechanism** and demotes parity to the fallback for files with no sync history on this device.

- new per-file baseline field `last_sync_server_hash` (additive migration 017, no backfill — existing state simply uses the fallback until the next sync stamps it)
- **honest provenance at every writer site**: only hashes the server actually produced are stored (upload response, adopted server save, keep_local's server save) — a locally computed value is never stored as the server hash; missing → `None`
- kernel: one pure helper implementing the disjunction — provenance route (local unchanged since baseline AND stored server hash equals `server.content_hash`) primary, parity route (`local_hash == server.content_hash`) fallback — at branch-5 no-baseline, branch-6 dedup, and `resolve_upload_conflict`
- soundness closure: a baseline update that changes the local hash **clears** the stored server hash in the same mutation, so a stale pair can never produce a false identity match; slot switches and file-tracking deletion always drop the whole pair
- tests prove the routes are distinct: the drift-simulation tests poison the computed hash and still observe a clean sync via the stored hash (they fail on the base branch); fresh-install byte-identical adopt still works via the parity fallback
- docs: `save-file-sync-architecture.md` (provenance-first identity, matrix table, files_state) + `database-design.md` (migration 017)

Merge gate: on-device — fresh-state sync round (no stored server hash → fallback path) plus a normal sync round confirming baselines now carry the server hash, alongside the #1460/#1463 checklist (one deploy covers all three PRs).
