### PR TITLE
fix(ui): acknowledge an already-synced manual save-sync click

### DIFF
--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -1255,11 +1255,14 @@ All four sync entry points share a single decision primitive — `compute_sync_a
 dict carries additive `uploaded` / `downloaded` counts beside the `synced` total (a 409-backstop download counts as a
 _download_, not the upload that lost the race). The completion toast names which way saves moved — "Saves uploaded to
 RomM", "Saves downloaded from RomM", or "Saves synced with RomM (1 up, 2 down)" when a run went both ways — and a run
-that transferred nothing shows no toast. The wording lives in exactly one place: the frontend helper `saveSyncToastBody`
-(`src/utils/saveSyncToast.ts`), which every surface renders through — pre-launch (`CustomPlayButton`), post-exit
-(`sessionManager`, from the counts on the `finalize_game_session` payload), and the manual per-game sync
-(`RomMPlaySection`). The backend delivers the counts as data, never the directional copy (#1481); the offline/failure
-body it still owns rides a separate `failure_toast` field on `SessionFinalizeSyncResult`.
+that transferred nothing shows no toast. **Exception (#1486):** the manual per-game "Sync Saves" click is an explicit
+user action, so when it moves nothing and hits no conflicts it acknowledges with a "Saves already up to date" toast
+rather than staying silent; the automatic surfaces (pre-launch, post-exit) keep the silent zero-case. The wording lives
+in exactly one place: the frontend helper `saveSyncToastBody` (`src/utils/saveSyncToast.ts`), which every surface
+renders through — pre-launch (`CustomPlayButton`), post-exit (`sessionManager`, from the counts on the
+`finalize_game_session` payload), and the manual per-game sync (`RomMPlaySection`). The backend delivers the counts as
+data, never the directional copy (#1481); the offline/failure body it still owns rides a separate `failure_toast` field
+on `SessionFinalizeSyncResult`.
 
 ### Pre-launch sync
 

--- a/src/components/RomMPlaySection.test.tsx
+++ b/src/components/RomMPlaySection.test.tsx
@@ -2006,7 +2006,7 @@ describe("RomMPlaySection", () => {
       );
     });
 
-    it("success with nothing moved and no conflicts → no toast (zero-case)", async () => {
+    it("success with nothing moved and no conflicts → 'Saves already up to date' acknowledgement (manual surface, #1486)", async () => {
       const items = await setupSavesAction();
       vi.mocked(backend.syncRomSaves).mockResolvedValue({
         success: true,
@@ -2020,9 +2020,13 @@ describe("RomMPlaySection", () => {
       await act(async () => {
         await items[2]!.props.onClick?.();
       });
-      expect(vi.mocked(toaster.toast)).not.toHaveBeenCalled();
+      // Exactly the up-to-date acknowledgement — no directional toast alongside it.
+      const bodies = vi.mocked(toaster.toast).mock.calls.map((c) => c[0].body);
+      expect(bodies).toEqual(["Saves already up to date"]);
     });
 
+    // Conflicts pending → the "up to date" acknowledgement is gated off (it would
+    // contradict them); only the conflict toast fires (#1486).
     it("success with conflicts but nothing moved → conflict toast only (signal preserved)", async () => {
       const items = await setupSavesAction();
       vi.mocked(backend.syncRomSaves).mockResolvedValue({

--- a/src/components/RomMPlaySection.tsx
+++ b/src/components/RomMPlaySection.tsx
@@ -721,16 +721,22 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
       const result = await syncRomSaves(info.romId);
       if (result.success) {
         // Directional completion toast via the shared helper — the single source
-        // of that copy across every save-sync surface (#1481). Nothing moved →
-        // no toast (the uniform zero-case).
+        // of that copy across every save-sync surface (#1481).
         const directionalBody = saveSyncToastBody(result.uploaded, result.downloaded);
+        const c = result.conflicts?.length ?? 0;
         if (directionalBody) {
           toaster.toast({ title: "RomM Save Sync", body: directionalBody });
+        } else if (c === 0) {
+          // Manual surface only (#1486): an explicit per-game "Sync Saves" click
+          // that moved nothing and hit no conflicts gets a short acknowledgement,
+          // so the click doesn't read as a no-op. The automatic surfaces
+          // (pre-launch, post-exit) stay silent on this zero-case.
+          toaster.toast({ title: "RomM Save Sync", body: "Saves already up to date" });
         }
         // Preserve the conflict signal as its own additive toast (mirroring the
         // post-exit conflicts_toast) — it must stay visible even when nothing
-        // transferred.
-        const c = result.conflicts?.length ?? 0;
+        // transferred. Gated above so "up to date" never contradicts pending
+        // conflicts.
         if (c > 0) {
           toaster.toast({ title: "RomM Save Sync", body: `${c} conflict(s) need resolution` });
         }


### PR DESCRIPTION
Closes #1486

Since #1481 the zero-case was uniformly silent on all three save-sync surfaces. Right for the automatic ones — but a manual "Sync Saves" click is an explicit action, and silence reads as "did anything happen?".

- the manual per-game surface now toasts "Saves already up to date" when a successful sync moved nothing and no conflicts pend
- gated so it can never lie: only on `success` with zero transfers AND zero conflicts (pending conflicts keep showing only the conflict toast); directional and mixed cases unchanged
- pre-launch and post-exit zero-cases stay silent (unchanged); the shared helper's null contract is untouched
- docs: the completion-toast section notes the manual-surface exception
