### PR TITLE
fix(saves): harden null-slot isolation via the shared save_in_slot funnel

### DIFF
--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -277,6 +277,18 @@ therefore deletes **only** the `slot: null` saves and never touches named slots.
 op was the bug: the server returned `[]`, the local tracking was cleared, and the slot resurrected on the next merge
 (zombie slot).
 
+The **active-slot matching filter** applies the same funnel from the other direction. The matrix sync run,
+`get_save_status`, and rollback narrow the fetched saves through `MatrixExecutor.filter_server_saves_to_slot`, and
+`switch_slot` client-filters its fetch the same way — every one keeps only `save_in_slot(save, active_slot)`. So a
+legacy `slot:null` save belongs **only** to the legacy slot and is **isolated from every named slot, including
+`"default"`** ([#877](https://github.com/danielcopper/decky-romm-sync/issues/877)): it never enters a named slot's
+`compute_sync_action` inputs (no spurious download or conflict from a newer legacy head), its status counts, or its slot
+listing, and a brand-new named slot is genuinely empty. The legacy saves stay readable through the legacy bucket
+(`get_slot_saves(rom, "")` and the Setup Wizard's server-slot grouping) — the null bucket is deliberately separate from
+`"default"`, never merged onto or aliased with it. The original bug matched `slot == active or slot is None` under every
+named slot (fixed by #1061); routing the switch fetch through the shared `save_in_slot` funnel closes the last
+hand-rolled site.
+
 The **upload** side honours the same equivalence (`MatrixExecutor._resolve_upload_slot`): a sync on the legacy slot
 (`active_slot=None` with a populated `slots` map) uploads with the `slot` param **omitted**, so the server stores a
 `slot: null` save. Only a brand-new ROM (no `slots` yet) seeds the configured default slot for its first sync. Since

--- a/py_modules/services/saves/slots/switching.py
+++ b/py_modules/services/saves/slots/switching.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any
 from domain.iso_time import parse_iso_to_epoch
 from domain.rom_save_state import RomSaveState
 from domain.save_layout import SAVE_SYNC_CONTENT_DIR_REASON
+from domain.save_slot import save_in_slot
 from lib.list_result import ErrorCode
 from services.saves._helpers import local_save_target
 from services.saves._messages import SAVE_SYNC_IN_CONTENT_DIR
@@ -230,9 +231,13 @@ class SlotSwitcher:
                     "message": str(e),
                 }
 
-            # Filter to the target slot (FakeSaveApi doesn't filter, real API may not either)
-            # Normalize "" and None both to None before comparing (legacy saves may use either)
-            slot_saves = [s for s in all_server_saves if (s.get("slot") or None) == resolved_slot]
+            # Filter to the target slot client-side. The fetch above omits the
+            # ``slot=`` param (RomM can't address ``slot:null``), so this is the
+            # legacy-safe path: route membership through the single
+            # ``domain.save_slot.save_in_slot`` funnel (#1061) so the legacy
+            # bucket stays isolated from every named switch target — a slot:null
+            # save is never pulled into a named slot (#877).
+            slot_saves = [s for s in all_server_saves if save_in_slot(s, resolved_slot)]
             self._log_debug(
                 f"switch_slot: fetch rom={rom_id} resolved_slot={resolved_slot!r} "
                 f"server_all={[(s.get('id'), s.get('slot')) for s in all_server_saves]} "

--- a/tests/contract/test_saves_read.py
+++ b/tests/contract/test_saves_read.py
@@ -174,6 +174,42 @@ async def test_get_slot_saves_server_failure_shape(harness):
     assert result["saves"] == []
 
 
+# ── #877 null-slot isolation ─────────────────────────────────────────────
+
+
+async def test_null_slot_save_isolated_from_named_slot_but_visible_in_legacy_bucket(harness):
+    """#877: a slot:null save never leaks into a named slot's status, yet stays
+    readable in the legacy bucket.
+
+    Non-vacuous: the legacy (slot:null) save (id=600) is NEWER than the
+    named-slot head (id=500). Absent slot isolation the newest-wins pick under
+    the active "default" slot would surface 600 in ``get_save_status``. The
+    legacy save stays legacy-only — invisible to the named slot, visible via
+    ``get_slot_saves(rom, "")`` (the legacy bucket the migration/browsing
+    surfaces render).
+    """
+    enable_save_sync(harness)
+    seed_install(harness, 42, system="gba", file_name="game.gba")
+    seed_save_state(harness, 42, RomSaveState(active_slot="default", slot_confirmed=True, system="gba"))
+    seed_server_save(
+        harness, save_id=500, rom_id=42, slot="default", file_name="game.srm", updated_at="2026-02-17T06:00:00Z"
+    )
+    seed_server_save(
+        harness, save_id=600, rom_id=42, slot=None, file_name="game.srm", updated_at="2026-02-17T20:00:00Z"
+    )
+
+    # Named-slot status: the newer legacy save is absent; only the "default" head shows.
+    status = await harness.plugin.get_save_status(42)
+    surfaced = [f["server_save_id"] for f in status["files"]]
+    assert 600 not in surfaced
+    assert surfaced == [500]
+
+    # The legacy bucket still renders the null save — and only it.
+    legacy = await harness.plugin.get_slot_saves(42, "")
+    assert legacy["success"] is True
+    assert [s["id"] for s in legacy["saves"]] == [600]
+
+
 # ── get_slot_delete_info ─────────────────────────────────────────────────
 
 

--- a/tests/services/saves/sync_engine/test_matrix.py
+++ b/tests/services/saves/sync_engine/test_matrix.py
@@ -434,6 +434,70 @@ class TestV47SyncFlow:
         # Verify download happened
         assert 100 in fake.downloaded_files
 
+    def test_sync_ignores_newer_legacy_save_under_named_slot(self, tmp_path):
+        """#877: a slot:null save NEWER than the named-slot head never enters the sync decision.
+
+        Non-vacuous regression: the legacy save (id=200, updated 20:00) is newer
+        than the named-slot head (id=100, updated 06:00) the local file is synced
+        to. Absent slot isolation the newest-wins pick for the "pokemon.srm"
+        target under the active "default" slot would choose 200 and download it —
+        so the leaky filter would report ``synced==1`` with 200 in the downloads.
+        With ``filter_server_saves_to_slot`` the "default" slot only sees 100
+        (matches local → Skip) and the legacy save is never pulled in.
+        """
+        svc, fake = make_service(tmp_path)
+        svc._config.settings["save_sync_enabled"] = True
+        _set_device_id(svc, "dev-1")
+        _install_rom(svc, tmp_path)
+        content = b"named-slot content"
+        _create_save(tmp_path, content=content)
+        local_hash = hashlib.md5(content).hexdigest()
+
+        # Local is synced to the named-slot head; active slot is "default".
+        _seed_save_state_dict(
+            svc,
+            42,
+            {
+                "active_slot": "default",
+                "slot_confirmed": True,
+                "files": {
+                    "pokemon.srm": {
+                        "last_sync_hash": local_hash,
+                        "last_sync_server_updated_at": "2026-02-17T06:00:00Z",
+                        "last_sync_server_save_id": 100,
+                        "last_sync_server_size": len(content),
+                    }
+                },
+            },
+        )
+        # Named-slot head (older, is_current) + a NEWER legacy save on the server.
+        fake.saves[100] = {
+            "id": 100,
+            "rom_id": 42,
+            "file_name": "pokemon.srm",
+            "updated_at": "2026-02-17T06:00:00Z",
+            "file_size_bytes": len(content),
+            "slot": "default",
+            "device_syncs": [{"device_id": "dev-1", "is_current": True}],
+        }
+        fake.saves[200] = {
+            "id": 200,
+            "rom_id": 42,
+            "file_name": "pokemon.srm",
+            "updated_at": "2026-02-17T20:00:00Z",
+            "file_size_bytes": 4096,
+            "slot": None,
+            "device_syncs": [{"device_id": "dev-1", "is_current": False}],
+        }
+
+        synced, errors, conflicts = _do_sync(svc, 42)
+
+        assert synced == 0
+        assert errors == []
+        assert conflicts == []
+        # The newer legacy save was never downloaded into the named slot.
+        assert 200 not in fake.downloaded_files
+
 
 class TestConfirmDownloadAfterSync:
     """Verify the device's last_synced_at ends up registered with RomM after each

--- a/tests/services/saves/test_status.py
+++ b/tests/services/saves/test_status.py
@@ -106,6 +106,69 @@ class TestSaveStatus:
         assert result["files"][0]["status"] == "upload"
         assert result["files"][0]["server_save_id"] is None
 
+    @pytest.mark.asyncio
+    async def test_status_ignores_newer_legacy_save_under_named_slot(self, tmp_path):
+        """#877: a slot:null save NEWER than the named-slot head is absent from status.
+
+        Non-vacuous regression: the legacy save (id=200, updated 20:00) is newer
+        than the named-slot head (id=100, updated 06:00) the local file is synced
+        to. Absent slot isolation the newest-wins pick under the active "default"
+        slot would surface 200 as a pending Download; with
+        ``filter_server_saves_to_slot`` the slot only sees 100 (matches local →
+        synced) and the legacy save never appears.
+        """
+        svc, fake = make_service(tmp_path)
+        svc._config.settings["save_sync_enabled"] = True
+        _set_device_id(svc, "dev-1")
+        _install_rom(svc, tmp_path)
+        content = b"named-slot content"
+        save_path = _create_save(tmp_path, content=content)
+        local_hash = _file_md5(str(save_path))
+
+        _seed_save_state_dict(
+            svc,
+            42,
+            {
+                "active_slot": "default",
+                "slot_confirmed": True,
+                "files": {
+                    "pokemon.srm": {
+                        "tracked_save_id": 100,
+                        "last_sync_hash": local_hash,
+                        "last_sync_server_updated_at": "2026-02-17T06:00:00Z",
+                        "last_sync_server_save_id": 100,
+                        "last_sync_server_size": len(content),
+                    }
+                },
+            },
+        )
+        fake.saves[100] = {
+            "id": 100,
+            "rom_id": 42,
+            "file_name": "pokemon.srm",
+            "updated_at": "2026-02-17T06:00:00Z",
+            "file_size_bytes": len(content),
+            "slot": "default",
+            "device_syncs": [{"device_id": "dev-1", "is_current": True}],
+        }
+        fake.saves[200] = {
+            "id": 200,
+            "rom_id": 42,
+            "file_name": "pokemon.srm",
+            "updated_at": "2026-02-17T20:00:00Z",
+            "file_size_bytes": 4096,
+            "slot": None,
+            "device_syncs": [{"device_id": "dev-1", "is_current": False}],
+        }
+
+        result = await svc.get_save_status(42)
+
+        assert len(result["files"]) == 1
+        entry = result["files"][0]
+        assert entry["server_save_id"] == 100
+        assert entry["status"] == "synced"
+        assert 200 not in [f["server_save_id"] for f in result["files"]]
+
 
 class TestSaveStatusContentDir:
     """get_save_status surfaces the additive ``savefiles_in_content_dir`` flag


### PR DESCRIPTION
Closes #877

> **Stacked PR — draft until #1474 (and the chain below it) merges.** Based on `fix/1470-badzip-fallback`; the diff shows the whole chain until then. Own commit: `77b0c989`.

The reported leak — legacy `slot:null` saves bleeding into every named slot — was fixed by #1061 (`save_in_slot` funnel). This PR closes the issue by **hardening** that isolation instead of implementing the issue's original null-as-default proposal, which is rejected: `null` (the web player's bucket — browser uploads carry no slot, and negotiate skips null-slot saves entirely) and the `"default"` slot are deliberately distinct and never merged.

- `switch_slot`'s hand-rolled slot match now routes through `domain/save_slot.py::save_in_slot` — behavior-preserving (the one divergent input combination is unreachable), one wire-contract source per the invariant register's funnel rule
- flow-level regression tests: a `slot:null` save NEWER than the named-slot head must not enter the named slot's sync decisions or status — proven non-vacuous by temporarily re-introducing the pre-#1061 leaky filter (all three new tests then fail)
- contract-tier test pins both directions: the named slot never sees the null save, and the legacy bucket still surfaces exactly the null save
- full `list_saves`-consumer sweep documented: every slot-membership filter routes through the funnel; the two remaining `.get("slot")` sites are grouping surfaces (show all slots) and correctly unfiltered
- docs: `save-file-sync-architecture.md` describes the funnel and the null/default separation

Merge gate: rides the stacked chain's on-device round (slot-switch + legacy-bucket visibility are part of the checklist).
