### PR TITLE
feat(saves): per-direction counts on the save-sync completion toast

### DIFF
--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -1204,6 +1204,15 @@ case: we believe the server's claim and write `last_sync_hash := local_hash` so 
 All four sync entry points share a single decision primitive — `compute_sync_action` — and a single dispatch path —
 `_dispatch_sync_action`. The flows differ only in _when_ they fire and how they surface results.
 
+**Completion toast — per-direction counts (#250).** `_dispatch_sync_action` returns a `TransferDirection` (`UPLOAD` /
+`DOWNLOAD` / `None`), so `sync_rom_saves` tallies uploads and downloads separately and each per-ROM result dict carries
+additive `uploaded` / `downloaded` counts beside the `synced` total (a 409-backstop download counts as a _download_, not
+the upload that lost the race). The completion toast names which way saves moved — "Saves uploaded to RomM", "Saves
+downloaded from RomM", or "Saves synced with RomM (1 up, 2 down)" when a run went both ways — and a run that transferred
+nothing shows no toast. The wording is a single contract mirrored on both sides: the frontend renders the pre-launch
+toast via `saveSyncToastBody` (`src/utils/saveSyncToast.ts`); the backend renders the post-exit toast itself via
+`sync_toast_body` (`services/session_lifecycle.py`) since that flow returns a pre-built `toast_body`.
+
 ### Pre-launch sync
 
 Triggered from the game detail page when the user clicks the Play button (if `sync_before_launch` is enabled). This is
@@ -1221,7 +1230,8 @@ Triggered from the game detail page when the user clicks the Play button (if `sy
    Sync Unavailable" fallback-launch confirm; the launch proceeds only if the user confirms it, and is aborted (the
    button returns to "play") if they decline (#1050). The benign `savefiles_in_content_dir` skip still proceeds
    silently.
-6. Toast notification shown on sync result.
+6. Toast notification shown on sync result — the per-direction completion toast above (uploaded / downloaded / both), or
+   the classified failure/offline message.
 
 ### Post-exit sync
 
@@ -1239,7 +1249,8 @@ Triggered automatically when a game stops (if `sync_after_exit` is enabled).
    409-backstopped).
 4. If a `Conflict` is returned, a toast notifies the user. The modal is **not** opened post-exit — the conflict re-fires
    at the next pre-launch sync, where the user resolves it via Keep Local / Use Server before launch.
-5. Toast notification shown on success or conflict.
+5. Toast notification shown on success or conflict — the per-direction completion toast above (uploaded / downloaded /
+   both) on a successful transfer, rendered backend-side into `SessionFinalizeSyncResult.toast_body`.
 
 ### Manual sync all
 

--- a/docs/user-guide/save-sync.md
+++ b/docs/user-guide/save-sync.md
@@ -67,8 +67,10 @@ Open **Save Sync** from the main QAM page to configure sync behavior.
 
 - **Sync before launch** (default: on) — runs sync when a game starts, whether via the Play button or the launch gate.
   If the server is unreachable, the game launches with whatever local save exists.
-- **Sync after exit** (default: on) — runs sync after closing a game. A toast confirms a successful upload; if the sync
-  fails, the toast names the actual cause (see [Offline Behavior](#offline-behavior)) instead of a generic message.
+- **Sync after exit** (default: on) — runs sync after closing a game. A toast confirms what moved and which way — "Saves
+  uploaded to RomM", "Saves downloaded from RomM", or "Saves synced with RomM (1 up, 2 down)" when a run went both ways;
+  a sync that transferred nothing shows no toast. If the sync fails, the toast names the actual cause (see
+  [Offline Behavior](#offline-behavior)) instead of a generic message.
 
 ### When saves conflict
 

--- a/py_modules/services/saves/sync_engine/engine.py
+++ b/py_modules/services/saves/sync_engine/engine.py
@@ -286,8 +286,12 @@ class SyncEngine:
         core_so: str | None,
         default_slot: str | None = None,
         autocleanup_limit: int | None = None,
-    ) -> tuple[int, list[str], list[dict[str, Any]]]:
-        """Sync saves for a single ROM (delegate to :class:`MatrixExecutor`)."""
+    ) -> tuple[int, int, list[str], list[dict[str, Any]]]:
+        """Sync saves for a single ROM (delegate to :class:`MatrixExecutor`).
+
+        Returns ``(uploaded, downloaded, errors, conflicts)`` — the per-direction
+        transfer counts (#250).
+        """
         return self._matrix.sync_rom_saves(rom_id, save_state, device_id, core_so, default_slot, autocleanup_limit)
 
     def do_download_save(
@@ -541,8 +545,13 @@ class SyncEngine:
         require_confirmed: bool = False,
         session_id: int | None = None,
         session_counts: list[int] | None = None,
-    ) -> tuple[int, list[str], list[dict[str, Any]]]:
+    ) -> tuple[int, int, list[str], list[dict[str, Any]]]:
         """Read inputs → sync in executor → persist, for one ROM under its lock.
+
+        Returns ``(uploaded, downloaded, errors, conflicts)`` — the matrix
+        worker's per-direction transfer counts (#250). The negotiate session
+        close and the bulk-sweep *session_counts* accumulator record the
+        combined ``uploaded + downloaded`` as the session's completed-op count.
 
         The narrow-UoW shape (ADR-0006): a short read UoW loads the aggregate +
         device id, the matrix transfer runs outside any transaction mutating the
@@ -573,11 +582,11 @@ class SyncEngine:
         info = await self._loop.run_in_executor(None, self._rom_info.get_rom_save_info, rom_id)
         if not info:
             self._log_debug(f"_run_rom_sync({rom_id}): ROM not installed, skipping")
-            return 0, [], []
+            return 0, 0, [], []
         save_state, device_id = await self._loop.run_in_executor(None, self._read_sync_inputs, rom_id)
         if require_confirmed and not save_state.slot_confirmed:
             self._log_debug(f"_run_rom_sync({rom_id}): slot not confirmed, skipping bulk sync")
-            return 0, [], []
+            return 0, 0, [], []
         core_so = await self._loop.run_in_executor(None, self.resolve_core, rom_id)
         default_slot = resolve_default_slot(self._settings)
         cleanup_limit = autocleanup_limit(self._settings)
@@ -592,21 +601,23 @@ class SyncEngine:
             if session_id is None and save_state.slot_confirmed and save_state.active_slot:
                 own_session_id = await self._open_negotiate_session(rom_id, device_id)
 
-            synced = 0
+            uploaded = 0
+            downloaded = 0
             errors: list[str] = []
             conflicts: list[dict[str, Any]] = []
             try:
-                synced, errors, conflicts = await self._loop.run_in_executor(
+                uploaded, downloaded, errors, conflicts = await self._loop.run_in_executor(
                     None, self.do_sync_rom_saves, rom_id, save_state, device_id, core_so, default_slot, cleanup_limit
                 )
                 await self._loop.run_in_executor(None, self._write_save_state, rom_id, save_state)
             finally:
+                synced = uploaded + downloaded
                 if own_session_id is not None:
                     await self._close_negotiate_session(own_session_id, synced, len(errors))
                 elif session_counts is not None:
                     session_counts[0] += synced
                     session_counts[1] += len(errors)
-            return synced, errors, conflicts
+            return uploaded, downloaded, errors, conflicts
 
     async def _open_negotiate_session(self, rom_id: int, device_id: str | None) -> int | None:
         """Open a transport-only negotiate session for a confirmed ROM; ``None`` on failure.
@@ -713,7 +724,8 @@ class SyncEngine:
                             "message": DEVICE_NOT_REGISTERED,
                         }
 
-                synced, errors, conflicts = await self._run_rom_sync(rom_id)
+                uploaded, downloaded, errors, conflicts = await self._run_rom_sync(rom_id)
+                synced = uploaded + downloaded
 
                 msg = f"Downloaded {synced} save(s)"
                 if errors:
@@ -722,6 +734,8 @@ class SyncEngine:
                     "success": len(errors) == 0,
                     "message": msg,
                     "synced": synced,
+                    "uploaded": uploaded,
+                    "downloaded": downloaded,
                     "errors": errors,
                     "conflicts": list(conflicts),
                 }
@@ -789,12 +803,14 @@ class SyncEngine:
                             "message": DEVICE_NOT_REGISTERED,
                         }
 
-                synced, errors, conflicts = await self._run_rom_sync(rom_id)
+                uploaded, downloaded, errors, conflicts = await self._run_rom_sync(rom_id)
+                synced = uploaded + downloaded
 
                 self._logger.info(
-                    "post_exit_sync complete for rom_id=%d: synced=%d, errors=%d, conflicts=%d",
+                    "post_exit_sync complete for rom_id=%d: uploaded=%d, downloaded=%d, errors=%d, conflicts=%d",
                     rom_id,
-                    synced,
+                    uploaded,
+                    downloaded,
                     len(errors),
                     len(conflicts),
                 )
@@ -806,6 +822,8 @@ class SyncEngine:
                     "success": len(errors) == 0,
                     "message": msg,
                     "synced": synced,
+                    "uploaded": uploaded,
+                    "downloaded": downloaded,
                     "errors": errors,
                     "conflicts": list(conflicts),
                 }
@@ -855,7 +873,8 @@ class SyncEngine:
                             "message": DEVICE_NOT_REGISTERED,
                         }
 
-                synced, errors, conflicts = await self._run_rom_sync(rom_id)
+                uploaded, downloaded, errors, conflicts = await self._run_rom_sync(rom_id)
+                synced = uploaded + downloaded
 
                 msg = _summarize_sync_result(
                     f"Synced {synced} save(s)", synced=synced, errors=errors, conflicts=len(conflicts)
@@ -864,6 +883,8 @@ class SyncEngine:
                     "success": len(errors) == 0,
                     "message": msg,
                     "synced": synced,
+                    "uploaded": uploaded,
+                    "downloaded": downloaded,
                     "errors": errors,
                     "conflicts": list(conflicts),
                 }
@@ -974,13 +995,13 @@ class SyncEngine:
                         for rom_id_int in rom_ids:
                             rom_count += 1
                             async with self.rom_lock(rom_id_int):
-                                synced, errors, conflicts = await self._run_rom_sync(
+                                uploaded, downloaded, errors, conflicts = await self._run_rom_sync(
                                     rom_id_int,
                                     require_confirmed=True,
                                     session_id=session_id,
                                     session_counts=session_counts if session_id is not None else None,
                                 )
-                            total_synced += synced
+                            total_synced += uploaded + downloaded
                             total_errors.extend(errors)
                             all_conflicts.extend(conflicts)
                     finally:

--- a/py_modules/services/saves/sync_engine/matrix.py
+++ b/py_modules/services/saves/sync_engine/matrix.py
@@ -16,6 +16,7 @@ import contextlib
 import os
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from enum import Enum
 from typing import TYPE_CHECKING, Any
 
 from domain.emulator_tag import build_emulator_tag
@@ -50,6 +51,22 @@ if TYPE_CHECKING:
 
 
 _BACKUP_RETENTION = 10  # max .romm-backup copies kept per save file (#974)
+
+
+class TransferDirection(Enum):
+    """Which way a dispatched save transfer actually moved (#250).
+
+    Returned by the sync dispatch so ``sync_rom_saves`` can split the total
+    transfer count into per-direction upload / download tallies for the
+    completion toast. Direction reflects what moved on the wire, not the
+    planned :class:`SyncAction`: an ``Upload`` that RomM rejects with a 409 and
+    the backstop downgrades to a fresh-head download is attributed as
+    ``DOWNLOAD``. A skip, a surfaced conflict, or a failed transfer yields no
+    direction (the dispatch returns ``None``).
+    """
+
+    UPLOAD = "upload"
+    DOWNLOAD = "download"
 
 
 @dataclass(frozen=True)
@@ -544,7 +561,7 @@ class MatrixExecutor:
         last_sync_server_hash: str | None,
         options: SyncRunOptions,
         sink: DispatchSink,
-    ) -> bool:
+    ) -> TransferDirection | None:
         """Execute an ``Upload`` action by POSTing a new save, with a 409 backstop.
 
         Every automatic upload POSTs a new save in the slot (``server_save=None``,
@@ -556,14 +573,16 @@ class MatrixExecutor:
         ``resolve_upload_conflict`` decide from hashes alone (download the fresh
         head when local is provably unchanged, else surface a conflict). Any other
         ``RommApiError`` propagates to the generic handler in
-        :meth:`_dispatch_sync_action`. Returns True iff a transfer was issued.
+        :meth:`_dispatch_sync_action`. Returns the transfer direction that was
+        issued (``UPLOAD`` on a clean POST, ``DOWNLOAD`` when the 409 backstop
+        downgrades), or ``None`` when nothing transferred.
         """
         if local_path is None:
             self._logger.warning(
                 f"_dispatch_upload({ctx.rom_id}): {filename}: upload requested but no local file on disk"
             )
             sink.errors.append(f"{filename}: upload requested but no local file")
-            return False
+            return None
         try:
             # POST (create) a new save in the slot. The retention cap is POST-only —
             # RomM stacks versions on create, so the limit is sent here alone.
@@ -580,7 +599,7 @@ class MatrixExecutor:
                 autocleanup_limit=options.autocleanup_limit,
                 overwrite=False,
             )
-            return True
+            return TransferDirection.UPLOAD
         except RommConflictError:
             return self._handle_upload_409(
                 ctx=ctx,
@@ -604,7 +623,7 @@ class MatrixExecutor:
         last_sync_server_hash: str | None,
         options: SyncRunOptions,
         sink: DispatchSink,
-    ) -> bool:
+    ) -> TransferDirection | None:
         """Re-decide an upload rejected by RomM's write-time 409.
 
         The POST proved the slot head moved past our last sync since the
@@ -615,6 +634,8 @@ class MatrixExecutor:
         local downloads the fresh head; anything else is a genuine two-sided
         divergence the user must resolve. An empty regroup (the head vanished
         again between the 409 and the re-fetch) is recorded as a non-fatal error.
+        Returns ``DOWNLOAD`` when the backstop pulled the fresh head, else ``None``
+        (empty regroup or surfaced conflict — nothing transferred).
         """
         server_saves = self._retry.with_retry(lambda: self._romm_api.list_saves(ctx.rom_id, device_id=ctx.device_id))
         server_in_slot = self.filter_server_saves_to_slot(server_saves, ctx.save_state.active_slot)
@@ -624,7 +645,7 @@ class MatrixExecutor:
                 f"_handle_upload_409({ctx.rom_id}): {filename}: 409 on POST but no server save in slot on re-fetch"
             )
             sink.errors.append(f"{filename}: upload rejected by server and no server save found to reconcile")
-            return False
+            return None
         fresh = max(group, key=lambda s: parse_iso_to_epoch(s.get("updated_at")) or 0.0)
         if (
             resolve_upload_conflict(local_hash, last_sync_hash, fresh.get("content_hash"), last_sync_server_hash)
@@ -633,9 +654,9 @@ class MatrixExecutor:
             self.do_download_save(
                 fresh, ctx.saves_dir, filename, ctx.save_state, ctx.device_id, ctx.system, options.default_slot
             )
-            return True
+            return TransferDirection.DOWNLOAD
         sink.conflicts.append(self.build_sync_conflict_entry(ctx.rom_id, filename, fresh, local_path, local_hash))
-        return False
+        return None
 
     def _dispatch_sync_action(
         self,
@@ -649,8 +670,8 @@ class MatrixExecutor:
         last_sync_server_hash: str | None,
         options: SyncRunOptions,
         sink: DispatchSink,
-    ) -> bool:
-        """Execute one ``SyncAction`` outcome. Returns True if a transfer happened.
+    ) -> TransferDirection | None:
+        """Execute one ``SyncAction`` outcome and report the transfer direction.
 
         Centralises the I/O dispatch so ``sync_rom_saves`` stays declarative.
         Errors are caught and pushed onto ``sink.errors`` so a single failure
@@ -658,6 +679,8 @@ class MatrixExecutor:
         ``sink.conflicts``. ``ctx.rom_name`` + the stored baseline pair
         (``last_sync_hash`` / ``last_sync_server_hash``) are threaded through for
         the upload 409 backstop (canonical-target regroup + hash re-decision).
+        Returns the :class:`TransferDirection` a transfer moved, or ``None`` for a
+        skip, a surfaced conflict, or a failed transfer.
         """
         try:
             if isinstance(action, Skip):
@@ -668,7 +691,7 @@ class MatrixExecutor:
                     filename=filename,
                     local_hash=local_hash,
                 )
-                return False
+                return None
             if isinstance(action, Upload):
                 return self._dispatch_upload(
                     ctx=ctx,
@@ -690,12 +713,12 @@ class MatrixExecutor:
                     ctx.system,
                     options.default_slot,
                 )
-                return True
+                return TransferDirection.DOWNLOAD
             if isinstance(action, Conflict):
                 sink.conflicts.append(
                     self.build_sync_conflict_entry(ctx.rom_id, filename, action.server_save, local_path, local_hash)
                 )
-                return False
+                return None
         except RommApiError as e:
             _code, _msg = classify_error(e)
             self._logger.warning(f"_dispatch_sync_action({ctx.rom_id}): {filename} failed: {_msg}")
@@ -703,7 +726,7 @@ class MatrixExecutor:
         except Exception as e:
             self._logger.warning(f"_dispatch_sync_action({ctx.rom_id}): {filename} unexpected error: {e}")
             self._handle_unexpected_error(e, filename, ctx.saves_dir, sink.errors)
-        return False
+        return None
 
     def adopt_baseline_hash(self, save_state: RomSaveState, filename: str, local_hash: str) -> None:
         """Record ``local_hash`` as the file's ``last_sync_hash`` baseline.
@@ -819,17 +842,19 @@ class MatrixExecutor:
         core_so: str | None,
         default_slot: str | None = None,
         autocleanup_limit: int | None = None,
-    ) -> tuple[int, list[str], list[dict[str, Any]]]:
+    ) -> tuple[int, int, list[str], list[dict[str, Any]]]:
         """Sync saves for a single ROM, mutating *save_state* in memory.
 
         Drives :meth:`iter_matrix_outcomes` and dispatches each emitted
         outcome through :meth:`_dispatch_sync_action`. Returns
-        ``(synced_count, errors_list, conflicts_list)``. *core_so* is the
-        active core resolved once by the caller (for the upload emulator tag);
-        *default_slot* seeds the active slot when a brand-new ROM's first sync
-        lands; *autocleanup_limit* caps server-retained versions on the POST
-        (create) upload; the operation entry owns the surrounding read/write
-        Unit of Work.
+        ``(uploaded_count, downloaded_count, errors_list, conflicts_list)`` — the
+        two directional counts split out of the old aggregate transfer count so
+        the completion toast can name which way saves moved (#250); a 409-backstop
+        download counts as a download, not an upload. *core_so* is the active core
+        resolved once by the caller (for the upload emulator tag); *default_slot*
+        seeds the active slot when a brand-new ROM's first sync lands;
+        *autocleanup_limit* caps server-retained versions on the POST (create)
+        upload; the operation entry owns the surrounding read/write Unit of Work.
         """
         t_total = self._clock.time()
         rom_id = int(rom_id)
@@ -837,7 +862,7 @@ class MatrixExecutor:
         info = self._rom_info.get_rom_save_info(rom_id)
         if not info:
             self._log_debug(f"do_sync_rom_saves({rom_id}): no save info, skipping")
-            return 0, [], []
+            return 0, 0, [], []
         system = info["system"]
         saves_dir = info["saves_dir"]
 
@@ -847,7 +872,7 @@ class MatrixExecutor:
         except Exception as e:
             self._logger.error(f"do_sync_rom_saves({rom_id}): failed to list saves: {e}")
             _code, _msg = classify_error(e)
-            return 0, [f"Failed to fetch saves: {_msg}"], []
+            return 0, 0, [f"Failed to fetch saves: {_msg}"], []
         self._log_debug(f"[TIMING] do_sync_rom_saves({rom_id}): list_saves {self._clock.time() - t0:.3f}s")
 
         active_slot = save_state.active_slot
@@ -871,7 +896,8 @@ class MatrixExecutor:
             system=system,
             core_so=core_so,
         )
-        synced = 0
+        uploaded = 0
+        downloaded = 0
 
         pending_migration = self._rom_info.is_save_sort_changed()
         for outcome in self.iter_matrix_outcomes(
@@ -886,7 +912,7 @@ class MatrixExecutor:
                     f"do_sync_rom_saves({rom_id}): skipping server_only {outcome.filename} — migration pending"
                 )
                 continue
-            if self._dispatch_sync_action(
+            direction = self._dispatch_sync_action(
                 outcome.action,
                 ctx=ctx,
                 filename=outcome.filename,
@@ -896,17 +922,20 @@ class MatrixExecutor:
                 last_sync_server_hash=outcome.file_state.last_sync_server_hash,
                 options=options,
                 sink=sink,
-            ):
-                synced += 1
+            )
+            if direction is TransferDirection.UPLOAD:
+                uploaded += 1
+            elif direction is TransferDirection.DOWNLOAD:
+                downloaded += 1
 
         # Record when this sync check ran (regardless of whether files transferred)
         save_state.mark_sync_evaluated(self._clock.now().isoformat())
 
         self._log_debug(
             f"[TIMING] do_sync_rom_saves({rom_id}): TOTAL {self._clock.time() - t_total:.3f}s"
-            f" synced={synced} errors={len(errors)}"
+            f" uploaded={uploaded} downloaded={downloaded} errors={len(errors)}"
         )
-        return synced, errors, conflicts
+        return uploaded, downloaded, errors, conflicts
 
 
 def _upload_response_proves_current(response: dict[str, Any], device_id: str) -> bool:

--- a/py_modules/services/saves/versions.py
+++ b/py_modules/services/saves/versions.py
@@ -365,7 +365,7 @@ class VersionsService:
 
             # Matrix pre-flight: get the tracked save in sync first, or surface
             # a conflict that the user must resolve before any switch can run.
-            _synced, errors, conflicts = await self._loop.run_in_executor(
+            _uploaded, _downloaded, errors, conflicts = await self._loop.run_in_executor(
                 None, self._sync_engine.do_sync_rom_saves, rom_id, save_state, device_id, core_so, default_slot
             )
             if conflicts:

--- a/py_modules/services/session_lifecycle.py
+++ b/py_modules/services/session_lifecycle.py
@@ -32,8 +32,27 @@ if TYPE_CHECKING:
 
 _TOAST_TITLE = "RomM Save Sync"
 _TOAST_BODY_OFFLINE = "Server offline — saves will sync next time"
-_TOAST_BODY_SYNCED = "Saves synced with RomM"
+_TOAST_BODY_UPLOADED = "Saves uploaded to RomM"
+_TOAST_BODY_DOWNLOADED = "Saves downloaded from RomM"
 _TOAST_BODY_FAILED = "Failed to sync saves after exit"
+
+
+def sync_toast_body(uploaded: int, downloaded: int) -> str | None:
+    """Compose the per-direction save-sync completion toast body (#250).
+
+    Mirrors the frontend ``saveSyncToastBody`` (``src/utils/saveSyncToast.ts``)
+    verbatim so the pre-launch (frontend-rendered) and post-exit (this,
+    backend-rendered) toasts read identically. Names the single direction when
+    saves moved only one way, both counts when a run went both ways, and returns
+    ``None`` when nothing transferred so a no-op sync fires no toast.
+    """
+    if uploaded > 0 and downloaded > 0:
+        return f"Saves synced with RomM ({uploaded} up, {downloaded} down)"
+    if uploaded > 0:
+        return _TOAST_BODY_UPLOADED
+    if downloaded > 0:
+        return _TOAST_BODY_DOWNLOADED
+    return None
 
 
 @dataclass(frozen=True)
@@ -112,26 +131,25 @@ class SessionLifecycleServiceConfig:
 
 
 def _render_sync_toast(
-    *, offline: bool, success: bool, synced: int | None, message: str | None = None
+    *, offline: bool, success: bool, uploaded: int, downloaded: int, message: str | None = None
 ) -> tuple[str | None, str | None]:
     """Map the raw post-exit-sync flags onto the (title, body) toast pair.
 
-    Branching: offline wins over success, success-with-uploads renders
-    the synced toast, a successful no-op produces no toast at all, and
-    any non-success/non-offline state falls through to the failure
-    toast. ``message`` is the classified failure cause from the sync
-    result (e.g. "Authentication failed — sign in again", #971); when
-    present it names the cause in the failure body instead of the
-    generic fallback, keeping the post-exit toast consistent with the
-    pre-launch fallback modal. Only the failure body honours it — the
-    offline and success branches are unaffected.
+    Branching: offline wins over success, a successful transfer renders the
+    per-direction body (:func:`sync_toast_body` — "uploaded" / "downloaded" /
+    both counts), a successful no-op produces no toast at all, and any
+    non-success/non-offline state falls through to the failure toast.
+    ``message`` is the classified failure cause from the sync result (e.g.
+    "Authentication failed — sign in again", #971); when present it names the
+    cause in the failure body instead of the generic fallback, keeping the
+    post-exit toast consistent with the pre-launch fallback modal. Only the
+    failure body honours it — the offline and success branches are unaffected.
     """
     if offline:
         return _TOAST_TITLE, _TOAST_BODY_OFFLINE
-    if success and synced is not None and synced > 0:
-        return _TOAST_TITLE, _TOAST_BODY_SYNCED
     if success:
-        return None, None
+        body = sync_toast_body(uploaded, downloaded)
+        return (_TOAST_TITLE, body) if body is not None else (None, None)
     return _TOAST_TITLE, message or _TOAST_BODY_FAILED
 
 
@@ -299,12 +317,18 @@ class SessionLifecycleService:
         success = bool(result.get("success"))
         raw_synced = result.get("synced")
         synced = raw_synced if isinstance(raw_synced, int) else None
+        raw_uploaded = result.get("uploaded")
+        uploaded = raw_uploaded if isinstance(raw_uploaded, int) else 0
+        raw_downloaded = result.get("downloaded")
+        downloaded = raw_downloaded if isinstance(raw_downloaded, int) else 0
         raw_conflicts = result.get("conflicts")
         conflicts: list[dict[str, Any]] = list(raw_conflicts) if isinstance(raw_conflicts, list) else []
         raw_message = result.get("message")
         message = raw_message if isinstance(raw_message, str) else None
 
-        toast_title, toast_body = _render_sync_toast(offline=offline, success=success, synced=synced, message=message)
+        toast_title, toast_body = _render_sync_toast(
+            offline=offline, success=success, uploaded=uploaded, downloaded=downloaded, message=message
+        )
         conflicts_toast = _render_conflicts_toast(conflicts)
 
         return SessionFinalizeSyncResult(

--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -532,11 +532,31 @@ export const listDevices = callable<[], ListDevicesResponse>("list_devices");
 export const getSaveStatus = callable<[number], SaveStatus>("get_save_status");
 export const preLaunchSync = callable<
   [number],
-  { success: boolean; message: string; synced?: number; errors?: string[]; conflicts?: SyncConflict[]; reason?: string }
+  {
+    success: boolean;
+    message: string;
+    synced?: number;
+    // Per-direction transfer counts (#250) — additive; absent on the skip /
+    // failure branches (treat absent as 0).
+    uploaded?: number;
+    downloaded?: number;
+    errors?: string[];
+    conflicts?: SyncConflict[];
+    reason?: string;
+  }
 >("pre_launch_sync");
 export const syncRomSaves = callable<
   [number],
-  { success: boolean; message: string; synced: number; errors?: string[]; conflicts?: SyncConflict[]; reason?: string }
+  {
+    success: boolean;
+    message: string;
+    synced: number;
+    uploaded?: number;
+    downloaded?: number;
+    errors?: string[];
+    conflicts?: SyncConflict[];
+    reason?: string;
+  }
 >("sync_rom_saves");
 export const syncAllSaves = callable<
   [],

--- a/src/components/CustomPlayButton.test.tsx
+++ b/src/components/CustomPlayButton.test.tsx
@@ -960,12 +960,14 @@ describe("CustomPlayButton — pre-launch failure shapes without an errors array
     await waitFor(() => expect(vi.mocked(SteamClient.Apps.RunGame)).toHaveBeenCalledWith("gid-1", "", -1, 100));
   });
 
-  it("proceeds with the synced toast and no fallback confirm on a clean pre-launch sync", async () => {
+  it("proceeds with the downloaded toast and no fallback confirm on a clean pre-launch download", async () => {
     mockCachedDetail();
     vi.mocked(backend.preLaunchSync).mockResolvedValue({
       success: true,
       message: "",
       synced: 1,
+      uploaded: 0,
+      downloaded: 1,
       errors: [],
       conflicts: [],
     });
@@ -979,7 +981,78 @@ describe("CustomPlayButton — pre-launch failure shapes without an errors array
     await waitFor(() => expect(vi.mocked(SteamClient.Apps.RunGame)).toHaveBeenCalled());
     expect(vi.mocked(showFallbackLaunchModal)).not.toHaveBeenCalled();
     expect(vi.mocked(SteamClient.Apps.RunGame)).toHaveBeenCalledWith("gid-1", "", -1, 100);
-    expect(vi.mocked(toaster.toast)).toHaveBeenCalledWith(expect.objectContaining({ body: "Saves synced with RomM" }));
+    expect(vi.mocked(toaster.toast)).toHaveBeenCalledWith(
+      expect.objectContaining({ body: "Saves downloaded from RomM" }),
+    );
+  });
+
+  it("shows the uploaded toast when a pre-launch sync only pushed saves (row-9 upload)", async () => {
+    mockCachedDetail();
+    vi.mocked(backend.preLaunchSync).mockResolvedValue({
+      success: true,
+      message: "",
+      synced: 1,
+      uploaded: 1,
+      downloaded: 0,
+      errors: [],
+      conflicts: [],
+    });
+
+    const { findByText } = render(<CustomPlayButton appId={100} />);
+    const playBtn = await findByText("Play");
+    await act(async () => {
+      playBtn.click();
+    });
+
+    await waitFor(() => expect(vi.mocked(SteamClient.Apps.RunGame)).toHaveBeenCalled());
+    expect(vi.mocked(toaster.toast)).toHaveBeenCalledWith(expect.objectContaining({ body: "Saves uploaded to RomM" }));
+  });
+
+  it("names both directions when a pre-launch sync moved saves both ways", async () => {
+    mockCachedDetail();
+    vi.mocked(backend.preLaunchSync).mockResolvedValue({
+      success: true,
+      message: "",
+      synced: 3,
+      uploaded: 1,
+      downloaded: 2,
+      errors: [],
+      conflicts: [],
+    });
+
+    const { findByText } = render(<CustomPlayButton appId={100} />);
+    const playBtn = await findByText("Play");
+    await act(async () => {
+      playBtn.click();
+    });
+
+    await waitFor(() => expect(vi.mocked(SteamClient.Apps.RunGame)).toHaveBeenCalled());
+    expect(vi.mocked(toaster.toast)).toHaveBeenCalledWith(
+      expect.objectContaining({ body: "Saves synced with RomM (1 up, 2 down)" }),
+    );
+  });
+
+  it("fires no toast when a clean pre-launch sync transferred nothing", async () => {
+    mockCachedDetail();
+    vi.mocked(toaster.toast).mockReset();
+    vi.mocked(backend.preLaunchSync).mockResolvedValue({
+      success: true,
+      message: "",
+      synced: 0,
+      uploaded: 0,
+      downloaded: 0,
+      errors: [],
+      conflicts: [],
+    });
+
+    const { findByText } = render(<CustomPlayButton appId={100} />);
+    const playBtn = await findByText("Play");
+    await act(async () => {
+      playBtn.click();
+    });
+
+    await waitFor(() => expect(vi.mocked(SteamClient.Apps.RunGame)).toHaveBeenCalled());
+    expect(vi.mocked(toaster.toast)).not.toHaveBeenCalled();
   });
 
   it("surfaces the shared fallback (empty message → generic copy) when pre-launch sync throws", async () => {

--- a/src/components/CustomPlayButton.tsx
+++ b/src/components/CustomPlayButton.tsx
@@ -54,6 +54,7 @@ import { SAVEFILES_IN_CONTENT_DIR_REASON } from "../types";
 import { detach } from "../utils/detach";
 import { setLaunchOptionsConfirmed } from "../utils/steamShortcuts";
 import { reconfirmLaunchOptions } from "../utils/launchOptionsReconcile";
+import { saveSyncToastBody } from "../utils/saveSyncToast";
 
 type PlayButtonState =
   "loading" | "not_romm" | "download" | "conflict" | "syncing" | "play" | "launching" | "dl_complete" | "uninstalling";
@@ -502,8 +503,9 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
       return { success: false, message: result.message };
     }
 
-    if (result.synced && result.synced > 0) {
-      toaster.toast({ title: "RomM Save Sync", body: "Saves synced with RomM" });
+    const toastBody = saveSyncToastBody(result.uploaded, result.downloaded);
+    if (toastBody) {
+      toaster.toast({ title: "RomM Save Sync", body: toastBody });
     }
     return { success: true, message: result.message };
   };

--- a/src/utils/saveSyncToast.test.ts
+++ b/src/utils/saveSyncToast.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { saveSyncToastBody } from "./saveSyncToast";
+
+describe("saveSyncToastBody", () => {
+  it("names uploads when saves only moved up", () => {
+    expect(saveSyncToastBody(2, 0)).toBe("Saves uploaded to RomM");
+  });
+
+  it("names downloads when saves only moved down", () => {
+    expect(saveSyncToastBody(0, 3)).toBe("Saves downloaded from RomM");
+  });
+
+  it("names both counts when a run went both ways", () => {
+    expect(saveSyncToastBody(1, 2)).toBe("Saves synced with RomM (1 up, 2 down)");
+  });
+
+  it("returns null for a no-op run (nothing transferred)", () => {
+    expect(saveSyncToastBody(0, 0)).toBeNull();
+  });
+
+  it("treats absent counts as zero → null", () => {
+    expect(saveSyncToastBody(undefined, undefined)).toBeNull();
+  });
+
+  it("treats a missing upload count as zero", () => {
+    expect(saveSyncToastBody(undefined, 1)).toBe("Saves downloaded from RomM");
+  });
+});

--- a/src/utils/saveSyncToast.ts
+++ b/src/utils/saveSyncToast.ts
@@ -1,0 +1,28 @@
+/**
+ * Save-sync completion toast copy (#250) — the canonical per-direction wording
+ * shared by the surfaces that confirm a sync. A run can move saves either way
+ * (a pre-launch download OR a row-9 upload; a post-exit upload OR a row-5/10
+ * adopt-download), so a single "synced" line hid which direction actually ran.
+ *
+ * ``saveSyncToastBody`` names the single direction when saves moved only one
+ * way, both counts when a run went both ways, and returns ``null`` when nothing
+ * transferred so a no-op sync fires no toast. The backend mirrors this verbatim
+ * in ``services/session_lifecycle.py`` (``sync_toast_body``) for the post-exit
+ * toast it renders itself; keep the two in lockstep.
+ */
+
+/**
+ * The toast body for a completed save-sync, or ``null`` for a no-op run.
+ *
+ * @param uploaded - files POSTed to RomM this run (absent → 0).
+ * @param downloaded - files pulled from RomM this run, including a 409-backstop
+ *   download of an upload that lost the currency race (absent → 0).
+ */
+export function saveSyncToastBody(uploaded?: number, downloaded?: number): string | null {
+  const up = uploaded ?? 0;
+  const down = downloaded ?? 0;
+  if (up > 0 && down > 0) return `Saves synced with RomM (${up} up, ${down} down)`;
+  if (up > 0) return "Saves uploaded to RomM";
+  if (down > 0) return "Saves downloaded from RomM";
+  return null;
+}

--- a/tests/contract/test_saves_upload_409.py
+++ b/tests/contract/test_saves_upload_409.py
@@ -70,6 +70,9 @@ async def test_saves_upload_409_stale_downgrades_to_download(harness):
 
     assert result["success"] is True
     assert result["synced"] == 1
+    # The 409-downgraded transfer is attributed as a download, not an upload (#250).
+    assert result["uploaded"] == 0
+    assert result["downloaded"] == 1
     assert result["conflicts"] == []
     # The POST was attempted overwrite=false so RomM's 409 could fire…
     upload_calls = [c for c in harness.romm.call_log if c[0] == "upload_save"]

--- a/tests/services/saves/_helpers.py
+++ b/tests/services/saves/_helpers.py
@@ -160,8 +160,8 @@ def _do_sync(svc, rom_id: int):
 
     Loads the ``RomSaveState`` + device id from the shared UoW, resolves the
     active core, runs ``do_sync_rom_saves`` (the matrix worker), persists the
-    mutated aggregate, and returns ``(synced, errors, conflicts)``. The
-    direct-worker tests use this in place of the old ``do_sync_rom_saves(rom_id)``
+    mutated aggregate, and returns ``(uploaded, downloaded, errors, conflicts)``.
+    The direct-worker tests use this in place of the old ``do_sync_rom_saves(rom_id)``
     call that reached into a global state dict.
     """
     engine = svc._sync_engine

--- a/tests/services/saves/sync_engine/test_engine.py
+++ b/tests/services/saves/sync_engine/test_engine.py
@@ -70,8 +70,9 @@ class TestSyncRomSaves:
         _install_rom(svc, tmp_path)
         _create_save(tmp_path, content=b"save data")
 
-        synced, errors, conflicts = _do_sync(svc, 42)
-        assert synced == 1
+        uploaded, downloaded, errors, conflicts = _do_sync(svc, 42)
+        assert uploaded == 1
+        assert downloaded == 0
         assert errors == []
         assert conflicts == []
         assert any(c[0] == "upload_save" for c in fake.call_log)
@@ -84,8 +85,9 @@ class TestSyncRomSaves:
         ss = _server_save()
         fake.saves[100] = ss
 
-        synced, errors, _ = _do_sync(svc, 42)
-        assert synced == 1
+        uploaded, downloaded, errors, _ = _do_sync(svc, 42)
+        assert uploaded == 0
+        assert downloaded == 1
         assert errors == []
         # Verify the file was downloaded
         saves_dir = tmp_path / "saves" / "gba"
@@ -93,8 +95,9 @@ class TestSyncRomSaves:
 
     def test_rom_not_installed(self, tmp_path):
         svc, _ = make_service(tmp_path)
-        synced, errors, _ = _do_sync(svc, 999)
-        assert synced == 0
+        uploaded, downloaded, errors, _ = _do_sync(svc, 999)
+        assert uploaded == 0
+        assert downloaded == 0
         assert errors == []
 
     def test_api_error_on_list_saves(self, tmp_path):
@@ -102,8 +105,9 @@ class TestSyncRomSaves:
         _install_rom(svc, tmp_path)
         fake.fail_on_next(RommApiError("Server error"))
 
-        synced, errors, _ = _do_sync(svc, 42)
-        assert synced == 0
+        uploaded, downloaded, errors, _ = _do_sync(svc, 42)
+        assert uploaded == 0
+        assert downloaded == 0
         assert len(errors) == 1
         assert "Failed to fetch saves" in errors[0]
 
@@ -126,9 +130,10 @@ class TestSyncRomSaves:
         ss = _server_save()
         fake.saves[100] = ss
 
-        synced, errors, conflicts = _do_sync(svc, 42)
+        uploaded, downloaded, errors, conflicts = _do_sync(svc, 42)
 
-        assert synced == 0
+        assert uploaded == 0
+        assert downloaded == 0
         assert errors == []
         assert conflicts == []
         # No download was initiated.
@@ -147,9 +152,10 @@ class TestSyncRomSaves:
         # Local save at the (previous == current, same layout) location.
         _create_save(tmp_path, content=b"user progress")
 
-        synced, errors, conflicts = _do_sync(svc, 42)
+        uploaded, downloaded, errors, conflicts = _do_sync(svc, 42)
 
-        assert synced == 1
+        assert uploaded == 1
+        assert downloaded == 0
         assert errors == []
         assert conflicts == []
         # Upload went through.
@@ -206,7 +212,7 @@ class TestSyncRomSaves:
 
         # Stub do_sync_rom_saves to return 1 conflict, 0 synced, 0 errors
         def stub_sync(rom_id, *args):
-            return (0, [], [{"type": "newer_in_slot", "rom_id": rom_id}])
+            return (0, 0, [], [{"type": "newer_in_slot", "rom_id": rom_id}])
 
         svc._sync_engine.do_sync_rom_saves = stub_sync  # type: ignore[method-assign]
 
@@ -366,7 +372,7 @@ class TestSyncAllSaves:
         # Stub the matrix worker to produce conflicts but no errors (every ROM
         # decides via do_sync_rom_saves now, ADR-0017).
         def stub_sync(rom_id, *args):
-            return (0, [], [{"type": "newer_in_slot", "rom_id": rom_id}])
+            return (0, 0, [], [{"type": "newer_in_slot", "rom_id": rom_id}])
 
         svc._sync_engine.do_sync_rom_saves = stub_sync  # type: ignore[method-assign]
 
@@ -623,7 +629,7 @@ class TestPostExitSync:
         _install_rom(svc, tmp_path)
 
         def stub_sync(rom_id, *args):
-            return (0, [], [{"type": "newer_in_slot", "rom_id": rom_id}])
+            return (0, 0, [], [{"type": "newer_in_slot", "rom_id": rom_id}])
 
         svc._sync_engine.do_sync_rom_saves = stub_sync  # type: ignore[method-assign]
 
@@ -921,7 +927,7 @@ class TestSyncCallableErrorMessages:
         _install_rom(svc, tmp_path)
 
         def stub_sync(rom_id, *args):
-            return (0, ["pokemon.srm: bad gateway"], [])
+            return (0, 0, ["pokemon.srm: bad gateway"], [])
 
         svc._sync_engine.do_sync_rom_saves = stub_sync  # type: ignore[method-assign]
 
@@ -939,7 +945,7 @@ class TestSyncCallableErrorMessages:
         _install_rom(svc, tmp_path)
 
         def stub_sync(rom_id, *args):
-            return (0, ["pokemon.srm: timeout"], [])
+            return (0, 0, ["pokemon.srm: timeout"], [])
 
         svc._sync_engine.do_sync_rom_saves = stub_sync  # type: ignore[method-assign]
 
@@ -957,7 +963,7 @@ class TestSyncCallableErrorMessages:
         _install_rom(svc, tmp_path)
 
         def stub_sync(rom_id, *args):
-            return (2, ["pokemon.srm: timeout"], [])
+            return (2, 0, ["pokemon.srm: timeout"], [])
 
         svc._sync_engine.do_sync_rom_saves = stub_sync  # type: ignore[method-assign]
 
@@ -974,7 +980,7 @@ class TestSyncCallableErrorMessages:
         _install_rom(svc, tmp_path)
 
         def stub_sync(rom_id, *args):
-            return (0, ["a.srm: timeout", "b.srm: timeout", "c.srm: timeout"], [])
+            return (0, 0, ["a.srm: timeout", "b.srm: timeout", "c.srm: timeout"], [])
 
         svc._sync_engine.do_sync_rom_saves = stub_sync  # type: ignore[method-assign]
 
@@ -990,7 +996,7 @@ class TestSyncCallableErrorMessages:
         _install_rom(svc, tmp_path)
 
         def stub_sync(rom_id, *args):
-            return (0, ["pokemon.srm: 502 bad gateway"], [])
+            return (0, 0, ["pokemon.srm: 502 bad gateway"], [])
 
         svc._sync_engine.do_sync_rom_saves = stub_sync  # type: ignore[method-assign]
 
@@ -998,6 +1004,71 @@ class TestSyncCallableErrorMessages:
 
         assert result["success"] is False
         assert result["message"] == "502 bad gateway"
+
+
+class TestSyncCallablesSurfaceDirectionCounts:
+    """The per-ROM sync callables surface per-direction counts (#250).
+
+    The completion toast names which way saves moved, so each result dict
+    carries ``uploaded`` / ``downloaded`` alongside the ``synced`` total.
+    """
+
+    @pytest.mark.asyncio
+    async def test_pre_launch_sync_reports_download_count(self, tmp_path):
+        svc, _ = make_service(tmp_path)
+        svc._config.settings["save_sync_enabled"] = True
+        _set_device_id(svc, "test-device")
+        _install_rom(svc, tmp_path)
+
+        def stub_sync(rom_id, *args):
+            return (0, 2, [], [])  # two downloads, no upload
+
+        svc._sync_engine.do_sync_rom_saves = stub_sync  # type: ignore[method-assign]
+
+        result = await svc.pre_launch_sync(42)
+
+        assert result["success"] is True
+        assert result["uploaded"] == 0
+        assert result["downloaded"] == 2
+        assert result["synced"] == 2
+
+    @pytest.mark.asyncio
+    async def test_post_exit_sync_reports_upload_count(self, tmp_path):
+        svc, _ = make_service(tmp_path)
+        svc._config.settings["save_sync_enabled"] = True
+        _set_device_id(svc, "test-device")
+        _install_rom(svc, tmp_path)
+
+        def stub_sync(rom_id, *args):
+            return (3, 0, [], [])  # three uploads, no download
+
+        svc._sync_engine.do_sync_rom_saves = stub_sync  # type: ignore[method-assign]
+
+        result = await svc.post_exit_sync(42)
+
+        assert result["success"] is True
+        assert result["uploaded"] == 3
+        assert result["downloaded"] == 0
+        assert result["synced"] == 3
+
+    @pytest.mark.asyncio
+    async def test_sync_rom_saves_reports_mixed_counts(self, tmp_path):
+        svc, _ = make_service(tmp_path)
+        svc._config.settings["save_sync_enabled"] = True
+        _set_device_id(svc, "test-device")
+        _install_rom(svc, tmp_path)
+
+        def stub_sync(rom_id, *args):
+            return (1, 2, [], [])  # one up, two down
+
+        svc._sync_engine.do_sync_rom_saves = stub_sync  # type: ignore[method-assign]
+
+        result = await svc.sync_rom_saves(42)
+
+        assert result["success"] is True
+        assert result["uploaded"] == 1
+        assert result["downloaded"] == 2
+        assert result["synced"] == 3
 
 
 class TestSyncCallablePromotesRealDispatchReason:
@@ -1441,7 +1512,7 @@ class TestSaveSyncDeviceGate:
             time.sleep(0.05)
             with counter_lock:
                 state["active"] -= 1
-            return (1, [], [])
+            return (1, 0, [], [])
 
         # Every ROM decides via the local matrix (ADR-0017); the device-gate
         # serialization is the same, so stub the matrix worker.
@@ -1476,9 +1547,10 @@ class TestRunRomSyncSession:
         _create_save(tmp_path, system="gba", rom_name="pokemon", content=b"local")
         _seed_save_state(svc, 42, RomSaveState(system="gba", slot_confirmed=True, active_slot="default"))
 
-        synced, errors, conflicts = await svc._sync_engine._run_rom_sync(42)
+        uploaded, downloaded, errors, conflicts = await svc._sync_engine._run_rom_sync(42)
 
-        assert synced == 1  # local-only save → matrix POST upload
+        assert uploaded == 1  # local-only save → matrix POST upload
+        assert downloaded == 0
         assert errors == []
         assert conflicts == []
         # The confirmed ROM opened a transport session AND decided via the matrix.
@@ -1515,14 +1587,15 @@ class TestRunRomSyncSession:
         # The session-open negotiate POST raises; the run proceeds without a session.
         fake.fail_on_next(RommConnectionError("negotiate down"))
 
-        synced, errors, conflicts = await svc._sync_engine._run_rom_sync(42)
+        uploaded, downloaded, errors, conflicts = await svc._sync_engine._run_rom_sync(42)
 
         # Session open was attempted and failed; the matrix still ran and POSTed.
         assert any(c[0] == "negotiate_sync" for c in fake.call_log)
         assert any(c[0] == "list_saves" for c in fake.call_log)
         # No session was opened, so none was completed.
         assert not any(c[0] == "complete_sync_session" for c in fake.call_log)
-        assert synced == 1  # matrix POST upload
+        assert uploaded == 1  # matrix POST upload
+        assert downloaded == 0
         assert errors == []
         assert conflicts == []
 
@@ -1541,11 +1614,12 @@ class TestRunRomSyncSession:
         )
         fake.set_server_save_content(888, b"other device save")
 
-        synced, errors, conflicts = await svc._sync_engine._run_rom_sync(42)
+        uploaded, downloaded, errors, conflicts = await svc._sync_engine._run_rom_sync(42)
 
         # The transport session opened and the matrix drove the download.
         assert any(c[0] == "negotiate_sync" for c in fake.call_log)
-        assert synced == 1
+        assert uploaded == 0
+        assert downloaded == 1
         assert errors == []
         assert conflicts == []
         local = tmp_path / "saves" / "gba" / "pokemon.srm"
@@ -1586,12 +1660,13 @@ class TestRunRomSyncSession:
 
         fake.negotiate_sync = malformed  # type: ignore[method-assign]
 
-        synced, errors, conflicts = await svc._sync_engine._run_rom_sync(42)
+        uploaded, downloaded, errors, conflicts = await svc._sync_engine._run_rom_sync(42)
 
         # The matrix ran and POSTed; no session was completed (none opened).
         assert any(c[0] == "list_saves" for c in fake.call_log)
         assert not any(c[0] == "complete_sync_session" for c in fake.call_log)
-        assert synced == 1
+        assert uploaded == 1
+        assert downloaded == 0
         assert errors == []
         assert conflicts == []
 

--- a/tests/services/saves/sync_engine/test_matrix.py
+++ b/tests/services/saves/sync_engine/test_matrix.py
@@ -388,8 +388,9 @@ class TestV47SyncFlow:
             "device_syncs": [{"device_id": "dev-1", "is_current": True}],
         }
 
-        synced, errors, conflicts = _do_sync(svc, 42)
-        assert synced == 0
+        uploaded, downloaded, errors, conflicts = _do_sync(svc, 42)
+        assert uploaded == 0
+        assert downloaded == 0
         assert errors == []
         assert conflicts == []
 
@@ -428,8 +429,9 @@ class TestV47SyncFlow:
             "device_syncs": [{"device_id": "dev-1", "is_current": False}],
         }
 
-        synced, errors, _conflicts = _do_sync(svc, 42)
-        assert synced == 1
+        uploaded, downloaded, errors, _conflicts = _do_sync(svc, 42)
+        assert uploaded == 0
+        assert downloaded == 1
         assert errors == []
         # Verify download happened
         assert 100 in fake.downloaded_files
@@ -490,9 +492,10 @@ class TestV47SyncFlow:
             "device_syncs": [{"device_id": "dev-1", "is_current": False}],
         }
 
-        synced, errors, conflicts = _do_sync(svc, 42)
+        uploaded, downloaded, errors, conflicts = _do_sync(svc, 42)
 
-        assert synced == 0
+        assert uploaded == 0
+        assert downloaded == 0
         assert errors == []
         assert conflicts == []
         # The newer legacy save was never downloaded into the named slot.
@@ -770,7 +773,7 @@ class TestTrackedSaveIdMatching:
         )
 
         # Sync should NOT download the timestamp-named file as a new server-only save
-        _synced, errors, _conflicts = _do_sync(svc, 42)
+        _uploaded, _downloaded, errors, _conflicts = _do_sync(svc, 42)
         assert len(errors) == 0
         # No downloads should have occurred (files are in sync)
         download_calls = [c for c in fake.call_log if c[0] == "download_save_content"]
@@ -908,9 +911,10 @@ class TestTrackedSaveIdMatching:
             },
         )
 
-        synced, errors, _conflicts = _do_sync(svc, 42)
+        uploaded, downloaded, errors, _conflicts = _do_sync(svc, 42)
         assert len(errors) == 0
-        assert synced == 1  # only ONE download
+        assert uploaded == 0
+        assert downloaded == 1  # only ONE download
 
         # Should download only once (the newest, id=18)
         download_calls = [c for c in fake.call_log if c[0] == "download_save_content"]
@@ -1013,7 +1017,7 @@ class TestOlderVersionSkipping:
             },
         )
 
-        _synced, _errors, _conflicts = _do_sync(svc, 42)
+        _uploaded, _downloaded, _errors, _conflicts = _do_sync(svc, 42)
         # pokemon [old].srm in slot=portable is filtered out — no download
         download_calls = [c for c in fake.call_log if c[0] == "download_save_content"]
         assert len(download_calls) == 0
@@ -1577,9 +1581,10 @@ class TestSyncRomSavesDispatch:
             },
         )
 
-        synced, errors, conflicts = _do_sync(svc, 42)
+        uploaded, downloaded, errors, conflicts = _do_sync(svc, 42)
 
-        assert synced == 0
+        assert uploaded == 0
+        assert downloaded == 0
         assert errors == []
         assert conflicts == []
         # No upload/download initiated.
@@ -1592,9 +1597,10 @@ class TestSyncRomSavesDispatch:
         _install_rom(svc, tmp_path)
         _create_save(tmp_path, content=b"new local")
 
-        synced, errors, conflicts = _do_sync(svc, 42)
+        uploaded, downloaded, errors, conflicts = _do_sync(svc, 42)
 
-        assert synced == 1
+        assert uploaded == 1
+        assert downloaded == 0
         assert errors == []
         assert conflicts == []
         upload_calls = [c for c in fake.call_log if c[0] == "upload_save"]
@@ -1633,9 +1639,10 @@ class TestSyncRomSavesDispatch:
             },
         )
 
-        synced, errors, conflicts = _do_sync(svc, 42)
+        uploaded, downloaded, errors, conflicts = _do_sync(svc, 42)
 
-        assert synced == 1
+        assert uploaded == 0
+        assert downloaded == 1
         assert errors == []
         assert conflicts == []
         # Download_save_content was called against the server save id.
@@ -1674,9 +1681,10 @@ class TestSyncRomSavesDispatch:
             },
         )
 
-        synced, errors, conflicts = _do_sync(svc, 42)
+        uploaded, downloaded, errors, conflicts = _do_sync(svc, 42)
 
-        assert synced == 0
+        assert uploaded == 0
+        assert downloaded == 0
         assert errors == []
         assert len(conflicts) == 1
         c = conflicts[0]
@@ -1704,13 +1712,48 @@ class TestSyncRomSavesDispatch:
         )
         fake.saves[100] = ss
 
-        synced, errors, conflicts = _do_sync(svc, 42)
+        uploaded, downloaded, errors, conflicts = _do_sync(svc, 42)
 
-        assert synced == 1
+        assert uploaded == 0
+        assert downloaded == 1
         assert errors == []
         assert conflicts == []
         saves_dir = tmp_path / "saves" / "gba"
         assert (saves_dir / "pokemon.srm").exists()
+
+    def test_sync_rom_saves_mixed_upload_and_download_counts_both(self, tmp_path):
+        """One file uploads and a sibling extension downloads in one run → 1 up, 1 down (#250).
+
+        A local ``.srm`` with no server counterpart is POSTed (upload); a
+        server-only ``.sav`` this device is not current on is pulled (download).
+        The two directions are tallied separately so the completion toast can
+        report the mix.
+        """
+        svc, fake = make_service(tmp_path)
+        _enable_sync_with_device(svc)
+        _install_rom(svc, tmp_path)
+        # Local .srm with no matching server save → Upload (POST).
+        _create_save(tmp_path, content=b"local srm progress", ext=".srm")
+        # Server-only .sav (different canonical target), not current here → Download.
+        sav = _server_save_with_syncs(
+            save_id=200,
+            filename="pokemon.sav",
+            device_syncs=[{"device_id": "device-1", "is_current": False}],
+        )
+        sav["file_extension"] = "sav"
+        fake.saves[200] = sav
+
+        uploaded, downloaded, errors, conflicts = _do_sync(svc, 42)
+
+        assert uploaded == 1
+        assert downloaded == 1
+        assert errors == []
+        assert conflicts == []
+        upload_calls = [c for c in fake.call_log if c[0] == "upload_save"]
+        assert len(upload_calls) == 1
+        download_calls = [c for c in fake.call_log if c[0] == "download_save_content"]
+        assert [c[1][0] for c in download_calls] == [200]
+        assert (tmp_path / "saves" / "gba" / "pokemon.sav").exists()
 
     def test_sync_rom_saves_upload_posts_when_local_diverged(self, tmp_path):
         """is_current=true + local hash diverges from baseline → Upload, POSTed as a
@@ -1742,9 +1785,10 @@ class TestSyncRomSavesDispatch:
             },
         )
 
-        synced, errors, conflicts = _do_sync(svc, 42)
+        uploaded, downloaded, errors, conflicts = _do_sync(svc, 42)
 
-        assert synced == 1
+        assert uploaded == 1
+        assert downloaded == 0
         assert errors == []
         assert conflicts == []
         upload_calls = [c for c in fake.call_log if c[0] == "upload_save"]
@@ -1792,9 +1836,10 @@ class TestSyncRomSavesDispatch:
             },
         )
 
-        synced, errors, conflicts = _do_sync(svc, 42)
+        uploaded, downloaded, errors, conflicts = _do_sync(svc, 42)
 
-        assert synced == 0
+        assert uploaded == 0
+        assert downloaded == 0
         assert errors == []
         # NO upload (PUT) was issued — the destructive overwrite was refused.
         assert not any(c[0] == "upload_save" for c in fake.call_log)
@@ -1827,9 +1872,10 @@ class TestSyncRomSavesDispatch:
         # No file_state at all — no baseline yet.
         _seed_save_state(svc, 42, RomSaveState())
 
-        synced, errors, conflicts = _do_sync(svc, 42)
+        uploaded, downloaded, errors, conflicts = _do_sync(svc, 42)
 
-        assert synced == 0
+        assert uploaded == 0
+        assert downloaded == 0
         assert errors == []
         assert conflicts == []
         # No I/O initiated.
@@ -1865,9 +1911,10 @@ class TestSyncRomSavesDispatch:
             },
         )
 
-        synced, errors, conflicts = _do_sync(svc, 42)
+        uploaded, downloaded, errors, conflicts = _do_sync(svc, 42)
 
-        assert synced == 1
+        assert uploaded == 0
+        assert downloaded == 1
         assert errors == []
         assert conflicts == []
         download_calls = [c for c in fake.call_log if c[0] == "download_save_content"]
@@ -1904,11 +1951,13 @@ class TestSyncRomSavesDispatch:
             },
         )
 
-        synced, errors, conflicts = _do_sync(svc, 42)
+        uploaded, downloaded, errors, conflicts = _do_sync(svc, 42)
 
         assert errors == []
         assert conflicts == []
-        assert synced == 1
+        # The 409-downgraded transfer is attributed as a download, not an upload (#250).
+        assert uploaded == 0
+        assert downloaded == 1
         # The POST was attempted overwrite=false (so RomM's 409 could fire)…
         upload_calls = [c for c in fake.call_log if c[0] == "upload_save"]
         assert len(upload_calls) == 1
@@ -1937,9 +1986,10 @@ class TestSyncRomSavesDispatch:
         # No baseline (files empty) — this device has never synced the slot.
         _seed_save_state_dict(svc, 42, {"active_slot": "default", "slot_confirmed": True, "files": {}})
 
-        synced, errors, conflicts = _do_sync(svc, 42)
+        uploaded, downloaded, errors, conflicts = _do_sync(svc, 42)
 
-        assert synced == 0
+        assert uploaded == 0
+        assert downloaded == 0
         assert errors == []
         assert len(conflicts) == 1
         c = conflicts[0]
@@ -1980,7 +2030,7 @@ class TestSyncRomSavesDispatch:
             sink=DispatchSink(errors=errors, conflicts=conflicts),
         )
 
-        assert result is False
+        assert result is None
         assert conflicts == []
         assert len(errors) == 1
         assert "pokemon.srm" in errors[0]
@@ -2063,7 +2113,7 @@ class TestHandleUnexpectedError:
         errors: list[str] = []
         conflicts: list[dict[str, Any]] = []
         action = Download(server_save={"id": 100, "file_name": "pokemon.srm"})
-        synced = svc._sync_engine._matrix._dispatch_sync_action(
+        direction = svc._sync_engine._matrix._dispatch_sync_action(
             action,
             ctx=RomDispatchContext(
                 rom_id=42,
@@ -2083,7 +2133,7 @@ class TestHandleUnexpectedError:
             sink=DispatchSink(errors=errors, conflicts=conflicts),
         )
 
-        assert synced is False
+        assert direction is None
         assert len(errors) == 1
         assert errors[0].startswith("pokemon.srm:")
         # The .tmp file was removed by the cleanup branch.
@@ -2114,7 +2164,7 @@ class TestDispatchSyncActionErrorBranches:
         errors: list[str] = []
         conflicts: list[dict[str, Any]] = []
         action = Download(server_save={"id": 100, "file_name": "pokemon.srm"})
-        synced = svc._sync_engine._matrix._dispatch_sync_action(
+        direction = svc._sync_engine._matrix._dispatch_sync_action(
             action,
             ctx=RomDispatchContext(
                 rom_id=42,
@@ -2134,7 +2184,7 @@ class TestDispatchSyncActionErrorBranches:
             sink=DispatchSink(errors=errors, conflicts=conflicts),
         )
 
-        assert synced is False
+        assert direction is None
         assert len(errors) == 1
         assert errors[0].startswith("pokemon.srm:")
         assert any(
@@ -2180,7 +2230,7 @@ class TestDispatchUploadDefensiveBranches:
             sink=DispatchSink(errors=errors, conflicts=conflicts),
         )
 
-        assert result is False
+        assert result is None
         assert len(errors) == 1
         assert "upload requested but no local file" in errors[0]
         # No upload was attempted.

--- a/tests/services/saves/test_status.py
+++ b/tests/services/saves/test_status.py
@@ -801,7 +801,7 @@ class TestMultiFileSlotConflictAggregation:
         fake.saves[201] = bcr_ss
 
         status_conflicts = {c["filename"] for c in svc._status._get_save_status_io(42, [bkr_ss, bcr_ss])["conflicts"]}
-        _synced, _errors, sync_conflicts = _do_sync(svc, 42)
+        _uploaded, _downloaded, _errors, sync_conflicts = _do_sync(svc, 42)
         sync_conflict_files = {c["filename"] for c in sync_conflicts}
 
         # Both paths agree, and the agreed set is the non-first component.

--- a/tests/services/test_session_lifecycle.py
+++ b/tests/services/test_session_lifecycle.py
@@ -264,9 +264,9 @@ class TestFinalizeSyncToasts:
         assert result.sync.toast_title == "RomM Save Sync"
         assert result.sync.toast_body == "Server offline — saves will sync next time"
 
-    def test_success_with_uploads_renders_synced_toast(self, event_loop, logger):
-        """``success=True, synced>0`` → synced toast."""
-        post = FakePostExitSync(payload={"success": True, "synced": 3, "conflicts": []})
+    def test_success_upload_only_renders_uploaded_toast(self, event_loop, logger):
+        """``success=True`` with only uploads → "Saves uploaded to RomM" (#250)."""
+        post = FakePostExitSync(payload={"success": True, "synced": 3, "uploaded": 3, "downloaded": 0, "conflicts": []})
         service = _make_service(
             playtime_recorder=FakePlaytimeRecorder(),
             post_exit_sync=post,
@@ -281,11 +281,45 @@ class TestFinalizeSyncToasts:
         assert result.sync.success is True
         assert result.sync.synced == 3
         assert result.sync.toast_title == "RomM Save Sync"
-        assert result.sync.toast_body == "Saves synced with RomM"
+        assert result.sync.toast_body == "Saves uploaded to RomM"
 
-    def test_success_with_no_uploads_renders_no_toast(self, event_loop, logger):
-        """``success=True, synced=0`` → no toast (frontend still dispatches event)."""
-        post = FakePostExitSync(payload={"success": True, "synced": 0, "conflicts": []})
+    def test_success_download_only_renders_downloaded_toast(self, event_loop, logger):
+        """``success=True`` with only downloads → "Saves downloaded from RomM" (#250)."""
+        post = FakePostExitSync(payload={"success": True, "synced": 2, "uploaded": 0, "downloaded": 2, "conflicts": []})
+        service = _make_service(
+            playtime_recorder=FakePlaytimeRecorder(),
+            post_exit_sync=post,
+            achievement_sync=FakeAchievementSync(),
+            migration_reader=FakeMigrationReader(),
+            logger=logger,
+        )
+
+        result = event_loop.run_until_complete(service.finalize(99))
+        event_loop.run_until_complete(_drain_background_tasks(service))
+
+        assert result.sync.success is True
+        assert result.sync.toast_body == "Saves downloaded from RomM"
+
+    def test_success_both_directions_renders_mixed_toast(self, event_loop, logger):
+        """``success=True`` with both directions → names both counts (#250)."""
+        post = FakePostExitSync(payload={"success": True, "synced": 3, "uploaded": 1, "downloaded": 2, "conflicts": []})
+        service = _make_service(
+            playtime_recorder=FakePlaytimeRecorder(),
+            post_exit_sync=post,
+            achievement_sync=FakeAchievementSync(),
+            migration_reader=FakeMigrationReader(),
+            logger=logger,
+        )
+
+        result = event_loop.run_until_complete(service.finalize(99))
+        event_loop.run_until_complete(_drain_background_tasks(service))
+
+        assert result.sync.success is True
+        assert result.sync.toast_body == "Saves synced with RomM (1 up, 2 down)"
+
+    def test_success_with_no_transfers_renders_no_toast(self, event_loop, logger):
+        """``success=True`` with nothing moved → no toast (frontend still dispatches event)."""
+        post = FakePostExitSync(payload={"success": True, "synced": 0, "uploaded": 0, "downloaded": 0, "conflicts": []})
         service = _make_service(
             playtime_recorder=FakePlaytimeRecorder(),
             post_exit_sync=post,
@@ -421,9 +455,16 @@ class TestFinalizeSyncToasts:
         assert result.sync.toast_body == "Server offline — saves will sync next time"
 
     def test_success_message_does_not_override_synced_body(self, event_loop, logger):
-        """Regression guard: a successful sync keeps the synced body, ignoring ``message``."""
+        """Regression guard: a successful sync keeps the per-direction body, ignoring ``message``."""
         post = FakePostExitSync(
-            payload={"success": True, "synced": 2, "conflicts": [], "message": "Uploaded 2 save(s)"}
+            payload={
+                "success": True,
+                "synced": 2,
+                "uploaded": 2,
+                "downloaded": 0,
+                "conflicts": [],
+                "message": "Uploaded 2 save(s)",
+            }
         )
         service = _make_service(
             playtime_recorder=FakePlaytimeRecorder(),
@@ -437,7 +478,7 @@ class TestFinalizeSyncToasts:
         event_loop.run_until_complete(_drain_background_tasks(service))
 
         assert result.sync.success is True
-        assert result.sync.toast_body == "Saves synced with RomM"
+        assert result.sync.toast_body == "Saves uploaded to RomM"
 
     def test_post_exit_exception_renders_failure_toast(self, event_loop, logger):
         """Post-exit sync raises → failure toast, downstream still runs."""
@@ -487,9 +528,11 @@ class TestFinalizeSyncToasts:
         # The exception text must never leak into the toast body.
         assert "Authentication failed" not in result.sync.toast_body
 
-    def test_synced_field_non_int_treated_as_falsy(self, event_loop, logger):
-        """``synced`` not an int (None, str) → no synced toast even when success=True."""
-        post = FakePostExitSync(payload={"success": True, "synced": None, "conflicts": []})
+    def test_direction_counts_non_int_treated_as_zero(self, event_loop, logger):
+        """``uploaded`` / ``downloaded`` not ints (None, str) → treated as 0 → no toast."""
+        post = FakePostExitSync(
+            payload={"success": True, "synced": None, "uploaded": None, "downloaded": "2", "conflicts": []}
+        )
         service = _make_service(
             playtime_recorder=FakePlaytimeRecorder(),
             post_exit_sync=post,
@@ -501,7 +544,7 @@ class TestFinalizeSyncToasts:
         result = event_loop.run_until_complete(service.finalize(99))
         event_loop.run_until_complete(_drain_background_tasks(service))
 
-        # synced was None → treated as no uploads → no toast
+        # Malformed counts default to 0 → no transfer detected → no toast.
         assert result.sync.synced is None
         assert result.sync.toast_title is None
         assert result.sync.toast_body is None
@@ -820,7 +863,9 @@ class TestFinalizeResultShape:
             {"type": "sync_conflict", "rom_id": 99, "filename": "a.srm", "server_save_id": 1},
         ]
         playtime = FakePlaytimeRecorder(payload={"success": True, "total_seconds": 1234})
-        post = FakePostExitSync(payload={"success": True, "synced": 2, "conflicts": conflicts})
+        post = FakePostExitSync(
+            payload={"success": True, "synced": 2, "uploaded": 2, "downloaded": 0, "conflicts": conflicts}
+        )
         migration = FakeMigrationReader(payload={"retrodeck": {"pending": False}, "save_sort": {"pending": False}})
         service = _make_service(
             playtime_recorder=playtime,
@@ -841,7 +886,7 @@ class TestFinalizeResultShape:
                 synced=2,
                 conflicts=conflicts,
                 toast_title="RomM Save Sync",
-                toast_body="Saves synced with RomM",
+                toast_body="Saves uploaded to RomM",
                 conflicts_toast="1 save conflict need resolution",
             ),
             migration=SessionFinalizeMigration(


### PR DESCRIPTION
Closes #250

> **Stacked PR — draft until #1476 (and the chain below it) merges.** Based on `fix/877-null-slot-isolation`; the diff shows the whole chain until then. Own commits: `4c5078fb`, `963f3df9`, `d023b9a3`.

The save-sync completion toast reported only an aggregate count; now it names the direction.

- the matrix dispatch returns a typed `TransferDirection` (upload / download / none) instead of a bool; `sync_rom_saves` tallies `uploaded` and `downloaded` separately, threaded additively onto the `pre_launch_sync` / `post_exit_sync` / `sync_rom_saves` payloads — no new events or callables, parity gates unchanged
- a 409-backstopped upload that re-decides to a download is attributed as a download (pinned by matrix + contract tests)
- toast copy: "Saves uploaded to RomM" / "Saves downloaded from RomM" / "Saves synced with RomM (N up, M down)" — and no toast at all when nothing moved
- the negotiate session-close counts and the bulk-sync aggregate are unchanged (`uploaded + downloaded` equals the old total)
- docs: user-guide toast description + architecture sync-flow section

Merge gate: rides the stacked chain's on-device round — the directional toasts are directly visible in the pre-launch and post-exit flows of the checklist.
