### PR TITLE
fix(saves): surface dedup-to-non-head upload responses as conflicts instead of recording synced

### DIFF
--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -177,11 +177,14 @@ On the automatic path there is no PUT-in-place to bump, so the #748 "drop the PU
 `add_save` (POST) already upserts this device's `device_save_sync` row (`last_synced_at = updated_at`) and serializes it
 into the response's `device_syncs`, so `is_current` is true for us the moment the POST returns — the follow-up
 `confirm_download` ack is redundant and is **skipped** when the response proves us current (`_confirm_upload_sync`,
-#1458). The one path that still needs the ack is `add_save`'s content-dedup early-return: a byte-identical
-`overwrite=false` POST returns the matching save **before** the upsert with `is_current=false`, so the ack is the only
-writer of our sync row there. The version-switch flow (`versions.py`) routes through the same `_confirm_upload_sync`
-after its PUT — the PUT upserts too, so the ack is at most an idempotent re-ack (and is skipped if the PUT response
-already proves us current) — and is out of scope here — see [Version Switch Flow](#version-switch-flow-rollback).
+#1458). The one path that still needs the ack is `add_save`'s content-dedup early-return: a POST returns the matching
+save **before** the upsert with `is_current=false`, so the ack is the only writer of our sync row there. On the
+automatic path this only fires for a **benign** dedup where the returned save is the slot head (e.g. the empty-slot
+race) — a dedup to an older, non-head save is guarded away first and routed to a conflict, never acked (see
+[Dedup-to-non-head](#upload-time-conflicts-the-409-backstop) below). The version-switch flow (`versions.py`) routes
+through the same `_confirm_upload_sync` after its PUT — the PUT upserts too, so the ack is at most an idempotent re-ack
+(and is skipped if the PUT response already proves us current) — and is out of scope here — see
+[Version Switch Flow](#version-switch-flow-rollback).
 
 ## Save Slots
 
@@ -613,7 +616,22 @@ current on the slot's newest save (see [The `add_save` POST 409-gate](#the-add_s
 predicate). The adapter maps that 409 to `RommConflictError`, which is non-retryable and propagates on the first
 attempt.
 
-On a 409 the executor re-fetches the slot, picks the newest save in the canonical group, and resolves through the pure
+**Dedup-to-non-head (detected client-side).** A second signal routes to the same backstop. RomM's `add_save` content
+dedup can early-return an **existing** save whose content matches the upload instead of creating a new version — and
+that returned save may not be the slot head. Because the automatic path only POSTs when local content diverged from the
+head, a dedup on that path resolves to an **older** save while a newer, different head still leads the slot: no new
+version, the foreign head stays authoritative, yet the response looks like a successful upload. Recording it as a synced
+baseline would falsely report "synced" while the upload intent (make our content the head) went silently unfulfilled
+cross-device. `do_upload_save` compares the POST response against the pre-upload `list_saves` snapshot
+(`_dedup_returned_non_head`: the response is a pre-existing snapshot member that is not the newest) and raises
+`RommConflictError` **before** any baseline / confirm / own-upload write, so the same backstop below surfaces the true
+state and nothing stamps currency on the non-head save
+([#1482](https://github.com/danielcopper/decky-romm-sync/issues/1482)). An **empty** planned slot (no head to bypass —
+the empty-slot race) keeps today's behavior: the dedup response holds our content, so it is recorded as the baseline and
+any concurrent newer head is caught on the next sync's fresh list.
+
+On a 409 (or a client-detected dedup-to-non-head) the executor re-fetches the slot, picks the newest save in the
+canonical group, and resolves through the pure
 `resolve_upload_conflict(local_hash, last_sync_hash, server_content_hash)`:
 
 | Condition                           | Result       | Why                                                                                 |

--- a/py_modules/services/saves/sync_engine/matrix.py
+++ b/py_modules/services/saves/sync_engine/matrix.py
@@ -409,6 +409,7 @@ class MatrixExecutor:
         default_slot: str | None = None,
         autocleanup_limit: int | None = None,
         overwrite: bool = False,
+        planned_group: list[dict[str, Any]] | None = None,
     ) -> dict[str, Any]:
         """Upload a local save file to server.
 
@@ -423,6 +424,15 @@ class MatrixExecutor:
         must win (the ``keep_local`` conflict resolution); the automatic sync
         dispatch leaves it ``False`` so the 409 backstop can catch a stale-current
         race (ADR-0017).
+
+        *planned_group* is the automatic POST path's pre-upload ``list_saves``
+        snapshot for this file (``None`` for the PUT / explicit-action callers,
+        who never dedup): when the POST response deduped to a pre-existing
+        non-head save (:func:`_dedup_returned_non_head`, #1482), this raises
+        ``RommConflictError`` BEFORE any baseline / own-upload / confirm write so
+        the same 409 backstop that catches a write-time stale-current race
+        surfaces the true state — no false "synced", no currency stamped on the
+        non-head response.
         """
         save_id = server_save.get("id") if server_save else None
         emulator = build_emulator_tag(core_so)
@@ -442,6 +452,19 @@ class MatrixExecutor:
                 autocleanup_limit=autocleanup_limit,
             )
         )
+
+        if planned_group is not None and _dedup_returned_non_head(result, planned_group):
+            # Dedup to a non-head save: RomM created no new version and the
+            # foreign head still leads the slot, so recording this response as a
+            # synced baseline would falsely report the upload landed (#1482).
+            # Route it through the write-time 409 backstop — the raise reaches
+            # ``_dispatch_upload``'s ``except RommConflictError`` before any
+            # baseline / confirm / own-upload write runs, so nothing stamps
+            # currency on the non-head response.
+            raise RommConflictError(
+                "add_save deduped to a non-head save; the slot head is newer",
+                method="POST",
+            )
 
         self.update_file_sync_state(
             save_state,
@@ -559,6 +582,7 @@ class MatrixExecutor:
         local_hash: str | None,
         last_sync_hash: str | None,
         last_sync_server_hash: str | None,
+        server_candidates: list[dict[str, Any]],
         options: SyncRunOptions,
         sink: DispatchSink,
     ) -> TransferDirection | None:
@@ -566,16 +590,19 @@ class MatrixExecutor:
 
         Every automatic upload POSTs a new save in the slot (``server_save=None``,
         ``overwrite=False``); ``Upload.target_save_id`` no longer selects a PUT
-        (ADR-0017). The POST is planned against a ``list_saves`` snapshot that can
-        be stale by the time it lands — another device may have moved the slot head
-        past our last sync in between. RomM answers that race with a 409;
-        :meth:`_handle_upload_409` re-fetches the slot and lets
-        ``resolve_upload_conflict`` decide from hashes alone (download the fresh
-        head when local is provably unchanged, else surface a conflict). Any other
-        ``RommApiError`` propagates to the generic handler in
-        :meth:`_dispatch_sync_action`. Returns the transfer direction that was
-        issued (``UPLOAD`` on a clean POST, ``DOWNLOAD`` when the 409 backstop
-        downgrades), or ``None`` when nothing transferred.
+        (ADR-0017). The POST is planned against a ``list_saves`` snapshot
+        (*server_candidates*) that can be stale by the time it lands — another
+        device may have moved the slot head past our last sync in between. Two
+        signals route to the same backstop: RomM rejects the stale POST with a
+        409, and RomM's content-dedup can early-return a pre-existing non-head
+        save (:func:`_dedup_returned_non_head`, #1482) that ``do_upload_save``
+        turns into a ``RommConflictError``. Either way :meth:`_handle_upload_409`
+        re-fetches the slot and lets ``resolve_upload_conflict`` decide from
+        hashes alone (download the fresh head when local is provably unchanged,
+        else surface a conflict). Any other ``RommApiError`` propagates to the
+        generic handler in :meth:`_dispatch_sync_action`. Returns the transfer
+        direction that was issued (``UPLOAD`` on a clean POST, ``DOWNLOAD`` when
+        the backstop downgrades), or ``None`` when nothing transferred.
         """
         if local_path is None:
             self._logger.warning(
@@ -586,6 +613,8 @@ class MatrixExecutor:
         try:
             # POST (create) a new save in the slot. The retention cap is POST-only —
             # RomM stacks versions on create, so the limit is sent here alone.
+            # ``planned_group`` lets the POST catch a dedup-to-non-head response
+            # (#1482) and route it through the same 409 backstop below.
             self.do_upload_save(
                 ctx.rom_id,
                 local_path,
@@ -598,6 +627,7 @@ class MatrixExecutor:
                 options.default_slot,
                 autocleanup_limit=options.autocleanup_limit,
                 overwrite=False,
+                planned_group=server_candidates,
             )
             return TransferDirection.UPLOAD
         except RommConflictError:
@@ -624,10 +654,14 @@ class MatrixExecutor:
         options: SyncRunOptions,
         sink: DispatchSink,
     ) -> TransferDirection | None:
-        """Re-decide an upload rejected by RomM's write-time 409.
+        """Re-decide an upload the POST could not land as a new slot head.
 
-        The POST proved the slot head moved past our last sync since the
-        ``list_saves`` snapshot that planned it. Re-fetch the slot, regroup to
+        Reached from two signals that mean the same thing — the slot head is not
+        where our POST assumed: RomM's write-time 409 (the head moved past our
+        last sync since the ``list_saves`` snapshot that planned the POST), and a
+        dedup-to-non-head early-return the POST turned into a ``RommConflictError``
+        (#1482, RomM created no new version and an older save came back while a
+        newer head still leads). Re-fetch the slot, regroup to
         this file's canonical target (the same grouping
         :meth:`iter_matrix_outcomes` uses), pick the newest, and let
         ``resolve_upload_conflict`` decide purely from hashes: a provably-unchanged
@@ -668,6 +702,7 @@ class MatrixExecutor:
         local_hash: str | None,
         last_sync_hash: str | None,
         last_sync_server_hash: str | None,
+        server_candidates: list[dict[str, Any]],
         options: SyncRunOptions,
         sink: DispatchSink,
     ) -> TransferDirection | None:
@@ -677,10 +712,12 @@ class MatrixExecutor:
         Errors are caught and pushed onto ``sink.errors`` so a single failure
         can't abort the whole rom-level sync; conflicts land on
         ``sink.conflicts``. ``ctx.rom_name`` + the stored baseline pair
-        (``last_sync_hash`` / ``last_sync_server_hash``) are threaded through for
-        the upload 409 backstop (canonical-target regroup + hash re-decision).
-        Returns the :class:`TransferDirection` a transfer moved, or ``None`` for a
-        skip, a surfaced conflict, or a failed transfer.
+        (``last_sync_hash`` / ``last_sync_server_hash``) + this file's
+        ``server_candidates`` (the pre-upload snapshot, for the dedup-to-non-head
+        guard) are threaded through for the upload 409 backstop (canonical-target
+        regroup + hash re-decision). Returns the :class:`TransferDirection` a
+        transfer moved, or ``None`` for a skip, a surfaced conflict, or a failed
+        transfer.
         """
         try:
             if isinstance(action, Skip):
@@ -700,6 +737,7 @@ class MatrixExecutor:
                     local_hash=local_hash,
                     last_sync_hash=last_sync_hash,
                     last_sync_server_hash=last_sync_server_hash,
+                    server_candidates=server_candidates,
                     options=options,
                     sink=sink,
                 )
@@ -920,6 +958,7 @@ class MatrixExecutor:
                 local_hash=outcome.local_hash,
                 last_sync_hash=outcome.file_state.last_sync_hash,
                 last_sync_server_hash=outcome.file_state.last_sync_server_hash,
+                server_candidates=outcome.server_candidates,
                 options=options,
                 sink=sink,
             )
@@ -936,6 +975,33 @@ class MatrixExecutor:
             f" uploaded={uploaded} downloaded={downloaded} errors={len(errors)}"
         )
         return uploaded, downloaded, errors, conflicts
+
+
+def _dedup_returned_non_head(response: dict[str, Any], planned_group: list[dict[str, Any]]) -> bool:
+    """Whether an ``add_save`` POST deduped to a pre-existing NON-head save (#1482).
+
+    RomM's ``add_save`` content-dedup can early-return an EXISTING save whose
+    content matches the upload instead of creating a new version. When that
+    returned save is not the slot head the run planned against — an older save
+    while a newer, different head still leads the slot — the upload intent (make
+    our content the slot head) went silently unfulfilled: no new version, the
+    foreign head stays authoritative, yet the response looks like a successful
+    upload. Recording it as a synced baseline would falsely report "synced".
+
+    Detected purely from ids against *planned_group* (the pre-upload
+    ``list_saves`` snapshot for this file, the same group ``compute_sync_action``
+    evaluated): the response is a member of that snapshot (an existing save, not
+    a freshly minted version whose id is absent from it) that is not the newest
+    save in it. Benign — today's baseline write stands — for an empty planned
+    slot (no head to bypass, e.g. an empty-slot race whose only signal is the
+    dedup response itself), a freshly created version, or the head coming back.
+    """
+    response_id = response.get("id")
+    if response_id is None or not planned_group:
+        return False
+    head = max(planned_group, key=lambda s: parse_iso_to_epoch(s.get("updated_at")) or 0.0)
+    group_ids = {s.get("id") for s in planned_group}
+    return response_id in group_ids and response_id != head.get("id")
 
 
 def _upload_response_proves_current(response: dict[str, Any], device_id: str) -> bool:

--- a/tests/contract/test_saves_confirm_skip.py
+++ b/tests/contract/test_saves_confirm_skip.py
@@ -1,11 +1,16 @@
-"""Contract tests for the post-upload confirm-download skip (#1458).
+"""Contract tests for the post-upload confirm-download skip (#1458) and the
+dedup-to-non-head guard (#1482).
 
 Driven frontend-shaped through the real ``Plugin`` / ``bootstrap`` harness. A
 normal automatic upload leaves this device ``is_current`` via ``add_save``'s own
 DeviceSaveSync upsert, so the sync engine skips the redundant
-``POST /saves/{id}/downloaded`` ack. The one path that still needs the ack is
-``add_save``'s content-dedup early-return (a byte-identical POST that returns the
-matching save before the upsert, reporting ``is_current=false``).
+``POST /saves/{id}/downloaded`` ack (#1458). When ``add_save``'s content-dedup
+early-returns a matching save that is *not* the slot head (an older version while
+a newer, different head still leads), the upload never became the head, so the
+guard routes the response through the 409 backstop and surfaces a conflict rather
+than a false ``synced`` (#1482) — no ack fires on that path. The #1458 ack itself
+(fail-open on a not-provably-current dedup response) is exercised at the unit tier
+(``TestConfirmUploadSyncDiscriminator``), where the guard is inert.
 
 Both scenarios stay on the legacy ``compute_sync_action`` matrix path
 (``active_slot`` set, ``slot_confirmed`` unset) so the POST is actually
@@ -57,16 +62,20 @@ async def test_normal_upload_skips_confirm_download(harness):
     assert our_sync["is_current"] is True
 
 
-async def test_dedup_response_still_confirms_download(harness):
-    """A byte-identical re-upload hits add_save's content-dedup early-return: the
-    response reports is_current=false, so the confirm ack stays load-bearing."""
+async def test_dedup_to_non_head_surfaces_conflict(harness):
+    """A POST that content-dedups to an OLDER save while a newer, different head
+    still leads the slot (#1482): no new version is created and the foreign head
+    stays authoritative, so recording the dedup response as ``synced`` would be a
+    silent no-op cross-device. The guard routes it through the 409 backstop and
+    surfaces a conflict on the head instead — no synced count, no confirm ack, DB
+    baseline untouched."""
     enable_save_sync(harness)
     seed_install(harness, 42, system="gba", file_name="game.gba")
     _write_local_save(harness, system="gba", content=b"reverted to older content", filename="game.srm")
 
     # Head we are current on (branch 4 → Upload) and an older sibling version we
     # never synced, both in the slot. The local edit diverged from the baseline,
-    # so the matrix POSTs — and the POST dedups against the older version.
+    # so the matrix POSTs — and the POST dedups against the older, non-head version.
     seed_server_save(
         harness, save_id=500, rom_id=42, slot="default", file_name="game.srm", updated_at="2026-03-02T00:00:00Z"
     )
@@ -79,15 +88,21 @@ async def test_dedup_response_still_confirms_download(harness):
     state.adopt_baseline("game.srm", tracked_save_id=500, last_sync_hash=hashlib.md5(b"head content").hexdigest())
     seed_save_state(harness, 42, state)
 
-    harness.romm.arm_add_save_dedup(400)
+    harness.romm.arm_add_save_dedup(400)  # the POST dedups to the OLDER, non-head save
 
     result = await harness.plugin.sync_rom_saves(42)
 
     assert result["success"] is True
-    assert result["synced"] == 1
-    assert result["conflicts"] == []
+    # Not a false "synced" — the true divergence surfaced as a conflict on the head.
+    assert result["synced"] == 0
+    assert len(result["conflicts"]) == 1
+    assert result["conflicts"][0]["server_save_id"] == 500
     upload_calls = [c for c in harness.romm.call_log if c[0] == "upload_save"]
     assert len(upload_calls) == 1
-    # The dedup response was NOT provably current, so the confirm ack fired.
-    confirm_calls = [c for c in harness.romm.call_log if c[0] == "confirm_download"]
-    assert confirm_calls == [("confirm_download", (400, "device-1"), {})]
+    # No confirm ack stamped currency on the non-head response…
+    assert not any(c[0] == "confirm_download" for c in harness.romm.call_log)
+    # …and the DB baseline was never rewritten onto the dedup response (400).
+    with harness.uow_factory() as uow:
+        reloaded = uow.rom_save_states.get(42)
+    assert reloaded is not None
+    assert reloaded.files["game.srm"].tracked_save_id == 500

--- a/tests/fakes/fake_romm_api.py
+++ b/tests/fakes/fake_romm_api.py
@@ -790,6 +790,11 @@ class FakeRommApi:
         row, no ledger write — with the uploading device reported ``is_current=false``.
         Mirrors saves.py:253-267 so a test can exercise the dedup path where the
         post-upload confirm ack is the only writer of our sync row (#1458).
+
+        *save_id* need not be the slot head: arm an OLDER save while a newer,
+        different head is present to model the dedup-to-non-head shape — the POST
+        deduped to a save that is not the slot head, so the upload never became
+        authoritative (#1482).
         """
         self._dedup_next_upload_save_id = save_id
 

--- a/tests/services/saves/sync_engine/test_matrix.py
+++ b/tests/services/saves/sync_engine/test_matrix.py
@@ -15,8 +15,13 @@ import pytest
 
 from domain.rom_save_state import RomSaveState
 from domain.sync_action import Conflict, Skip, compute_sync_action
-from lib.errors import RommApiError
-from services.saves.sync_engine.matrix import DispatchSink, RomDispatchContext, SyncRunOptions
+from lib.errors import RommApiError, RommConflictError
+from services.saves.sync_engine.matrix import (
+    DispatchSink,
+    RomDispatchContext,
+    SyncRunOptions,
+    _dedup_returned_non_head,
+)
 from tests.services.saves._helpers import (
     _create_save,
     _do_sync,
@@ -727,6 +732,165 @@ class TestConfirmUploadSyncDiscriminator:
         matrix._confirm_upload_sync(response, "dev-1")
 
         assert self._confirmed(fake) is False
+
+
+_DEDUP_GROUP = [
+    {"id": 100, "updated_at": "2026-02-17T06:00:00Z"},  # older
+    {"id": 200, "updated_at": "2026-03-01T00:00:00Z"},  # newest = head
+]
+
+
+class TestDedupReturnedNonHeadPredicate:
+    """`_dedup_returned_non_head` — pure id-based detection of an ``add_save``
+    POST that deduped to a pre-existing NON-head save (#1482)."""
+
+    def test_empty_planned_group_is_benign(self):
+        """No planned head to bypass (e.g. an empty-slot race) → benign."""
+        assert _dedup_returned_non_head({"id": 100}, []) is False
+
+    def test_missing_response_id_is_benign(self):
+        assert _dedup_returned_non_head({}, _DEDUP_GROUP) is False
+
+    def test_response_is_the_head_is_benign(self):
+        """Dedup returned the newest save in the snapshot → benign."""
+        assert _dedup_returned_non_head({"id": 200}, _DEDUP_GROUP) is False
+
+    def test_new_version_id_absent_from_snapshot_is_benign(self):
+        """A freshly minted version (id not in the pre-upload snapshot) → benign."""
+        assert _dedup_returned_non_head({"id": 999}, _DEDUP_GROUP) is False
+
+    def test_pre_existing_non_head_is_flagged(self):
+        """Dedup returned the older 100 while 200 still leads the slot → flagged."""
+        assert _dedup_returned_non_head({"id": 100}, _DEDUP_GROUP) is True
+
+
+class TestDedupToNonHeadUploadGuard:
+    """``do_upload_save`` routes a dedup-to-non-head POST response through the
+    409 backstop instead of recording a false ``synced`` baseline (#1482).
+
+    RomM's ``add_save`` content-dedup can early-return an older matching save
+    while a newer, different head still leads the slot — no new version, the
+    foreign head stays authoritative. The automatic POST path passes its
+    pre-upload ``list_saves`` snapshot as ``planned_group`` so the response can
+    be classified; the PUT / explicit-action callers pass none and are inert.
+    """
+
+    def test_dedup_to_non_head_raises_conflict_without_baseline_or_confirm(self, tmp_path):
+        """Non-head dedup → RommConflictError before any baseline / own-upload /
+        confirm write (value-exact: nothing was stamped on the non-head save)."""
+        svc, fake = make_service(tmp_path)
+        _set_device_id(svc, "device-1")
+        _install_rom(svc, tmp_path)
+        save_path = _create_save(tmp_path, content=b"local reverted content")
+
+        older = _server_save(save_id=100, slot="default", updated_at="2026-02-17T06:00:00Z")
+        head = _server_save(save_id=200, slot="default", updated_at="2026-03-01T00:00:00Z")
+        fake.saves[100] = older
+        fake.saves[200] = head
+        fake.arm_add_save_dedup(100)  # the POST dedups to the OLDER save
+
+        state = RomSaveState(active_slot="default")
+        with pytest.raises(RommConflictError):
+            svc._sync_engine._matrix.do_upload_save(
+                42,
+                str(save_path),
+                "pokemon.srm",
+                state,
+                "device-1",
+                "gba",
+                None,
+                planned_group=[older, head],
+            )
+
+        # No baseline recorded for the dedup response…
+        assert "pokemon.srm" not in state.files
+        # …no own-upload attribution, no slot promotion, and no confirm ack that
+        # would falsely stamp currency on the non-head save.
+        assert state.own_upload_ids is None
+        assert not any(c[0] == "confirm_download" for c in fake.call_log)
+
+    def test_dedup_to_head_records_baseline_and_confirms(self, tmp_path):
+        """Dedup to the head itself is benign — baseline recorded on the head and
+        the #1458 confirm ack still fires (today's behavior, unchanged)."""
+        svc, fake = make_service(tmp_path)
+        _set_device_id(svc, "device-1")
+        _install_rom(svc, tmp_path)
+        save_path = _create_save(tmp_path, content=b"head content")
+
+        older = _server_save(save_id=100, slot="default", updated_at="2026-02-17T06:00:00Z")
+        head = _server_save(save_id=200, slot="default", updated_at="2026-03-01T00:00:00Z")
+        fake.saves[100] = older
+        fake.saves[200] = head
+        fake.arm_add_save_dedup(200)  # dedup to the HEAD → benign
+
+        state = RomSaveState(active_slot="default")
+        result = svc._sync_engine._matrix.do_upload_save(
+            42,
+            str(save_path),
+            "pokemon.srm",
+            state,
+            "device-1",
+            "gba",
+            None,
+            planned_group=[older, head],
+        )
+
+        assert result["id"] == 200
+        assert state.files["pokemon.srm"].tracked_save_id == 200
+        # Dedup response reported is_current=false → the ack stays load-bearing.
+        assert fake.call_log[-1] == ("confirm_download", (200, "device-1"), {})
+
+    def test_empty_planned_group_records_baseline(self, tmp_path):
+        """Empty planned slot (no head to bypass — the empty-slot race) keeps
+        today's behavior: the dedup response is recorded as the baseline. Safe
+        because the response holds our content; a concurrent newer head is caught
+        on the next sync's fresh ``list_saves`` (#1482 documented edge)."""
+        svc, fake = make_service(tmp_path)
+        _set_device_id(svc, "device-1")
+        _install_rom(svc, tmp_path)
+        save_path = _create_save(tmp_path, content=b"raced content")
+
+        raced = _server_save(save_id=300, slot="default", updated_at="2026-03-01T00:00:00Z")
+        fake.saves[300] = raced
+        fake.arm_add_save_dedup(300)
+
+        state = RomSaveState(active_slot="default")
+        result = svc._sync_engine._matrix.do_upload_save(
+            42,
+            str(save_path),
+            "pokemon.srm",
+            state,
+            "device-1",
+            "gba",
+            None,
+            planned_group=[],  # the plan saw an empty slot
+        )
+
+        assert result["id"] == 300
+        assert state.files["pokemon.srm"].tracked_save_id == 300
+
+    def test_no_planned_group_leaves_guard_inert(self, tmp_path):
+        """A caller that passes no ``planned_group`` (PUT / explicit actions)
+        never triggers the guard, even on a non-head dedup shape — baseline is
+        recorded as before."""
+        svc, fake = make_service(tmp_path)
+        _set_device_id(svc, "device-1")
+        _install_rom(svc, tmp_path)
+        save_path = _create_save(tmp_path, content=b"local content")
+
+        older = _server_save(save_id=100, slot="default", updated_at="2026-02-17T06:00:00Z")
+        head = _server_save(save_id=200, slot="default", updated_at="2026-03-01T00:00:00Z")
+        fake.saves[100] = older
+        fake.saves[200] = head
+        fake.arm_add_save_dedup(100)  # non-head dedup, but no planned_group passed
+
+        state = RomSaveState(active_slot="default")
+        result = svc._sync_engine._matrix.do_upload_save(
+            42, str(save_path), "pokemon.srm", state, "device-1", "gba", None
+        )
+
+        assert result["id"] == 100
+        assert state.files["pokemon.srm"].tracked_save_id == 100
 
 
 class TestTrackedSaveIdMatching:
@@ -2049,6 +2213,77 @@ class TestSyncRomSavesDispatch:
         assert save_path.read_bytes() == b"local unsynced edit"
         assert not any(x[0] == "download_save_content" for x in fake.call_log)
 
+    def test_sync_rom_saves_dedup_to_non_head_surfaces_conflict(self, tmp_path):
+        """On-device #1482 repro: slot holds an older save A and a newer head B
+        (different content); this device is current on B; local content reverted
+        to A. The automatic POST content-dedups to A while B still leads the slot
+        — the upload never became the head. The guard routes it through the 409
+        backstop, surfacing the true state as a conflict on B instead of a false
+        ``synced`` on A, and leaves the DB baseline untouched."""
+        svc, fake = make_service(tmp_path)
+        _enable_sync_with_device(svc)
+        _install_rom(svc, tmp_path)
+        save_path = _create_save(tmp_path, content=b"reverted-to-A content")
+
+        # B: the newer head this device is current on (branch 4 → Upload).
+        head = fake.seed_foreign_save(
+            42,
+            save_id=200,
+            uploaded_by="device-1",
+            slot="default",
+            updated_at="2026-03-01T00:00:00Z",
+            content=b"head B content",
+        )
+        # A: an older sibling version we never synced; the POST dedups to it.
+        older = fake.seed_foreign_save(
+            42,
+            save_id=100,
+            uploaded_by="device-B",
+            slot="default",
+            updated_at="2026-02-17T06:00:00Z",
+            content=b"old A content",
+        )
+        _seed_save_state_dict(
+            svc,
+            42,
+            {
+                "active_slot": "default",
+                "slot_confirmed": True,
+                "files": {
+                    "pokemon.srm": {
+                        "last_sync_hash": hashlib.md5(b"head B content").hexdigest(),
+                        "tracked_save_id": 200,
+                        "last_sync_server_save_id": 200,
+                    }
+                },
+            },
+        )
+        fake.arm_add_save_dedup(older["id"])
+
+        uploaded, downloaded, errors, conflicts = _do_sync(svc, 42)
+
+        assert errors == []
+        assert uploaded == 0
+        assert downloaded == 0
+        # The true state surfaced: a conflict against the head B, not a false sync on A.
+        assert len(conflicts) == 1
+        c = conflicts[0]
+        assert c["type"] == "sync_conflict"
+        assert c["server_save_id"] == head["id"]
+        # Exactly one POST was attempted (overwrite=false), then no download/confirm.
+        upload_calls = [x for x in fake.call_log if x[0] == "upload_save"]
+        assert len(upload_calls) == 1
+        assert upload_calls[0][2]["overwrite"] is False
+        assert not any(x[0] == "download_save_content" for x in fake.call_log)
+        assert not any(x[0] == "confirm_download" for x in fake.call_log)
+        # Local file untouched (no download), and the baseline still points at B —
+        # the dedup response A was never recorded as synced.
+        assert save_path.read_bytes() == b"reverted-to-A content"
+        file_state = _require_save_state(svc, 42).files["pokemon.srm"]
+        assert file_state.tracked_save_id == 200
+        assert file_state.last_sync_server_save_id == 200
+        assert file_state.last_sync_hash == hashlib.md5(b"head B content").hexdigest()
+
     def test_handle_upload_409_empty_regroup_records_error(self, tmp_path):
         """A 409 whose re-fetch finds no server save in the file's canonical group
         is a non-fatal error — never a crash or a blind download."""
@@ -2178,6 +2413,7 @@ class TestHandleUnexpectedError:
             local_hash=None,
             last_sync_hash=None,
             last_sync_server_hash=None,
+            server_candidates=[],
             options=SyncRunOptions(),
             sink=DispatchSink(errors=errors, conflicts=conflicts),
         )
@@ -2229,6 +2465,7 @@ class TestDispatchSyncActionErrorBranches:
             local_hash=None,
             last_sync_hash=None,
             last_sync_server_hash=None,
+            server_candidates=[],
             options=SyncRunOptions(),
             sink=DispatchSink(errors=errors, conflicts=conflicts),
         )
@@ -2275,6 +2512,7 @@ class TestDispatchUploadDefensiveBranches:
             local_hash=None,
             last_sync_hash=None,
             last_sync_server_hash=None,
+            server_candidates=[],
             options=SyncRunOptions(),
             sink=DispatchSink(errors=errors, conflicts=conflicts),
         )


### PR DESCRIPTION
Closes #1482

RomM's `add_save` content-dedup can return an **older** existing save (matching content) while a **newer, different** head sits in the slot — no new version is created, the foreign head stays authoritative, but the plugin recorded the response as a synced baseline and reported success. Cross-device, the upload intent was silently unfulfilled. Reproduced on-device (2026-07-18): older save A, newer head B, local restored to A's bytes, device current on B → POST dedups to A → the plugin said "synced" while B kept winning.

- new pure predicate `_dedup_returned_non_head(response, planned_group)`: the response id exists in the pre-upload snapshot AND is not the planned head → the true state is "server holds newer, different content"
- on detection the upload raises the existing conflict signal **before any writer runs** (no baseline, no server-hash provenance, no ack, no own-upload tracking) and routes through the standard 409 fallback — re-fetch, `resolve_upload_conflict`, surface the conflict flow; no `overwrite=true` automation
- benign cases unchanged: dedup **to the head** keeps today's behavior including the #1458 confirm handling; an empty planned slot records the dedup response as before (no head was planned against — the next sync's fresh listing catches any race)
- the previous contract test pinning the buggy outcome (dedup-to-non-head reported `synced`) is converted to pin the conflict; the #1458 fail-open ack coverage stays intact at the unit tier plus a new benign dedup-to-head end-to-end test
- docs: the 409-backstop section gains the dedup-to-non-head case

Client half of the on-device dedup find; the server-side root (dedup without a head bump) is deliberately not reported upstream for now.
