### PR TITLE
fix(saves): adopt instead of conflicting when both sides moved to identical content

### DIFF
--- a/docs/adr/0017-client-baseline-detection-authoritative-negotiate-is-transport.md
+++ b/docs/adr/0017-client-baseline-detection-authoritative-negotiate-is-transport.md
@@ -27,7 +27,7 @@ the detection handoff:
   the device out of. In practice the server almost never returns `conflict`. Handing it detection therefore silences the
   client's baseline-anchored safety branches — the [#1062](https://github.com/danielcopper/decky-romm-sync/issues/1062)
   corrupt/shrunk-local guard, the [#1013](https://github.com/danielcopper/decky-romm-sync/issues/1013) byte-identical
-  dedup, and the "both sides moved to content we never synced" conflict (matrix rows 6c / 12).
+  dedup, and the "both sides moved to content we never synced" conflict (matrix rows 6c / 12b).
 - **`POST /api/saves` self-guards with a 409.** RomM's `add_save` rejects a plain (non-`overwrite`) POST into a slot the
   device is not current on — **including a device that has never synced that slot** (the `not sync` branch of the gate).
   This is a real server-side conflict backstop the detection path never leaned on.
@@ -105,7 +105,7 @@ transport.**
 
 - **A — Keep the server's operation list authoritative (ADR-0016 as written) and only bolt the 409 backstop onto
   uploads.** Rejected: the 4.9.2 comparator is timestamp-only with a near-dead `conflict` branch, so it cannot reproduce
-  the client's baseline-anchored safety (the #1062 shrink guard, the #1013 dedup, and the rows 6c / 12 both-sides-moved
+  the client's baseline-anchored safety (the #1062 shrink guard, the #1013 dedup, and the rows 6c / 12b both-sides-moved
   conflict), and it leaves the `StatusService`-versus-sync divergence in place — the SAVES tab and the sync run would
   still decide from different sources.
 - **B — Drop `negotiate` entirely and return to pure `list_saves` + `compute_sync_action` with no session.** Rejected:

--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -486,15 +486,16 @@ Dimensions:
 | 10  | yes        | ≥1             | current=false | unchanged         | n/a                  | `Download(picked)`                  | another device synced; we did nothing — adopt their version                                                                                                             |
 | 11a | yes        | ≥1             | current=false | no baseline       | n/a                  | `Download(picked)`                  | no baseline (so parity only, #1468), but `server.content_hash == local_hash` — byte-identical, adopt the server head safely                                             |
 | 11b | yes        | ≥1             | current=false | no baseline       | n/a                  | **`Conflict(picked)`**              | no baseline and content differs from the server head — cannot prove which side is newer; refuse the silent overwrite (#1276)                                            |
-| 12  | yes        | ≥1             | current=false | changed           | n/a                  | **`Conflict(picked)`**              | both sides changed independently — only true conflict                                                                                                                   |
+| 12a | yes        | ≥1             | current=false | changed           | n/a                  | `Download(picked)`                  | both sides moved off the baseline but landed on the SAME bytes (`server.content_hash == local_hash`, parity only) — adopt the head, nothing to reconcile (#1480)        |
+| 12b | yes        | ≥1             | current=false | changed           | n/a                  | **`Conflict(picked)`**              | both sides moved to DIFFERENT content — the only true conflict                                                                                                          |
 
-Conflict happens in four rows — #12 (we already hold an entry on the picked save and our local diverged from the
-baseline), #6c (we hold a baseline from a prior sync but no entry on the picked head), #11b (we hold an
-`is_current=false` entry, have no baseline, and our local content differs from the server head), and #9b (we own the
-picked save and our local diverged, but the local file is 0-byte / implausibly shrunk). #12, #6c, and #11b are all "both
-sides hold content we never reconciled" situations; #9b is a different hazard — protecting the server's only good copy
-from being overwritten in place by a corrupt-looking local file (#1062). Every other row resolves silently to a Skip,
-Upload, or Download.
+Conflict happens in four rows — #12b (we already hold an entry on the picked save and our local diverged from the
+baseline to content that differs from the head), #6c (we hold a baseline from a prior sync but no entry on the picked
+head), #11b (we hold an `is_current=false` entry, have no baseline, and our local content differs from the server head),
+and #9b (we own the picked save and our local diverged, but the local file is 0-byte / implausibly shrunk). #12b, #6c,
+and #11b are all "both sides hold content we never reconciled" situations; #9b is a different hazard — protecting the
+server's only good copy from being overwritten in place by a corrupt-looking local file (#1062). Every other row
+resolves silently to a Skip, Upload, or Download.
 
 ### Why row 6d adopts instead of posting
 
@@ -520,12 +521,14 @@ newest. Subsequent syncs pick our save naturally.
 
 ### Why row 6c conflicts instead of downloading
 
-Row 6c is the never-touched sibling of row 12. We hold a baseline (`last_sync_hash`) from a prior sync, but the picked
+Row 6c is the never-touched sibling of row 12b. We hold a baseline (`last_sync_hash`) from a prior sync, but the picked
 head is a save we have no `device_syncs` entry for — another timeline became newest while our local diverged from the
-baseline (`local_hash != last_sync_hash`). That is the same "both sides moved independently" situation as row 12, so it
+baseline (`local_hash != last_sync_hash`). That is the same "both sides moved independently" situation as row 12b, so it
 takes the same exit: a `Conflict` the user resolves, never a silent `Download` that would discard the diverged local
-progress (whose only surviving copy would be the `.romm-backup`). When there is no baseline, or local still matches it,
-we cannot claim divergence — rows 6a/6b apply and the mtime heuristic breaks the tie.
+progress (whose only surviving copy would be the `.romm-backup`). As in row 12b, byte-identity is checked first — if the
+diverged local happens to match the head's `content_hash`, row 6d adopts it instead of conflicting — so 6c fires only on
+genuinely-different content. When there is no baseline, or local still matches it, we cannot claim divergence — rows
+6a/6b apply and the mtime heuristic breaks the tie.
 
 ### Why row 9b conflicts instead of uploading
 
@@ -564,9 +567,34 @@ The content hash breaks the tie:
   which is newer. The earlier design silently `Download`ed here, quarantining the local bytes into `.romm-backup` on the
   bet that another device's work mattered more — a silent overwrite of possibly-newer local progress. Under
   [#1276](https://github.com/danielcopper/decky-romm-sync/issues/1276) this is a **`Conflict`** instead: the user
-  decides via Keep Local / Use Server, the same exit rows 6c and 12 take. When the server save carries no `content_hash`
-  (older / migrated saves) the equality fails closed to this conflict — the safe default. mtime is never trusted to
-  break this tie.
+  decides via Keep Local / Use Server, the same exit rows 6c and 12b take. When the server save carries no
+  `content_hash` (older / migrated saves) the equality fails closed to this conflict — the safe default. mtime is never
+  trusted to break this tie.
+
+### Why row 12 splits into download (12a) vs conflict (12b)
+
+Row 12 is the both-sides-moved case where we already hold an `is_current=false` entry on the picked head **and** a
+baseline our local has diverged from (`local_hash != last_sync_hash`). The intuition is "two timelines, user decides",
+and 12b is exactly that. But the two independent moves can coincidentally land on the **same** bytes — the same change
+synced from another device, or an identical backup restored on both sides — and then there is nothing to reconcile.
+
+The content hash breaks the tie, mirroring row 11's split:
+
+- **12a — `server.content_hash == local_hash`.** The bytes on disk already equal the moved-past head, so adopting it is
+  risk-free by construction (nothing differs to lose). We `Download(picked)`; the normal download bookkeeping
+  re-establishes the baseline and `is_current`, so the next sync is a plain `Skip`. This is the
+  [#1480](https://github.com/danielcopper/decky-romm-sync/issues/1480) fix — before it, this collision surfaced a
+  needless conflict modal.
+- **12b — the content differs.** Both sides genuinely hold unreconciled bytes → **`Conflict`**, the user decides via
+  Keep Local / Use Server. Unchanged from before.
+
+The identity check reuses the shared `_local_matches_server` helper (the same one rows 6d / 11a use). One subtlety: in
+this slice the local has **diverged** from the baseline, so the helper's provenance route — which requires local
+_unchanged_ since baseline (`local_hash == last_sync_hash`) — can never fire; only the parity route
+(`local_hash ==
+server.content_hash`) can prove identity here. The helper is called anyway for a uniform call shape; the
+provenance leg is simply inert. When the head carries no `content_hash` (older / migrated saves) or either hash is
+empty, parity fails closed to 12b — the safe default.
 
 ### Why is there no foreign-save modal anymore
 
@@ -899,10 +927,10 @@ frontend no longer fetches or checks capability flags.
 
 ## Conflict Resolution
 
-A `Conflict` outcome from `compute_sync_action` (matrix rows 12, 6c, 11b, and 9b) is the only surface that shows a
+A `Conflict` outcome from `compute_sync_action` (matrix rows 12b, 6c, 11b, and 9b) is the only surface that shows a
 modal. The common case fires when the local file has diverged from the recorded baseline
 (`local_hash != last_sync_hash`) while the server moved to content we never synced — either on a save we already have an
-entry for (`device_syncs[me].is_current=false`, row 12) or on a new head we have no entry for (row 6c). Row 11b is the
+entry for (`device_syncs[me].is_current=false`, row 12b) or on a new head we have no entry for (row 6c). Row 11b is the
 no-baseline sibling: we hold an `is_current=false` entry, have no baseline, and our local content differs from the
 server head — the same both-sides-unreconciled hazard (#1276). In all three the two sides have unsynced changes that
 cannot be silently merged. Row 9b is the corrupt-local guard: we own the picked save and our local diverged, but the
@@ -919,7 +947,7 @@ side by side, each with size and timestamp. Three actions:
 - **Use Server** → `resolveSyncConflict(rom_id, filename, "use_server")` → backend downloads the picked server save and
   overwrites local.
 - **Cancel** → pure UI close, no callable, no state mutation. The conflict re-fires on the next sync as long as the
-  underlying state still produces matrix row 12, 6c, 11b, or 9b.
+  underlying state still produces matrix row 12b, 6c, 11b, or 9b.
 
 On a successful resolution the modal closes and surfaces a branch-specific confirmation toast — **Keep Local** confirms
 the local save was uploaded to the server, **Use Server** confirms the server save is now in use and the prior local
@@ -1479,7 +1507,7 @@ names and constraints.
 | `saves.<id>.last_sync_check_at`                     | ISO-8601 string / null  | Timestamp of the most recent `do_sync_rom_saves` run for this rom (regardless of whether files transferred).                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | `saves.<id>.files`                                  | object                  | Per-file sync state, keyed by filename (e.g. `"game.srm"`)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
 | `saves.<id>.files.<fn>.tracked_save_id`             | integer / null          | Most recent RomM save id this device tracked. Used to exclude the active save from the Previous Versions dropdown and as an uploader-attribution hint; **not** consulted by `compute_sync_action` (the algorithm picks newest by `updated_at`).                                                                                                                                                                                                                                                                                                          |
-| `saves.<id>.files.<fn>.last_sync_hash`              | content-hash hex string | RomM-parity `content_hash` of the save file at last sync (zip-aware: MD5 for a single file, per-entry combined for a zip — `SaveFileStore.content_hash`, #1457). Drift baseline used by matrix rows 7/8/9/10/11a/11b/12.                                                                                                                                                                                                                                                                                                                                 |
+| `saves.<id>.files.<fn>.last_sync_hash`              | content-hash hex string | RomM-parity `content_hash` of the save file at last sync (zip-aware: MD5 for a single file, per-entry combined for a zip — `SaveFileStore.content_hash`, #1457). Drift baseline used by matrix rows 7/8/9/10/11a/11b/12a/12b.                                                                                                                                                                                                                                                                                                                            |
 | `saves.<id>.files.<fn>.last_sync_at`                | ISO-8601 string         | Timestamp of last successful sync.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
 | `saves.<id>.files.<fn>.last_sync_server_updated_at` | ISO-8601 string         | Server's `updated_at` at last sync.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
 | `saves.<id>.files.<fn>.last_sync_server_save_id`    | integer                 | RomM save id for the most recently synced server save.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
@@ -1505,7 +1533,7 @@ games adopt (`"default"`); `autocleanup_limit` caps retained save versions per s
 
 Conflicts are no longer persisted. They are returned ephemerally from `do_sync_rom_saves` and `_get_save_status_io` and
 surfaced via the modal at the moment of the sync. If the user dismisses the modal (Cancel), the conflict re-fires on the
-next sync as long as the underlying state still produces a conflict row (12, 6c, 11b, or 9b).
+next sync as long as the underlying state still produces a conflict row (12b, 6c, 11b, or 9b).
 
 ### Legacy field migration
 

--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -602,8 +602,8 @@ Earlier versions surfaced every server save in the slot the user had not authore
 pragmatic newest-wins model used by the official RomM clients (Argosy, Grout) treats the slot as a single timeline:
 whichever save has the highest `updated_at` wins, regardless of which device PUT it. We adopted that model in v0.16
 because it eliminates ~1500 lines of foreign-tracking code and aligns with the wider RomM ecosystem. Cross-device
-uploads are silently adopted unless local edits diverge from baseline (rows 12 / 11b). This is documented behaviour, not
-a regression.
+uploads are silently adopted unless local edits diverge from baseline (rows 12b / 11b). This is documented behaviour,
+not a regression.
 
 ### Upload-time conflicts (the 409 backstop)
 

--- a/py_modules/domain/sync_action.py
+++ b/py_modules/domain/sync_action.py
@@ -29,9 +29,13 @@ only good copy over the cliff we route that case to ``Conflict``
 (``domain/save_size.is_implausibly_shrunken``).
 
 When ``is_current=false`` (the server moved past us) AND a present local either
-diverges from the baseline or has no baseline yet and does not match the
-server's content, both sides moved independently — a true ``Conflict`` that
-requires a user choice via ``resolve_sync_conflict``.
+diverges from the baseline or has no baseline yet, both sides moved
+independently. That is a true ``Conflict`` requiring a user choice via
+``resolve_sync_conflict`` UNLESS the two independent moves happen to have landed
+on the same content: a present local that is byte-identical to the moved-past
+head is adopted via ``Download`` (row 12a — adopting identical bytes loses
+nothing and re-establishes the baseline + is_current through normal download
+bookkeeping). Only genuinely-different content is the conflict (row 12b).
 
 Recovery: ``is_current=true`` + no local file means our last upload is
 still tracked on the server but the local copy disappeared. We download to
@@ -46,8 +50,11 @@ survives a future drift between our local hashing and the server's; the
 **fallback** route is the direct parity check ``local_hash == content_hash``,
 the only one available to a file with no sync history on this device (fresh
 reinstall, copied SD card, second device — branch 5's no-baseline slice and true
-fresh installs can *only* ever use it, by design). The stored server hash makes
-identity robust; parity stays correct (#1457) as the no-history fallback (#1468).
+fresh installs can *only* ever use it, by design) and the only one that CAN fire
+in branch 5's diverged slice (row 12a): a local that diverged from the baseline
+can never satisfy the provenance route's unchanged-since-baseline precondition,
+so there the provenance leg is inert. The stored server hash makes identity
+robust; parity stays correct (#1457) as the no-history fallback (#1468).
 
 When our device has never touched the picked save (no entry in
 ``device_syncs``) and the local file is present: first, if the local content is
@@ -257,7 +264,19 @@ def _decide_when_not_current(
             return Download(server_save=server)
         return Conflict(server_save=server)
     if local_hash and local_hash != last_sync_hash:
-        # Both sides changed — the only true Conflict.
+        # Both sides moved off the baseline. Before declaring a conflict, check
+        # whether the two independent moves happen to have landed on the SAME
+        # bytes — if so there is nothing to reconcile.
+        if _local_matches_server(local_hash, server.get("content_hash"), last_sync_hash, last_sync_server_hash):
+            # 12a: byte-identical to the moved-past head. Adopting it via
+            # download re-establishes the baseline + is_current through the
+            # normal bookkeeping, and adopting identical content loses nothing.
+            # Only the parity route can fire here: the provenance route requires
+            # local UNCHANGED since baseline (``local_hash == last_sync_hash``),
+            # which this branch has already ruled out — it is inert, called only
+            # for a uniform identity-check shape shared with branches 6 / 11a.
+            return Download(server_save=server)
+        # 12b: both sides moved to DIFFERENT content — the only true Conflict.
         return Conflict(server_save=server)
     return Download(server_save=server)
 

--- a/tests/domain/test_sync_action.py
+++ b/tests/domain/test_sync_action.py
@@ -285,6 +285,115 @@ def test_both_changed_returns_conflict():
     assert result == Conflict(server_save=server)
 
 
+# ---------------------------------------------------------------------------
+# #1480 — row 12 split: both sides moved off the baseline, check byte-identity
+# before conflicting.
+# ---------------------------------------------------------------------------
+
+
+def test_not_current_diverged_but_identical_to_head_downloads():
+    """Row 12a (#1480) — is_current=false, baseline held, local diverged from it
+    (``local_hash != last_sync_hash``), but the picked head's ``content_hash``
+    equals ``local_hash`` (both sides independently moved to the SAME bytes). The
+    two moves collide on identical content, so there is nothing to reconcile:
+    adopt the head via ``Download`` (re-establishes baseline + is_current), never
+    a spurious Conflict. Only the parity route can prove identity here — the
+    diverged local can't satisfy the provenance route's unchanged-since-baseline
+    precondition.
+    """
+    server = _server_save(
+        content_hash="moved-content",
+        device_syncs=[_device_sync(DEVICE_ID, is_current=False)],
+    )
+    result = compute_sync_action(
+        local_file=_local(),
+        server_saves_in_slot=[server],
+        files_state={"last_sync_hash": "old-baseline"},
+        device_id=DEVICE_ID,
+        local_hash="moved-content",  # != baseline, but == server.content_hash
+    )
+    assert result == Download(server_save=server)
+
+
+def test_not_current_diverged_and_differs_from_head_returns_conflict():
+    """Row 12b (#1480) — is_current=false, baseline held, local diverged, and the
+    picked head's ``content_hash`` differs from ``local_hash``. Both sides moved
+    to DIFFERENT content — the only true Conflict. The 12a identity check must
+    NOT swallow a genuine two-sided divergence.
+    """
+    server = _server_save(
+        content_hash="server-content",
+        device_syncs=[_device_sync(DEVICE_ID, is_current=False)],
+    )
+    result = compute_sync_action(
+        local_file=_local(),
+        server_saves_in_slot=[server],
+        files_state={"last_sync_hash": "old-baseline"},
+        device_id=DEVICE_ID,
+        local_hash="local-content",  # != baseline AND != server.content_hash
+    )
+    assert result == Conflict(server_save=server)
+
+
+def test_not_current_diverged_empty_server_hash_stays_conflict():
+    """Row 12b guard (#1480) — an empty-string ``content_hash`` on the head proves
+    nothing (truthiness guard in ``_local_matches_server``). A diverged local can
+    never parity-match it, so the 12a path never fires → ``Conflict``.
+    """
+    server = _server_save(
+        content_hash="",
+        device_syncs=[_device_sync(DEVICE_ID, is_current=False)],
+    )
+    result = compute_sync_action(
+        local_file=_local(),
+        server_saves_in_slot=[server],
+        files_state={"last_sync_hash": "old-baseline"},
+        device_id=DEVICE_ID,
+        local_hash="local-content",
+    )
+    assert result == Conflict(server_save=server)
+
+
+def test_not_current_diverged_missing_server_hash_stays_conflict():
+    """Row 12b guard (#1480) — the picked head carries NO ``content_hash`` key
+    (older / migrated saves). ``server.get("content_hash")`` is ``None``, so the
+    diverged local can't parity-match → the 12a path never fires → ``Conflict``.
+    """
+    server = _server_save(  # no content_hash key
+        device_syncs=[_device_sync(DEVICE_ID, is_current=False)],
+    )
+    result = compute_sync_action(
+        local_file=_local(),
+        server_saves_in_slot=[server],
+        files_state={"last_sync_hash": "old-baseline"},
+        device_id=DEVICE_ID,
+        local_hash="local-content",
+    )
+    assert result == Conflict(server_save=server)
+
+
+def test_not_current_diverged_stale_stored_server_hash_stays_conflict():
+    """Row 12b guard (#1480) — the provenance leg is inert in the diverged slice.
+    A stored ``last_sync_server_hash`` equal to the head's ``content_hash`` must
+    NOT rescue a local that DIVERGED from the baseline: provenance requires
+    ``local_hash == last_sync_hash`` (false here), and parity requires
+    ``local_hash == server.content_hash`` (also false here). So the stale stored
+    hash can never fabricate a 12a match → ``Conflict``.
+    """
+    server = _server_save(
+        content_hash="server-content",
+        device_syncs=[_device_sync(DEVICE_ID, is_current=False)],
+    )
+    result = compute_sync_action(
+        local_file=_local(),
+        server_saves_in_slot=[server],
+        files_state={"last_sync_hash": "old-baseline", "last_sync_server_hash": "server-content"},
+        device_id=DEVICE_ID,
+        local_hash="CHANGED",  # != baseline AND != server.content_hash
+    )
+    assert result == Conflict(server_save=server)
+
+
 def test_no_device_entry_no_local_returns_download():
     server = _server_save(device_syncs=[_device_sync(OTHER_DEVICE_ID, is_current=True)])
     result = compute_sync_action(

--- a/tests/domain/test_sync_action_property.py
+++ b/tests/domain/test_sync_action_property.py
@@ -52,6 +52,12 @@ Invariants encoded here:
   live parity hash matches (fallback). The provenance route never fires when
   local has diverged from the baseline, so a stored server hash can never
   fabricate a false identity for changed local content.
+- Inv11 (#1480): whenever ``local_hash`` and the picked head's ``content_hash``
+  are both truthy and equal (byte-identical content), the kernel never returns
+  ``Conflict`` — the row-12 split (12a). The sole carve-out is the branch-4
+  size-corruption guard (#1062 / row 9b), which is orthogonal to content
+  identity: a truncated local that happens to hash-match an equally-truncated
+  head is still refused in place.
 """
 
 from __future__ import annotations
@@ -658,3 +664,81 @@ def test_no_entry_adopts_baseline_only_on_proven_identity(
     # The literal safety statement: provenance can never rescue a diverged local.
     if baseline is not None and local_hash != baseline and not parity:
         assert not (isinstance(result, Skip) and result.adopt_baseline)
+
+
+# ---------------------------------------------------------------------------
+# Invariant 11 (#1480): byte-identical content never surfaces a Conflict
+# (except the orthogonal branch-4 size-corruption guard).
+# ---------------------------------------------------------------------------
+
+
+@st.composite
+def _identical_content_scenario(draw: st.DrawFn) -> dict[str, Any]:
+    """A present local plus a SINGLE server head whose ``content_hash`` EQUALS the
+    truthy ``local_hash`` — byte-identical by construction — with arbitrary
+    ``device_syncs`` (all three branches: our device current / not-current /
+    absent), an arbitrary baseline, and arbitrary sizes.
+
+    A single head keeps ``max(updated_at)`` selection unambiguous, so the invariant
+    can be stated against *the* picked head without replaying the pick logic here.
+    """
+    local_hash = draw(_hashes)
+    local_file = {
+        "filename": "Game.srm",
+        "path": "/tmp/Game.srm",
+        "size": draw(_sizes),
+        "mtime": draw(_epochs),
+    }
+    device_syncs: list[dict[str, Any]] = []
+    if draw(st.booleans()):
+        device_syncs.append({"device_id": DEVICE_ID, "is_current": draw(st.booleans())})
+    if draw(st.booleans()):
+        device_syncs.append({"device_id": OTHER_DEVICE_ID, "is_current": draw(st.booleans())})
+    server = {
+        "id": draw(st.integers(min_value=1, max_value=9999)),
+        "slot": 0,
+        "updated_at": _epoch_to_iso(draw(_epochs), zulu=draw(st.booleans()), micros=draw(st.booleans())),
+        "file_extension": "srm",
+        "content_hash": local_hash,  # byte-identical by construction
+        "device_syncs": device_syncs,
+    }
+    return {
+        "local_file": local_file,
+        "server": server,
+        "files_state": draw(_files_states),
+        "local_hash": local_hash,
+    }
+
+
+@given(scenario=_identical_content_scenario())
+def test_identical_content_never_conflicts(scenario: dict[str, Any]) -> None:
+    """Branch 5 / #1480 (also re-verified at branches 6 and 5's no-baseline
+    slice) — whenever ``local_hash`` and the picked head's ``content_hash`` are
+    both truthy and EQUAL, the kernel never returns ``Conflict``. Two independent
+    moves that land on identical bytes have nothing to reconcile, so the safe
+    outcome is always a ``Download`` (adopt the head) or a ``Skip`` (adopt the
+    baseline) — the row-12 split (12a) stated directly.
+
+    The single documented carve-out is the branch-4 (``is_current=true``)
+    size-corruption guard (#1062 / row 9b): a 0-byte or truncated local that
+    happens to hash-match an equally-truncated server head is still refused in
+    place. That guard is size-based, orthogonal to content identity — so the ONLY
+    identical-content ``Conflict`` the kernel may emit is that shrink-guarded one.
+    """
+    local_file = scenario["local_file"]
+    server = scenario["server"]
+    files_state = scenario["files_state"]
+    local_hash = scenario["local_hash"]
+
+    result = _action(local_file, [server], files_state, local_hash)
+
+    if isinstance(result, Conflict):
+        # Must be the branch-4 shrink guard and nothing else.
+        our_entry = next(
+            (d for d in server["device_syncs"] if d["device_id"] == DEVICE_ID),
+            None,
+        )
+        assert our_entry is not None and our_entry["is_current"] is True
+        # Divergence from a held baseline is the precondition for reaching the guard.
+        assert files_state.get("last_sync_hash") not in (None, local_hash)
+        assert is_implausibly_shrunken(local_file["size"], files_state.get("last_sync_local_size"))

--- a/tests/services/saves/sync_engine/test_matrix.py
+++ b/tests/services/saves/sync_engine/test_matrix.py
@@ -1701,6 +1701,55 @@ class TestSyncRomSavesDispatch:
         assert c["local_size"] == os.path.getsize(str(save_path))
         assert "created_at" in c
 
+    def test_sync_rom_saves_download_when_both_moved_to_identical_content(self, tmp_path):
+        """Row 12a (#1480) — is_current=false + local diverged from baseline, but
+        byte-identical to the moved-past head (``server.content_hash ==
+        local_hash``) → Download, not Conflict. Both sides independently landed on
+        the same bytes, so there is nothing to reconcile: the served decision
+        downloads (adopting the head re-establishes baseline + is_current), and no
+        conflict is surfaced.
+        """
+        svc, fake = make_service(tmp_path)
+        _enable_sync_with_device(svc)
+        _install_rom(svc, tmp_path)
+        save_path = _create_save(tmp_path, content=b"converged content")
+        local_hash = _file_md5(str(save_path))
+
+        ss = _server_save_with_syncs(
+            device_syncs=[{"device_id": "device-1", "is_current": False}],
+        )
+        # The moved-past head holds exactly the local's bytes.
+        ss["content_hash"] = local_hash
+        fake.saves[100] = ss
+
+        _seed_save_state_dict(
+            svc,
+            42,
+            {
+                "files": {
+                    "pokemon.srm": {
+                        "tracked_save_id": 100,
+                        "last_sync_hash": "deadbeef" * 4,  # baseline differs → diverged
+                        "last_sync_server_updated_at": "2025-01-01T00:00:00Z",
+                    }
+                }
+            },
+        )
+
+        uploaded, downloaded, errors, conflicts = _do_sync(svc, 42)
+
+        assert uploaded == 0
+        assert downloaded == 1
+        assert errors == []
+        assert conflicts == []
+        download_calls = [c for c in fake.call_log if c[0] == "download_save_content"]
+        assert len(download_calls) == 1
+        assert download_calls[0][1][0] == 100
+
+        file_state = _require_save_state(svc, 42).files["pokemon.srm"]
+        assert file_state.tracked_save_id == 100
+        assert file_state.last_sync_hash
+
     def test_sync_rom_saves_server_only_downloads(self, tmp_path):
         """No local file, one server save in slot → Download."""
         svc, fake = make_service(tmp_path)


### PR DESCRIPTION
Closes #1480

Matrix row 12 (`is_current=false`, baseline present, local diverged) went straight to the conflict modal without checking whether both sides had moved to the **same bytes**. When local and the picked server head are byte-identical there is nothing to decide — the modal was pure friction. Branch 6 already ran the identity check first; this closes the same gap in branch 5.

- the shared identity helper (`_local_matches_server`, provenance + parity) now runs before the diverged→Conflict return: identical → `Download(picked)` (row 12a, mirroring row 11a — adopting the identical head re-establishes baseline and `is_current` through normal download bookkeeping); different → `Conflict` (row 12b, unchanged)
- the provenance leg is documented as inert on this row (a diverged local can never satisfy its unchanged-since-baseline precondition) — only the parity route can prove identity here, and a test pins that a stale stored server hash cannot fabricate a match
- new property invariant: **identical content never surfaces a Conflict** — with one honest carve-out (the branch-4 #1062 shrink guard is deliberately kept: a 0-byte local that matches an equally-broken head should still be refused, identity must not weaken the corruption guard)
- docs: matrix table split into 12a/12b with rationale; all row-12 cross-references updated (incl. two one-token accuracy fixes in ADR-0017's row pointers)

Surfaced by the 2026-07-18 on-device round.
