### PR TITLE
fix(ui): correct the enable-save-sync modal claim that only .srm files sync

### DIFF
--- a/docs/user-guide/save-sync.md
+++ b/docs/user-guide/save-sync.md
@@ -5,7 +5,7 @@ Deck, then continue where you left off on your HTPC — your saves travel with y
 
 ## How It Works
 
-The plugin uploads and downloads RetroArch save files (`.srm`) to and from your RomM server. When you start a game, the
+The plugin uploads and downloads your RetroArch game saves to and from your RomM server. When you start a game, the
 plugin checks if the server has a newer save and downloads it. When you stop playing, it uploads your updated save.
 
 > **Important:** Save sync runs in **Game Mode only**, but there it covers every way a game can start: the Play button
@@ -48,14 +48,11 @@ the plugin.
 
 ## Supported Systems
 
-Save sync currently supports **RetroArch per-game `.srm` saves only**. This covers all systems that use RetroArch cores
-through RetroDECK:
-
-- NES, SNES, Game Boy, Game Boy Color, Game Boy Advance
-- Genesis / Mega Drive, Master System, Nintendo 64
-- PlayStation (via RetroArch cores like SwanStation/Beetle PSX)
-- Saturn, Dreamcast, PC Engine / TurboGrafx-16
-- Neo Geo Pocket, WonderSwan, Atari Lynx
+Save sync works on the **per-game save files RetroArch writes** for the systems RetroDECK supports. Standard cartridge
+saves (SRAM) sync automatically; several systems also sync their own formats — RTC, EEPROM, and console-specific backup
+RAM — so it is not limited to a single file type. Exactly what syncs varies by system: for the current per-system
+breakdown of what carries across devices today and what's planned, see the
+[save sync support matrix](save-sync-support-matrix.md).
 
 Standalone emulator saves (PCSX2, DuckStation, Dolphin, PPSSPP, melonDS, etc.) are **not yet supported** and are planned
 for a future update.

--- a/src/components/SettingsPage.test.tsx
+++ b/src/components/SettingsPage.test.tsx
@@ -1178,7 +1178,10 @@ describe("SettingsPage", () => {
         onCancel?: () => void;
       }>();
       expect(props?.strTitle).toBe("Enable Save Sync?");
-      expect(props?.strDescription).toContain("RetroArch save files");
+      expect(props?.strDescription).toContain("RetroArch game saves");
+      // #1189: the copy must not claim only .srm files sync, and points at the support matrix instead.
+      expect(props?.strDescription).not.toContain("(.srm)");
+      expect(props?.strDescription).toContain("support matrix");
       expect(props?.strOKButtonText).toBe("I am sure");
       expect(props?.strCancelButtonText).toBe("Cancel");
     });

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -231,7 +231,10 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
       <ConfirmModal
         strTitle="Enable Save Sync?"
         strDescription={
-          "This will sync RetroArch save files (.srm) between this device and your RomM server.\n\n" +
+          "This will sync your RetroArch game saves between this device and your RomM server. " +
+          "Save sync covers the per-game save files RetroArch writes for the systems it supports " +
+          "- SRAM, RTC, EEPROM, and other per-system formats, not a single file type. " +
+          "Coverage varies by system; see the save sync support matrix in the docs.\n\n" +
           "Before enabling, please back up your local save files. " +
           "They are stored in your RetroArch/RetroDECK saves directory.\n\n" +
           "IMPORTANT: Save sync requires RetroArch's save sorting to be set to " +


### PR DESCRIPTION
Closes #1189

The enable-save-sync modal claimed only `.srm` files are synced — wrong since per-system extension support landed. New copy describes the behavior at a level that stays true (per-game save files RetroArch writes; SRAM/RTC/EEPROM and other per-system formats; coverage varies by system, see the support matrix) instead of an extension list that would rot.

- `docs/user-guide/save-sync.md`: same `.srm`-only framing fixed in two places; the hand-maintained "Supported Systems" list is replaced with a link to the authoritative support matrix — it contradicted the matrix (named systems the matrix marks as not-synced/planned) and was a second drifting source of truth
- regression guards pin the rendered modal copy (must not contain `(.srm)`, must reference the support matrix)
