### PR TITLE
fix(saves): fall back to plain MD5 when a save sniffs as zip but is unreadable

### DIFF
--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -66,7 +66,12 @@ the negotiate inventory param. See
 The plugin reproduces this `content_hash` byte-for-byte so a save's local and server hashes agree and sync converges:
 single-file MD5 via `SaveFileStore.checksum_md5`, and the zip per-entry scheme via `SaveFileStore.content_hash` →
 `domain.save_hash.combine_zip_entry_hashes` (sorted `name:md5(entry)` lines joined by `\n`, then MD5'd; dispatch is by
-`zipfile.is_zipfile`, a content sniff, not the extension). This hash reproduction is what the sync decision needs
+`zipfile.is_zipfile`, a content sniff, not the extension). A file that `is_zipfile` accepts but that cannot actually be
+read as a zip — a corrupt or truncated archive, an encrypted entry, or a compression method this Python runtime lacks —
+falls back to the plain `checksum_md5` rather than raising, so one poison save can never abort the whole sweep (#1470);
+RomM's server degrades the same file to `content_hash=None`, so the kernel's truthiness guards reject a `None`-side
+identity match and the fallback can never manufacture a false byte-identical match — it only keeps the local drift
+baseline working. This hash reproduction is what the sync decision needs
 ([ADR-0016](../adr/0016-save-sync-hands-detection-to-romm-negotiate.md) /
 [ADR-0017](../adr/0017-client-baseline-detection-authoritative-negotiate-is-transport.md) / #1234): the client's
 `compute_sync_action` decides `upload` / `download` / `conflict` / `no_op` without a download-and-rehash, for every ROM

--- a/py_modules/adapters/save_file.py
+++ b/py_modules/adapters/save_file.py
@@ -16,14 +16,29 @@ import hashlib
 import os
 import tempfile
 import zipfile
+import zlib
 from typing import TYPE_CHECKING
 
 from domain.save_hash import combine_zip_entry_hashes
 
 if TYPE_CHECKING:
+    import logging
     from collections.abc import Iterator
 
 _MD5_CHUNK_SIZE = 8192
+
+# Zip-decode failures a positive ``zipfile.is_zipfile`` sniff can still hit once
+# the archive is actually read (the sniff only inspects the End-Of-Central-
+# Directory record): a corrupt / truncated central directory or a bad entry CRC
+# (``BadZipFile``), a compressed stream ``zlib`` cannot inflate (``zlib.error``),
+# or an entry this runtime cannot decode — an encrypted member or a compression
+# method the stdlib lacks (``RuntimeError``; the unknown-method
+# ``NotImplementedError`` is a ``RuntimeError`` subclass, e.g. a save zipped with
+# zstd, which ``zipfile`` only learns to read in 3.14). ``OSError`` is
+# deliberately excluded so a genuine I/O fault (a vanished / unreadable file)
+# still surfaces, matching the non-zip branch and ``checksum_md5``;
+# ``LargeZipFile`` is excluded as an unreachable write-time ZIP64 guard.
+_ZIP_READ_ERRORS = (zipfile.BadZipFile, zlib.error, RuntimeError)
 
 
 class SaveFileAdapter:
@@ -34,7 +49,8 @@ class SaveFileAdapter:
     ``loop.run_in_executor``.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, *, logger: logging.Logger) -> None:
+        self._logger = logger
         # Per-run content-hash memo, live only inside ``hash_memo_scope``.
         # ``None`` outside a scope so non-sync callers never populate a
         # process-lifetime cache; a fresh dict per outermost scope bounds it to
@@ -109,7 +125,9 @@ class SaveFileAdapter:
         content sniff, not the extension) is hashed per entry and combined via
         :func:`domain.save_hash.combine_zip_entry_hashes`; any other file is the
         plain streamed MD5 of :meth:`checksum_md5`. Directory entries inside the
-        archive are skipped. Non-security use, like ``checksum_md5``.
+        archive are skipped. A positive sniff over a file that cannot be read as
+        a zip falls back to the plain MD5 rather than raising (see
+        :meth:`_compute_content_hash`). Non-security use, like ``checksum_md5``.
 
         Inside a :meth:`hash_memo_scope` the digest is memoized by the file's
         ``(path, mtime_ns, size)`` so one sync run's repeated hashings of the
@@ -129,15 +147,30 @@ class SaveFileAdapter:
         return digest
 
     def _compute_content_hash(self, path: str) -> str:
-        """Read *path* and compute its zip-aware RomM content hash (no memo)."""
+        """Read *path* and compute its zip-aware RomM content hash (no memo).
+
+        A file that ``zipfile.is_zipfile`` accepts but that cannot be read as a
+        zip (``_ZIP_READ_ERRORS``) falls back to the plain streamed MD5 of
+        :meth:`checksum_md5`. RomM's server degrades the same file to
+        ``content_hash=None``, so the kernel's truthiness guards reject a
+        ``None``-side identity match and the fallback can never manufacture a
+        false byte-identical match — it only keeps the local drift baseline
+        working. Both sides of the memo see the fallback value: the public
+        :meth:`content_hash` memoizes whatever this method returns under the
+        file's stat key.
+        """
         if not zipfile.is_zipfile(path):
             return self.checksum_md5(path)
-        with zipfile.ZipFile(path, "r") as zf:
-            entries = [
-                (name, hashlib.md5(zf.read(name), usedforsecurity=False).hexdigest())
-                for name in zf.namelist()
-                if not name.endswith("/")
-            ]
+        try:
+            with zipfile.ZipFile(path, "r") as zf:
+                entries = [
+                    (name, hashlib.md5(zf.read(name), usedforsecurity=False).hexdigest())
+                    for name in zf.namelist()
+                    if not name.endswith("/")
+                ]
+        except _ZIP_READ_ERRORS as exc:
+            self._logger.debug("content_hash: %s sniffed as zip but unreadable (%s); MD5 fallback", path, exc)
+            return self.checksum_md5(path)
         return combine_zip_entry_hashes(entries)
 
     @contextlib.contextmanager

--- a/py_modules/bootstrap.py
+++ b/py_modules/bootstrap.py
@@ -352,7 +352,7 @@ def bootstrap(
     firmware_file_store = FirmwareFileAdapter()
     migration_file_store = MigrationFileAdapter()
     rom_file_store = RomFileAdapter()
-    save_file_store = SaveFileAdapter()
+    save_file_store = SaveFileAdapter(logger=logger)
     path_probe = PathProbeAdapter()
     renderer_rss = RendererRssAdapter()
     renderer_gc = RendererGcAdapter(logger=logger)

--- a/py_modules/services/protocols/files.py
+++ b/py_modules/services/protocols/files.py
@@ -431,7 +431,10 @@ class SaveFileStore(Protocol):
         Identical to :meth:`checksum_md5` for a plain file; for a zip archive
         (a multi-file save) the per-entry combined hash RomM computes, so a
         zipped save converges on its content rather than mismatching on the
-        archive container's framing. Non-security use, like ``checksum_md5``.
+        archive container's framing. A file that sniffs as a zip but cannot be
+        read as one falls back to the plain MD5 rather than raising, so one
+        unreadable save never aborts a sync sweep. Non-security use, like
+        ``checksum_md5``.
 
         Inside a :meth:`hash_memo_scope` the result is memoized per file; see
         that method.

--- a/tests/adapters/test_save_file.py
+++ b/tests/adapters/test_save_file.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 import hashlib
+import logging
 import os
 import re
+import struct
 import zipfile
+import zlib
 
 import pytest
 
@@ -20,7 +23,7 @@ _GOLDEN_TWO_ENTRY_ZIP_HASH = "6e42de0bba44de86f213ca48f5c388dd"
 
 @pytest.fixture
 def save_files() -> SaveFileAdapter:
-    return SaveFileAdapter()
+    return SaveFileAdapter(logger=logging.getLogger("test"))
 
 
 class TestExists:
@@ -188,6 +191,45 @@ def _write_zip(path, entries: list[tuple[str, bytes]]) -> None:
             zf.writestr(name, data)
 
 
+def _write_corrupt_central_dir_zip(path) -> None:
+    """Write a real zip, then clobber its central-directory signature.
+
+    The End-Of-Central-Directory record stays intact, so ``is_zipfile`` still
+    sniffs it as a zip — but ``ZipFile(path)`` raises ``BadZipFile`` on open. The
+    dominant real-world poison: a corrupt / truncated archive.
+    """
+    _write_zip(path, [("battery.srm", b"battery-bytes"), ("rtc.bin", b"rtc-bytes")])
+    data = bytearray(path.read_bytes())
+    cd_offset = struct.unpack("<I", data[-22:][16:20])[0]  # EOCD → central-dir offset
+    data[cd_offset : cd_offset + 4] = b"\x00\x00\x00\x00"  # kill the PK\x01\x02 magic
+    path.write_bytes(bytes(data))
+
+
+def _write_unknown_compression_zip(path) -> None:
+    """Write a stored zip, then patch both compression-method fields to a value
+    this runtime cannot decode → ``NotImplementedError`` (a ``RuntimeError``) on
+    read. Models a save compressed with a method the stdlib lacks (e.g. zstd,
+    which ``zipfile`` only learns to read in 3.14)."""
+    _write_zip(path, [("a.srm", b"hello world")])
+    data = bytearray(path.read_bytes())
+    data[8:10] = struct.pack("<H", 99)  # local file header compression method
+    cd = data.find(b"PK\x01\x02")
+    data[cd + 10 : cd + 12] = struct.pack("<H", 99)  # central directory method
+    path.write_bytes(bytes(data))
+
+
+def _write_corrupt_deflate_zip(path) -> None:
+    """Write a deflate zip with an intact directory, then scramble the compressed
+    payload bytes → ``zlib.error`` (a decompression failure) on read."""
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("a.srm", b"A" * 5000)
+    data = bytearray(path.read_bytes())
+    cd = data.find(b"PK\x01\x02")
+    for i in range(40, min(80, cd)):
+        data[i] ^= 0xFF
+    path.write_bytes(bytes(data))
+
+
 class TestContentHash:
     """``content_hash`` mirrors RomM's ``compute_content_hash`` (zip-aware MD5)."""
 
@@ -239,6 +281,45 @@ class TestContentHash:
     def test_missing_file_raises(self, save_files, tmp_path):
         with pytest.raises(OSError):
             save_files.content_hash(str(tmp_path / "missing.srm"))
+
+
+class TestContentHashUnreadableZipFallback:
+    """#1470 — a file that sniffs as a zip but cannot be read as one falls back to
+    the plain ``checksum_md5`` instead of raising, so one poison save can never
+    abort the whole sync sweep. RomM's server degrades the same file to
+    ``content_hash=None``; the plain MD5 keeps the local drift baseline working
+    and the kernel's truthiness guards reject the ``None``-side identity match.
+    """
+
+    _POISON_BUILDERS = (_write_corrupt_central_dir_zip, _write_unknown_compression_zip, _write_corrupt_deflate_zip)
+
+    @pytest.mark.parametrize("build", _POISON_BUILDERS)
+    def test_fixture_sniffs_as_zip_but_is_unreadable(self, build, tmp_path):
+        """Guard against a vacuous fixture: each poison must genuinely pass the
+        ``is_zipfile`` sniff yet raise when actually read — otherwise the fallback
+        tests would go green without exercising the fallback at all."""
+        f = tmp_path / "poison.srm"
+        build(f)
+        assert zipfile.is_zipfile(str(f)) is True
+        with pytest.raises((zipfile.BadZipFile, zlib.error, RuntimeError)), zipfile.ZipFile(str(f), "r") as zf:
+            for name in zf.namelist():
+                zf.read(name)
+
+    @pytest.mark.parametrize("build", _POISON_BUILDERS)
+    def test_falls_back_to_checksum_md5(self, build, save_files, tmp_path):
+        """No raise, and the digest is the whole-file MD5 (never a partial zip
+        per-entry hash) — the same value RomM's local drift baseline expects."""
+        f = tmp_path / "poison.srm"
+        build(f)
+        assert save_files.content_hash(str(f)) == save_files.checksum_md5(str(f))
+
+    def test_fallback_is_debug_logged(self, save_files, tmp_path, caplog):
+        f = tmp_path / "poison.srm"
+        _write_corrupt_central_dir_zip(f)
+        with caplog.at_level(logging.DEBUG, logger="test"):
+            save_files.content_hash(str(f))
+        messages = [r.getMessage() for r in caplog.records]
+        assert any("unreadable" in m and str(f) in m for m in messages)
 
 
 class TestHashMemoScope:
@@ -349,6 +430,41 @@ class TestHashMemoScope:
         # Scope closed → memo discarded → recompute now reflects the new bytes,
         # confirming the in-scope value was served from the memo, not recomputed.
         assert save_files.content_hash(str(z)) != first
+
+    def test_unreadable_zip_fallback_is_memoized(self, save_files, tmp_path):
+        """#1470 — the fallback digest populates the memo under the file's stat key
+        (it does not bypass it): a same-stat rewrite to readable content still
+        serves the fallback digest, proving the in-scope value came from the memo."""
+        f = tmp_path / "poison.srm"
+        _write_corrupt_central_dir_zip(f)
+        fallback = hashlib.md5(f.read_bytes()).hexdigest()
+        with save_files.hash_memo_scope():
+            assert save_files.content_hash(str(f)) == fallback
+            # Overwrite with a readable single-file save of identical (mtime_ns,
+            # size) → same memo key → a hit must still return the fallback digest.
+            before = os.stat(f)
+            new = b"Z" * before.st_size
+            f.write_bytes(new)
+            os.utime(f, ns=(before.st_atime_ns, before.st_mtime_ns))
+            assert os.stat(f).st_size == before.st_size  # guards against a vacuous pass
+            assert save_files.content_hash(str(f)) == fallback
+            assert save_files.content_hash(str(f)) != hashlib.md5(new).hexdigest()
+
+    def test_unreadable_zip_fallback_memo_invalidated_on_change(self, save_files, tmp_path):
+        """#1470 — a stat change to the poison file misses the memo and re-hashes,
+        so the fallback digest is bound to ``(path, mtime_ns, size)``, not pinned
+        across a real edit."""
+        f = tmp_path / "poison.srm"
+        _write_corrupt_central_dir_zip(f)
+        with save_files.hash_memo_scope():
+            first = save_files.content_hash(str(f))
+            assert first == hashlib.md5(f.read_bytes()).hexdigest()
+            # Grow the file → different size → new memo key → recompute reflects the
+            # new bytes (still whole-file MD5: garbage can't become a readable zip).
+            f.write_bytes(f.read_bytes() + b"tail-bytes")
+            recomputed = save_files.content_hash(str(f))
+            assert recomputed == hashlib.md5(f.read_bytes()).hexdigest()
+            assert recomputed != first
 
 
 class TestMakeTempPath:

--- a/tests/services/saves/_helpers.py
+++ b/tests/services/saves/_helpers.py
@@ -31,7 +31,7 @@ async def _noop_emit(_event: str, /, *_args: object) -> None:
 
 def make_service(tmp_path, fake_api=None, *, emit=None, **overrides) -> tuple["SaveService", "FakeSaveApi"]:
     """Create a SaveService with sensible defaults for testing."""
-    save_file_store = SaveFileAdapter()
+    save_file_store = SaveFileAdapter(logger=logging.getLogger("test"))
     fake: FakeSaveApi = fake_api or FakeSaveApi(save_file_store=save_file_store)
     # Tests that build their own FakeSaveApi without wiring the adapter get
     # the same instance as the service so download_save_content materializes

--- a/tests/services/saves/sync_engine/test_engine.py
+++ b/tests/services/saves/sync_engine/test_engine.py
@@ -7,9 +7,12 @@ conflict rollback in tests/services/saves/sync_engine/test_rollback.py.
 """
 
 import asyncio
+import io
 import logging
+import struct
 import threading
 import time
+import zipfile
 
 import pytest
 
@@ -40,6 +43,24 @@ from tests.services.saves._helpers import (
     _set_sort_settings_previous,
     make_service,
 )
+
+
+def _corrupt_zip_bytes() -> bytes:
+    """Bytes that ``zipfile.is_zipfile`` accepts but ``ZipFile`` cannot open.
+
+    A real two-member zip with its central-directory signature clobbered — the
+    #1470 poison: an intact End-Of-Central-Directory record makes it sniff as a
+    zip, but reading it raises ``BadZipFile``, the failure that used to escape
+    the sweep and abort every remaining ROM.
+    """
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_STORED) as zf:
+        zf.writestr("battery.srm", b"battery-bytes")
+        zf.writestr("rtc.bin", b"rtc-bytes")
+    data = bytearray(buf.getvalue())
+    cd_offset = struct.unpack("<I", data[-22:][16:20])[0]  # EOCD → central-dir offset
+    data[cd_offset : cd_offset + 4] = b"\x00\x00\x00\x00"  # kill the PK\x01\x02 magic
+    return bytes(data)
 
 
 class TestSyncRomSaves:
@@ -222,6 +243,38 @@ class TestSyncAllSaves:
         assert result["roms_checked"] == 2
         # Exactly one whole-device transport session for both ROMs.
         assert len([c for c in fake.call_log if c[0] == "negotiate_sync"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_unreadable_zip_save_does_not_abort_sweep(self, tmp_path):
+        """#1470 — a save that sniffs as a zip but cannot be read as one must not
+        crash the whole sweep: the other ROM still syncs, and the poison ROM falls
+        back to its plain MD5 and uploads like any new save. Before the adapter
+        fallback, the matrix per-file hash raised ``BadZipFile`` and aborted the run.
+        """
+        svc, fake = make_service(tmp_path)
+        svc._config.settings["save_sync_enabled"] = True
+        _set_device_id(svc, "test-device")
+
+        _install_rom(svc, tmp_path, rom_id=1, system="gba", file_name="game1.gba")
+        _install_rom(svc, tmp_path, rom_id=2, system="snes", file_name="game2.sfc")
+        _seed_save_state(svc, 1, RomSaveState(system="gba", slot_confirmed=True, active_slot="default"))
+        _seed_save_state(
+            svc, 2, RomSaveState(system="snes", slot_confirmed=True, active_slot="default"), platform_slug="snes"
+        )
+        _create_save(tmp_path, system="gba", rom_name="game1", content=b"good-save")
+        # ROM 2's save is the poison: it sniffs as a zip but cannot be read as one.
+        _create_save(tmp_path, system="snes", rom_name="game2", content=_corrupt_zip_bytes())
+
+        result = await svc.sync_all_saves()
+
+        # The run completed (no BadZipFile escaped) and swept both ROMs cleanly.
+        assert result["success"] is True
+        assert result["roms_checked"] == 2
+        assert result["errors"] == []
+        assert result["synced"] == 2
+        # Both uploaded — the good save normally, the poison via its MD5 fallback.
+        uploaded_roms = {c[1][0] for c in fake.call_log if c[0] == "upload_save"}
+        assert uploaded_roms == {1, 2}
 
     @pytest.mark.asyncio
     async def test_disabled_returns_early(self, tmp_path):

--- a/tests/services/test_game_detail.py
+++ b/tests/services/test_game_detail.py
@@ -94,7 +94,7 @@ def plugin(tmp_path):
             logger=logging.getLogger("test"),
             clock=FakeClock(now=datetime(2026, 1, 1, tzinfo=UTC)),
             settings_persister=MagicMock(),
-            save_file_store=SaveFileAdapter(),
+            save_file_store=SaveFileAdapter(logger=logging.getLogger("test")),
             retrodeck_paths=FakeRetroDeckPaths(
                 saves=saves_path,
                 roms=str(tmp_path / "retrodeck" / "roms"),

--- a/tests/test_plugin_saves.py
+++ b/tests/test_plugin_saves.py
@@ -82,7 +82,7 @@ def plugin(tmp_path):
 
     # Wire services with FakeSaveApi sharing the SaveFileAdapter so download
     # bytes land on the same filesystem view the service inspects.
-    save_file_adapter = SaveFileAdapter()
+    save_file_adapter = SaveFileAdapter(logger=logging.getLogger("test"))
     fake_api = FakeSaveApi(save_file_store=save_file_adapter)
     # One shared Unit of Work so test seeds and the saves vertical agree on state.
     p._uow_factory = FakeUnitOfWorkFactory()


### PR DESCRIPTION
Closes #1470

> **Stacked PR — draft until #1469 (and its parents #1460/#1463) merge.** Based on `feature/1468-server-hash-baseline`; the diff shows the whole chain until then. Own commit: `ef2da82b`.

A file that sniffs as a zip (`zipfile.is_zipfile` content sniff) but cannot be read raised out of the save-file adapter, and two call sites (the matrix per-file hash and the pre-negotiate inventory build) let that abort the entire sync sweep — while RomM's server degrades to `content_hash=None` for the same file.

- the adapter now catches `(BadZipFile, zlib.error, RuntimeError)` around the stdlib zip read after a positive sniff and falls back to `checksum_md5`; each class maps to an empirically verified failure (corrupt central directory / bad CRC, corrupt deflate stream, encrypted entry, unknown compression method incl. future zstd)
- deliberately **narrower** than the server's catch-all: `OSError` still surfaces (a genuine I/O fault must not be silently hashed around), and the domain combiner sits outside the try so real bugs are never swallowed
- fail-safe by construction: the server yields `None` for the same file and the kernel's truthiness guards reject any match against `None`; the fallback value keeps the local drift baseline working and flows through the per-run memo unchanged
- `SaveFileAdapter` takes an injected `logging.Logger` (sibling-adapter pattern) and logs the fallback at debug
- tests: three poison fixtures with non-vacuous precondition guards, memo hit/invalidation for the fallback value, and a sweep-level test proving one unreadable file no longer aborts `sync_all_saves`
- docs: `save-file-sync-architecture.md` hashing section notes the divergence handling

Merge gate: rides the stacked chain's on-device round; no separate device scenario needed (unit/sweep-covered).
