### PR TITLE
fix(ui): label the legacy save bucket "Legacy" instead of "(no slot)"

### DIFF
--- a/src/components/SlotSetupWizard.test.tsx
+++ b/src/components/SlotSetupWizard.test.tsx
@@ -382,7 +382,7 @@ describe("SlotSetupWizard", () => {
       expect(container.textContent).toContain("No saves on server");
     });
 
-    it("displays a null slot as '(no slot)'", async () => {
+    it("displays a null slot as 'Legacy'", async () => {
       const info = makeSetupInfo({
         server_slots: [{ slot: null, saves: [], count: 1, latest_updated_at: null }],
       });
@@ -391,10 +391,11 @@ describe("SlotSetupWizard", () => {
       });
       const { container } = render(<SlotSetupWizard {...defaultProps()} />);
       await flushAsync();
-      expect(container.textContent).toContain("Legacy (no slot)");
+      expect(container.textContent).toContain("Legacy");
+      expect(container.textContent).not.toContain("(no slot)");
     });
 
-    it("displays an empty-string slot as '(no slot)'", async () => {
+    it("displays an empty-string slot as 'Legacy'", async () => {
       const info = makeSetupInfo({
         server_slots: [{ slot: "", saves: [], count: 1, latest_updated_at: null }],
       });
@@ -403,7 +404,8 @@ describe("SlotSetupWizard", () => {
       });
       const { container } = render(<SlotSetupWizard {...defaultProps()} />);
       await flushAsync();
-      expect(container.textContent).toContain("Legacy (no slot)");
+      expect(container.textContent).toContain("Legacy");
+      expect(container.textContent).not.toContain("(no slot)");
     });
 
     it("falls back to the raw iso string when the timestamp is malformed", async () => {

--- a/src/components/SlotSetupWizard.tsx
+++ b/src/components/SlotSetupWizard.tsx
@@ -17,15 +17,11 @@ import { formatBytes } from "../utils/formatters";
 import type { SaveSetupInfo } from "../types";
 import { detach } from "../utils/detach";
 import { ConnectingIndicator } from "./saves/ConnectingIndicator";
+import { displaySlot } from "./saves/helpers";
 
 interface SlotSetupWizardProps {
   romId: number;
   onComplete: () => void;
-}
-
-function displaySlot(slot: string | null): string {
-  if (slot === null || slot === "") return "Legacy (no slot)";
-  return slot;
 }
 
 function formatTimestamp(iso: string | null): string {

--- a/src/components/saves/SlotPanel.test.tsx
+++ b/src/components/saves/SlotPanel.test.tsx
@@ -724,9 +724,10 @@ describe("SlotPanel", () => {
     });
   });
 
-  it("renders '(no slot)' for an empty slot name", () => {
+  it("renders 'Legacy' for an empty slot name", () => {
     const { container } = render(<SlotPanel {...defaultProps({ slot: makeSummary({ slot: "" }) })} />);
-    expect(container.textContent).toContain("Legacy (no slot)");
+    expect(container.textContent).toContain("Legacy");
+    expect(container.textContent).not.toContain("(no slot)");
   });
 
   it("loads and renders inactive slot files when expanded", async () => {

--- a/src/components/saves/helpers.test.ts
+++ b/src/components/saves/helpers.test.ts
@@ -12,16 +12,16 @@ import {
 import type { DeviceSyncInfo, SaveStatus, SyncConflict, SlotDeleteInfo } from "../../types";
 
 describe("displaySlot", () => {
-  it("returns '(no slot)' for null", () => {
-    expect(displaySlot(null)).toBe("Legacy (no slot)");
+  it("returns 'Legacy' for null", () => {
+    expect(displaySlot(null)).toBe("Legacy");
   });
 
-  it("returns '(no slot)' for undefined", () => {
-    expect(displaySlot(undefined)).toBe("Legacy (no slot)");
+  it("returns 'Legacy' for undefined", () => {
+    expect(displaySlot(undefined)).toBe("Legacy");
   });
 
-  it("returns '(no slot)' for empty string", () => {
-    expect(displaySlot("")).toBe("Legacy (no slot)");
+  it("returns 'Legacy' for empty string", () => {
+    expect(displaySlot("")).toBe("Legacy");
   });
 
   it("returns the slot name as-is for non-empty input", () => {

--- a/src/components/saves/helpers.ts
+++ b/src/components/saves/helpers.ts
@@ -10,7 +10,7 @@ export const MUTED_COLOR = "#8f98a0";
 
 /** Display a slot name, labelling the null/empty (legacy) slot explicitly */
 export function displaySlot(slot: string | null | undefined): string {
-  if (slot === null || slot === undefined || slot === "") return "Legacy (no slot)";
+  if (slot === null || slot === undefined || slot === "") return "Legacy";
   return slot;
 }
 

--- a/src/components/settings/SaveSyncSection.test.tsx
+++ b/src/components/settings/SaveSyncSection.test.tsx
@@ -228,11 +228,12 @@ describe("SaveSyncSection", () => {
       expect(container.textContent).toContain("speedrun");
     });
 
-    it("shows '(no slot)' when default_slot is empty", () => {
+    it("shows 'Legacy' when default_slot is empty", () => {
       const { container } = render(
         <SaveSyncSection {...defaultProps({ saveSyncSettings: makeSettings({ default_slot: "" }) })} />,
       );
-      expect(container.textContent).toContain("(no slot)");
+      expect(container.textContent).toContain("Legacy");
+      expect(container.textContent).not.toContain("(no slot)");
     });
 
     it("opens a TextInputModal on Edit with the current default_slot", () => {

--- a/src/components/settings/SaveSyncSection.tsx
+++ b/src/components/settings/SaveSyncSection.tsx
@@ -89,7 +89,7 @@ export const SaveSyncSection: FC<SaveSyncSectionProps> = ({
               <PanelSectionRow>
                 <Field
                   label="Default Save Slot"
-                  description={`${saveSyncSettings.default_slot || "(no slot)"} — applies to new games and games without a per-game slot override`}
+                  description={`${saveSyncSettings.default_slot || "Legacy"} — applies to new games and games without a per-game slot override`}
                 >
                   <DialogButton
                     style={{ minWidth: "auto", width: "auto" }}


### PR DESCRIPTION
Closes #876

The legacy/no-slot save bucket rendered as "Legacy (no slot)" (originally "(no slot)"). It now renders as plain "Legacy" everywhere.

- the label was forked across two copies — the shared `displaySlot()` helper and a local duplicate in the slot-setup wizard — which is how it drifted in the first place; the wizard is consolidated onto the shared helper so it cannot drift again
- the default-slot setting's fallback shows "Legacy" too: it only renders in the explicit clear-default flow whose confirm modal announces legacy mode, so the label matches what the user just chose
- regression guards pin the rendered "Legacy" label and assert "(no slot)" is gone

docs: N/A — UI label only, no behavior or flow change; no user-guide page references the old label (grep-verified).
