### PR TITLE
fix(saves): refuse save upload when no device is registered

### DIFF
--- a/py_modules/lib/errors.py
+++ b/py_modules/lib/errors.py
@@ -151,6 +151,20 @@ class PairingCodeRateLimitedError(RommApiError):
     """Pairing-code exchange rejected: too many exchange attempts from this client (429)."""
 
 
+class DeviceNotRegisteredError(Exception):
+    """A save upload was attempted with no registered device id.
+
+    A client-side precondition failure, not a RomM HTTP error (hence a plain
+    ``Exception``, outside the :class:`RommApiError` hierarchy). The RomM >= 4.9
+    floor makes device registration the norm, so a missing device id must refuse
+    the upload rather than fall back to a slot-less (legacy) POST that would
+    misfile a named-slot save into the ``slot:null`` bucket (#1478). Save-sync
+    funnels catch it and surface the ``device_not_registered`` reason slug —
+    they own the slug/message (a save-sync concern) since ``lib`` cannot import
+    the service-layer message constants.
+    """
+
+
 def classify_error(exc):
     """Return ``(reason, user_friendly_message)`` for an exception.
 

--- a/py_modules/services/saves/sync_engine/matrix.py
+++ b/py_modules/services/saves/sync_engine/matrix.py
@@ -33,8 +33,9 @@ from domain.sync_action import (
     compute_sync_action,
     resolve_upload_conflict,
 )
-from lib.errors import RommApiError, RommConflictError, classify_error
+from lib.errors import DeviceNotRegisteredError, RommApiError, RommConflictError, classify_error
 from services.saves._helpers import local_save_target
+from services.saves._messages import DEVICE_NOT_REGISTERED
 
 if TYPE_CHECKING:
     import logging
@@ -344,15 +345,15 @@ class MatrixExecutor:
         return True
 
     @staticmethod
-    def _resolve_upload_slot(
-        save_state: RomSaveState, device_id: str | None, default_slot: str | None = None
-    ) -> str | None:
-        """The slot field to send with an upload; ``None`` when device sync is off.
+    def _resolve_upload_slot(save_state: RomSaveState, default_slot: str | None = None) -> str | None:
+        """The slot field to send with an upload; ``None`` only for an explicit-legacy save.
 
-        With device sync on, a named ``active_slot`` uploads to that slot. An
-        ``active_slot`` of ``None`` is ambiguous and must be disambiguated by the
-        ``slots`` map (the same signal :meth:`update_file_sync_state` uses to seed
-        the active slot):
+        Reached only once :meth:`do_upload_save` has confirmed a registered
+        ``device_id`` (a missing one refuses the upload outright, #1478), so the
+        slot resolves purely from the aggregate's slot state. A named
+        ``active_slot`` uploads to that slot; an ``active_slot`` of ``None`` is
+        ambiguous and is disambiguated by the ``slots`` map (the same signal
+        :meth:`update_file_sync_state` uses to seed the active slot):
 
         - **Explicit legacy** (``active_slot`` None but ``slots`` populated — the
           state after switching to / confirming the legacy slot) → ``None`` so the
@@ -362,8 +363,6 @@ class MatrixExecutor:
           configured) → the configured ``default_slot`` so its first sync lands in
           the default slot, matching the active-slot seeding.
         """
-        if not device_id:
-            return None
         if save_state.active_slot is not None:
             return save_state.active_slot
         if save_state.slots:
@@ -433,12 +432,24 @@ class MatrixExecutor:
         the same 409 backstop that catches a write-time stale-current race
         surfaces the true state — no false "synced", no currency stamped on the
         non-head response.
+
+        A missing *device_id* refuses the upload outright (raises
+        :class:`DeviceNotRegisteredError` before any server call, #1478): the
+        RomM >= 4.9 floor makes device registration the norm, so a falsy id no
+        longer means "device sync off" — uploading without it would drop the slot
+        field and land a named-slot save in the legacy (``slot:null``) bucket, the
+        migration-005 retirement violation that seeds the #1478 corruption. The
+        raise reaches every caller's error funnel (the sync dispatch's per-file
+        errors, rollback / version-switch surfaced failures) so the file is
+        reported, not silently misfiled.
         """
+        if not device_id:
+            raise DeviceNotRegisteredError(DEVICE_NOT_REGISTERED)
+
         save_id = server_save.get("id") if server_save else None
         emulator = build_emulator_tag(core_so)
 
-        # v4.7: pass device_id and slot
-        slot = self._resolve_upload_slot(save_state, device_id, default_slot)
+        slot = self._resolve_upload_slot(save_state, default_slot)
 
         result = self._retry.with_retry(
             lambda: self._romm_api.upload_save(
@@ -757,6 +768,14 @@ class MatrixExecutor:
                     self.build_sync_conflict_entry(ctx.rom_id, filename, action.server_save, local_path, local_hash)
                 )
                 return None
+        except DeviceNotRegisteredError:
+            # Precondition refusal, not a transfer error: surface the same
+            # device-not-registered message the automatic pre-flight uses so the
+            # per-file error reads consistently (#1478). No slug field exists on a
+            # per-file sync error (the list is message-only); the reason slug is
+            # carried where a failure dict has one — the keep_local resolve path.
+            self._logger.warning(f"_dispatch_sync_action({ctx.rom_id}): {filename}: {DEVICE_NOT_REGISTERED}")
+            sink.errors.append(f"{filename}: {DEVICE_NOT_REGISTERED}")
         except RommApiError as e:
             _code, _msg = classify_error(e)
             self._logger.warning(f"_dispatch_sync_action({ctx.rom_id}): {filename} failed: {_msg}")

--- a/py_modules/services/saves/sync_engine/rollback.py
+++ b/py_modules/services/saves/sync_engine/rollback.py
@@ -24,9 +24,10 @@ from typing import TYPE_CHECKING, Any
 from domain.iso_time import parse_iso_to_epoch
 from domain.rom_save_state import RomSaveState
 from domain.save_path import sanitize_save_filename
-from lib.errors import classify_error
+from lib.errors import DeviceNotRegisteredError, classify_error
 from lib.list_result import ErrorCode
 from services.saves._helpers import local_save_target
+from services.saves._messages import DEVICE_NOT_REGISTERED, DEVICE_NOT_REGISTERED_REASON
 
 if TYPE_CHECKING:
     import asyncio
@@ -206,6 +207,16 @@ class RollbackOrchestrator:
                 action,
             )
             return {"success": True, "action": action}
+        except DeviceNotRegisteredError:
+            # keep_local's POST hit the do_upload_save device-registration guard
+            # (#1478): carry the device-not-registered reason slug + message the
+            # automatic pre-flight uses, not the generic UNKNOWN.
+            self._logger.warning(
+                "resolve_sync_conflict(rom_id=%d, action=%s): no registered device — refusing keep_local upload",
+                rom_id,
+                action,
+            )
+            return {"success": False, "reason": DEVICE_NOT_REGISTERED_REASON, "message": DEVICE_NOT_REGISTERED}
         except Exception as e:
             self._logger.error(f"resolve_sync_conflict({rom_id}, {filename}, {action}) failed: {e}")
             return {"success": False, "reason": ErrorCode.UNKNOWN.value, "message": str(e)}

--- a/tests/services/saves/sync_engine/test_engine.py
+++ b/tests/services/saves/sync_engine/test_engine.py
@@ -69,6 +69,7 @@ class TestSyncRomSaves:
     def test_local_only_uploads(self, tmp_path):
         svc, fake = make_service(tmp_path)
         svc._config.settings["save_sync_enabled"] = True
+        _set_device_id(svc, "dev-1")
         _install_rom(svc, tmp_path)
         _create_save(tmp_path, content=b"save data")
 
@@ -148,6 +149,7 @@ class TestSyncRomSaves:
         """local_only matches must still upload during pending migration (#238)."""
         svc, fake = make_service(tmp_path)
         svc._config.settings["save_sync_enabled"] = True
+        _set_device_id(svc, "dev-1")
         _install_rom(svc, tmp_path)
         _set_sort_settings(svc, {"sort_by_content": True, "sort_by_core": False})
         _set_sort_settings_previous(svc, {"sort_by_content": True, "sort_by_core": False})

--- a/tests/services/saves/sync_engine/test_matrix.py
+++ b/tests/services/saves/sync_engine/test_matrix.py
@@ -15,7 +15,7 @@ import pytest
 
 from domain.rom_save_state import RomSaveState
 from domain.sync_action import Conflict, Skip, compute_sync_action
-from lib.errors import RommApiError, RommConflictError
+from lib.errors import DeviceNotRegisteredError, RommApiError, RommConflictError
 from services.saves.sync_engine.matrix import (
     DispatchSink,
     RomDispatchContext,
@@ -323,20 +323,50 @@ class TestV47SyncFlow:
         assert len(upload_calls) == 1
         assert upload_calls[0][2]["slot"] is None  # legacy → slot:null, NOT "default"
 
+    def test_named_slot_upload_without_device_refused_in_sync(self, tmp_path):
+        """#1478: a named-slot Upload with no registered device is refused, not misfiled.
+
+        The buggy path dropped the slot field and POSTed the named-slot save into
+        the legacy (slot:null) bucket with an emulator tag — a migration-005
+        retirement violation. Now the dispatch's error funnel records the file with
+        a clear message and ``upload_save`` is never called.
+        """
+        svc, fake = make_service(tmp_path)
+        svc._config.settings["save_sync_enabled"] = True
+        # No device registered — server_device_id stays None.
+        _install_rom(svc, tmp_path)
+        _create_save(tmp_path)  # local only → Upload
+        _seed_save_state(
+            svc,
+            42,
+            RomSaveState(system="gba", active_slot="default", slot_confirmed=True),
+        )
+
+        uploaded, downloaded, errors, conflicts = _do_sync(svc, 42)
+
+        assert (uploaded, downloaded, conflicts) == (0, 0, [])
+        # Message aligned to the pre-flight's canonical constant (the per-file sync
+        # error carries no reason-slug field — the list is message-only).
+        assert errors == ["pokemon.srm: Device not registered"]
+        assert not any(c[0] == "upload_save" for c in fake.call_log)
+
     def test_resolve_upload_slot_branches(self):
-        """_resolve_upload_slot maps each (active_slot, slots, device) case correctly."""
+        """_resolve_upload_slot maps each (active_slot, slots) case correctly.
+
+        Device presence is no longer a branch here: ``do_upload_save`` refuses a
+        slot-less upload when the device id is missing (#1478), so by the time this
+        resolver runs a registered device is guaranteed.
+        """
         from services.saves.sync_engine.matrix import MatrixExecutor as M
 
-        # No device sync → always None.
-        assert M._resolve_upload_slot(RomSaveState(active_slot="desktop"), None, "default") is None
         # Named active slot → that slot.
-        assert M._resolve_upload_slot(RomSaveState(active_slot="desktop"), "dev", "default") == "desktop"
+        assert M._resolve_upload_slot(RomSaveState(active_slot="desktop"), "default") == "desktop"
         # Brand-new ROM (active None, no slots) → the configured default slot.
-        assert M._resolve_upload_slot(RomSaveState(), "dev", "main") == "main"
+        assert M._resolve_upload_slot(RomSaveState(), "main") == "main"
         # Explicit legacy (active None, slots populated) → None (slot:null), not default.
         legacy = RomSaveState()
         legacy.switch_active_slot(None)  # active=None, adds the "" slots key
-        assert M._resolve_upload_slot(legacy, "dev", "default") is None
+        assert M._resolve_upload_slot(legacy, "default") is None
 
     def test_filter_server_saves_to_slot_isolates_legacy(self):
         """#1061: a legacy (slot:null) save belongs ONLY to the legacy slot.
@@ -573,17 +603,25 @@ class TestConfirmDownloadAfterSync:
         assert len(confirm_calls) == 1
         assert confirm_calls[0][1] == (100, "dev-1")
 
-    def test_do_upload_save_skips_confirm_when_no_device_id(self, tmp_path):
-        """No registered device → confirm_download is not called (no-op)."""
+    def test_do_upload_save_refuses_without_device_id(self, tmp_path):
+        """No registered device → upload is refused before any server call (#1478).
+
+        A missing device_id can no longer disable device sync (RomM >= 4.9 makes
+        registration the norm). Uploading without it would drop the slot field and
+        misfile a named-slot save into the legacy (slot:null) bucket, so
+        ``do_upload_save`` raises ``DeviceNotRegisteredError`` before
+        ``upload_save`` — neither the upload nor the confirm round-trip is issued.
+        """
         svc, fake = make_service(tmp_path)
         # server_device_id stays None — device not registered
         _install_rom(svc, tmp_path)
-        save_path = _create_save(tmp_path)
+        save_path = str(_create_save(tmp_path))
 
-        _do_upload(svc, 42, str(save_path), "pokemon.srm", "gba")
+        with pytest.raises(DeviceNotRegisteredError, match="Device not registered"):
+            _do_upload(svc, 42, save_path, "pokemon.srm", "gba")
 
-        confirm_calls = [c for c in fake.call_log if c[0] == "confirm_download"]
-        assert confirm_calls == []
+        assert not any(c[0] == "upload_save" for c in fake.call_log)
+        assert not any(c[0] == "confirm_download" for c in fake.call_log)
 
     def test_do_upload_save_swallows_confirm_download_error(self, tmp_path):
         """confirm_download failure must NOT bubble — upload is reported successful.
@@ -1409,6 +1447,7 @@ class TestOwnUploadIds:
     async def test_post_upload_idempotent_in_own_list(self, tmp_path):
         """Calling do_upload_save twice with the same resulting save_id does not duplicate."""
         svc, fake = make_service(tmp_path)
+        _set_device_id(svc, "dev-1")
         _install_rom(svc, tmp_path)
         save_file = _create_save(tmp_path)
 
@@ -1438,6 +1477,7 @@ class TestOwnUploadIds:
     async def test_put_upload_appends_own_upload_id(self, tmp_path):
         """A PUT upload (existing save id) records that id in own_upload_ids."""
         svc, fake = make_service(tmp_path)
+        _set_device_id(svc, "dev-1")
         _install_rom(svc, tmp_path)
         save_file = _create_save(tmp_path)
 
@@ -1465,6 +1505,7 @@ class TestOwnUploadIds:
     async def test_put_upload_idempotent_in_own_list(self, tmp_path):
         """Two PUT uploads to the same save id record it only once (dedup)."""
         svc, fake = make_service(tmp_path)
+        _set_device_id(svc, "dev-1")
         _install_rom(svc, tmp_path)
         save_file = _create_save(tmp_path)
 
@@ -1519,6 +1560,7 @@ class TestOwnUploadIds:
     async def test_rollback_to_foreign_version_records_target_id(self, tmp_path):
         """Rolling back PUTs the target's content back, so this device now owns that id."""
         svc, fake = make_service(tmp_path)
+        _set_device_id(svc, "dev-1")
         _install_rom(svc, tmp_path)
 
         save_file = _create_save(tmp_path)

--- a/tests/services/saves/sync_engine/test_rollback.py
+++ b/tests/services/saves/sync_engine/test_rollback.py
@@ -149,6 +149,45 @@ class TestResolveSyncConflict:
         assert file_state.last_sync_hash == local_hash
 
     @pytest.mark.asyncio
+    async def test_resolve_keep_local_refuses_without_device_id(self, tmp_path):
+        """#1478: keep_local with no registered device surfaces the device-not-registered slug.
+
+        keep_local would POST the local content, but the do_upload_save
+        device-registration guard refuses it — the failure dict carries the
+        ``device_not_registered`` reason + message, not the generic UNKNOWN, and
+        ``upload_save`` is never called.
+        """
+        svc, fake = make_service(tmp_path)
+        # No device registered — get_device_id() returns None.
+        _install_rom(svc, tmp_path)
+        _seed_save_state(svc, 42, RomSaveState(system="gba", active_slot="default", slot_confirmed=True))
+        _create_save(tmp_path, content=b"local-edited")  # on-disk local save keep_local reads
+
+        ss = _server_save_with_syncs(
+            slot="default",
+            device_syncs=[{"device_id": "device-1", "is_current": False}],
+        )
+        # Server content differs from local → keep_local proceeds to the upload.
+        other = tmp_path / "other.bin"
+        other.write_bytes(b"server-flavor")
+        fake.saves[100] = ss
+        fake.uploaded_files[100] = str(other)
+
+        result = await svc.resolve_sync_conflict(
+            rom_id=42,
+            filename="pokemon.srm",
+            server_save_id=100,
+            action="keep_local",
+        )
+
+        assert result == {
+            "success": False,
+            "reason": "device_not_registered",
+            "message": "Device not registered",
+        }
+        assert not any(c[0] == "upload_save" for c in fake.call_log)
+
+    @pytest.mark.asyncio
     async def test_resolve_keep_local_falls_back_when_server_hash_fetch_raises(self, tmp_path):
         """When ``_get_server_save_hash`` raises out of retry (retries exhausted),
         the keep_local resolver swallows it and treats ``server_hash`` as ``None``.

--- a/tests/services/saves/test_service.py
+++ b/tests/services/saves/test_service.py
@@ -625,7 +625,7 @@ class TestEmulatorTag:
             str(tmp_path / "saves" / "gba" / "pokemon.srm"),
             "pokemon.srm",
             RomSaveState(),
-            None,
+            "dev-1",
             "gba",
             "mgba_libretro",
         )
@@ -647,7 +647,7 @@ class TestEmulatorTag:
             str(tmp_path / "saves" / "gba" / "pokemon.srm"),
             "pokemon.srm",
             RomSaveState(),
-            None,
+            "dev-1",
             "gba",
             None,
         )

--- a/tests/test_plugin_saves.py
+++ b/tests/test_plugin_saves.py
@@ -1125,6 +1125,7 @@ class TestSavesVersionHistoryCallables:
     async def test_saves_rollback_to_version_happy_path(self, plugin, tmp_path):
         """saves_rollback_to_version downloads the target save on success."""
         _install_rom(plugin, tmp_path)
+        _set_device_id(plugin, "dev-1")
 
         # Create local save file with content matching last_sync_hash
         saves_dir = tmp_path / "retrodeck" / "saves" / "gba"


### PR DESCRIPTION
Found during #1478 triage — does not close the issue.

## Problem

`_resolve_upload_slot` returned `None` (→ slot-less upload) whenever no device was registered — even for a ROM on a named slot — and uploads always attach an emulator tag. A named-slot ROM could therefore write a tagged, slot-less row into the retired legacy bucket: exactly the corruption seed pattern behind #1478. The path is reachable: the automatic sync entry points gate on device registration, but the version-rollback pre-flight, the rollback itself, and `keep_local` conflict resolution read the device id ungated — and "no device registered" is a live state since the origin-change forget (#1437), not just a fresh install. Two pre-existing tests only passed *because* of the slot-less no-device upload.

## Change

`do_upload_save` refuses up front when no device is registered — before any server call — and the refusal surfaces through each caller's existing error funnel. `_resolve_upload_slot` loses its dead no-device branch (and the now-unused parameter). Behavior for registered devices is unchanged: explicit-legacy resolution and brand-new-ROM default-slot resolution are preserved byte-for-byte.

The refusal raises a dedicated `DeviceNotRegisteredError` and surfaces with the same `device_not_registered` reason slug the automatic pre-flight already uses (`keep_local` previously reported a generic unknown); the version-rollback flow keeps its `status: "put_failed"` shape, and the per-file sync error channel carries the canonical message.

## Tests

Value-exact refusal tests for the sync funnel, the chokepoint, and the `keep_local` failure dict; the two tests that had encoded the buggy contract were rewritten to assert the refusal; remaining edits only add registered-device preconditions. Full local gate green (5541 tests, ruff, basedpyright, import-linter, failure-shape).

docs: N/A (internal hardening — the rare no-device case now surfaces a sync error instead of silently writing a slot-less save).
