### PR TITLE
fix(saves): honor RomM's per-device sync-disabled switch as a policy stop (#1489)

### DIFF
--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -157,8 +157,14 @@ Playtime does **not** ride this session: it must be recorded for every ROM on ev
 unconfirmed-slot ROMs), so it ingests through the standalone `/api/play-sessions` endpoint instead
 ([ADR-0018](../adr/0018-native-play-session-tracking-additive-ingest.md), which narrows the "ingest rides `negotiate`"
 aside of ADR-0016/0017). The server's returned `operations` are **discarded** — detection is the client's
-`compute_sync_action`. Opening the session is best-effort: a `negotiate` failure is non-fatal, the run simply proceeds
-**without** a session (the kernel still syncs). Legacy `slot:null` ROMs open no session at all (RomM cannot address
+`compute_sync_action`. Opening the session is best-effort: a `negotiate` **transport** failure is non-fatal, the run
+simply proceeds **without** a session (the kernel still syncs). The **one** exception is RomM's per-device
+`sync_enabled` switch — `negotiate` is the only API-mode endpoint that enforces it, answering a 400 with detail
+`"Sync is disabled for this device"` when the user has disabled sync for this device server-side. That specific 400 is
+translated to `RommSyncDisabledError` and **stops** the run with `reason: device_sync_disabled` (a visible policy stop,
+not a silent sessionless degrade); pre-launch treats it like the local save-sync toggle being off and skips silently so
+the launch always proceeds (#1489). Scope limit: legacy/unconfirmed ROMs never open a session, so a library with no
+confirmed named-slot ROM never reaches the switch. Legacy `slot:null` ROMs open no session at all (RomM cannot address
 `slot:null` through the negotiate inventory param) but take the identical kernel path. The `complete` close is likewise
 **non-fatal** — a session the server never hears closed times out and is cancelled by the next `negotiate`, so a failed
 `complete` never fails the run.

--- a/docs/user-guide/save-sync.md
+++ b/docs/user-guide/save-sync.md
@@ -172,6 +172,15 @@ yellow **Local changes** badge (not a green "synced"), and its "Last synced" lin
 _successful_ sync — a green checkmark appears only once a sync actually succeeds. A separate "Checked" line shows when
 the plugin last attempted a sync, so a recent failed attempt and the last good sync are both visible.
 
+## Sync Disabled for This Device on the Server
+
+RomM lets you turn save sync off for a specific device in its own **device settings** (on the RomM web UI). If you
+disable sync for this device there, the plugin stops syncing that device's saves and tells you so — a manual sync
+reports "Save sync is disabled for this device on the RomM server", and the after-exit toast says the same. Your local
+saves are left untouched, and the game still launches normally (before-launch sync just skips). Re-enable sync for the
+device in RomM to resume. This is separate from the plugin's own **Save Sync** toggle in the QAM — either one being off
+stops syncing.
+
 ## Playtime Tracking
 
 The plugin tracks playtime per game. Session start and end times are recorded, and time the device spent suspended

--- a/py_modules/adapters/romm/http.py
+++ b/py_modules/adapters/romm/http.py
@@ -685,6 +685,11 @@ class RommHttpAdapter:
                     return json.loads(resp.read().decode())
             except RommApiError:
                 raise
+            except urllib.error.HTTPError as exc:
+                # Attach the FastAPI ``detail`` so a caller can branch on two
+                # responses that share a status code (the negotiate 400 that
+                # carries the per-device sync-disabled detail, #1489).
+                raise self._translate_with_detail(exc, url, method) from exc
             except Exception as exc:
                 raise self.translate_http_error(exc, url, method) from exc
 

--- a/py_modules/adapters/romm/romm_api.py
+++ b/py_modules/adapters/romm/romm_api.py
@@ -15,11 +15,20 @@ from lib.errors import (
     PairingCodeOwnerDisabledError,
     PairingCodeRateLimitedError,
     PairingCodeTokenGoneError,
+    RommApiError,
     RommForbiddenError,
     RommNotFoundError,
     RommServerError,
+    RommSyncDisabledError,
 )
 from lib.romm_paging import LIST_PAGE_SIZE
+
+# RomM 5.0.0 returns a 400 with this exact FastAPI detail from ``negotiate`` when
+# the user disabled sync for this device server-side (the only API-mode
+# enforcement point of the per-device ``sync_enabled`` switch). Matched verbatim:
+# a changed server copy safely degrades to the prior sessionless behavior rather
+# than mistranslating an unrelated 400.
+_SYNC_DISABLED_DETAIL = "Sync is disabled for this device"
 
 if TYPE_CHECKING:
     from models.cover import CoverRevalidation
@@ -309,8 +318,17 @@ class RommApiAdapter:
         ``conflict`` / ``no_op`` operations to execute. It detects but never
         resolves — a ``conflict`` carries no resolution directive. Opening a
         session cancels this device's prior in-flight sessions server-side.
+
+        A 400 carrying the per-device sync-disabled ``detail`` is translated to
+        :class:`RommSyncDisabledError` so the engine can stop the run with a
+        visible policy reason (#1489); every other error propagates unchanged.
         """
-        return self._client.post_json("/api/sync/negotiate", {"device_id": device_id, "saves": saves})
+        try:
+            return self._client.post_json("/api/sync/negotiate", {"device_id": device_id, "saves": saves})
+        except RommApiError as e:
+            if getattr(e, "detail", None) == _SYNC_DISABLED_DETAIL:
+                raise RommSyncDisabledError(_SYNC_DISABLED_DETAIL, url=e.url, method=e.method) from e
+            raise
 
     def complete_sync_session(
         self,

--- a/py_modules/lib/errors.py
+++ b/py_modules/lib/errors.py
@@ -123,6 +123,18 @@ class TokenHostMismatchError(RommApiError):
     """
 
 
+class RommSyncDisabledError(RommApiError):
+    """RomM has save sync disabled for this device (the negotiate 400 policy signal).
+
+    RomM's per-device ``sync_enabled`` switch is enforced only at the
+    ``negotiate`` endpoint, which 400s with detail "Sync is disabled for this
+    device" when the user turned sync off for this device server-side. Distinct
+    from a transport failure so the engine can stop the run with a visible
+    policy reason instead of degrading to a sessionless sync. Non-retryable:
+    replaying it cannot succeed, only re-enabling sync in RomM can.
+    """
+
+
 class PairingCodeInvalidError(RommApiError):
     """Pairing-code exchange rejected: the code is invalid, expired, or already used (404)."""
 
@@ -179,6 +191,11 @@ def classify_error(exc):
         return ErrorCode.UNSUPPORTED.value, f"This feature requires RomM {exc.min_version} or newer"
     if isinstance(exc, TokenHostMismatchError):
         return "config_error", "Your saved RomM login is for a different server. Sign in again to continue."
+    if isinstance(exc, RommSyncDisabledError):
+        return (
+            "device_sync_disabled",
+            "Save sync is disabled for this device on the RomM server — enable it in RomM's device settings",
+        )
     if isinstance(exc, RommApiError):
         return ErrorCode.SERVER_UNREACHABLE.value, str(exc)
     return ErrorCode.UNKNOWN.value, str(exc)

--- a/py_modules/services/saves/_messages.py
+++ b/py_modules/services/saves/_messages.py
@@ -15,6 +15,10 @@ DEVICE_NOT_REGISTERED = "Device not registered"
 # domain-specific skip/guard categories, not server-reachability failures.
 SAVE_SYNC_DISABLED_REASON = "sync_disabled"
 DEVICE_NOT_REGISTERED_REASON = "device_not_registered"
+# RomM's per-device ``sync_enabled`` switch is off server-side (the negotiate 400
+# policy stop, #1489). Distinct from ``sync_disabled``, which is the LOCAL toggle.
+DEVICE_SYNC_DISABLED_REASON = "device_sync_disabled"
+DEVICE_SYNC_DISABLED = "Save sync is disabled for this device on the RomM server"
 # RetroArch ``savefiles_in_content_dir=true``: saves are written next to the
 # ROM, outside the saves tree the plugin syncs, so save sync is unavailable.
 # Neutral phrasing — the frontend treats this as a benign skip, not an error.

--- a/py_modules/services/saves/sync_engine/engine.py
+++ b/py_modules/services/saves/sync_engine/engine.py
@@ -35,11 +35,13 @@ from typing import TYPE_CHECKING, Any
 
 from domain.rom_save_state import RomSaveState
 from domain.save_layout import ContentDir
-from lib.errors import RommConnectionError, RommTimeoutError, classify_error
+from lib.errors import RommConnectionError, RommSyncDisabledError, RommTimeoutError, classify_error
 from lib.list_result import ErrorCode
 from services.saves._messages import (
     DEVICE_NOT_REGISTERED,
     DEVICE_NOT_REGISTERED_REASON,
+    DEVICE_SYNC_DISABLED,
+    DEVICE_SYNC_DISABLED_REASON,
     SAVE_SYNC_DISABLED,
     SAVE_SYNC_DISABLED_REASON,
     SAVE_SYNC_IN_CONTENT_DIR,
@@ -625,11 +627,12 @@ class SyncEngine:
         POSTs the ROM-scoped inventory to ``negotiate`` and keeps only the
         ``session_id`` — the planned ``operations`` are intentionally discarded
         because the local ``compute_sync_action`` matrix is the sole detection
-        authority (ADR-0017). Any failure (transport error, or a 200 body missing
-        ``session_id``) degrades to ``None``: the sync run proceeds without a
-        session envelope rather than aborting. An unclosed session lingers
-        harmlessly until this device's next ``negotiate`` cancels it, so a missed
-        close is harmless.
+        authority (ADR-0017). Any failure degrades to ``None`` — the sync run
+        proceeds without a session envelope rather than aborting — EXCEPT the
+        server-side sync-disabled 400 (:class:`RommSyncDisabledError`), which is
+        re-raised so the run aborts with a visible policy reason (#1489). An
+        unclosed session lingers harmlessly until this device's next
+        ``negotiate`` cancels it, so a missed close is harmless.
         """
         try:
             inventory = await self._loop.run_in_executor(None, self._build_inventory, rom_id)
@@ -638,6 +641,8 @@ class SyncEngine:
                 lambda: self._retry.with_retry(lambda: self._romm_api.negotiate_sync(device_id or "", inventory)),
             )
             return response["session_id"]
+        except RommSyncDisabledError:
+            raise
         except Exception as e:
             self._log_debug(f"_run_rom_sync({rom_id}): negotiate session open failed ({e}) — syncing without a session")
             return None
@@ -750,6 +755,12 @@ class SyncEngine:
                 "synced": 0,
                 "offline": True,
             }
+        except RommSyncDisabledError:
+            # RomM has save sync disabled for this device server-side. Mirror the
+            # LOCAL toggle-off silent skip (a success-shaped result, no ``offline``
+            # and no failure ``reason``) so the launch proceeds and the result
+            # never routes into the offline/launch-gate flow (#1489).
+            return {"success": True, "message": DEVICE_SYNC_DISABLED, "synced": 0}
 
     async def post_exit_sync(self, rom_id: int) -> dict[str, Any]:
         """Upload changed saves after game exit."""
@@ -838,6 +849,19 @@ class SyncEngine:
                 "synced": 0,
                 "offline": True,
             }
+        except RommSyncDisabledError:
+            # RomM has save sync disabled for this device server-side — stop with
+            # a visible policy reason. The session-end toast reads the dedicated
+            # copy via ``_render_failure_toast`` keyed on this reason (#1489).
+            self._logger.info("post_exit_sync stopped: sync disabled for this device on the server")
+            return {
+                "success": False,
+                "reason": DEVICE_SYNC_DISABLED_REASON,
+                "message": DEVICE_SYNC_DISABLED,
+                "synced": 0,
+                "errors": [],
+                "conflicts": [],
+            }
 
     async def sync_rom_saves(self, rom_id: int) -> dict[str, Any]:
         """Bidirectional sync for a single ROM (manual trigger from game detail)."""
@@ -898,6 +922,17 @@ class SyncEngine:
                 "errors": [],
                 "conflicts": [],
             }
+        except RommSyncDisabledError:
+            # RomM has save sync disabled for this device server-side — surface it
+            # as a policy stop; the game-detail toast renders ``message`` (#1489).
+            return {
+                "success": False,
+                "reason": DEVICE_SYNC_DISABLED_REASON,
+                "message": DEVICE_SYNC_DISABLED,
+                "synced": 0,
+                "errors": [],
+                "conflicts": [],
+            }
 
     def _installed_rom_ids(self) -> list[int]:
         """Read the installed-ROM ids from the rom_installs aggregate (WS3)."""
@@ -915,7 +950,9 @@ class SyncEngine:
         any negotiate failure. When ``None``, each confirmed non-legacy ROM opens
         its own per-ROM session inside ``_run_rom_sync`` — the sweep degrades,
         never aborts. The sync verdicts are unaffected either way; only the
-        session envelope (one shared vs. per-ROM) differs.
+        session envelope (one shared vs. per-ROM) differs. The one exception is
+        the server-side sync-disabled 400 (:class:`RommSyncDisabledError`), which
+        is re-raised so the whole sweep aborts with a visible policy reason (#1489).
         """
         full_inventory = await self._loop.run_in_executor(None, self._build_inventory, None)
         if not full_inventory:
@@ -929,6 +966,8 @@ class SyncEngine:
             # degrade like a failure (session_id None → per-ROM sessions), not
             # abort the whole sweep.
             return response["session_id"]
+        except RommSyncDisabledError:
+            raise
         except Exception as e:
             self._logger.warning("sync_all_saves: negotiate session open failed (%s) — per-ROM sessions", e)
             return None
@@ -1004,6 +1043,21 @@ class SyncEngine:
                             total_synced += uploaded + downloaded
                             total_errors.extend(errors)
                             all_conflicts.extend(conflicts)
+                    except RommSyncDisabledError:
+                        # A per-ROM negotiate hit RomM's per-device sync-disabled
+                        # switch mid-sweep (the bulk session had degraded to None).
+                        # Abort the loop and report the partial totals accrued so
+                        # far (#1489). The finally still closes any bulk session.
+                        return {
+                            "success": False,
+                            "reason": DEVICE_SYNC_DISABLED_REASON,
+                            "message": f"{DEVICE_SYNC_DISABLED} — stopped after syncing {total_synced} save(s)",
+                            "synced": total_synced,
+                            "conflicts": len(all_conflicts),
+                            "conflicts_list": list(all_conflicts),
+                            "roms_checked": rom_count,
+                            "errors": total_errors,
+                        }
                     finally:
                         if session_id is not None:
                             await self._close_negotiate_session(session_id, session_counts[0], session_counts[1])
@@ -1030,6 +1084,20 @@ class SyncEngine:
                 "success": False,
                 "reason": "sync_busy",
                 "message": "Another save-sync run is in progress",
+                "synced": 0,
+                "conflicts": 0,
+                "conflicts_list": [],
+                "roms_checked": 0,
+                "errors": [],
+            }
+        except RommSyncDisabledError:
+            # The whole-device bulk pre-negotiate hit RomM's per-device
+            # sync-disabled switch before the sweep began — abort with the policy
+            # reason and no partial totals (nothing was synced yet, #1489).
+            return {
+                "success": False,
+                "reason": DEVICE_SYNC_DISABLED_REASON,
+                "message": DEVICE_SYNC_DISABLED,
                 "synced": 0,
                 "conflicts": 0,
                 "conflicts_list": [],

--- a/py_modules/services/session_lifecycle.py
+++ b/py_modules/services/session_lifecycle.py
@@ -38,6 +38,13 @@ if TYPE_CHECKING:
 
 _TOAST_BODY_OFFLINE = "Server offline — saves will sync next time"
 _TOAST_BODY_FAILED = "Failed to sync saves after exit"
+_TOAST_BODY_SYNC_DISABLED = "Save sync is disabled for this device on the RomM server"
+
+# Reason slug the saves engine returns when RomM's per-device sync-disabled switch
+# stops the post-exit run (#1489). Mirrored here as a literal — a service must not
+# import another service's module — kept in step with the saves engine's
+# ``DEVICE_SYNC_DISABLED_REASON``.
+_DEVICE_SYNC_DISABLED_REASON = "device_sync_disabled"
 
 
 @dataclass(frozen=True)
@@ -121,21 +128,26 @@ class SessionLifecycleServiceConfig:
     logger: logging.Logger
 
 
-def _render_failure_toast(*, offline: bool, success: bool, message: str | None = None) -> str | None:
+def _render_failure_toast(
+    *, offline: bool, success: bool, message: str | None = None, reason: str | None = None
+) -> str | None:
     """Map the non-success post-exit-sync flags onto the failure/offline toast body.
 
     The directional success toast is presentation the frontend renders from the
     transfer counts (``saveSyncToastBody``), so a successful run returns ``None``
-    here. Offline wins over the generic failure body; a classified ``message``
-    (e.g. "Authentication failed — sign in again", #971) names the cause instead
-    of the generic fallback, keeping the post-exit toast consistent with the
-    pre-launch fallback modal. The #239 content-dir benign skip is suppressed by
-    its caller before this is reached.
+    here. Offline wins over the generic failure body; the per-device
+    sync-disabled policy stop (#1489) gets its own dedicated copy; a classified
+    ``message`` (e.g. "Authentication failed — sign in again", #971) names the
+    cause instead of the generic fallback, keeping the post-exit toast consistent
+    with the pre-launch fallback modal. The #239 content-dir benign skip is
+    suppressed by its caller before this is reached.
     """
     if offline:
         return _TOAST_BODY_OFFLINE
     if success:
         return None
+    if reason == _DEVICE_SYNC_DISABLED_REASON:
+        return _TOAST_BODY_SYNC_DISABLED
     return message or _TOAST_BODY_FAILED
 
 
@@ -319,8 +331,10 @@ class SessionLifecycleService:
         conflicts: list[dict[str, Any]] = list(raw_conflicts) if isinstance(raw_conflicts, list) else []
         raw_message = result.get("message")
         message = raw_message if isinstance(raw_message, str) else None
+        raw_reason = result.get("reason")
+        reason = raw_reason if isinstance(raw_reason, str) else None
 
-        failure_toast = _render_failure_toast(offline=offline, success=success, message=message)
+        failure_toast = _render_failure_toast(offline=offline, success=success, message=message, reason=reason)
         conflicts_toast = _render_conflicts_toast(conflicts)
 
         return SessionFinalizeSyncResult(

--- a/tests/adapters/romm/test_http.py
+++ b/tests/adapters/romm/test_http.py
@@ -700,6 +700,35 @@ class TestRommJsonRequest:
         assert req.get_header("Authorization") is None
         assert req.get_header("User-agent") == "decky-romm-sync/9.9.9"
 
+    def test_post_json_attaches_detail_from_400(self, plugin):
+        """A 400 with a JSON ``{"detail": ...}`` body surfaces the detail on the raised error (#1489)."""
+        plugin.settings["romm_url"] = "http://romm.local"
+        plugin.settings["romm_allow_insecure_ssl"] = False
+
+        body = json.dumps({"detail": "Sync is disabled for this device"}).encode()
+        exc = urllib.error.HTTPError(
+            "http://romm.local/api/sync/negotiate", 400, "Bad Request", http.client.HTTPMessage(), io.BytesIO(body)
+        )
+        with patch("urllib.request.urlopen", side_effect=exc), pytest.raises(RommApiError) as exc_info:
+            plugin._http_adapter.post_json("/api/sync/negotiate", {"device_id": "d"})
+        assert exc_info.value.detail == "Sync is disabled for this device"
+
+    def test_post_json_non_json_body_degrades_detail_to_none(self, plugin):
+        """A 400 whose body is not JSON degrades to ``detail=None`` (no crash, #1489)."""
+        plugin.settings["romm_url"] = "http://romm.local"
+        plugin.settings["romm_allow_insecure_ssl"] = False
+
+        exc = urllib.error.HTTPError(
+            "http://romm.local/api/sync/negotiate",
+            400,
+            "Bad Request",
+            http.client.HTTPMessage(),
+            io.BytesIO(b"<html>nope</html>"),
+        )
+        with patch("urllib.request.urlopen", side_effect=exc), pytest.raises(RommApiError) as exc_info:
+            plugin._http_adapter.post_json("/api/sync/negotiate", {"device_id": "d"})
+        assert exc_info.value.detail is None
+
 
 class TestRommUploadMultipart:
     def test_upload_sends_multipart(self, plugin, tmp_path):

--- a/tests/adapters/romm/test_romm_api.py
+++ b/tests/adapters/romm/test_romm_api.py
@@ -13,9 +13,11 @@ from lib.errors import (
     PairingCodeOwnerDisabledError,
     PairingCodeRateLimitedError,
     PairingCodeTokenGoneError,
+    RommApiError,
     RommForbiddenError,
     RommNotFoundError,
     RommServerError,
+    RommSyncDisabledError,
     RommUnprocessableEntityError,
 )
 
@@ -845,6 +847,35 @@ class TestNegotiateSync:
         client.post_json.side_effect = RommServerError("boom", status_code=500)
         with pytest.raises(RommServerError):
             api.negotiate_sync("dev-1", [])
+
+    def test_translates_sync_disabled_400(self):
+        """A 400 carrying the exact per-device sync-disabled detail becomes RommSyncDisabledError (#1489)."""
+        api, client = _make_api()
+        err = RommApiError("HTTP 400: Bad Request", url="/api/sync/negotiate", method="POST")
+        err.detail = "Sync is disabled for this device"
+        client.post_json.side_effect = err
+        with pytest.raises(RommSyncDisabledError) as exc_info:
+            api.negotiate_sync("dev-1", [])
+        # Chains the original so the cause is preserved for logs.
+        assert exc_info.value.__cause__ is err
+
+    def test_generic_400_with_other_detail_stays_plain(self):
+        """A 400 whose detail is NOT the sync-disabled copy propagates unchanged (#1489)."""
+        api, client = _make_api()
+        err = RommApiError("HTTP 400: Bad Request", url="/api/sync/negotiate", method="POST")
+        err.detail = "Some other validation failure"
+        client.post_json.side_effect = err
+        with pytest.raises(RommApiError) as exc_info:
+            api.negotiate_sync("dev-1", [])
+        assert not isinstance(exc_info.value, RommSyncDisabledError)
+
+    def test_400_without_detail_stays_plain(self):
+        """A 400 with no detail at all propagates unchanged (#1489)."""
+        api, client = _make_api()
+        client.post_json.side_effect = RommApiError("HTTP 400: Bad Request", url="/api/sync/negotiate", method="POST")
+        with pytest.raises(RommApiError) as exc_info:
+            api.negotiate_sync("dev-1", [])
+        assert not isinstance(exc_info.value, RommSyncDisabledError)
 
 
 class TestCompleteSyncSession:

--- a/tests/contract/test_saves_device_sync_disabled.py
+++ b/tests/contract/test_saves_device_sync_disabled.py
@@ -1,0 +1,49 @@
+"""Contract test for RomM's per-device sync-disabled policy stop (#1489).
+
+Driven frontend-shaped through the real ``Plugin`` / ``bootstrap`` harness: when
+RomM has save sync disabled for this device, the negotiate 400 surfaces as a
+``device_sync_disabled`` policy stop carrying the canonical failure shape, and no
+upload is attempted (the run aborts at the negotiate step, before the matrix).
+"""
+
+from __future__ import annotations
+
+import os
+
+from domain.rom_save_state import RomSaveState
+
+from ._seed import enable_save_sync, seed_install, seed_save_state
+
+
+def _write_local_save(harness, *, system: str, content: bytes, filename: str) -> str:
+    """Write a real local save under the resolved saves dir; return its path."""
+    saves_dir = os.path.join(harness.plugin._retrodeck_paths.saves_path(), system)
+    os.makedirs(saves_dir, exist_ok=True)
+    path = os.path.join(saves_dir, filename)
+    with open(path, "wb") as fh:
+        fh.write(content)
+    return path
+
+
+async def test_sync_rom_saves_device_sync_disabled_returns_policy_failure(harness):
+    """A confirmed-slot ROM whose device has sync disabled server-side stops with the
+    ``device_sync_disabled`` reason and the canonical failure shape — no upload runs."""
+    enable_save_sync(harness)
+    seed_install(harness, 42, system="gba", file_name="game.gba")
+    _write_local_save(harness, system="gba", content=b"local save bytes", filename="game.srm")
+    # A confirmed named slot makes the run open a real negotiate session, which the
+    # server rejects with the per-device sync-disabled 400.
+    seed_save_state(harness, 42, RomSaveState(active_slot="default", slot_confirmed=True, system="gba"))
+    harness.romm.negotiate_sync_disabled = True
+
+    result = await harness.plugin.sync_rom_saves(42)
+
+    assert result["success"] is False
+    assert result["reason"] == "device_sync_disabled"
+    assert isinstance(result["message"], str) and result["message"]
+    assert result["synced"] == 0
+    # Canonical failure shape — the forbidden legacy keys are absent.
+    assert "error" not in result
+    assert "error_code" not in result
+    # The run aborted at negotiate, before the upload matrix.
+    assert not any(c[0] == "upload_save" for c in harness.romm.call_log)

--- a/tests/fakes/fake_romm_api.py
+++ b/tests/fakes/fake_romm_api.py
@@ -42,7 +42,7 @@ from fakes._romm_save_semantics import (
     tag_filename,
     with_absent_device_placeholder,
 )
-from lib.errors import RommUnprocessableEntityError
+from lib.errors import RommSyncDisabledError, RommUnprocessableEntityError
 from lib.romm_paging import LIST_PAGE_SIZE
 
 if TYPE_CHECKING:
@@ -168,6 +168,10 @@ class FakeRommApi:
         self.mint_client_token_side_effect: Exception | None = None
         self.delete_client_token_side_effect: Exception | None = None
         self.exchange_pairing_code_side_effect: Exception | None = None
+        # When set, ``negotiate_sync`` raises ``RommSyncDisabledError`` to model
+        # RomM's per-device sync-disabled 400 (#1489), independent of the generic
+        # ``_check_fail`` arming.
+        self.negotiate_sync_disabled: bool = False
 
         # Client-token mint: tests stage the response the next mint returns.
         self.mint_client_token_response: dict[str, Any] = {"id": 1, "raw_token": "rmm_faketoken"}
@@ -705,6 +709,8 @@ class FakeRommApi:
     def negotiate_sync(self, device_id: str, saves: list[ClientSaveState]) -> SyncNegotiateResponse:
         self._log("negotiate_sync", (device_id, saves))
         self._check_fail()
+        if self.negotiate_sync_disabled:
+            raise RommSyncDisabledError("Sync is disabled for this device", url="/api/sync/negotiate", method="POST")
         return {
             "session_id": 1,
             "operations": [],

--- a/tests/fakes/fake_save_api.py
+++ b/tests/fakes/fake_save_api.py
@@ -12,6 +12,7 @@ from fakes._romm_save_semantics import (
     tag_filename,
     with_absent_device_placeholder,
 )
+from lib.errors import RommSyncDisabledError
 
 if TYPE_CHECKING:
     from models.cover import CoverRevalidation
@@ -80,6 +81,10 @@ class FakeSaveApi:
         # drive the negotiate path stage ops via ``stage_negotiate``.
         self._negotiate_operations: list[SyncOperation] = []
         self._negotiate_session_id = 1
+        # When set, negotiate_sync raises ``RommSyncDisabledError`` to model RomM's
+        # per-device sync-disabled 400 (#1489) — the policy stop, distinct from the
+        # generic ``fail_on_next`` arming that models a transient degrade.
+        self.negotiate_sync_disabled: bool = False
         # When set, complete_sync_session raises this AFTER logging the call, to
         # exercise the non-fatal session-close path without failing the run.
         self.complete_raises: Exception | None = None
@@ -370,6 +375,8 @@ class FakeSaveApi:
     def negotiate_sync(self, device_id: str, saves: list[ClientSaveState]) -> SyncNegotiateResponse:
         self.call_log.append(("negotiate_sync", (device_id, saves), {}))
         self._check_fail()
+        if self.negotiate_sync_disabled:
+            raise RommSyncDisabledError("Sync is disabled for this device", url="/api/sync/negotiate", method="POST")
         ops = list(self._negotiate_operations)
         totals = {"upload": 0, "download": 0, "conflict": 0, "no_op": 0}
         for op in ops:

--- a/tests/lib/test_errors.py
+++ b/tests/lib/test_errors.py
@@ -9,6 +9,7 @@ from lib.errors import (
     RommNotFoundError,
     RommServerError,
     RommSSLError,
+    RommSyncDisabledError,
     RommTimeoutError,
     RommUnsupportedError,
     TokenHostMismatchError,
@@ -221,6 +222,14 @@ class TestClassifyError:
         assert code == "config_error"
         assert "different server" in msg
         assert "Sign in again" in msg
+
+    def test_sync_disabled_maps_to_device_sync_disabled(self):
+        """RommSyncDisabledError routes to device_sync_disabled — NOT server_unreachable,
+        even though it subclasses RommApiError — with a re-enable-in-RomM message (#1489)."""
+        code, msg = classify_error(RommSyncDisabledError("Sync is disabled for this device"))
+        assert code == "device_sync_disabled"
+        assert "disabled for this device" in msg
+        assert "RomM's device settings" in msg
 
     def test_conflict_error_is_api_error(self):
         """RommConflictError is a subclass of RommApiError, not specifically handled."""

--- a/tests/services/saves/sync_engine/test_engine.py
+++ b/tests/services/saves/sync_engine/test_engine.py
@@ -24,9 +24,11 @@ from lib.errors import (
     RommConnectionError,
     RommForbiddenError,
     RommSSLError,
+    RommSyncDisabledError,
     RommTimeoutError,
 )
 from lib.list_result import ErrorCode
+from services.saves._messages import DEVICE_SYNC_DISABLED, DEVICE_SYNC_DISABLED_REASON
 from services.saves.sync_engine.engine import _first_error_reason, _summarize_sync_result
 from tests.services.saves._helpers import (
     _create_save,
@@ -638,6 +640,161 @@ class TestPostExitSync:
         assert result["success"] is True
         assert "1 conflict(s)" in result["message"]
         assert result["synced"] == 0
+
+
+class TestDeviceSyncDisabled:
+    """RomM's per-device sync-disabled 400 (#1489) stops the run with a policy reason.
+
+    The negotiate ``RommSyncDisabledError`` is re-raised out of the openers and
+    caught at each entry point; every OTHER negotiate failure keeps the existing
+    degrade-to-sessionless behavior, and pre-launch skips silently like the local
+    toggle so the launch always proceeds.
+    """
+
+    @staticmethod
+    def _seed_confirmed_rom(
+        svc,
+        tmp_path,
+        *,
+        rom_id=42,
+        system="gba",
+        rom_name="pokemon",
+        file_name="pokemon.gba",
+        content=b"save data",
+    ):
+        """Install a ROM with a confirmed named slot and a local-only save file."""
+        svc._config.settings["save_sync_enabled"] = True
+        _set_device_id(svc, "test-device")
+        _install_rom(svc, tmp_path, rom_id=rom_id, system=system, file_name=file_name)
+        _seed_save_state(
+            svc,
+            rom_id,
+            RomSaveState(system=system, slot_confirmed=True, active_slot="default"),
+            platform_slug=system,
+        )
+        _create_save(tmp_path, system=system, rom_name=rom_name, content=content)
+
+    @pytest.mark.asyncio
+    async def test_open_negotiate_session_degrades_to_none_on_generic_error(self, tmp_path):
+        """A transient negotiate failure still degrades to a sessionless run (None)."""
+        svc, fake = make_service(tmp_path)
+        self._seed_confirmed_rom(svc, tmp_path)
+        fake.fail_on_next(RommConnectionError("transient"))
+        session_id = await svc._sync_engine._open_negotiate_session(42, "test-device")
+        assert session_id is None
+
+    @pytest.mark.asyncio
+    async def test_open_negotiate_session_reraises_policy_error(self, tmp_path):
+        """The per-device sync-disabled 400 is re-raised, not swallowed like transports."""
+        svc, fake = make_service(tmp_path)
+        self._seed_confirmed_rom(svc, tmp_path)
+        fake.negotiate_sync_disabled = True
+        with pytest.raises(RommSyncDisabledError):
+            await svc._sync_engine._open_negotiate_session(42, "test-device")
+
+    @pytest.mark.asyncio
+    async def test_sync_rom_saves_returns_policy_failure(self, tmp_path):
+        svc, fake = make_service(tmp_path)
+        self._seed_confirmed_rom(svc, tmp_path)
+        fake.negotiate_sync_disabled = True
+
+        result = await svc.sync_rom_saves(42)
+
+        assert result["success"] is False
+        assert result["reason"] == DEVICE_SYNC_DISABLED_REASON
+        assert result["message"] == DEVICE_SYNC_DISABLED
+        assert result["synced"] == 0
+        assert result["errors"] == []
+        assert result["conflicts"] == []
+        # Aborted before the matrix — no upload happened.
+        assert not any(c[0] == "upload_save" for c in fake.call_log)
+
+    @pytest.mark.asyncio
+    async def test_post_exit_sync_returns_policy_failure(self, tmp_path):
+        svc, fake = make_service(tmp_path)
+        self._seed_confirmed_rom(svc, tmp_path)
+        fake.negotiate_sync_disabled = True
+
+        result = await svc.post_exit_sync(42)
+
+        assert result["success"] is False
+        assert result["reason"] == DEVICE_SYNC_DISABLED_REASON
+        assert result["message"] == DEVICE_SYNC_DISABLED
+        assert result["synced"] == 0
+        assert not any(c[0] == "upload_save" for c in fake.call_log)
+
+    @pytest.mark.asyncio
+    async def test_pre_launch_sync_silently_skips(self, tmp_path):
+        """Pre-launch mirrors the local toggle-off skip: success shape, no offline/reason routing."""
+        svc, fake = make_service(tmp_path)
+        self._seed_confirmed_rom(svc, tmp_path)
+        fake.negotiate_sync_disabled = True
+
+        result = await svc.pre_launch_sync(42)
+
+        assert result["success"] is True
+        assert result["message"] == DEVICE_SYNC_DISABLED
+        assert result["synced"] == 0
+        # Must NOT route into the offline / launch-gate / failure flow.
+        assert "offline" not in result
+        assert "reason" not in result
+        assert not any(c[0] == "upload_save" for c in fake.call_log)
+
+    @pytest.mark.asyncio
+    async def test_sync_all_saves_bulk_abort_returns_policy_failure(self, tmp_path):
+        """The whole-device bulk pre-negotiate hits the switch → abort before the sweep."""
+        svc, fake = make_service(tmp_path)
+        self._seed_confirmed_rom(svc, tmp_path, rom_id=1, rom_name="game1", file_name="game1.gba", content=b"s1")
+        self._seed_confirmed_rom(
+            svc, tmp_path, rom_id=2, system="snes", rom_name="game2", file_name="game2.sfc", content=b"s2"
+        )
+        fake.negotiate_sync_disabled = True
+
+        result = await svc.sync_all_saves()
+
+        assert result["success"] is False
+        assert result["reason"] == DEVICE_SYNC_DISABLED_REASON
+        assert result["message"] == DEVICE_SYNC_DISABLED
+        assert result["synced"] == 0
+        assert result["roms_checked"] == 0
+        assert not any(c[0] == "upload_save" for c in fake.call_log)
+
+    @pytest.mark.asyncio
+    async def test_sync_all_saves_midsweep_abort_reports_partial_totals(self, tmp_path):
+        """When the bulk session degrades and a LATER per-ROM negotiate hits the switch,
+        the sweep aborts reporting the partial totals synced so far (#1489)."""
+        svc, fake = make_service(tmp_path)
+        self._seed_confirmed_rom(svc, tmp_path, rom_id=1, rom_name="game1", file_name="game1.gba", content=b"s1")
+        self._seed_confirmed_rom(
+            svc, tmp_path, rom_id=2, system="snes", rom_name="game2", file_name="game2.sfc", content=b"s2"
+        )
+
+        empty = {"operations": [], "total_upload": 0, "total_download": 0, "total_conflict": 0, "total_no_op": 0}
+        calls = {"n": 0}
+
+        def negotiate(device_id, saves):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                # Bulk pre-negotiate degrades (no session_id) → per-ROM sessions.
+                return {"session_id": None, **empty}
+            if calls["n"] == 2:
+                # ROM 1's per-ROM session opens fine → it syncs and uploads.
+                return {"session_id": 100, **empty}
+            # ROM 2's per-ROM negotiate hits the per-device switch mid-sweep.
+            raise RommSyncDisabledError("Sync is disabled for this device", url="/api/sync/negotiate", method="POST")
+
+        fake.negotiate_sync = negotiate  # type: ignore[method-assign]
+
+        result = await svc.sync_all_saves()
+
+        assert result["success"] is False
+        assert result["reason"] == DEVICE_SYNC_DISABLED_REASON
+        assert result["synced"] == 1
+        assert "after syncing 1 save(s)" in result["message"]
+        assert result["roms_checked"] == 2
+        # ROM 1 uploaded before the abort; ROM 2 never did.
+        uploaded = {c[1][0] for c in fake.call_log if c[0] == "upload_save"}
+        assert uploaded == {1}
 
 
 class TestCheckSaveStatusBackground:

--- a/tests/services/test_session_lifecycle.py
+++ b/tests/services/test_session_lifecycle.py
@@ -409,6 +409,34 @@ class TestFinalizeSyncToasts:
 
         assert result.sync.failure_toast == "SSL certificate verification failed"
 
+    def test_device_sync_disabled_renders_dedicated_toast(self, event_loop, logger):
+        """#1489: RomM's per-device sync-disabled stop gets its own toast copy, keyed on the reason."""
+        post = FakePostExitSync(
+            payload={
+                "success": False,
+                "reason": "device_sync_disabled",
+                "message": "Save sync is disabled for this device on the RomM server",
+                "synced": 0,
+                "errors": [],
+                "conflicts": [],
+            }
+        )
+        service = _make_service(
+            playtime_recorder=FakePlaytimeRecorder(),
+            post_exit_sync=post,
+            achievement_sync=FakeAchievementSync(),
+            migration_reader=FakeMigrationReader(),
+            logger=logger,
+        )
+
+        result = event_loop.run_until_complete(service.finalize(99))
+        event_loop.run_until_complete(_drain_background_tasks(service))
+
+        assert result.sync.failure_toast == "Save sync is disabled for this device on the RomM server"
+        # Not offline and not the generic fallback.
+        assert result.sync.offline is False
+        assert result.sync.failure_toast != "Failed to sync saves after exit"
+
     def test_failure_without_message_falls_back_to_generic_body(self, event_loop, logger):
         """A failure with no ``message`` key falls back to the generic failure body."""
         post = FakePostExitSync(payload={"success": False, "synced": 0})


### PR DESCRIPTION
Closes #1489.

## Problem

RomM's per-device `sync_enabled` switch is enforced in API mode only by `POST /api/sync/negotiate` (400 "Sync is disabled for this device", RomM 5.0.0 `backend/endpoints/sync.py:143-147`). Both negotiate session openers swallowed every exception and proceeded with a sessionless sync — a device the user disabled on the server kept syncing.

## Fix

The specific 400 becomes a policy stop; every other negotiate failure keeps degrading to a sessionless run.

- `json_request` now attaches the FastAPI `detail` to HTTP errors (reusing `_translate_with_detail`, additive for all POST/PUT callers).
- `negotiate_sync` translates an exact-match detail `"Sync is disabled for this device"` into the new typed `RommSyncDisabledError`; a changed server copy safely degrades to the old behavior.
- Both openers (`_open_negotiate_session`, `_bulk_pre_negotiate`) re-raise the typed error instead of swallowing it.
- Entry points map it to the canonical failure shape with the new slug `device_sync_disabled` (distinct from the local-toggle `sync_disabled`):
  - `sync_rom_saves` / `sync_all_saves`: failure result → existing toast via `message`; the sweep also aborts mid-run with partial totals if a per-ROM open hits the 400 after the bulk session degraded transiently.
  - `pre_launch_sync`: mirrors the local-toggle-off silent skip — launch proceeds, no offline/launch-gate routing.
  - post-exit: dedicated `_render_failure_toast` branch, session-end toast says sync is disabled for this device on the server.
- No frontend changes: the emitting callables are typed `reason?: string`, manual surfaces render `result.message`, post-exit renders the backend `failure_toast` verbatim; the `api.ts` reason catalog lists only frontend-routed slugs, which this is not.

## Scope limits (documented in the architecture page)

- Legacy/unconfirmed ROMs never negotiate, and the bulk session only opens with a non-empty confirmed inventory — a library with no confirmed named-slot ROM never sees the server switch.
- A mid-run disable after a successful session open is not re-checked (negotiate is a one-shot snapshot).

## Tests

Full suite 5554 passed. New coverage: error classification, `json_request` detail attach + non-JSON degrade, negotiate translation (exact match / generic 400 / no detail), opener degrade-vs-re-raise, all four entry points including bulk abort and mid-sweep partial totals, the rendered session-end toast string, and a contract test driving the real `sync_rom_saves` callable against the fake's sync-disabled mode.

## Docs

Same PR: `docs/architecture/save-file-sync-architecture.md` (the "session open is best-effort" invariant now carries its one exception) and `docs/user-guide/save-sync.md` (user-facing behavior + how to re-enable).

## On-device verification still needed

The exact RomM 5.0.0 400 copy against a real server, the pre-launch silent skip, and the session-end toast in a real Game Mode session can't be exercised by unit/contract tests — worth one manual pass with sync disabled for the Deck's device in RomM's device settings.