### PR TITLE
fix(ui): reset the default save slot honestly instead of promising a dead legacy mode

### DIFF
--- a/src/components/SettingsPage.test.tsx
+++ b/src/components/SettingsPage.test.tsx
@@ -1251,38 +1251,28 @@ describe("SettingsPage", () => {
       );
     });
 
-    it("opens the clear-default-slot ConfirmModal when the value is empty", async () => {
-      render(<SettingsPage onBack={vi.fn()} />);
-      await flushAsync();
-      act(() => {
-        capturedSaveSync[capturedSaveSync.length - 1]?.onDefaultSlotSubmit("   ");
-      });
-      const props = lastConfirmModalProps<{
-        strTitle?: string;
-        strOKButtonText?: string;
-        onOK?: () => void | Promise<void>;
-      }>();
-      expect(props?.strTitle).toBe("Clear Default Slot?");
-      expect(props?.strOKButtonText).toBe("Clear Slot");
-    });
-
-    it("clears default_slot when the clear-default-slot confirmation is OK'd", async () => {
+    it("resets to 'default' without a confirm modal when the value is empty", async () => {
       vi.mocked(backend.updateSaveSyncSettings).mockResolvedValue({ success: true });
       render(<SettingsPage onBack={vi.fn()} />);
       await flushAsync();
-      act(() => {
-        capturedSaveSync[capturedSaveSync.length - 1]?.onDefaultSlotSubmit("");
-      });
-      const props = lastConfirmModalProps<{ onOK?: () => void | Promise<void> }>();
       await act(async () => {
-        await props?.onOK?.();
+        capturedSaveSync[capturedSaveSync.length - 1]?.onDefaultSlotSubmit("   ");
+        await Promise.resolve();
       });
       expect(vi.mocked(backend.updateSaveSyncSettings)).toHaveBeenCalledWith(
-        expect.objectContaining({ default_slot: null }),
+        expect.objectContaining({ default_slot: "default" }),
+      );
+      // The old "enables legacy mode" clear-slot confirm modal is gone.
+      expect(vi.mocked(showModal)).not.toHaveBeenCalled();
+      expect(vi.mocked(toaster.toast)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "RomM Sync",
+          body: 'Default save slot reset to "default".',
+        }),
       );
     });
 
-    it("handleResetDefaultSlot sets default_slot='default'", async () => {
+    it("handleResetDefaultSlot sets default_slot='default' and toasts", async () => {
       vi.mocked(backend.updateSaveSyncSettings).mockResolvedValue({ success: true });
       render(<SettingsPage onBack={vi.fn()} />);
       await flushAsync();
@@ -1292,6 +1282,12 @@ describe("SettingsPage", () => {
       });
       expect(vi.mocked(backend.updateSaveSyncSettings)).toHaveBeenCalledWith(
         expect.objectContaining({ default_slot: "default" }),
+      );
+      expect(vi.mocked(toaster.toast)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "RomM Sync",
+          body: 'Default save slot reset to "default".',
+        }),
       );
     });
   });

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -268,22 +268,6 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
 
   const saveSyncEnabled = saveSyncSettings?.save_sync_enabled ?? false;
 
-  /** Show confirmation modal and clear the default slot on OK. */
-  function confirmClearDefaultSlot(): void {
-    showModal(
-      <ConfirmModal
-        strTitle="Clear Default Slot?"
-        strDescription="Clearing the default slot enables legacy mode. New games will not use a slot, which limits saves to one version per game. Are you sure?"
-        strOKButtonText="Clear Slot"
-        strCancelButtonText="Cancel"
-        onOK={() => {
-          setSaveSyncSettings((prev) => (prev ? { ...prev, default_slot: null } : prev));
-          detach(handleSaveSyncSettingChange({ default_slot: null }));
-        }}
-      />,
-    );
-  }
-
   // --- Connection handlers wired into ConnectionSection ---
   const handleUrlChange = async (value: string) => {
     const trimmed = trimServerUrl(value);
@@ -394,18 +378,22 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
   };
 
   // --- Save-sync default-slot handlers ---
+  const handleResetDefaultSlot = () => {
+    setSaveSyncSettings((prev) => (prev ? { ...prev, default_slot: "default" } : prev));
+    detach(handleSaveSyncSettingChange({ default_slot: "default" }));
+    toaster.toast({
+      title: "RomM Sync",
+      body: 'Default save slot reset to "default".',
+    });
+  };
   const handleDefaultSlotSubmit = (value: string) => {
     const trimmed = value.trim();
     if (trimmed) {
       setSaveSyncSettings((prev) => (prev ? { ...prev, default_slot: trimmed } : prev));
       detach(handleSaveSyncSettingChange({ default_slot: trimmed }));
     } else {
-      confirmClearDefaultSlot();
+      handleResetDefaultSlot();
     }
-  };
-  const handleResetDefaultSlot = () => {
-    setSaveSyncSettings((prev) => (prev ? { ...prev, default_slot: "default" } : prev));
-    detach(handleSaveSyncSettingChange({ default_slot: "default" }));
   };
 
   // --- Controller handlers ---

--- a/src/components/settings/SaveSyncSection.test.tsx
+++ b/src/components/settings/SaveSyncSection.test.tsx
@@ -228,14 +228,6 @@ describe("SaveSyncSection", () => {
       expect(container.textContent).toContain("speedrun");
     });
 
-    it("shows 'Legacy' when default_slot is empty", () => {
-      const { container } = render(
-        <SaveSyncSection {...defaultProps({ saveSyncSettings: makeSettings({ default_slot: "" }) })} />,
-      );
-      expect(container.textContent).toContain("Legacy");
-      expect(container.textContent).not.toContain("(no slot)");
-    });
-
     it("opens a TextInputModal on Edit with the current default_slot", () => {
       const onDefaultSlotSubmit = vi.fn();
       const { getByText } = render(
@@ -251,14 +243,6 @@ describe("SaveSyncSection", () => {
       expect(props?.label).toBe("Default Save Slot");
       expect(props?.value).toBe("main");
       expect(props?.onSubmit).toBe(onDefaultSlotSubmit);
-    });
-
-    it("passes an empty string to the modal when default_slot is null", () => {
-      const { getByText } = render(
-        <SaveSyncSection {...defaultProps({ saveSyncSettings: makeSettings({ default_slot: null }) })} />,
-      );
-      fireEvent.click(getByText("Edit"));
-      expect(lastShownModalProps()?.value).toBe("");
     });
   });
 
@@ -280,13 +264,6 @@ describe("SaveSyncSection", () => {
       );
       fireEvent.click(getByText("Reset to default"));
       expect(onResetDefaultSlot).toHaveBeenCalledTimes(1);
-    });
-
-    it("is rendered when default_slot is null (null !== 'default')", () => {
-      const { getByText } = render(
-        <SaveSyncSection {...defaultProps({ saveSyncSettings: makeSettings({ default_slot: null }) })} />,
-      );
-      expect(getByText("Reset to default")).toBeInTheDocument();
     });
   });
 

--- a/src/components/settings/SaveSyncSection.tsx
+++ b/src/components/settings/SaveSyncSection.tsx
@@ -89,7 +89,7 @@ export const SaveSyncSection: FC<SaveSyncSectionProps> = ({
               <PanelSectionRow>
                 <Field
                   label="Default Save Slot"
-                  description={`${saveSyncSettings.default_slot || "Legacy"} — applies to new games and games without a per-game slot override`}
+                  description={`${saveSyncSettings.default_slot} — applies to new games and games without a per-game slot override`}
                 >
                   <DialogButton
                     style={{ minWidth: "auto", width: "auto" }}
@@ -97,7 +97,7 @@ export const SaveSyncSection: FC<SaveSyncSectionProps> = ({
                       showModal(
                         <TextInputModal
                           label="Default Save Slot"
-                          value={saveSyncSettings.default_slot ?? ""}
+                          value={saveSyncSettings.default_slot}
                           onSubmit={onDefaultSlotSubmit}
                         />,
                       )

--- a/src/types/saves.ts
+++ b/src/types/saves.ts
@@ -8,7 +8,7 @@ export interface SaveSyncSettings {
   save_sync_enabled: boolean;
   sync_before_launch: boolean;
   sync_after_exit: boolean;
-  default_slot: string | null;
+  default_slot: string;
   autocleanup_limit: number;
 }
 


### PR DESCRIPTION
Closes #1473

> **Stacked PR — draft until #1472 merges.** Based on `chore/876-legacy-slot-label`; the diff shows its commit until then. Own commit: `dcd2e0b`.

The "clear default slot" flow promised a legacy mode the backend no longer honors: since ADR-0017 the backend coerces a blank default slot to `"default"` (and legacy `slot:null` is retired as a confirmable target), so the flow was a mislabeled no-op — the UI briefly showed "Legacy", then the round-trip flipped it to "default".

- the legacy-claiming confirm modal is deleted; a blank submit now routes through the existing honest reset handler (`default_slot: "default"`, optimistic + persisted, no confirm — the setting is non-destructive and trivially reversible, matching the repo's confirm-only-destructive pattern)
- a toast confirms the reset (`Default save slot reset to "default".`)
- the now-unreachable `"Legacy"` display fallback is removed and `SaveSyncSettings.default_slot` is tightened `string | null` → `string` (the wire never delivers null)
- note: this touches only the frontend CONFIG affordance — server-side slot addressing is untouched; RomM's `slot:null` bucket stays isolated from the `default` slot (deliberate project invariant)

docs: N/A — no user-guide page documented the removed flow (grep-verified); the architecture mentions remain accurate.
