### PR TITLE
refactor(ui): single-source all save-sync toast copy in the frontend helper

### DIFF
--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -1204,14 +1204,16 @@ case: we believe the server's claim and write `last_sync_hash := local_hash` so 
 All four sync entry points share a single decision primitive — `compute_sync_action` — and a single dispatch path —
 `_dispatch_sync_action`. The flows differ only in _when_ they fire and how they surface results.
 
-**Completion toast — per-direction counts (#250).** `_dispatch_sync_action` returns a `TransferDirection` (`UPLOAD` /
-`DOWNLOAD` / `None`), so `sync_rom_saves` tallies uploads and downloads separately and each per-ROM result dict carries
-additive `uploaded` / `downloaded` counts beside the `synced` total (a 409-backstop download counts as a _download_, not
-the upload that lost the race). The completion toast names which way saves moved — "Saves uploaded to RomM", "Saves
-downloaded from RomM", or "Saves synced with RomM (1 up, 2 down)" when a run went both ways — and a run that transferred
-nothing shows no toast. The wording is a single contract mirrored on both sides: the frontend renders the pre-launch
-toast via `saveSyncToastBody` (`src/utils/saveSyncToast.ts`); the backend renders the post-exit toast itself via
-`sync_toast_body` (`services/session_lifecycle.py`) since that flow returns a pre-built `toast_body`.
+**Completion toast — per-direction counts (#250, #1481).** `_dispatch_sync_action` returns a `TransferDirection`
+(`UPLOAD` / `DOWNLOAD` / `None`), so `sync_rom_saves` tallies uploads and downloads separately and each per-ROM result
+dict carries additive `uploaded` / `downloaded` counts beside the `synced` total (a 409-backstop download counts as a
+_download_, not the upload that lost the race). The completion toast names which way saves moved — "Saves uploaded to
+RomM", "Saves downloaded from RomM", or "Saves synced with RomM (1 up, 2 down)" when a run went both ways — and a run
+that transferred nothing shows no toast. The wording lives in exactly one place: the frontend helper `saveSyncToastBody`
+(`src/utils/saveSyncToast.ts`), which every surface renders through — pre-launch (`CustomPlayButton`), post-exit
+(`sessionManager`, from the counts on the `finalize_game_session` payload), and the manual per-game sync
+(`RomMPlaySection`). The backend delivers the counts as data, never the directional copy (#1481); the offline/failure
+body it still owns rides a separate `failure_toast` field on `SessionFinalizeSyncResult`.
 
 ### Pre-launch sync
 
@@ -1250,7 +1252,9 @@ Triggered automatically when a game stops (if `sync_after_exit` is enabled).
 4. If a `Conflict` is returned, a toast notifies the user. The modal is **not** opened post-exit — the conflict re-fires
    at the next pre-launch sync, where the user resolves it via Keep Local / Use Server before launch.
 5. Toast notification shown on success or conflict — the per-direction completion toast above (uploaded / downloaded /
-   both) on a successful transfer, rendered backend-side into `SessionFinalizeSyncResult.toast_body`.
+   both) on a successful transfer, rendered frontend-side by `sessionManager` from the `uploaded` / `downloaded` counts
+   on the `SessionFinalizeSyncResult` payload via `saveSyncToastBody` (#1481). Offline / failure keeps its backend-owned
+   body on `SessionFinalizeSyncResult.failure_toast`.
 
 ### Manual sync all
 

--- a/py_modules/services/session_lifecycle.py
+++ b/py_modules/services/session_lifecycle.py
@@ -192,8 +192,10 @@ class SessionLifecycleService:
         SessionFinalizeResult
             ``total_seconds`` carries the updated total when the
             playtime record succeeded, ``None`` otherwise. ``sync``
-            carries the pre-rendered toast strings and the raw offline /
-            success flags the frontend still needs for the
+            carries the per-direction transfer counts (the frontend
+            renders the directional toast from them), the backend-owned
+            ``failure_toast`` / ``conflicts_toast`` strings, and the raw
+            offline / success flags the frontend still needs for the
             ``romm_data_changed`` event dispatch. ``migration`` carries
             the two migration-status payloads.
         """

--- a/py_modules/services/session_lifecycle.py
+++ b/py_modules/services/session_lifecycle.py
@@ -4,11 +4,17 @@ Composes the four cross-service reads the frontend's game-stop handler
 used to interleave into one round-trip: end-of-session playtime
 record, fire-and-forget achievement refresh, post-exit save sync, and
 the migration-state refresh. Returns a typed ``SessionFinalizeResult``
-carrying the playtime delta plus the rendered toast strings and the
-migration-status payloads the frontend feeds into its in-memory
+carrying the playtime delta plus the per-direction transfer counts and
+the migration-status payloads the frontend feeds into its in-memory
 stores. The playtime-display update (Steam's ``appStore`` mutation)
 stays on the frontend because it touches Steam IPC; everything else
 about the end-of-session flow is now a backend decision.
+
+Save-sync completion copy is split by kind: the directional success
+toast is presentation the frontend renders from the counts (via the
+shared ``saveSyncToastBody`` helper, the single source of that copy and
+i18n-ready), while the offline/failure body (``failure_toast``) follows
+the backend-owned message convention.
 """
 
 from __future__ import annotations
@@ -30,51 +36,36 @@ if TYPE_CHECKING:
     )
 
 
-_TOAST_TITLE = "RomM Save Sync"
 _TOAST_BODY_OFFLINE = "Server offline — saves will sync next time"
-_TOAST_BODY_UPLOADED = "Saves uploaded to RomM"
-_TOAST_BODY_DOWNLOADED = "Saves downloaded from RomM"
 _TOAST_BODY_FAILED = "Failed to sync saves after exit"
-
-
-def sync_toast_body(uploaded: int, downloaded: int) -> str | None:
-    """Compose the per-direction save-sync completion toast body (#250).
-
-    Mirrors the frontend ``saveSyncToastBody`` (``src/utils/saveSyncToast.ts``)
-    verbatim so the pre-launch (frontend-rendered) and post-exit (this,
-    backend-rendered) toasts read identically. Names the single direction when
-    saves moved only one way, both counts when a run went both ways, and returns
-    ``None`` when nothing transferred so a no-op sync fires no toast.
-    """
-    if uploaded > 0 and downloaded > 0:
-        return f"Saves synced with RomM ({uploaded} up, {downloaded} down)"
-    if uploaded > 0:
-        return _TOAST_BODY_UPLOADED
-    if downloaded > 0:
-        return _TOAST_BODY_DOWNLOADED
-    return None
 
 
 @dataclass(frozen=True)
 class SessionFinalizeSyncResult:
-    """Post-exit-sync verdict rendered for the frontend.
+    """Post-exit-sync verdict handed to the frontend for toast rendering + dispatch.
 
-    Carries the raw outcome flags the frontend still needs for event
-    dispatch (``offline`` / ``success``) plus the pre-rendered toast
-    strings. ``toast_body=None`` means "do not fire a toast for this
-    scenario" — for example a successful sync that uploaded nothing.
-    ``conflicts_toast`` is the second, additive toast fired when the
-    sync surfaces unresolved conflicts; ``None`` when there are no
-    conflicts. Conflict-string rendering lives here so the frontend
-    receives a ready-to-display body.
+    Carries the raw outcome flags (``offline`` / ``success``) plus the
+    per-direction transfer counts (``uploaded`` / ``downloaded``) the
+    frontend renders the directional completion toast from via its shared
+    ``saveSyncToastBody`` helper — the single source of that copy.
+    ``failure_toast`` is the backend-owned body for the non-directional
+    outcomes (offline, classified failure, generic failure); ``None``
+    means no failure toast — including the #239 content-dir benign skip,
+    whose suppression stays a backend decision. The directional and
+    failure toasts are mutually exclusive by construction: a successful
+    run renders directional from the counts and carries
+    ``failure_toast=None``. ``conflicts_toast`` is the additive
+    "N save conflict(s) need resolution" body, ``None`` when there are no
+    conflicts.
     """
 
     offline: bool
     success: bool
     synced: int | None
+    uploaded: int
+    downloaded: int
     conflicts: list[dict[str, Any]]
-    toast_title: str | None
-    toast_body: str | None
+    failure_toast: str | None
     conflicts_toast: str | None
 
 
@@ -130,27 +121,22 @@ class SessionLifecycleServiceConfig:
     logger: logging.Logger
 
 
-def _render_sync_toast(
-    *, offline: bool, success: bool, uploaded: int, downloaded: int, message: str | None = None
-) -> tuple[str | None, str | None]:
-    """Map the raw post-exit-sync flags onto the (title, body) toast pair.
+def _render_failure_toast(*, offline: bool, success: bool, message: str | None = None) -> str | None:
+    """Map the non-success post-exit-sync flags onto the failure/offline toast body.
 
-    Branching: offline wins over success, a successful transfer renders the
-    per-direction body (:func:`sync_toast_body` — "uploaded" / "downloaded" /
-    both counts), a successful no-op produces no toast at all, and any
-    non-success/non-offline state falls through to the failure toast.
-    ``message`` is the classified failure cause from the sync result (e.g.
-    "Authentication failed — sign in again", #971); when present it names the
-    cause in the failure body instead of the generic fallback, keeping the
-    post-exit toast consistent with the pre-launch fallback modal. Only the
-    failure body honours it — the offline and success branches are unaffected.
+    The directional success toast is presentation the frontend renders from the
+    transfer counts (``saveSyncToastBody``), so a successful run returns ``None``
+    here. Offline wins over the generic failure body; a classified ``message``
+    (e.g. "Authentication failed — sign in again", #971) names the cause instead
+    of the generic fallback, keeping the post-exit toast consistent with the
+    pre-launch fallback modal. The #239 content-dir benign skip is suppressed by
+    its caller before this is reached.
     """
     if offline:
-        return _TOAST_TITLE, _TOAST_BODY_OFFLINE
+        return _TOAST_BODY_OFFLINE
     if success:
-        body = sync_toast_body(uploaded, downloaded)
-        return (_TOAST_TITLE, body) if body is not None else (None, None)
-    return _TOAST_TITLE, message or _TOAST_BODY_FAILED
+        return None
+    return message or _TOAST_BODY_FAILED
 
 
 def _render_conflicts_toast(conflicts: list[dict[str, Any]]) -> str | None:
@@ -264,21 +250,25 @@ class SessionLifecycleService:
             self._logger.warning(f"SessionLifecycle achievement sync failed for rom_id={rom_id}: {e}")
 
     async def _build_sync_result(self, rom_id: int) -> SessionFinalizeSyncResult:
-        """Run post-exit sync and render the resulting toast strings.
+        """Run post-exit sync and build the frontend's sync verdict.
 
+        Carries the per-direction transfer counts (from which the
+        frontend renders the directional success toast) plus the
+        backend-owned ``failure_toast`` / ``conflicts_toast`` bodies.
         Honours the ``@migration_blocked`` gate: when a RetroDECK
         migration is pending the destructive post-exit sync is skipped
-        and rendered as the standard "failed to sync saves after exit"
-        toast.
+        and surfaced as the standard "failed to sync saves after exit"
+        failure toast.
         """
         if self._migration_reader.is_retrodeck_migration_pending():
             return SessionFinalizeSyncResult(
                 offline=False,
                 success=False,
                 synced=None,
+                uploaded=0,
+                downloaded=0,
                 conflicts=[],
-                toast_title=_TOAST_TITLE,
-                toast_body=_TOAST_BODY_FAILED,
+                failure_toast=_TOAST_BODY_FAILED,
                 conflicts_toast=None,
             )
 
@@ -293,9 +283,10 @@ class SessionLifecycleService:
                 offline=False,
                 success=False,
                 synced=None,
+                uploaded=0,
+                downloaded=0,
                 conflicts=[],
-                toast_title=_TOAST_TITLE,
-                toast_body=_TOAST_BODY_FAILED,
+                failure_toast=_TOAST_BODY_FAILED,
                 conflicts_toast=None,
             )
 
@@ -307,9 +298,10 @@ class SessionLifecycleService:
                 offline=False,
                 success=False,
                 synced=0,
+                uploaded=0,
+                downloaded=0,
                 conflicts=[],
-                toast_title=None,
-                toast_body=None,
+                failure_toast=None,
                 conflicts_toast=None,
             )
 
@@ -326,18 +318,17 @@ class SessionLifecycleService:
         raw_message = result.get("message")
         message = raw_message if isinstance(raw_message, str) else None
 
-        toast_title, toast_body = _render_sync_toast(
-            offline=offline, success=success, uploaded=uploaded, downloaded=downloaded, message=message
-        )
+        failure_toast = _render_failure_toast(offline=offline, success=success, message=message)
         conflicts_toast = _render_conflicts_toast(conflicts)
 
         return SessionFinalizeSyncResult(
             offline=offline,
             success=success,
             synced=synced,
+            uploaded=uploaded,
+            downloaded=downloaded,
             conflicts=conflicts,
-            toast_title=toast_title,
-            toast_body=toast_body,
+            failure_toast=failure_toast,
             conflicts_toast=conflicts_toast,
         )
 

--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -660,9 +660,17 @@ interface SessionFinalizeSyncResult {
   offline: boolean;
   success: boolean;
   synced: number | null;
+  // Per-direction transfer counts. The directional completion toast is rendered
+  // frontend-side from these via the shared `saveSyncToastBody` helper — the
+  // single source of that copy (#1481).
+  uploaded: number;
+  downloaded: number;
   conflicts: SyncConflict[];
-  toast_title: string | null;
-  toast_body: string | null;
+  // Backend-owned body for the non-directional outcomes (offline / classified
+  // failure / generic failure); `null` when no failure toast should fire —
+  // including the #239 content-dir benign skip. Mutually exclusive with the
+  // directional toast by construction.
+  failure_toast: string | null;
   conflicts_toast: string | null;
 }
 

--- a/src/components/RomMPlaySection.test.tsx
+++ b/src/components/RomMPlaySection.test.tsx
@@ -1949,12 +1949,14 @@ describe("RomMPlaySection", () => {
       return openRomMMenuAndGetItems(testAppId);
     }
 
-    it("success with synced=0 → label 'no files updated'", async () => {
+    it("success upload-only → directional 'Saves uploaded to RomM' via the shared helper", async () => {
       const items = await setupSavesAction();
       vi.mocked(backend.syncRomSaves).mockResolvedValue({
         success: true,
         message: "ok",
-        synced: 0,
+        synced: 2,
+        uploaded: 2,
+        downloaded: 0,
         conflicts: [],
       });
       vi.mocked(toaster.toast).mockClear();
@@ -1962,66 +1964,100 @@ describe("RomMPlaySection", () => {
         await items[2]!.props.onClick?.();
       });
       expect(vi.mocked(toaster.toast)).toHaveBeenCalledWith(
-        expect.objectContaining({
-          body: "Saves synced (no files updated)",
-        }),
+        expect.objectContaining({ body: "Saves uploaded to RomM" }),
       );
     });
 
-    it("success with synced=1 → singular form", async () => {
-      const items = await setupSavesAction();
-      vi.mocked(backend.syncRomSaves).mockResolvedValue({
-        success: true,
-        message: "",
-        synced: 1,
-        conflicts: [],
-      });
-      vi.mocked(toaster.toast).mockClear();
-      await act(async () => {
-        await items[2]!.props.onClick?.();
-      });
-      expect(vi.mocked(toaster.toast)).toHaveBeenCalledWith(
-        expect.objectContaining({
-          body: "Saves synced (1 file updated)",
-        }),
-      );
-    });
-
-    it("success with synced=N + conflicts → label '... N files updated, M conflict(s) need resolution'", async () => {
+    it("success download-only → directional 'Saves downloaded from RomM'", async () => {
       const items = await setupSavesAction();
       vi.mocked(backend.syncRomSaves).mockResolvedValue({
         success: true,
         message: "",
         synced: 3,
+        uploaded: 0,
+        downloaded: 3,
+        conflicts: [],
+      });
+      vi.mocked(toaster.toast).mockClear();
+      await act(async () => {
+        await items[2]!.props.onClick?.();
+      });
+      expect(vi.mocked(toaster.toast)).toHaveBeenCalledWith(
+        expect.objectContaining({ body: "Saves downloaded from RomM" }),
+      );
+    });
+
+    it("success both directions → directional 'Saves synced with RomM (1 up, 2 down)'", async () => {
+      const items = await setupSavesAction();
+      vi.mocked(backend.syncRomSaves).mockResolvedValue({
+        success: true,
+        message: "",
+        synced: 3,
+        uploaded: 1,
+        downloaded: 2,
+        conflicts: [],
+      });
+      vi.mocked(toaster.toast).mockClear();
+      await act(async () => {
+        await items[2]!.props.onClick?.();
+      });
+      expect(vi.mocked(toaster.toast)).toHaveBeenCalledWith(
+        expect.objectContaining({ body: "Saves synced with RomM (1 up, 2 down)" }),
+      );
+    });
+
+    it("success with nothing moved and no conflicts → no toast (zero-case)", async () => {
+      const items = await setupSavesAction();
+      vi.mocked(backend.syncRomSaves).mockResolvedValue({
+        success: true,
+        message: "",
+        synced: 0,
+        uploaded: 0,
+        downloaded: 0,
+        conflicts: [],
+      });
+      vi.mocked(toaster.toast).mockClear();
+      await act(async () => {
+        await items[2]!.props.onClick?.();
+      });
+      expect(vi.mocked(toaster.toast)).not.toHaveBeenCalled();
+    });
+
+    it("success with conflicts but nothing moved → conflict toast only (signal preserved)", async () => {
+      const items = await setupSavesAction();
+      vi.mocked(backend.syncRomSaves).mockResolvedValue({
+        success: true,
+        message: "",
+        synced: 0,
+        uploaded: 0,
+        downloaded: 0,
         conflicts: [{ filename: "x" } as never, { filename: "y" } as never],
       });
       vi.mocked(toaster.toast).mockClear();
       await act(async () => {
         await items[2]!.props.onClick?.();
       });
-      expect(vi.mocked(toaster.toast)).toHaveBeenCalledWith(
-        expect.objectContaining({
-          body: "Saves synced (3 files updated, 2 conflict(s) need resolution)",
-        }),
-      );
+      const bodies = vi.mocked(toaster.toast).mock.calls.map((c) => c[0].body);
+      expect(bodies).toEqual(["2 conflict(s) need resolution"]);
     });
 
-    it("success with synced=0 / conflicts=undefined → treats conflicts as 0", async () => {
+    it("success with transfers + conflicts → directional toast plus additive conflict toast", async () => {
       const items = await setupSavesAction();
       vi.mocked(backend.syncRomSaves).mockResolvedValue({
         success: true,
         message: "",
-        synced: 0,
+        synced: 3,
+        uploaded: 3,
+        downloaded: 0,
+        conflicts: [{ filename: "x" } as never, { filename: "y" } as never],
       });
       vi.mocked(toaster.toast).mockClear();
       await act(async () => {
         await items[2]!.props.onClick?.();
       });
-      expect(vi.mocked(toaster.toast)).toHaveBeenCalledWith(
-        expect.objectContaining({
-          body: "Saves synced (no files updated)",
-        }),
-      );
+      const bodies = vi.mocked(toaster.toast).mock.calls.map((c) => c[0].body);
+      expect(bodies).toContain("Saves uploaded to RomM");
+      expect(bodies).toContain("2 conflict(s) need resolution");
     });
 
     it("failure → surfaces result.message", async () => {

--- a/src/components/RomMPlaySection.tsx
+++ b/src/components/RomMPlaySection.tsx
@@ -31,6 +31,7 @@ import { WarningCard } from "./WarningCard";
 import { SgdbGamePickerModalContent } from "./SgdbGamePickerModal";
 import { applyArtwork } from "../utils/artwork";
 import { hasAnySaveConflict } from "../utils/saveStatus";
+import { saveSyncToastBody } from "../utils/saveSyncToast";
 import { scrollToTop } from "../utils/scrollHelpers";
 import { getEventTarget } from "../utils/events";
 import {
@@ -719,18 +720,20 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
     try {
       const result = await syncRomSaves(info.romId);
       if (result.success) {
-        const n = result.synced;
-        const c = result.conflicts?.length ?? 0;
-        let label: string;
-        if (n === 0) {
-          label = "no files updated";
-        } else if (n === 1) {
-          label = "1 file updated";
-        } else {
-          label = `${n} files updated`;
+        // Directional completion toast via the shared helper — the single source
+        // of that copy across every save-sync surface (#1481). Nothing moved →
+        // no toast (the uniform zero-case).
+        const directionalBody = saveSyncToastBody(result.uploaded, result.downloaded);
+        if (directionalBody) {
+          toaster.toast({ title: "RomM Save Sync", body: directionalBody });
         }
-        if (c > 0) label += `, ${c} conflict(s) need resolution`;
-        toaster.toast({ title: "RomM Sync", body: `Saves synced (${label})` });
+        // Preserve the conflict signal as its own additive toast (mirroring the
+        // post-exit conflicts_toast) — it must stay visible even when nothing
+        // transferred.
+        const c = result.conflicts?.length ?? 0;
+        if (c > 0) {
+          toaster.toast({ title: "RomM Save Sync", body: `${c} conflict(s) need resolution` });
+        }
         globalThis.dispatchEvent(
           new CustomEvent("romm_data_changed", { detail: { type: "save_sync", rom_id: info.romId } }),
         );

--- a/src/utils/saveSyncToast.ts
+++ b/src/utils/saveSyncToast.ts
@@ -1,14 +1,18 @@
 /**
- * Save-sync completion toast copy (#250) — the canonical per-direction wording
- * shared by the surfaces that confirm a sync. A run can move saves either way
- * (a pre-launch download OR a row-9 upload; a post-exit upload OR a row-5/10
- * adopt-download), so a single "synced" line hid which direction actually ran.
+ * Save-sync completion toast copy (#250, #1481) — the single source of the
+ * per-direction wording for every surface that confirms a sync. A run can move
+ * saves either way (a pre-launch download OR a row-9 upload; a post-exit upload
+ * OR a row-5/10 adopt-download), so a single "synced" line hid which direction
+ * actually ran.
  *
  * ``saveSyncToastBody`` names the single direction when saves moved only one
  * way, both counts when a run went both ways, and returns ``null`` when nothing
- * transferred so a no-op sync fires no toast. The backend mirrors this verbatim
- * in ``services/session_lifecycle.py`` (``sync_toast_body``) for the post-exit
- * toast it renders itself; keep the two in lockstep.
+ * transferred so a no-op sync fires no toast. Every surface renders through this
+ * helper from the per-direction counts on its result — pre-launch
+ * (``CustomPlayButton``), post-exit (``sessionManager``, from the
+ * ``finalize_game_session`` payload), and the manual per-game sync
+ * (``RomMPlaySection``). The backend delivers the counts as data, never this
+ * copy; it owns only the offline/failure body it renders itself (#1481).
  */
 
 /**

--- a/src/utils/sessionManager.test.ts
+++ b/src/utils/sessionManager.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { toaster } from "@decky/api";
 import * as backend from "../api/backend";
 import { updatePlaytimeDisplay } from "../patches/metadataPatches";
 import { initSessionManager, destroySessionManager, ADOPTION_POLL_MAX_MS } from "./sessionManager";
@@ -33,9 +34,10 @@ const IDLE_FINALIZE = {
     offline: false,
     success: true,
     synced: 0,
+    uploaded: 0,
+    downloaded: 0,
     conflicts: [],
-    toast_title: null,
-    toast_body: null,
+    failure_toast: null,
     conflicts_toast: null,
   },
   migration: null,
@@ -146,9 +148,10 @@ describe("sessionManager lifecycle forwarding", () => {
         offline: false,
         success: false,
         synced: 0,
+        uploaded: 0,
+        downloaded: 0,
         conflicts: [],
-        toast_title: "RomM Save Sync",
-        toast_body: "Access denied — your account lacks permissions for this action",
+        failure_toast: "Access denied — your account lacks permissions for this action",
         conflicts_toast: null,
       },
       migration: null,
@@ -167,6 +170,94 @@ describe("sessionManager lifecycle forwarding", () => {
     } finally {
       globalThis.removeEventListener("romm_data_changed", listener);
     }
+  });
+});
+
+describe("sessionManager post-exit save-sync toast (#1481)", () => {
+  // The directional completion toast is rendered frontend-side from the transfer
+  // counts via `saveSyncToastBody`; the offline/failure body stays backend-owned
+  // (`failure_toast`). These pin both surfaces onto the finalize payload.
+  type SyncOverride = Partial<Awaited<ReturnType<typeof backend.finalizeGameSession>>["sync"]>;
+
+  const finalizeWithSync = (override: SyncOverride) =>
+    vi.mocked(backend.finalizeGameSession).mockResolvedValue({
+      ...IDLE_FINALIZE,
+      sync: { ...IDLE_FINALIZE.sync, ...override },
+    });
+
+  const runStop = async () => {
+    await initDrainingAdoptionPoll();
+    const lifetime = captureLifetimeCb();
+    await startGame(lifetime);
+    await stopGame(lifetime);
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    stubLifecycleSteamClient();
+    vi.mocked(backend.getAppIdRomIdMap).mockResolvedValue({ [String(APP_ID)]: ROM_ID });
+    vi.mocked(backend.finalizeGameSession).mockResolvedValue({ ...IDLE_FINALIZE });
+  });
+
+  afterEach(() => {
+    destroySessionManager();
+    vi.useRealTimers();
+  });
+
+  it("renders the upload-only directional toast from the counts", async () => {
+    finalizeWithSync({ success: true, uploaded: 2, downloaded: 0 });
+    await runStop();
+    expect(vi.mocked(toaster.toast)).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "RomM Save Sync", body: "Saves uploaded to RomM" }),
+    );
+  });
+
+  it("renders the both-directions directional toast from the counts", async () => {
+    finalizeWithSync({ success: true, uploaded: 1, downloaded: 2 });
+    await runStop();
+    expect(vi.mocked(toaster.toast)).toHaveBeenCalledWith(
+      expect.objectContaining({ body: "Saves synced with RomM (1 up, 2 down)" }),
+    );
+  });
+
+  it("renders the backend-owned failure_toast when the sync failed", async () => {
+    finalizeWithSync({ success: false, uploaded: 0, downloaded: 0, failure_toast: "Failed to sync saves after exit" });
+    await runStop();
+    expect(vi.mocked(toaster.toast)).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "RomM Save Sync", body: "Failed to sync saves after exit" }),
+    );
+  });
+
+  it("fires no toast when nothing moved and there was no failure (zero-case)", async () => {
+    // IDLE_FINALIZE is success=true with zero counts and no failure_toast.
+    finalizeWithSync({ success: true, uploaded: 0, downloaded: 0, failure_toast: null });
+    await runStop();
+    expect(vi.mocked(toaster.toast)).not.toHaveBeenCalled();
+  });
+
+  it("does not render the failure_toast on a successful transfer (mutual exclusivity)", async () => {
+    // A success result carries failure_toast=null by construction; even if a
+    // stray body slipped through, the directional path wins on success.
+    finalizeWithSync({ success: true, uploaded: 3, downloaded: 0, failure_toast: null });
+    await runStop();
+    const bodies = vi.mocked(toaster.toast).mock.calls.map((c) => c[0].body);
+    expect(bodies).toContain("Saves uploaded to RomM");
+    expect(bodies).not.toContain("Failed to sync saves after exit");
+  });
+
+  it("fires the additive conflicts toast alongside the directional toast", async () => {
+    finalizeWithSync({
+      success: true,
+      uploaded: 1,
+      downloaded: 0,
+      conflicts_toast: "2 save conflicts need resolution",
+    });
+    await runStop();
+    const bodies = vi.mocked(toaster.toast).mock.calls.map((c) => c[0].body);
+    expect(bodies).toContain("Saves uploaded to RomM");
+    expect(bodies).toContain("2 save conflicts need resolution");
   });
 });
 
@@ -574,9 +665,10 @@ describe("sessionManager session-changed dispatch (#1313)", () => {
         offline: false,
         success: true,
         synced: 0,
+        uploaded: 0,
+        downloaded: 0,
         conflicts: [],
-        toast_title: null,
-        toast_body: null,
+        failure_toast: null,
         conflicts_toast: null,
       },
       migration: null,

--- a/src/utils/sessionManager.ts
+++ b/src/utils/sessionManager.ts
@@ -9,6 +9,7 @@
 
 import { toaster } from "@decky/api";
 import { recordSessionStart, getAppIdRomIdMap, finalizeGameSession, logInfo, logError, debugLog } from "../api/backend";
+import { saveSyncToastBody } from "./saveSyncToast";
 import { setMigrationStatus } from "./migrationStore";
 import { setSaveSortMigrationStatus } from "./saveSortMigrationStore";
 import { updatePlaytimeDisplay } from "../patches/metadataPatches";
@@ -189,9 +190,18 @@ async function handleGameStop(): Promise<void> {
       }
     }
 
-    // Post-exit sync toast (backend rendered).
-    if (result.sync.toast_title && result.sync.toast_body) {
-      toaster.toast({ title: result.sync.toast_title, body: result.sync.toast_body });
+    // Post-exit save-sync toast. The directional success toast is rendered
+    // frontend-side from the transfer counts via the shared helper (the single
+    // source of that copy, #1481); the offline/failure body stays backend-owned
+    // (failure_toast). The two are mutually exclusive — a successful run carries
+    // failure_toast=null — so only one fires.
+    const directionalBody = result.sync.success
+      ? saveSyncToastBody(result.sync.uploaded, result.sync.downloaded)
+      : null;
+    if (directionalBody) {
+      toaster.toast({ title: "RomM Save Sync", body: directionalBody });
+    } else if (result.sync.failure_toast) {
+      toaster.toast({ title: "RomM Save Sync", body: result.sync.failure_toast });
     }
 
     // Save-sync event dispatch — fires unconditionally so open surfaces refresh

--- a/tests/contract/test_session_finalize.py
+++ b/tests/contract/test_session_finalize.py
@@ -126,3 +126,29 @@ async def test_finalize_unregistered_device_folds_locally_no_ingest(harness):
 
     assert result["total_seconds"] == 300  # counted locally
     assert harness.romm.play_sessions == {}  # nothing ingested
+
+
+async def test_finalize_sync_payload_carries_counts_not_toast_keys(harness):
+    """The ``sync`` payload carries per-direction counts + ``failure_toast``; the
+    removed backend-rendered ``toast_title`` / ``toast_body`` keys are gone (#1481)."""
+    seed_rom(harness, 1)
+    harness.plugin.settings["save_sync_enabled"] = False
+    await harness.plugin.record_session_start(1)
+    harness.clock.advance(60)
+
+    result = await harness.plugin.finalize_game_session(1)
+
+    sync = result["sync"]
+    assert set(sync.keys()) == {
+        "offline",
+        "success",
+        "synced",
+        "uploaded",
+        "downloaded",
+        "conflicts",
+        "failure_toast",
+        "conflicts_toast",
+    }
+    # The directional copy is rendered frontend-side now — no backend toast strings.
+    assert "toast_title" not in sync
+    assert "toast_body" not in sync

--- a/tests/services/test_session_lifecycle.py
+++ b/tests/services/test_session_lifecycle.py
@@ -261,11 +261,14 @@ class TestFinalizeSyncToasts:
         event_loop.run_until_complete(_drain_background_tasks(service))
 
         assert result.sync.offline is True
-        assert result.sync.toast_title == "RomM Save Sync"
-        assert result.sync.toast_body == "Server offline — saves will sync next time"
+        assert result.sync.failure_toast == "Server offline — saves will sync next time"
 
-    def test_success_upload_only_renders_uploaded_toast(self, event_loop, logger):
-        """``success=True`` with only uploads → "Saves uploaded to RomM" (#250)."""
+    def test_success_upload_only_carries_upload_counts(self, event_loop, logger):
+        """``success=True`` with only uploads → counts carried, no failure toast (#250, #1481).
+
+        The directional "Saves uploaded to RomM" string is rendered frontend-side
+        from these counts; the backend only carries the data.
+        """
         post = FakePostExitSync(payload={"success": True, "synced": 3, "uploaded": 3, "downloaded": 0, "conflicts": []})
         service = _make_service(
             playtime_recorder=FakePlaytimeRecorder(),
@@ -280,11 +283,12 @@ class TestFinalizeSyncToasts:
 
         assert result.sync.success is True
         assert result.sync.synced == 3
-        assert result.sync.toast_title == "RomM Save Sync"
-        assert result.sync.toast_body == "Saves uploaded to RomM"
+        assert result.sync.uploaded == 3
+        assert result.sync.downloaded == 0
+        assert result.sync.failure_toast is None
 
-    def test_success_download_only_renders_downloaded_toast(self, event_loop, logger):
-        """``success=True`` with only downloads → "Saves downloaded from RomM" (#250)."""
+    def test_success_download_only_carries_download_counts(self, event_loop, logger):
+        """``success=True`` with only downloads → counts carried, no failure toast (#250, #1481)."""
         post = FakePostExitSync(payload={"success": True, "synced": 2, "uploaded": 0, "downloaded": 2, "conflicts": []})
         service = _make_service(
             playtime_recorder=FakePlaytimeRecorder(),
@@ -298,10 +302,12 @@ class TestFinalizeSyncToasts:
         event_loop.run_until_complete(_drain_background_tasks(service))
 
         assert result.sync.success is True
-        assert result.sync.toast_body == "Saves downloaded from RomM"
+        assert result.sync.uploaded == 0
+        assert result.sync.downloaded == 2
+        assert result.sync.failure_toast is None
 
-    def test_success_both_directions_renders_mixed_toast(self, event_loop, logger):
-        """``success=True`` with both directions → names both counts (#250)."""
+    def test_success_both_directions_carries_both_counts(self, event_loop, logger):
+        """``success=True`` with both directions → both counts carried (#250, #1481)."""
         post = FakePostExitSync(payload={"success": True, "synced": 3, "uploaded": 1, "downloaded": 2, "conflicts": []})
         service = _make_service(
             playtime_recorder=FakePlaytimeRecorder(),
@@ -315,10 +321,12 @@ class TestFinalizeSyncToasts:
         event_loop.run_until_complete(_drain_background_tasks(service))
 
         assert result.sync.success is True
-        assert result.sync.toast_body == "Saves synced with RomM (1 up, 2 down)"
+        assert result.sync.uploaded == 1
+        assert result.sync.downloaded == 2
+        assert result.sync.failure_toast is None
 
-    def test_success_with_no_transfers_renders_no_toast(self, event_loop, logger):
-        """``success=True`` with nothing moved → no toast (frontend still dispatches event)."""
+    def test_success_with_no_transfers_carries_zero_counts(self, event_loop, logger):
+        """``success=True`` with nothing moved → zero counts, no failure toast (frontend fires no toast)."""
         post = FakePostExitSync(payload={"success": True, "synced": 0, "uploaded": 0, "downloaded": 0, "conflicts": []})
         service = _make_service(
             playtime_recorder=FakePlaytimeRecorder(),
@@ -333,11 +341,12 @@ class TestFinalizeSyncToasts:
 
         assert result.sync.success is True
         assert result.sync.synced == 0
-        assert result.sync.toast_title is None
-        assert result.sync.toast_body is None
+        assert result.sync.uploaded == 0
+        assert result.sync.downloaded == 0
+        assert result.sync.failure_toast is None
 
     def test_failure_renders_failure_toast(self, event_loop, logger):
-        """``success=False, offline=False`` → failure toast."""
+        """``success=False, offline=False`` → generic failure toast on ``failure_toast``."""
         post = FakePostExitSync(payload={"success": False})
         service = _make_service(
             playtime_recorder=FakePlaytimeRecorder(),
@@ -350,8 +359,7 @@ class TestFinalizeSyncToasts:
         result = event_loop.run_until_complete(service.finalize(99))
         event_loop.run_until_complete(_drain_background_tasks(service))
 
-        assert result.sync.toast_title == "RomM Save Sync"
-        assert result.sync.toast_body == "Failed to sync saves after exit"
+        assert result.sync.failure_toast == "Failed to sync saves after exit"
 
     def test_failure_with_auth_message_names_the_cause(self, event_loop, logger):
         """#971: a classified auth failure surfaces its own message, not the generic body."""
@@ -374,10 +382,9 @@ class TestFinalizeSyncToasts:
         result = event_loop.run_until_complete(service.finalize(99))
         event_loop.run_until_complete(_drain_background_tasks(service))
 
-        assert result.sync.toast_title == "RomM Save Sync"
-        assert result.sync.toast_body == "Authentication failed — sign in again"
+        assert result.sync.failure_toast == "Authentication failed — sign in again"
         # The generic fallback must NOT be used when a classified cause is present.
-        assert result.sync.toast_body != "Failed to sync saves after exit"
+        assert result.sync.failure_toast != "Failed to sync saves after exit"
 
     def test_failure_with_ssl_message_names_the_cause(self, event_loop, logger):
         """#971: an SSL/server-classified failure surfaces its specific message."""
@@ -400,8 +407,7 @@ class TestFinalizeSyncToasts:
         result = event_loop.run_until_complete(service.finalize(99))
         event_loop.run_until_complete(_drain_background_tasks(service))
 
-        assert result.sync.toast_title == "RomM Save Sync"
-        assert result.sync.toast_body == "SSL certificate verification failed"
+        assert result.sync.failure_toast == "SSL certificate verification failed"
 
     def test_failure_without_message_falls_back_to_generic_body(self, event_loop, logger):
         """A failure with no ``message`` key falls back to the generic failure body."""
@@ -417,8 +423,7 @@ class TestFinalizeSyncToasts:
         result = event_loop.run_until_complete(service.finalize(99))
         event_loop.run_until_complete(_drain_background_tasks(service))
 
-        assert result.sync.toast_title == "RomM Save Sync"
-        assert result.sync.toast_body == "Failed to sync saves after exit"
+        assert result.sync.failure_toast == "Failed to sync saves after exit"
 
     def test_failure_with_non_str_message_falls_back_to_generic_body(self, event_loop, logger):
         """A non-str ``message`` (e.g. None) is coerced away → generic failure body."""
@@ -434,8 +439,7 @@ class TestFinalizeSyncToasts:
         result = event_loop.run_until_complete(service.finalize(99))
         event_loop.run_until_complete(_drain_background_tasks(service))
 
-        assert result.sync.toast_title == "RomM Save Sync"
-        assert result.sync.toast_body == "Failed to sync saves after exit"
+        assert result.sync.failure_toast == "Failed to sync saves after exit"
 
     def test_offline_message_does_not_override_offline_body(self, event_loop, logger):
         """Regression guard: the offline branch keeps its body even when a message is present."""
@@ -452,10 +456,14 @@ class TestFinalizeSyncToasts:
         event_loop.run_until_complete(_drain_background_tasks(service))
 
         assert result.sync.offline is True
-        assert result.sync.toast_body == "Server offline — saves will sync next time"
+        assert result.sync.failure_toast == "Server offline — saves will sync next time"
 
-    def test_success_message_does_not_override_synced_body(self, event_loop, logger):
-        """Regression guard: a successful sync keeps the per-direction body, ignoring ``message``."""
+    def test_success_message_does_not_leak_into_failure_toast(self, event_loop, logger):
+        """Regression guard: a successful sync carries no failure toast, even with a ``message``.
+
+        The directional success toast is rendered frontend-side from the counts;
+        a ``message`` on a successful result must never surface as a failure body.
+        """
         post = FakePostExitSync(
             payload={
                 "success": True,
@@ -478,7 +486,9 @@ class TestFinalizeSyncToasts:
         event_loop.run_until_complete(_drain_background_tasks(service))
 
         assert result.sync.success is True
-        assert result.sync.toast_body == "Saves uploaded to RomM"
+        assert result.sync.uploaded == 2
+        assert result.sync.downloaded == 0
+        assert result.sync.failure_toast is None
 
     def test_post_exit_exception_renders_failure_toast(self, event_loop, logger):
         """Post-exit sync raises → failure toast, downstream still runs."""
@@ -497,8 +507,7 @@ class TestFinalizeSyncToasts:
 
         assert result.sync.offline is False
         assert result.sync.success is False
-        assert result.sync.toast_title == "RomM Save Sync"
-        assert result.sync.toast_body == "Failed to sync saves after exit"
+        assert result.sync.failure_toast == "Failed to sync saves after exit"
         assert result.sync.conflicts == []
         # Post-exit failure must NOT short-circuit migration refresh.
         assert migration.refresh_calls == 1
@@ -524,9 +533,9 @@ class TestFinalizeSyncToasts:
         result = event_loop.run_until_complete(service.finalize(99))
         event_loop.run_until_complete(_drain_background_tasks(service))
 
-        assert result.sync.toast_body == "Failed to sync saves after exit"
-        # The exception text must never leak into the toast body.
-        assert "Authentication failed" not in result.sync.toast_body
+        assert result.sync.failure_toast == "Failed to sync saves after exit"
+        # The exception text must never leak into the failure toast body.
+        assert "Authentication failed" not in result.sync.failure_toast
 
     def test_direction_counts_non_int_treated_as_zero(self, event_loop, logger):
         """``uploaded`` / ``downloaded`` not ints (None, str) → treated as 0 → no toast."""
@@ -544,10 +553,11 @@ class TestFinalizeSyncToasts:
         result = event_loop.run_until_complete(service.finalize(99))
         event_loop.run_until_complete(_drain_background_tasks(service))
 
-        # Malformed counts default to 0 → no transfer detected → no toast.
+        # Malformed counts default to 0 → the frontend helper renders no toast.
         assert result.sync.synced is None
-        assert result.sync.toast_title is None
-        assert result.sync.toast_body is None
+        assert result.sync.uploaded == 0
+        assert result.sync.downloaded == 0
+        assert result.sync.failure_toast is None
 
 
 class TestFinalizeContentDirBenignSkip:
@@ -580,8 +590,7 @@ class TestFinalizeContentDirBenignSkip:
         # The post-exit sync ran (benign skip is the sync's own verdict)...
         assert post.calls == [99]
         # ...but NO toast fires — neither the failure toast nor any other.
-        assert result.sync.toast_title is None
-        assert result.sync.toast_body is None
+        assert result.sync.failure_toast is None
         assert result.sync.conflicts_toast is None
         # Verdict flags reflect a non-error skip.
         assert result.sync.offline is False
@@ -603,8 +612,7 @@ class TestFinalizeContentDirBenignSkip:
         result = event_loop.run_until_complete(service.finalize(99))
         event_loop.run_until_complete(_drain_background_tasks(service))
 
-        assert result.sync.toast_title == "RomM Save Sync"
-        assert result.sync.toast_body == "Failed to sync saves after exit"
+        assert result.sync.failure_toast == "Failed to sync saves after exit"
 
 
 class TestFinalizeConflicts:
@@ -805,8 +813,7 @@ class TestFinalizeMigrationGate:
         assert post.calls == []
         assert result.sync.offline is False
         assert result.sync.success is False
-        assert result.sync.toast_title == "RomM Save Sync"
-        assert result.sync.toast_body == "Failed to sync saves after exit"
+        assert result.sync.failure_toast == "Failed to sync saves after exit"
         # Playtime + migration refresh still ran.
         assert result.total_seconds == 3600
         assert migration.refresh_calls == 1
@@ -884,9 +891,10 @@ class TestFinalizeResultShape:
                 offline=False,
                 success=True,
                 synced=2,
+                uploaded=2,
+                downloaded=0,
                 conflicts=conflicts,
-                toast_title="RomM Save Sync",
-                toast_body="Saves uploaded to RomM",
+                failure_toast=None,
                 conflicts_toast="1 save conflict need resolution",
             ),
             migration=SessionFinalizeMigration(


### PR DESCRIPTION
Closes #1481

Save-sync toast copy lived in three places: a frontend helper (pre-launch), a backend renderer (post-exit — the duplicate), and a third wording on the manual per-game sync. Now **one frontend helper owns every directional string.**

- the post-exit toast was always rendered by the frontend (the session manager awaits `finalizeGameSession` and calls the toaster from its result — the backend only pre-rendered strings), so moving composition frontend-side drops zero toasts
- `SessionFinalizeSyncResult` now carries `uploaded`/`downloaded` counts as data; the backend `sync_toast_body` and the `toast_title`/`toast_body` keys are gone. Offline/failure copy stays backend-owned as `failure_toast: str | None` (mirroring `conflicts_toast`), preserving the #239 benign-skip suppression; directional and failure toasts are mutually exclusive by construction on both sides
- the manual per-game sync renders through the same helper; its conflict signal survives as a separate additive toast that also fires when nothing transferred
- zero-case is uniform: nothing moved → no toast, on all three surfaces
- success copy is presentation (frontend, i18n-ready per #133); failure copy follows the backend-owned message convention

docs: architecture completion-toast section updated (single source, per-surface rendering).
