### PR TITLE
fix(saves): reject the legacy bucket as a slot switch target (#1478)

### DIFF
--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -223,8 +223,8 @@ different save states per device).
 
 `switch_slot` makes the active slot, the local saves directory, and per-file tracking coherent with the chosen slot in
 one locked critical section (the per-rom `asyncio.Lock` — see the "Per-rom asyncio.Lock" section). After the pre-checks
-pass (sync enabled, ROM installed, not a content-dir layout, no un-uploaded local changes on tracked files, server
-reachable):
+pass (sync enabled, a real non-empty target slot name, ROM installed, not a content-dir layout, no un-uploaded local
+changes on tracked files, server reachable):
 
 1. The active slot is flipped in memory.
 2. Every local save file the target slot does **not** provide is quarantined into `.romm-backup` (never deleted
@@ -239,8 +239,10 @@ reachable):
    are already correct, and a failed target re-resolves as `Download` on the next sync. Saves are never carried between
    slots; the switch only downloads or quarantines, never uploads.
 
-An empty target slot is just the case where step 3 is a no-op: every local file is quarantined, tracking is cleared, and
-the slot starts fresh — with every prior save recoverable under `.romm-backup`.
+A **named** target slot with no server saves is just the case where step 3 is a no-op: every local file is quarantined,
+tracking is cleared, and the slot starts fresh — with every prior save recoverable under `.romm-backup`. (An empty /
+whitespace / `None` slot **name** is a different thing entirely: it is rejected up front with
+`reason="invalid_slot_name"` — the slot-less legacy bucket is no longer a switch target, see below.)
 
 #### Inside `.romm-backup` — naming and retention
 
@@ -263,6 +265,13 @@ backup.
   [ADR-0017](../adr/0017-client-baseline-detection-authoritative-negotiate-is-transport.md)): a ROM can no longer be
   confirmed onto the legacy slot. Every confirmed slot is now a real, addressable name. The Slot Setup Wizard detects
   legacy saves and offers to **migrate them into a named slot**, never to "track legacy in place."
+- **`switch_slot` and `set_active_slot` reject the legacy bucket too** — not just `confirm_slot_choice`. An empty /
+  whitespace / `None` slot name returns `{success: false, reason: "invalid_slot_name", …}` before any lock or I/O, so a
+  ROM can never be switched _into_ legacy mode through the slot switcher. The SAVES-tab UI matches this: it no longer
+  offers a "Use Legacy Mode?" action, and the legacy bucket's panel is **view-only** (its saves stay listable and
+  expandable, but it has no "Activate Slot" button). Only the _entry_ is closed, not existing state — a ROM already in
+  legacy mode keeps syncing until migration `005` re-opens the wizard
+  ([#1478](https://github.com/danielcopper/decky-romm-sync/issues/1478)).
 - **Migration `005`** (`005_unconfirm_legacy_slot_confirmations.sql`) un-confirms any ROM previously confirmed in legacy
   mode — `UPDATE rom_save_states SET slot_confirmed=0 WHERE active_slot IS NULL AND slot_confirmed=1`. No save data is
   touched; the wizard simply reappears for that ROM and the user re-picks a named slot (optionally migrating the legacy

--- a/py_modules/services/saves/slots/switching.py
+++ b/py_modules/services/saves/slots/switching.py
@@ -88,27 +88,31 @@ class SlotSwitcher:
     async def set_active_slot(self, rom_id: int, slot: str) -> dict[str, Any]:
         """Set the active save slot for a specific game.
 
-        If the slot doesn't exist yet (not on server), it is persisted
-        as a local slot. It will be promoted to server once a save is
-        uploaded to it. Owns its own read→mutate→write Unit of Work, held
-        under the per-ROM lock so the flip serialises against any in-flight
-        sync/status on the same ROM (see SyncEngine.rom_lock).
+        The slot name must be a real, non-empty value: switching a ROM into the
+        slot-less legacy bucket is retired (#1276), so an empty / whitespace-only
+        / ``None`` name is rejected up front with the canonical
+        ``invalid_slot_name`` failure — before any state change or lock
+        acquisition. If the (named) slot doesn't exist yet on the server, it is
+        persisted as a local slot and promoted to server once a save is uploaded
+        to it. Owns its own read→mutate→write Unit of Work, held under the
+        per-ROM lock so the flip serialises against any in-flight sync/status on
+        the same ROM (see SyncEngine.rom_lock).
         """
         rom_id = int(rom_id)
         slot_str = str(slot).strip() if slot else ""
-        # Empty string = legacy mode (None slot)
-        resolved_slot: str | None = slot_str if slot_str else None
+        if not slot_str:
+            return {"success": False, "reason": "invalid_slot_name", "message": "Slot name cannot be empty"}
 
         async with self._sync_engine.rom_lock(rom_id):
             with self._uow_factory() as uow:
                 rom_state = uow.rom_save_states.get(rom_id) or RomSaveState()
-                rom_state.switch_active_slot(resolved_slot)
+                rom_state.switch_active_slot(slot_str)
                 uow.rom_save_states.save(rom_id, rom_state)
 
         # The background check re-acquires rom_lock when it runs later, so it
         # must be scheduled outside the held lock above.
         self._loop.create_task(self._status_service.check_save_status_background(rom_id))
-        return {"success": True, "active_slot": resolved_slot}
+        return {"success": True, "active_slot": slot_str}
 
     def _check_slot_switch_readiness(self, rom_id: int, save_state: RomSaveState) -> dict[str, Any]:
         """Check whether it is safe to switch slots for this ROM.
@@ -147,12 +151,16 @@ class SlotSwitcher:
 
         Pre-checks (all must pass):
         1. Save sync must be enabled.
-        2. ROM must be installed.
-        3. RetroArch must not write saves to the content dir — otherwise the
+        2. The target slot name must be real (non-empty). Switching into the
+           slot-less legacy bucket is retired (#1276): an empty / whitespace-only
+           / ``None`` name is rejected with ``reason="invalid_slot_name"`` before
+           any lock acquisition or I/O.
+        3. ROM must be installed.
+        4. RetroArch must not write saves to the content dir — otherwise the
            switch's ``saves_dir`` writes are ignored by RetroArch (#239). The
            refusal carries ``reason="savefiles_in_content_dir"``.
-        4. No local files with pending changes (changed since last sync to current slot).
-        5. Server must be reachable.
+        5. No local files with pending changes (changed since last sync to current slot).
+        6. Server must be reachable.
 
         On success the local saves dir and per-file tracking are made coherent
         with the new slot: every local file the new slot does not provide is
@@ -168,9 +176,14 @@ class SlotSwitcher:
         if not save_sync_enabled(self._settings):
             return {"success": False, "reason": "sync_disabled", "message": "Save sync is disabled"}
 
-        # 2. Slot normalisation (empty → None for legacy mode)
+        # 2. Reject the slot-less legacy bucket as a switch target (#1276): an
+        #    empty / whitespace-only / None slot name is rejected before any lock
+        #    acquisition or I/O. Legacy saves stay readable via the legacy
+        #    bucket, but a ROM is never switched into legacy mode.
         slot_str = str(new_slot).strip() if new_slot else ""
-        resolved_slot: str | None = slot_str if slot_str else None
+        if not slot_str:
+            return {"success": False, "reason": "invalid_slot_name", "message": "Slot name cannot be empty"}
+        resolved_slot = slot_str
 
         # 3. ROM must be installed
         info = self._rom_info.get_rom_save_info(rom_id)

--- a/src/components/SavesTab.test.tsx
+++ b/src/components/SavesTab.test.tsx
@@ -14,16 +14,10 @@ import type { SlotPanel } from "./saves/SlotPanel";
 import { installDomEventListenerSpy, uninstallDomEventListenerSpy } from "../test-utils/dom-event-listener-spy";
 
 // showModal from the global @decky/ui mock receives a React element created via
-// createElement(NewSlotModal, props) or createElement(ConfirmModal, props).
-// Tests pull `props.onSubmit` / `props.onOK` off the captured element to drive
-// the new-slot + legacy-confirm flows.
+// createElement(NewSlotModal, props). Tests pull `props.onSubmit` off the
+// captured element to drive the new-slot flow.
 interface NewSlotModalProps {
   onSubmit?: (name: string) => void | Promise<void>;
-}
-interface ConfirmModalProps {
-  onOK?: () => void | Promise<void>;
-  strTitle?: string;
-  strDescription?: string;
 }
 
 // The real in-memory connection store is driven directly (setRommConnectionState)
@@ -124,19 +118,11 @@ function defaultProps(
 }
 
 // Helper: pull the onSubmit prop off the NewSlotModal element passed to
-// showModal at call index `idx`. Mirrors SlotPanel.test's
-// `lastConfirmModalProps()` helper but for the named-arg flow we own here.
+// showModal at call index `idx`, for the named-arg flow we own here.
 function newSlotModalSubmit(idx = 0): ((name: string) => Promise<void>) | undefined {
   const calls = vi.mocked(showModal).mock.calls;
   const el = calls[idx]?.[0] as ReactElement<NewSlotModalProps> | undefined;
   return el?.props.onSubmit as ((name: string) => Promise<void>) | undefined;
-}
-
-function lastConfirmModalProps(): ConfirmModalProps | null {
-  const calls = vi.mocked(showModal).mock.calls;
-  if (calls.length === 0) return null;
-  const el = calls[calls.length - 1]?.[0] as ReactElement<ConfirmModalProps> | undefined;
-  return el?.props ?? null;
 }
 
 describe("SavesTab", () => {
@@ -378,70 +364,21 @@ describe("SavesTab", () => {
     });
   });
 
-  describe("new-slot submit — empty name (legacy mode)", () => {
-    it("opens a ConfirmModal with the legacy-mode warning", async () => {
-      const { getByText } = render(<SavesTab {...defaultProps()} />);
-      fireEvent.click(getByText("+ New Slot"));
-      const submit = newSlotModalSubmit();
-      await act(async () => {
-        await submit?.("");
-      });
-      // Two showModal calls now: 1) NewSlotModal, 2) ConfirmModal legacy warning.
-      expect(vi.mocked(showModal).mock.calls.length).toBe(2);
-      const confirmProps = lastConfirmModalProps();
-      expect(confirmProps?.strTitle).toBe("Use Legacy Mode?");
-      expect(confirmProps?.strDescription).toContain("Legacy mode");
-    });
-
-    it("calls switchSlot('') and onSlotSwitched when the legacy confirm is OK'd", async () => {
-      const newStatus = makeSaveStatus();
-      vi.mocked(backend.switchSlot).mockResolvedValue({
-        success: true,
-        save_status: newStatus,
-      });
-      const onSlotSwitched = vi.fn();
-      const { getByText } = render(<SavesTab {...defaultProps({ onSlotSwitched })} />);
-      fireEvent.click(getByText("+ New Slot"));
-      const submit = newSlotModalSubmit();
-      await act(async () => {
-        await submit?.("");
-      });
-      await act(async () => {
-        await lastConfirmModalProps()?.onOK?.();
-      });
-      expect(vi.mocked(backend.switchSlot)).toHaveBeenCalledWith(1, "");
-      expect(onSlotSwitched).toHaveBeenCalledWith("", newStatus);
-    });
-
-    it("logs but does not throw when the legacy switch returns success=false", async () => {
-      vi.mocked(backend.switchSlot).mockResolvedValue({
-        success: false,
-        reason: "sync_disabled",
-      });
+  describe("new-slot submit — empty name", () => {
+    it("is a no-op: no legacy-mode confirm modal and no switchSlot call (#1478)", async () => {
+      // Switching into the slot-less legacy bucket is retired (#1276): an empty
+      // slot name is ignored — it must not open a "Use Legacy Mode?" confirm or
+      // call switchSlot("").
       const onSlotSwitched = vi.fn();
       const { getByText } = render(<SavesTab {...defaultProps({ onSlotSwitched })} />);
       fireEvent.click(getByText("+ New Slot"));
       await act(async () => {
         await newSlotModalSubmit()?.("");
       });
-      await act(async () => {
-        await lastConfirmModalProps()?.onOK?.();
-      });
-      expect(vi.mocked(backend.debugLog)).toHaveBeenCalledWith(expect.stringContaining("legacy switch failed"));
+      // Only the NewSlotModal opened — no second (legacy-confirm) modal.
+      expect(vi.mocked(showModal).mock.calls).toHaveLength(1);
+      expect(vi.mocked(backend.switchSlot)).not.toHaveBeenCalled();
       expect(onSlotSwitched).not.toHaveBeenCalled();
-    });
-
-    it("logs but does not throw when the legacy switch throws", async () => {
-      vi.mocked(backend.switchSlot).mockRejectedValue(new Error("boom"));
-      const { getByText } = render(<SavesTab {...defaultProps()} />);
-      fireEvent.click(getByText("+ New Slot"));
-      await act(async () => {
-        await newSlotModalSubmit()?.("");
-      });
-      await act(async () => {
-        await lastConfirmModalProps()?.onOK?.();
-      });
-      expect(vi.mocked(backend.debugLog)).toHaveBeenCalledWith(expect.stringContaining("legacy switch error"));
     });
   });
 

--- a/src/components/SavesTab.tsx
+++ b/src/components/SavesTab.tsx
@@ -11,7 +11,7 @@
  */
 
 import { useState, useEffect, useRef, createElement, FC } from "react";
-import { ConfirmModal, DialogButton, Focusable, showModal } from "@decky/ui";
+import { DialogButton, Focusable, showModal } from "@decky/ui";
 import { switchSlot, getVersionList, checkLocalDrift, debugLog, logWarn } from "../api/backend";
 import { getRommConnectionState, onRommConnectionChange, reportServerReachable } from "../utils/connectionState";
 import type { SaveStatus, SyncConflict, SaveSlotSummary } from "../types";
@@ -220,35 +220,13 @@ export const SavesTab: FC<SavesTabProps> = ({
     showModal(
       createElement(NewSlotModal, {
         onSubmit: (name: string) => {
+          // Switching into the slot-less legacy bucket is retired (#1276): an
+          // empty name is not a valid slot target, so ignore it rather than
+          // offering legacy mode. Legacy saves stay viewable in their own panel.
+          if (!name) return;
           detach(
             (async () => {
-              if (!name) {
-                // Empty = legacy mode — show warning
-                showModal(
-                  createElement(ConfirmModal, {
-                    strTitle: "Use Legacy Mode?",
-                    strDescription: "Legacy mode (no slot) limits saves to one version per game. Are you sure?",
-                    onOK: () => {
-                      detach(
-                        (async () => {
-                          try {
-                            const result = await switchSlot(romId, "");
-                            if (result.success && result.save_status) {
-                              onSlotSwitched("", result.save_status);
-                            } else {
-                              detach(debugLog(`SavesTab: legacy switch failed: ${result.reason}`));
-                            }
-                          } catch (e) {
-                            detach(debugLog(`SavesTab: legacy switch error: ${e}`));
-                          }
-                        })(),
-                      );
-                    },
-                  }),
-                );
-                return;
-              }
-              // Named slot — also use switchSlot to do pre-checks + immediate download
+              // Named slot — use switchSlot to do pre-checks + immediate download
               try {
                 const result = await switchSlot(romId, name);
                 if (result.success && result.save_status) {

--- a/src/components/saves/InactiveSlotBody.test.tsx
+++ b/src/components/saves/InactiveSlotBody.test.tsx
@@ -41,6 +41,7 @@ function defaultProps(overrides: Partial<InactiveSlotBodyProps> = {}): InactiveS
     switching: false,
     switchError: null,
     isOffline: false,
+    canActivate: true,
     handleActivate: vi.fn(),
     handleDelete: vi.fn(),
     deleting: false,
@@ -162,5 +163,38 @@ describe("InactiveSlotBody", () => {
       (el) => el.style.color === "rgb(217, 65, 38)" || el.style.color === "#d94126",
     );
     expect(errorTextNodes.length).toBe(0);
+  });
+
+  // The slot-less legacy bucket is view-only (#1276): switching into it is
+  // retired, so the panel drops Activate + the switch-only hints while keeping
+  // the file list and Delete control.
+  describe("view-only (canActivate=false)", () => {
+    it("hides the Activate button but keeps the Delete button", () => {
+      const { queryByText } = render(<InactiveSlotBody {...defaultProps({ canActivate: false })} />);
+      expect(queryByText("Activate Slot")).toBeNull();
+      expect(queryByText("Switching...")).toBeNull();
+      expect(queryByText("Delete Slot")).not.toBeNull();
+    });
+
+    it("still lists the slot's save files", () => {
+      const { container } = render(
+        <InactiveSlotBody
+          {...defaultProps({ canActivate: false, slotFiles: [makeFile({ filename: "legacy.srm" })] })}
+        />,
+      );
+      expect(container.textContent).toContain("legacy.srm");
+    });
+
+    it("hides the offline switching hint even when offline", () => {
+      const { container } = render(<InactiveSlotBody {...defaultProps({ canActivate: false, isOffline: true })} />);
+      expect(container.textContent).not.toContain("Offline — slot switching unavailable");
+    });
+
+    it("hides the switchError line", () => {
+      const { container } = render(
+        <InactiveSlotBody {...defaultProps({ canActivate: false, switchError: "Something went wrong" })} />,
+      );
+      expect(container.textContent).not.toContain("Something went wrong");
+    });
   });
 });

--- a/src/components/saves/InactiveSlotBody.tsx
+++ b/src/components/saves/InactiveSlotBody.tsx
@@ -17,6 +17,13 @@ export interface InactiveSlotBodyProps {
   switching: boolean;
   switchError: string | null;
   isOffline: boolean;
+  /**
+   * Whether this slot may be activated. The slot-less legacy bucket is
+   * view-only (#1276): switching into it is retired, so its panel drops the
+   * Activate button and the switch-only hints while keeping the file list and
+   * Delete control.
+   */
+  canActivate: boolean;
   handleActivate: () => void;
   handleDelete: () => void;
   deleting: boolean;
@@ -28,6 +35,7 @@ export const InactiveSlotBody: FC<InactiveSlotBodyProps> = ({
   switching,
   switchError,
   isOffline,
+  canActivate,
   handleActivate,
   handleDelete,
   deleting,
@@ -55,15 +63,8 @@ export const InactiveSlotBody: FC<InactiveSlotBodyProps> = ({
   const activateLabel = switching ? "Switching..." : "Activate Slot";
   const deleteLabel = deleting ? "Deleting..." : "Delete Slot";
 
-  children.push(
-    createElement(
-      Focusable as never,
-      {
-        key: "activate-row",
-        "flow-children": "right",
-        style: { marginTop: "10px", display: "flex", gap: "8px", alignItems: "center" },
-      },
-      createElement(
+  const activateButton = canActivate
+    ? createElement(
         DialogButton,
         {
           key: "activate-btn",
@@ -74,7 +75,18 @@ export const InactiveSlotBody: FC<InactiveSlotBodyProps> = ({
           onClick: handleActivate,
         },
         activateLabel,
-      ),
+      )
+    : null;
+
+  children.push(
+    createElement(
+      Focusable as never,
+      {
+        key: "activate-row",
+        "flow-children": "right",
+        style: { marginTop: "10px", display: "flex", gap: "8px", alignItems: "center" },
+      },
+      activateButton,
       createElement(
         DialogButton,
         {
@@ -88,7 +100,9 @@ export const InactiveSlotBody: FC<InactiveSlotBodyProps> = ({
         deleteLabel,
       ),
     ),
-    isOffline
+    // Offline hint + switch error relate to the activate flow, so a view-only
+    // legacy panel (canActivate === false) drops them.
+    canActivate && isOffline
       ? createElement(
           "div",
           {
@@ -98,7 +112,7 @@ export const InactiveSlotBody: FC<InactiveSlotBodyProps> = ({
           "Offline — slot switching unavailable",
         )
       : null,
-    switchError
+    canActivate && switchError
       ? createElement(
           "div",
           {

--- a/src/components/saves/SlotPanel.test.tsx
+++ b/src/components/saves/SlotPanel.test.tsx
@@ -730,6 +730,20 @@ describe("SlotPanel", () => {
     expect(container.textContent).not.toContain("(no slot)");
   });
 
+  it("the legacy '' slot is view-only: no Activate button, files still shown (#1478)", async () => {
+    // Switching into the slot-less legacy bucket is retired (#1276) — the panel
+    // may be expanded to view its saves, but never activated.
+    const files: SlotSaveFile[] = [{ id: 1, filename: "legacy.srm", size: 512, updated_at: "", emulator: "mgba" }];
+    vi.mocked(backend.getSlotSaves).mockResolvedValue({ success: true, slot: "", saves: files });
+    const { container, queryByText } = render(<SlotPanel {...defaultProps({ slot: makeSummary({ slot: "" }) })} />);
+    fireEvent.click(container.querySelector("button")!); // expand
+    await flushAsync();
+    expect(container.textContent).toContain("legacy.srm");
+    expect(queryByText("Activate Slot")).toBeNull();
+    // Named slots keep the Activate button — the suppression is legacy-only.
+    expect(queryByText("Delete Slot")).not.toBeNull();
+  });
+
   it("loads and renders inactive slot files when expanded", async () => {
     const files: SlotSaveFile[] = [{ id: 1, filename: "remote-a.srm", size: 1024, updated_at: "", emulator: "mgba" }];
     vi.mocked(backend.getSlotSaves).mockResolvedValue({

--- a/src/components/saves/SlotPanel.tsx
+++ b/src/components/saves/SlotPanel.tsx
@@ -357,6 +357,8 @@ export const SlotPanel: FC<SlotPanelProps> = ({
           switching,
           switchError,
           isOffline,
+          // The slot-less legacy bucket is view-only (#1276) — no Activate.
+          canActivate: slotName !== "",
           deleting,
           handleActivate: () => {
             detach(handleActivate());

--- a/tests/contract/test_saves_slot_choice.py
+++ b/tests/contract/test_saves_slot_choice.py
@@ -1,11 +1,14 @@
-"""Contract tests for ``confirm_slot_choice`` — the #1004/#1008 wire contract.
+"""Contract tests for the slot-choice mutations — ``confirm_slot_choice`` and
+``switch_slot`` — where they reject the retired legacy slot.
 
-Driven frontend-shaped per ``src/api/backend.ts``: positional
-``(rom_id, chosen_slot, migrate, migrate_from_slot)`` with the TS arg types
-(``string | null`` for the slot, ``boolean`` for migrate, ``string | null``
-for the source). These pin the explicit-contract fix: ``migrate`` is a real
-bool (no ``"__no_migration__"`` sentinel string), ``chosen_slot=None`` confirms
-the legacy slot, and the default call runs no migration.
+``confirm_slot_choice`` is driven frontend-shaped per ``src/api/backend.ts``:
+positional ``(rom_id, chosen_slot, migrate, migrate_from_slot)`` with the TS arg
+types (``string | null`` for the slot, ``boolean`` for migrate, ``string | null``
+for the source). These pin the explicit-contract fix: ``migrate`` is a real bool
+(no ``"__no_migration__"`` sentinel string) and the default call runs no
+migration. Both callables share one rule: the slot-less legacy bucket is no
+longer a confirmable / switchable target (#1276), so an empty / ``None`` slot
+name returns the canonical ``invalid_slot_name`` failure and never mutates state.
 """
 
 from __future__ import annotations
@@ -57,3 +60,27 @@ async def test_confirm_legacy_slot_none_rejected(harness):
     assert state is None
     # No migration delete fired.
     assert not any(c[0] == "delete_server_saves" for c in harness.romm.call_log)
+
+
+# ── switch_slot ───────────────────────────────────────────────────────────
+
+
+async def test_switch_slot_empty_rejected(harness):
+    """switch_slot("") is rejected — the legacy bucket is not a switch target (#1276).
+
+    Driven frontend-shaped per ``src/api/backend.ts`` (``switchSlot`` is
+    ``callable<[number, string], …>``). The callable returns the canonical
+    ``invalid_slot_name`` failure and never switches the ROM into legacy mode.
+    """
+    enable_save_sync(harness)
+    seed_rom(harness, 42)
+
+    result = await harness.plugin.switch_slot(42, "")
+
+    assert result["success"] is False
+    assert result["reason"] == "invalid_slot_name"
+    assert isinstance(result["message"], str)
+    # No state written — the ROM is not switched into legacy mode.
+    with harness.uow_factory() as uow:
+        state = uow.rom_save_states.get(42)
+    assert state is None

--- a/tests/services/saves/test_slots.py
+++ b/tests/services/saves/test_slots.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import hashlib
+from typing import cast
 
 import pytest
 
@@ -190,14 +191,38 @@ class TestSaveSlots:
         assert _require_save_state(svc, 456).active_slot == "my-slot"
 
     @pytest.mark.asyncio
-    async def test_set_active_slot_empty_sets_none(self, tmp_path):
-        """Empty string sets active_slot to None (legacy mode)."""
+    async def test_set_active_slot_empty_rejected(self, tmp_path):
+        """An empty slot name is rejected — legacy is no longer a switch target (#1276)."""
         svc, _ = make_service(tmp_path)
         _seed_rom(svc, 123)
         result = await svc._slots.set_active_slot(123, "")
-        assert result["success"] is True
-        assert result["active_slot"] is None
-        assert _require_save_state(svc, 123).active_slot is None
+        assert result == {
+            "success": False,
+            "reason": "invalid_slot_name",
+            "message": "Slot name cannot be empty",
+        }
+        # No state mutation — the ROM is never switched into legacy mode.
+        assert _get_save_state(svc, 123) is None
+
+    @pytest.mark.asyncio
+    async def test_set_active_slot_whitespace_rejected(self, tmp_path):
+        """A whitespace-only slot name normalises to empty and is rejected."""
+        svc, _ = make_service(tmp_path)
+        _seed_rom(svc, 123)
+        result = await svc._slots.set_active_slot(123, "   ")
+        assert result["success"] is False
+        assert result["reason"] == "invalid_slot_name"
+        assert _get_save_state(svc, 123) is None
+
+    @pytest.mark.asyncio
+    async def test_set_active_slot_none_rejected(self, tmp_path):
+        """A None slot name hits the defensive fallback and is rejected the same way."""
+        svc, _ = make_service(tmp_path)
+        _seed_rom(svc, 123)
+        result = await svc._slots.set_active_slot(123, cast("str", None))
+        assert result["success"] is False
+        assert result["reason"] == "invalid_slot_name"
+        assert _get_save_state(svc, 123) is None
 
     @pytest.mark.asyncio
     async def test_set_active_slot_triggers_background_check(self, tmp_path):
@@ -1081,29 +1106,50 @@ class TestSwitchSlot:
         assert _require_save_state(svc, 42).active_slot == "desktop"
 
     @pytest.mark.asyncio
-    async def test_switch_to_legacy_slot(self, tmp_path):
-        """switch_slot("") sets active_slot=None, persists "" in slots dict, returns success."""
-        svc, fake = make_service(tmp_path)
+    async def test_switch_slot_empty_rejected(self, tmp_path):
+        """switch_slot("") is rejected — the legacy bucket is not a switch target (#1276).
+
+        The refusal fires before any lock or server I/O, so the active slot is
+        left untouched (no switch into legacy mode).
+        """
+        svc, _ = make_service(tmp_path)
         svc._config.settings["save_sync_enabled"] = True
-        _install_rom(svc, tmp_path)
-        save_path = _create_save(tmp_path)
-        local_hash = _file_md5(str(save_path))
-
-        # Start in a named slot, fully synced (active_slot="default")
-        _seed_save_state(svc, 42, self._synced_state(local_hash))
-
-        # Server has a legacy save (slot=None)
-        fake.saves[200] = _server_save(save_id=200, slot=None)
+        _seed_save_state(svc, 42, RomSaveState(active_slot="default", slot_confirmed=True))
 
         result = await svc.switch_slot(42, "")
 
-        assert result["success"] is True
-        assert "save_status" in result
-        # active_slot in state is None (legacy)
-        assert _require_save_state(svc, 42).active_slot is None
-        # Legacy slot "" appears in the slots dict
-        slots_dict = _require_save_state(svc, 42).slots
-        assert "" in slots_dict
+        assert result == {
+            "success": False,
+            "reason": "invalid_slot_name",
+            "message": "Slot name cannot be empty",
+        }
+        assert _require_save_state(svc, 42).active_slot == "default"
+
+    @pytest.mark.asyncio
+    async def test_switch_slot_whitespace_rejected(self, tmp_path):
+        """A whitespace-only target slot normalises to empty and is rejected."""
+        svc, _ = make_service(tmp_path)
+        svc._config.settings["save_sync_enabled"] = True
+        _seed_save_state(svc, 42, RomSaveState(active_slot="default", slot_confirmed=True))
+
+        result = await svc.switch_slot(42, "  \t ")
+
+        assert result["success"] is False
+        assert result["reason"] == "invalid_slot_name"
+        assert _require_save_state(svc, 42).active_slot == "default"
+
+    @pytest.mark.asyncio
+    async def test_switch_slot_none_rejected(self, tmp_path):
+        """A None target slot hits the defensive fallback and is rejected the same way."""
+        svc, _ = make_service(tmp_path)
+        svc._config.settings["save_sync_enabled"] = True
+        _seed_save_state(svc, 42, RomSaveState(active_slot="default", slot_confirmed=True))
+
+        result = await svc.switch_slot(42, cast("str", None))
+
+        assert result["success"] is False
+        assert result["reason"] == "invalid_slot_name"
+        assert _require_save_state(svc, 42).active_slot == "default"
 
     @pytest.mark.asyncio
     async def test_legacy_slot_persisted_in_get_save_slots(self, tmp_path):


### PR DESCRIPTION
Part of #1478 — first of the triage fixes; intentionally does not close the issue.

## Problem

Migration 005 retired the legacy (slot-less) bucket as a confirmable target, but the slot switcher kept a backdoor: an empty slot name was normalized to `None` and silently switched the ROM into legacy mode (reachable in the QAM via the "Use Legacy Mode?" path when creating a slot with a blank name). That is most likely how the #1478 setup ended up actively syncing against the legacy bucket.

## Change

- `set_active_slot` / `switch_slot` reject an empty/whitespace/`None` slot name up front — before any lock or I/O — with the canonical failure shape (`reason: "invalid_slot_name"`, the same slug the setup wizard already uses).
- SAVES tab: the "Use Legacy Mode?" gesture is removed; the Legacy bucket panel becomes view-only (file list and delete stay, Activate is no longer offered).
- Existing state is untouched: ROMs already on the legacy bucket keep working exactly as before — this closes the entry, not the state.

## Tests

Rejection unit tests (empty/whitespace/`None`) for both callables including no-state-mutation assertions, a contract-tier test, and frontend tests for the removed gesture and the view-only panel. Full local gate green (5544 backend + 2009 frontend tests).

Docs: `docs/architecture/save-file-sync-architecture.md` updated in this PR.
