### PR TITLE
test(domain): run gavel ladder conformance vectors against resolve_upload_conflict

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -550,6 +550,15 @@ also surfaced inside the pytest run by `tests/contract/test_callable_manifest.py
 functions and asserts live parity — so a renamed/added/removed callable or an arity drift breaks both the lint gate and
 the test run.
 
+### Gavel conformance vectors — vendored contract tier
+
+`tests/domain/test_sync_action_gavel_vectors.py` runs the [romm-gavel](https://github.com/danielcopper/romm-gavel) 409
+ladder conformance vectors against `domain/sync_action.resolve_upload_conflict` — self-conformance of the production
+kernel against the contract that was extracted from it. The vectors are vendored verbatim under
+`tests/domain/gavel_vectors/` (no submodule, no network in CI), so a contract change must land as a reviewable diff.
+Updating means deliberately re-copying the JSON and bumping the commit reference in that folder's `README.md`; never
+edit a vector to match the kernel.
+
 ### Frontend component tests — `@decky/api` event harness
 
 `src/test-utils/decky-api-mock.ts` exposes an in-memory event bus that `addEventListener` / `removeEventListener` route

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -104,6 +104,22 @@ python -m pytest tests/contract/ -q
 A `backend.ts` manifest gate (Phase 2) that pins the frontend and backend to one parsed artifact is a forthcoming
 separate change. See the CLAUDE.md "Testing" section for the full contract-tier rules.
 
+### Gavel conformance vectors
+
+The 409 resolution ladder (`domain/sync_action.resolve_upload_conflict`) is also published as a standalone client
+contract, [romm-gavel](https://github.com/danielcopper/romm-gavel). `tests/domain/test_sync_action_gavel_vectors.py`
+runs that contract's normative conformance vectors against the production kernel, so the kernel and the published spec
+can't silently drift apart. The vectors are vendored verbatim under `tests/domain/gavel_vectors/` (a curated named-case
+set plus the exhaustive equivalence classes) — there is no submodule and no network in CI, so every contract change
+lands as a reviewable diff. Run them like any other test:
+
+```bash
+python -m pytest tests/domain/test_sync_action_gavel_vectors.py -q
+```
+
+Updating the vectors means deliberately re-copying the JSON from upstream `vectors/ladder/` and bumping the commit
+reference in `tests/domain/gavel_vectors/README.md`; never edit a vector to match the kernel.
+
 Every backend feature or callable where testing makes sense should have unit tests covering:
 
 - **Happy path** — normal successful operation

--- a/tests/domain/gavel_vectors/README.md
+++ b/tests/domain/gavel_vectors/README.md
@@ -1,0 +1,20 @@
+# Gavel ladder conformance vectors — vendored
+
+These JSON files are vendored verbatim from [danielcopper/romm-gavel](https://github.com/danielcopper/romm-gavel)
+`vectors/ladder/`, at commit `b2e550b`.
+
+They are the normative conformance vectors for the 409 resolution ladder (`resolve_upload_conflict`) — gavel is the
+client companion contract for RomM Device Sync, itself extracted from this repo's `py_modules/domain/sync_action.py`.
+`tests/domain/test_sync_action_gavel_vectors.py` runs every vector against the production kernel, so this tier proves
+the kernel still conforms to the published contract.
+
+## Updating
+
+There is no submodule and no network access in CI — a vector change must surface as a reviewable diff in this repo.
+Updating means deliberately re-copying the files from the upstream `vectors/ladder/` directory and updating the commit
+reference above:
+
+- `named-cases.json` — curated, named cases (each carries a `rationale`).
+- `equivalence-classes.json` — the exhaustive equivalence-class set.
+
+Do not reformat the copied files; they must stay byte-for-byte identical to upstream.

--- a/tests/domain/gavel_vectors/equivalence-classes.json
+++ b/tests/domain/gavel_vectors/equivalence-classes.json
@@ -1,0 +1,1517 @@
+{
+  "family": "upload-409-ladder",
+  "spec": "SPEC.md \u2014 The 409 resolution ladder (normative)",
+  "description": "Exhaustive equivalence classes over the four ladder inputs. Each slot is absent (null), empty (\"\"), or one of up to four distinct hash values; equality patterns are canonicalized by first occurrence, so this set covers every distinguishable input shape the ladder can see. Hash strings are placeholders \u2014 only presence and equality carry meaning.",
+  "vectors": [
+    {
+      "name": "none-none-none-none",
+      "input": {
+        "local_hash": null,
+        "last_sync_hash": null,
+        "server_content_hash": null,
+        "last_sync_server_hash": null
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "none-none-none-empty",
+      "input": {
+        "local_hash": null,
+        "last_sync_hash": null,
+        "server_content_hash": null,
+        "last_sync_server_hash": ""
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "none-none-none-a",
+      "input": {
+        "local_hash": null,
+        "last_sync_hash": null,
+        "server_content_hash": null,
+        "last_sync_server_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "none-none-empty-none",
+      "input": {
+        "local_hash": null,
+        "last_sync_hash": null,
+        "server_content_hash": "",
+        "last_sync_server_hash": null
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "none-none-empty-empty",
+      "input": {
+        "local_hash": null,
+        "last_sync_hash": null,
+        "server_content_hash": "",
+        "last_sync_server_hash": ""
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "none-none-empty-a",
+      "input": {
+        "local_hash": null,
+        "last_sync_hash": null,
+        "server_content_hash": "",
+        "last_sync_server_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "none-none-a-none",
+      "input": {
+        "local_hash": null,
+        "last_sync_hash": null,
+        "server_content_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_server_hash": null
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "none-none-a-empty",
+      "input": {
+        "local_hash": null,
+        "last_sync_hash": null,
+        "server_content_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_server_hash": ""
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "none-none-a-a",
+      "input": {
+        "local_hash": null,
+        "last_sync_hash": null,
+        "server_content_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_server_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "none-none-a-b",
+      "input": {
+        "local_hash": null,
+        "last_sync_hash": null,
+        "server_content_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_server_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "none-empty-none-none",
+      "input": {
+        "local_hash": null,
+        "last_sync_hash": "",
+        "server_content_hash": null,
+        "last_sync_server_hash": null
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "none-empty-none-empty",
+      "input": {
+        "local_hash": null,
+        "last_sync_hash": "",
+        "server_content_hash": null,
+        "last_sync_server_hash": ""
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "none-empty-none-a",
+      "input": {
+        "local_hash": null,
+        "last_sync_hash": "",
+        "server_content_hash": null,
+        "last_sync_server_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "none-empty-empty-none",
+      "input": {
+        "local_hash": null,
+        "last_sync_hash": "",
+        "server_content_hash": "",
+        "last_sync_server_hash": null
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "none-empty-empty-empty",
+      "input": {
+        "local_hash": null,
+        "last_sync_hash": "",
+        "server_content_hash": "",
+        "last_sync_server_hash": ""
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "none-empty-empty-a",
+      "input": {
+        "local_hash": null,
+        "last_sync_hash": "",
+        "server_content_hash": "",
+        "last_sync_server_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "none-empty-a-none",
+      "input": {
+        "local_hash": null,
+        "last_sync_hash": "",
+        "server_content_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_server_hash": null
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "none-empty-a-empty",
+      "input": {
+        "local_hash": null,
+        "last_sync_hash": "",
+        "server_content_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_server_hash": ""
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "none-empty-a-a",
+      "input": {
+        "local_hash": null,
+        "last_sync_hash": "",
+        "server_content_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_server_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "none-empty-a-b",
+      "input": {
+        "local_hash": null,
+        "last_sync_hash": "",
+        "server_content_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_server_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "none-a-none-none",
+      "input": {
+        "local_hash": null,
+        "last_sync_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "server_content_hash": null,
+        "last_sync_server_hash": null
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "none-a-none-empty",
+      "input": {
+        "local_hash": null,
+        "last_sync_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "server_content_hash": null,
+        "last_sync_server_hash": ""
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "none-a-none-a",
+      "input": {
+        "local_hash": null,
+        "last_sync_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "server_content_hash": null,
+        "last_sync_server_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "none-a-none-b",
+      "input": {
+        "local_hash": null,
+        "last_sync_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "server_content_hash": null,
+        "last_sync_server_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "none-a-empty-none",
+      "input": {
+        "local_hash": null,
+        "last_sync_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "server_content_hash": "",
+        "last_sync_server_hash": null
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "none-a-empty-empty",
+      "input": {
+        "local_hash": null,
+        "last_sync_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "server_content_hash": "",
+        "last_sync_server_hash": ""
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "none-a-empty-a",
+      "input": {
+        "local_hash": null,
+        "last_sync_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "server_content_hash": "",
+        "last_sync_server_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "none-a-empty-b",
+      "input": {
+        "local_hash": null,
+        "last_sync_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "server_content_hash": "",
+        "last_sync_server_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "none-a-a-none",
+      "input": {
+        "local_hash": null,
+        "last_sync_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "server_content_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_server_hash": null
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "none-a-a-empty",
+      "input": {
+        "local_hash": null,
+        "last_sync_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "server_content_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_server_hash": ""
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "none-a-a-a",
+      "input": {
+        "local_hash": null,
+        "last_sync_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "server_content_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_server_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "none-a-a-b",
+      "input": {
+        "local_hash": null,
+        "last_sync_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "server_content_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_server_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "none-a-b-none",
+      "input": {
+        "local_hash": null,
+        "last_sync_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "server_content_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "last_sync_server_hash": null
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "none-a-b-empty",
+      "input": {
+        "local_hash": null,
+        "last_sync_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "server_content_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "last_sync_server_hash": ""
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "none-a-b-a",
+      "input": {
+        "local_hash": null,
+        "last_sync_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "server_content_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "last_sync_server_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "none-a-b-b",
+      "input": {
+        "local_hash": null,
+        "last_sync_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "server_content_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "last_sync_server_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "none-a-b-c",
+      "input": {
+        "local_hash": null,
+        "last_sync_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "server_content_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "last_sync_server_hash": "cccccccccccccccccccccccccccccccc"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "empty-none-none-none",
+      "input": {
+        "local_hash": "",
+        "last_sync_hash": null,
+        "server_content_hash": null,
+        "last_sync_server_hash": null
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "empty-none-none-empty",
+      "input": {
+        "local_hash": "",
+        "last_sync_hash": null,
+        "server_content_hash": null,
+        "last_sync_server_hash": ""
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "empty-none-none-a",
+      "input": {
+        "local_hash": "",
+        "last_sync_hash": null,
+        "server_content_hash": null,
+        "last_sync_server_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "empty-none-empty-none",
+      "input": {
+        "local_hash": "",
+        "last_sync_hash": null,
+        "server_content_hash": "",
+        "last_sync_server_hash": null
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "empty-none-empty-empty",
+      "input": {
+        "local_hash": "",
+        "last_sync_hash": null,
+        "server_content_hash": "",
+        "last_sync_server_hash": ""
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "empty-none-empty-a",
+      "input": {
+        "local_hash": "",
+        "last_sync_hash": null,
+        "server_content_hash": "",
+        "last_sync_server_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "empty-none-a-none",
+      "input": {
+        "local_hash": "",
+        "last_sync_hash": null,
+        "server_content_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_server_hash": null
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "empty-none-a-empty",
+      "input": {
+        "local_hash": "",
+        "last_sync_hash": null,
+        "server_content_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_server_hash": ""
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "empty-none-a-a",
+      "input": {
+        "local_hash": "",
+        "last_sync_hash": null,
+        "server_content_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_server_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "empty-none-a-b",
+      "input": {
+        "local_hash": "",
+        "last_sync_hash": null,
+        "server_content_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_server_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "empty-empty-none-none",
+      "input": {
+        "local_hash": "",
+        "last_sync_hash": "",
+        "server_content_hash": null,
+        "last_sync_server_hash": null
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "empty-empty-none-empty",
+      "input": {
+        "local_hash": "",
+        "last_sync_hash": "",
+        "server_content_hash": null,
+        "last_sync_server_hash": ""
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "empty-empty-none-a",
+      "input": {
+        "local_hash": "",
+        "last_sync_hash": "",
+        "server_content_hash": null,
+        "last_sync_server_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "empty-empty-empty-none",
+      "input": {
+        "local_hash": "",
+        "last_sync_hash": "",
+        "server_content_hash": "",
+        "last_sync_server_hash": null
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "empty-empty-empty-empty",
+      "input": {
+        "local_hash": "",
+        "last_sync_hash": "",
+        "server_content_hash": "",
+        "last_sync_server_hash": ""
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "empty-empty-empty-a",
+      "input": {
+        "local_hash": "",
+        "last_sync_hash": "",
+        "server_content_hash": "",
+        "last_sync_server_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "empty-empty-a-none",
+      "input": {
+        "local_hash": "",
+        "last_sync_hash": "",
+        "server_content_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_server_hash": null
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "empty-empty-a-empty",
+      "input": {
+        "local_hash": "",
+        "last_sync_hash": "",
+        "server_content_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_server_hash": ""
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "empty-empty-a-a",
+      "input": {
+        "local_hash": "",
+        "last_sync_hash": "",
+        "server_content_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_server_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "empty-empty-a-b",
+      "input": {
+        "local_hash": "",
+        "last_sync_hash": "",
+        "server_content_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_server_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "empty-a-none-none",
+      "input": {
+        "local_hash": "",
+        "last_sync_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "server_content_hash": null,
+        "last_sync_server_hash": null
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "empty-a-none-empty",
+      "input": {
+        "local_hash": "",
+        "last_sync_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "server_content_hash": null,
+        "last_sync_server_hash": ""
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "empty-a-none-a",
+      "input": {
+        "local_hash": "",
+        "last_sync_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "server_content_hash": null,
+        "last_sync_server_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "empty-a-none-b",
+      "input": {
+        "local_hash": "",
+        "last_sync_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "server_content_hash": null,
+        "last_sync_server_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "empty-a-empty-none",
+      "input": {
+        "local_hash": "",
+        "last_sync_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "server_content_hash": "",
+        "last_sync_server_hash": null
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "empty-a-empty-empty",
+      "input": {
+        "local_hash": "",
+        "last_sync_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "server_content_hash": "",
+        "last_sync_server_hash": ""
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "empty-a-empty-a",
+      "input": {
+        "local_hash": "",
+        "last_sync_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "server_content_hash": "",
+        "last_sync_server_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "empty-a-empty-b",
+      "input": {
+        "local_hash": "",
+        "last_sync_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "server_content_hash": "",
+        "last_sync_server_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "empty-a-a-none",
+      "input": {
+        "local_hash": "",
+        "last_sync_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "server_content_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_server_hash": null
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "empty-a-a-empty",
+      "input": {
+        "local_hash": "",
+        "last_sync_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "server_content_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_server_hash": ""
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "empty-a-a-a",
+      "input": {
+        "local_hash": "",
+        "last_sync_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "server_content_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_server_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "empty-a-a-b",
+      "input": {
+        "local_hash": "",
+        "last_sync_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "server_content_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_server_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "empty-a-b-none",
+      "input": {
+        "local_hash": "",
+        "last_sync_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "server_content_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "last_sync_server_hash": null
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "empty-a-b-empty",
+      "input": {
+        "local_hash": "",
+        "last_sync_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "server_content_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "last_sync_server_hash": ""
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "empty-a-b-a",
+      "input": {
+        "local_hash": "",
+        "last_sync_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "server_content_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "last_sync_server_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "empty-a-b-b",
+      "input": {
+        "local_hash": "",
+        "last_sync_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "server_content_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "last_sync_server_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "empty-a-b-c",
+      "input": {
+        "local_hash": "",
+        "last_sync_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "server_content_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "last_sync_server_hash": "cccccccccccccccccccccccccccccccc"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "a-none-none-none",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": null,
+        "server_content_hash": null,
+        "last_sync_server_hash": null
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "a-none-none-empty",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": null,
+        "server_content_hash": null,
+        "last_sync_server_hash": ""
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "a-none-none-a",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": null,
+        "server_content_hash": null,
+        "last_sync_server_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "a-none-none-b",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": null,
+        "server_content_hash": null,
+        "last_sync_server_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "a-none-empty-none",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": null,
+        "server_content_hash": "",
+        "last_sync_server_hash": null
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "a-none-empty-empty",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": null,
+        "server_content_hash": "",
+        "last_sync_server_hash": ""
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "a-none-empty-a",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": null,
+        "server_content_hash": "",
+        "last_sync_server_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "a-none-empty-b",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": null,
+        "server_content_hash": "",
+        "last_sync_server_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "a-none-a-none",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": null,
+        "server_content_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_server_hash": null
+      },
+      "expected": "download"
+    },
+    {
+      "name": "a-none-a-empty",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": null,
+        "server_content_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_server_hash": ""
+      },
+      "expected": "download"
+    },
+    {
+      "name": "a-none-a-a",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": null,
+        "server_content_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_server_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "expected": "download"
+    },
+    {
+      "name": "a-none-a-b",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": null,
+        "server_content_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_server_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      "expected": "download"
+    },
+    {
+      "name": "a-none-b-none",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": null,
+        "server_content_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "last_sync_server_hash": null
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "a-none-b-empty",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": null,
+        "server_content_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "last_sync_server_hash": ""
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "a-none-b-a",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": null,
+        "server_content_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "last_sync_server_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "a-none-b-b",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": null,
+        "server_content_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "last_sync_server_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "a-none-b-c",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": null,
+        "server_content_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "last_sync_server_hash": "cccccccccccccccccccccccccccccccc"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "a-empty-none-none",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "",
+        "server_content_hash": null,
+        "last_sync_server_hash": null
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "a-empty-none-empty",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "",
+        "server_content_hash": null,
+        "last_sync_server_hash": ""
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "a-empty-none-a",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "",
+        "server_content_hash": null,
+        "last_sync_server_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "a-empty-none-b",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "",
+        "server_content_hash": null,
+        "last_sync_server_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "a-empty-empty-none",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "",
+        "server_content_hash": "",
+        "last_sync_server_hash": null
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "a-empty-empty-empty",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "",
+        "server_content_hash": "",
+        "last_sync_server_hash": ""
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "a-empty-empty-a",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "",
+        "server_content_hash": "",
+        "last_sync_server_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "a-empty-empty-b",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "",
+        "server_content_hash": "",
+        "last_sync_server_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "a-empty-a-none",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "",
+        "server_content_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_server_hash": null
+      },
+      "expected": "download"
+    },
+    {
+      "name": "a-empty-a-empty",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "",
+        "server_content_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_server_hash": ""
+      },
+      "expected": "download"
+    },
+    {
+      "name": "a-empty-a-a",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "",
+        "server_content_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_server_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "expected": "download"
+    },
+    {
+      "name": "a-empty-a-b",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "",
+        "server_content_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_server_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      "expected": "download"
+    },
+    {
+      "name": "a-empty-b-none",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "",
+        "server_content_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "last_sync_server_hash": null
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "a-empty-b-empty",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "",
+        "server_content_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "last_sync_server_hash": ""
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "a-empty-b-a",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "",
+        "server_content_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "last_sync_server_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "a-empty-b-b",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "",
+        "server_content_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "last_sync_server_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "a-empty-b-c",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "",
+        "server_content_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "last_sync_server_hash": "cccccccccccccccccccccccccccccccc"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "a-a-none-none",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "server_content_hash": null,
+        "last_sync_server_hash": null
+      },
+      "expected": "download"
+    },
+    {
+      "name": "a-a-none-empty",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "server_content_hash": null,
+        "last_sync_server_hash": ""
+      },
+      "expected": "download"
+    },
+    {
+      "name": "a-a-none-a",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "server_content_hash": null,
+        "last_sync_server_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "expected": "download"
+    },
+    {
+      "name": "a-a-none-b",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "server_content_hash": null,
+        "last_sync_server_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      "expected": "download"
+    },
+    {
+      "name": "a-a-empty-none",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "server_content_hash": "",
+        "last_sync_server_hash": null
+      },
+      "expected": "download"
+    },
+    {
+      "name": "a-a-empty-empty",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "server_content_hash": "",
+        "last_sync_server_hash": ""
+      },
+      "expected": "download"
+    },
+    {
+      "name": "a-a-empty-a",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "server_content_hash": "",
+        "last_sync_server_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "expected": "download"
+    },
+    {
+      "name": "a-a-empty-b",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "server_content_hash": "",
+        "last_sync_server_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      "expected": "download"
+    },
+    {
+      "name": "a-a-a-none",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "server_content_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_server_hash": null
+      },
+      "expected": "download"
+    },
+    {
+      "name": "a-a-a-empty",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "server_content_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_server_hash": ""
+      },
+      "expected": "download"
+    },
+    {
+      "name": "a-a-a-a",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "server_content_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_server_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "expected": "download"
+    },
+    {
+      "name": "a-a-a-b",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "server_content_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_server_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      "expected": "download"
+    },
+    {
+      "name": "a-a-b-none",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "server_content_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "last_sync_server_hash": null
+      },
+      "expected": "download"
+    },
+    {
+      "name": "a-a-b-empty",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "server_content_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "last_sync_server_hash": ""
+      },
+      "expected": "download"
+    },
+    {
+      "name": "a-a-b-a",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "server_content_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "last_sync_server_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "expected": "download"
+    },
+    {
+      "name": "a-a-b-b",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "server_content_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "last_sync_server_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      "expected": "download"
+    },
+    {
+      "name": "a-a-b-c",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "server_content_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "last_sync_server_hash": "cccccccccccccccccccccccccccccccc"
+      },
+      "expected": "download"
+    },
+    {
+      "name": "a-b-none-none",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "server_content_hash": null,
+        "last_sync_server_hash": null
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "a-b-none-empty",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "server_content_hash": null,
+        "last_sync_server_hash": ""
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "a-b-none-a",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "server_content_hash": null,
+        "last_sync_server_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "a-b-none-b",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "server_content_hash": null,
+        "last_sync_server_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "a-b-none-c",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "server_content_hash": null,
+        "last_sync_server_hash": "cccccccccccccccccccccccccccccccc"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "a-b-empty-none",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "server_content_hash": "",
+        "last_sync_server_hash": null
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "a-b-empty-empty",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "server_content_hash": "",
+        "last_sync_server_hash": ""
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "a-b-empty-a",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "server_content_hash": "",
+        "last_sync_server_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "a-b-empty-b",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "server_content_hash": "",
+        "last_sync_server_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "a-b-empty-c",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "server_content_hash": "",
+        "last_sync_server_hash": "cccccccccccccccccccccccccccccccc"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "a-b-a-none",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "server_content_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_server_hash": null
+      },
+      "expected": "download"
+    },
+    {
+      "name": "a-b-a-empty",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "server_content_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_server_hash": ""
+      },
+      "expected": "download"
+    },
+    {
+      "name": "a-b-a-a",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "server_content_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_server_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "expected": "download"
+    },
+    {
+      "name": "a-b-a-b",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "server_content_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_server_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      "expected": "download"
+    },
+    {
+      "name": "a-b-a-c",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "server_content_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_server_hash": "cccccccccccccccccccccccccccccccc"
+      },
+      "expected": "download"
+    },
+    {
+      "name": "a-b-b-none",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "server_content_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "last_sync_server_hash": null
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "a-b-b-empty",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "server_content_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "last_sync_server_hash": ""
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "a-b-b-a",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "server_content_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "last_sync_server_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "a-b-b-b",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "server_content_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "last_sync_server_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "a-b-b-c",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "server_content_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "last_sync_server_hash": "cccccccccccccccccccccccccccccccc"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "a-b-c-none",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "server_content_hash": "cccccccccccccccccccccccccccccccc",
+        "last_sync_server_hash": null
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "a-b-c-empty",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "server_content_hash": "cccccccccccccccccccccccccccccccc",
+        "last_sync_server_hash": ""
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "a-b-c-a",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "server_content_hash": "cccccccccccccccccccccccccccccccc",
+        "last_sync_server_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "a-b-c-b",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "server_content_hash": "cccccccccccccccccccccccccccccccc",
+        "last_sync_server_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "a-b-c-c",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "server_content_hash": "cccccccccccccccccccccccccccccccc",
+        "last_sync_server_hash": "cccccccccccccccccccccccccccccccc"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "a-b-c-d",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "server_content_hash": "cccccccccccccccccccccccccccccccc",
+        "last_sync_server_hash": "dddddddddddddddddddddddddddddddd"
+      },
+      "expected": "conflict"
+    }
+  ]
+}

--- a/tests/domain/gavel_vectors/named-cases.json
+++ b/tests/domain/gavel_vectors/named-cases.json
@@ -1,0 +1,117 @@
+{
+  "family": "upload-409-ladder",
+  "spec": "SPEC.md — The 409 resolution ladder (normative)",
+  "description": "Curated, named cases for the 409 resolution ladder. Every case here is also covered by the exhaustive equivalence-class set; this file exists so the load-bearing scenarios carry a name and a rationale. Hash strings are placeholders — only presence and equality carry meaning.",
+  "vectors": [
+    {
+      "name": "unchanged-since-baseline",
+      "rationale": "Local equals the recorded baseline: the client holds no un-synced work, so there is nothing of its own to protect. Adopt the server head.",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "server_content_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "last_sync_server_hash": "cccccccccccccccccccccccccccccccc"
+      },
+      "expected": "download"
+    },
+    {
+      "name": "diverged-but-reproduces-head",
+      "rationale": "Local diverged from the baseline, yet is byte-identical to what the server now holds. Adopting identical bytes loses nothing; downloading re-establishes the baseline.",
+      "input": {
+        "local_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "last_sync_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "server_content_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "last_sync_server_hash": "cccccccccccccccccccccccccccccccc"
+      },
+      "expected": "download"
+    },
+    {
+      "name": "two-sided-divergence",
+      "rationale": "Local carries changes AND the server independently moved (which is exactly what the 409 proves). Genuine divergence — the user decides.",
+      "input": {
+        "local_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "last_sync_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "server_content_hash": "cccccccccccccccccccccccccccccccc",
+        "last_sync_server_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "no-baseline-no-parity",
+      "rationale": "No recorded baseline, and local does not match the server head: local provenance is unknown, so nothing proves it safe to discard. Uncertainty resolves to conflict, never to a silent overwrite.",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": null,
+        "server_content_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "last_sync_server_hash": null
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "no-baseline-but-parity",
+      "rationale": "No recorded baseline (fresh reinstall, copied SD card, second device), but local is byte-identical to the server head — the parity route is the only identity route such a client has, and it is sufficient.",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": null,
+        "server_content_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_server_hash": null
+      },
+      "expected": "download"
+    },
+    {
+      "name": "empty-hashes-prove-nothing",
+      "rationale": "Both local hash and baseline are empty strings. They compare equal, but an empty hash cannot read as \"provably unchanged\" — absence of evidence resolves to conflict.",
+      "input": {
+        "local_hash": "",
+        "last_sync_hash": "",
+        "server_content_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_server_hash": null
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "empty-server-hash-no-match",
+      "rationale": "The server head carries no content hash (older or migrated save). A present local hash cannot match an absent server hash — uncertainty resolves to conflict.",
+      "input": {
+        "local_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "server_content_hash": "",
+        "last_sync_server_hash": null
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "stored-server-hash-alone-proves-nothing",
+      "rationale": "The stored server hash matches the live server head, but local diverged from the baseline. Provenance requires local to be unchanged since the baseline — a matching server-side pair says nothing about un-synced local work.",
+      "input": {
+        "local_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "last_sync_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "server_content_hash": "cccccccccccccccccccccccccccccccc",
+        "last_sync_server_hash": "cccccccccccccccccccccccccccccccc"
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "all-unknown",
+      "rationale": "No information at all. The safe default under uncertainty is conflict — never a silent overwrite in either direction.",
+      "input": {
+        "local_hash": null,
+        "last_sync_hash": null,
+        "server_content_hash": null,
+        "last_sync_server_hash": null
+      },
+      "expected": "conflict"
+    },
+    {
+      "name": "local-hash-unknown",
+      "rationale": "The local file's hash could not be computed. Without it neither ladder rule can prove safety, whatever the other inputs say.",
+      "input": {
+        "local_hash": null,
+        "last_sync_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "server_content_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_sync_server_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "expected": "conflict"
+    }
+  ]
+}

--- a/tests/domain/test_sync_action_gavel_vectors.py
+++ b/tests/domain/test_sync_action_gavel_vectors.py
@@ -1,0 +1,65 @@
+"""Self-conformance of the 409 resolution ladder against the published gavel contract.
+
+This tier proves ``domain.sync_action.resolve_upload_conflict`` still conforms to the gavel
+ladder contract — the normative 409-resolution spec that was extracted from this very kernel.
+The vendored JSON vectors under ``gavel_vectors/`` are the contract's normative artifact: each
+one pins a ``(local_hash, last_sync_hash, server_content_hash, last_sync_server_hash)`` input
+to the ladder outcome the spec mandates, so any drift between kernel and contract surfaces here
+as a failing vector. Vectors change only by a deliberate re-copy from upstream (see
+``gavel_vectors/README.md``) — never by editing them to match the kernel.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from domain.sync_action import resolve_upload_conflict
+
+_VECTORS_DIR = Path(__file__).parent / "gavel_vectors"
+
+
+def _load_vectors() -> tuple[list[tuple[dict[str, str | None], str, str | None]], list[str]]:
+    """Flatten every ``gavel_vectors/*.json`` file into parametrize argvalues + ids.
+
+    Returns a ``(argvalues, ids)`` pair. Each argvalue is
+    ``(input, expected, rationale)`` — ``rationale`` is ``None`` for the exhaustive
+    equivalence-class vectors, present on the curated named cases. Each id is
+    ``<filestem>:<vector name>`` so a failure names the offending vector directly.
+    """
+    argvalues: list[tuple[dict[str, str | None], str, str | None]] = []
+    ids: list[str] = []
+    for path in sorted(_VECTORS_DIR.glob("*.json")):
+        data: dict[str, Any] = json.loads(path.read_text(encoding="utf-8"))
+        for vector in data["vectors"]:
+            argvalues.append((vector["input"], vector["expected"], vector.get("rationale")))
+            ids.append(f"{path.stem}:{vector['name']}")
+    return argvalues, ids
+
+
+_ARGVALUES, _IDS = _load_vectors()
+
+# An empty glob is a vendoring regression (files deleted or moved), not a valid
+# "nothing to test" state — fail loudly at collection rather than silently pass.
+assert _ARGVALUES, f"no gavel vectors loaded from {_VECTORS_DIR}"
+
+
+@pytest.mark.parametrize(("vector_input", "expected", "rationale"), _ARGVALUES, ids=_IDS)
+def test_resolve_upload_conflict_conforms(
+    vector_input: dict[str, str | None],
+    expected: str,
+    rationale: str | None,
+) -> None:
+    result = resolve_upload_conflict(
+        vector_input["local_hash"],
+        vector_input["last_sync_hash"],
+        vector_input["server_content_hash"],
+        vector_input["last_sync_server_hash"],
+    )
+    context = f" — {rationale}" if rationale else ""
+    assert result == expected, (
+        f"gavel vector expected {expected!r}, kernel returned {result!r} for input {vector_input!r}{context}"
+    )


### PR DESCRIPTION
Vendors the gavel ladder conformance vectors into `tests/domain/gavel_vectors/` and runs all 161 of them against `domain/sync_action.resolve_upload_conflict` — self-conformance of the kernel against the published companion contract ([romm-gavel](https://github.com/danielcopper/romm-gavel) `vectors/ladder/` @ `b2e550b`, the contract that was extracted from this kernel).

- The two vector files are vendored **verbatim** (byte-for-byte); provenance and the update procedure (deliberate re-copy, no submodule, no network in CI) are documented in the vector directory's README.
- `tests/domain/test_sync_action_gavel_vectors.py` parametrizes every vector with `<file>:<name>` ids and surfaces the vector's rationale on mismatch — a kernel change that drifts from the contract fails CI here with a named case.
- Docs: new "Gavel conformance vectors" subsection in `docs/contributing/development.md` plus the corresponding tier paragraph in `CLAUDE.md`.

Part of #1461.