### PR TITLE
fix(saves): make wizard legacy migration content-based with a local-save collision decision (#1498)

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -3,6 +3,6 @@
     "name": "dist/index.js (raw)",
     "path": "dist/index.js",
     "brotli": false,
-    "limit": "750 KB"
+    "limit": "775 KB"
   }
 ]

--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -309,12 +309,15 @@ local target** (`<rom_name>.<ext>`, the same mapping `switch_slot` uses) the mig
    409-backstopped), adopting the per-file baseline — so the migrated slot is immediately in sync.
 
 The legacy source saves are **never deleted** — a migration copies their content into the slot and leaves the sources in
-the read-only legacy bucket. A per-target download or upload failure is **counted, not fatal**
-(`Could not migrate N
-save(s)`): the slot is still confirmed and the failed source is left in place, so no save that
-lives only in the legacy bucket is ever lost. The wizard names the target slot on **every** surface — the pre-click
-explainer under the legacy entry, the confirm modal, and the completion toast (`Migrated 1 save into 'default'`) — never
-log-only.
+the read-only legacy bucket. Deleting them would reopen the legacy-write door #1478/#1496 just closed and would yank the
+web player's bucket head away from a browser session still on the v1 player. A per-target download or upload failure is
+**counted, not fatal** (`Could not migrate N save(s)`): the slot is still confirmed and the failed source is left in
+place, so no save that lives only in the legacy bucket is ever lost. The wizard names the target slot on **every**
+surface — the pre-click explainer under the legacy entry ("the legacy save itself is left untouched"), the confirm
+modal, and the completion toast
+(`Migrated 1 save into 'default'. The legacy save stays in the read-only legacy
+bucket.`) — never log-only, and the
+completion copy pre-empts the "why is the legacy save still there?" confusion.
 
 #### Addressing legacy saves on the wire (#1061)
 

--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -304,9 +304,10 @@ local target** (`<rom_name>.<ext>`, the same mapping `switch_slot` uses) the mig
      sides' size + timestamp — the comparison that stops a newer local save being buried unnoticed. The dialog offers
      exactly two ways out: _Replace local save_ (the second call, with `use_server_on_conflict`), which quarantines the
      local file into `.romm-backup` (never deleted, #965) before writing the server content, or _Cancel_, which makes no
-     second call at all — nothing changes, the slot stays unconfirmed, and the wizard's start-fresh route ("Use slot
-     '<default>'") is still open. There is deliberately **no** "keep my local save" action: it would produce exactly the
-     same end state as that start-fresh button while re-opening a decision the user already made by clicking Track.
+     second call at all — nothing changes, the slot stays unconfirmed, and the wizard's start-fresh route
+     (`Use slot '<default>'`) is still open. There is deliberately **no** "keep my local save" action: it would produce
+     exactly the same end state as that start-fresh button while re-opening a decision the user already made by clicking
+     Track.
 3. Copies the content into the slot through the normal upload path (`do_upload_save`, `overwrite=false`,
    409-backstopped), adopting the per-file baseline — so the migrated slot is immediately in sync.
 

--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -310,13 +310,22 @@ local target** (`<rom_name>.<ext>`, the same mapping `switch_slot` uses) the mig
 
 The legacy source saves are **never deleted** — a migration copies their content into the slot and leaves the sources in
 the read-only legacy bucket. Deleting them would reopen the legacy-write door #1478/#1496 just closed and would yank the
-web player's bucket head away from a browser session still on the v1 player. A per-target download or upload failure is
-**counted, not fatal** (`Could not migrate N save(s)`): the slot is still confirmed and the failed source is left in
-place, so no save that lives only in the legacy bucket is ever lost. The wizard names the target slot on **every**
-surface — the pre-click explainer under the legacy entry ("the legacy save itself is left untouched"), the confirm
-modal, and the completion toast
-(`Migrated 1 save into 'default'. The legacy save stays in the read-only legacy
-bucket.`) — never log-only, and the
+web player's bucket head away from a browser session still on the v1 player.
+
+Failure handling splits on **whether the apply phase began** (#1498 review): the migration first checks its
+preconditions (a registered device — otherwise the #1478 upload guard would only fire _after_ local files were touched —
+and an installed ROM), then downloads every target to a scratch `.tmp` sibling (never the real save files) and
+classifies it. A **wholesale** failure _before_ the apply phase — the device/install precheck, a `list_saves` throw, or
+a phase-1 download throw — returns the **canonical failure** (`{success: false, reason, message}`, the `reason` from
+`classify_error`) and confirms **nothing**: the scratch temps are cleared and the wizard stays open on the message, so
+the user can simply retry Track. Once the apply phase begins, a **per-target** upload failure is **counted, not fatal**
+(`Could not migrate N save(s)`): the slot is still confirmed and the failed source is left in place, so no save that
+lives only in the legacy bucket is ever lost. (A migration whose server had no legacy saves is a no-op that confirms the
+slot silently; a requested migration can never return `success: true` with nothing migrated while legacy saves existed.)
+
+The wizard names the target slot on **every** surface — the pre-click explainer under the legacy entry ("the legacy save
+itself is left untouched"), the confirm modal, and the completion toast
+(`Migrated 1 save into 'default'. The legacy save stays in the read-only legacy bucket.`) — never log-only, and the
 completion copy pre-empts the "why is the legacy save still there?" confusion.
 
 #### Addressing legacy saves on the wire (#1061)

--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -284,6 +284,38 @@ backup.
   the server returns `slot: null`) so those saves can be read and deleted on the wire (below), but they are never the
   active slot of a confirmed ROM.
 
+#### Migrating legacy saves into a named slot (content-based, #1498)
+
+When the wizard's **Track** action carries a game's legacy (`slot:null`) saves into a chosen named slot, the migration
+is **content-based**, not filename-based. RomM's web player writes legacy saves under timestamped names (e.g.
+`Game [2026-07-19 13-41-44-611].srm`) that never equal the canonical local name, so the old filename-equality migration
+silently left the target slot empty (the [#1498](https://github.com/danielcopper/decky-romm-sync/issues/1498) defect,
+part of the [#1478](https://github.com/danielcopper/decky-romm-sync/issues/1478) triage). Instead, for each **canonical
+local target** (`<rom_name>.<ext>`, the same mapping `switch_slot` uses) the migration:
+
+1. Groups the legacy saves by the canonical filename each maps to — independent of the legacy row's own name — and picks
+   the **newest** by `updated_at` per target. Two legacy saves that resolve to one target collapse to the newest; the
+   older one is neither carried nor deleted.
+2. Downloads that save's **content** and classifies it against the local file:
+   - **No local file** → the content is written locally under the canonical name and copied into the slot.
+   - **Byte-identical** local file (same zip-aware content hash the sync kernel uses) → migrated silently.
+   - **Differing** local file → the wizard **asks** (a modal shows both sides' size + timestamp). _Use the server save_
+     quarantines the local file into `.romm-backup` (never deleted, #965) then replaces it with the server content;
+     _Keep my local save_ confirms the slot **without** migrating, leaving the legacy save in the read-only bucket — the
+     local file becomes the slot's first save on the next sync. A differing local file holds the whole migration: the
+     slot is **not** confirmed until the user chooses (`needs_conflict_resolution` + a `conflicts` list on the
+     response).
+3. Copies the content into the slot through the normal upload path (`do_upload_save`, `overwrite=false`,
+   409-backstopped), adopting the per-file baseline — so the migrated slot is immediately in sync.
+
+The legacy source saves are **never deleted** — a migration copies their content into the slot and leaves the sources in
+the read-only legacy bucket. A per-target download or upload failure is **counted, not fatal**
+(`Could not migrate N
+save(s)`): the slot is still confirmed and the failed source is left in place, so no save that
+lives only in the legacy bucket is ever lost. The wizard names the target slot on **every** surface — the pre-click
+explainer under the legacy entry, the confirm modal, and the completion toast (`Migrated 1 save into 'default'`) — never
+log-only.
+
 #### Addressing legacy saves on the wire (#1061)
 
 RomM filters the `slot` query param by **exact string match**, and legacy saves are stored as `slot: null` — which **no

--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -299,12 +299,14 @@ local target** (`<rom_name>.<ext>`, the same mapping `switch_slot` uses) the mig
 2. Downloads that save's **content** and classifies it against the local file:
    - **No local file** → the content is written locally under the canonical name and copied into the slot.
    - **Byte-identical** local file (same zip-aware content hash the sync kernel uses) → migrated silently.
-   - **Differing** local file → the wizard **asks** (a modal shows both sides' size + timestamp). _Use the server save_
-     quarantines the local file into `.romm-backup` (never deleted, #965) then replaces it with the server content;
-     _Keep my local save_ confirms the slot **without** migrating, leaving the legacy save in the read-only bucket — the
-     local file becomes the slot's first save on the next sync. A differing local file holds the whole migration: the
-     slot is **not** confirmed until the user chooses (`needs_conflict_resolution` + a `conflicts` list on the
-     response).
+   - **Differing** local file → the migration **holds** for an informed confirmation: nothing is migrated and the slot
+     is **not** confirmed (`needs_conflict_resolution` + a `conflicts` list on the response), and the wizard shows both
+     sides' size + timestamp — the comparison that stops a newer local save being buried unnoticed. The dialog offers
+     exactly two ways out: _Replace local save_ (the second call, with `use_server_on_conflict`), which quarantines the
+     local file into `.romm-backup` (never deleted, #965) before writing the server content, or _Cancel_, which makes no
+     second call at all — nothing changes, the slot stays unconfirmed, and the wizard's start-fresh route ("Use slot
+     '<default>'") is still open. There is deliberately **no** "keep my local save" action: it would produce exactly the
+     same end state as that start-fresh button while re-opening a decision the user already made by clicking Track.
 3. Copies the content into the slot through the normal upload path (`do_upload_save`, `overwrite=false`,
    409-backstopped), adopting the per-file baseline — so the migrated slot is immediately in sync.
 

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -110,7 +110,13 @@ aside into the `.romm-backup` folder next to your saves first, so nothing is los
 certain the small/empty local file is the one you want to keep — that uploads it and replaces the server copy.
 
 If you need to recover a save by hand, look in the `.romm-backup` folder inside your saves directory (e.g.
-`<saves_path>/gba/.romm-backup/`): every file the plugin moves aside is timestamped there.
+`<saves_path>/gba/.romm-backup/`): every file the plugin moves aside is timestamped there. The plugin moves a save aside
+whenever it is about to be overwritten or removed — not just when resolving a conflict with **Use Server**, but also
+when you switch save slots and when the setup wizard migrates a legacy save into a slot.
+
+Backups are **not** kept forever. The folder keeps the **newest 10 backups per save file**; older ones are pruned the
+next time that same save is moved aside. Backups of a different save file are never pruned to make room. If you want to
+keep a particular recovery copy long-term, move it out of `.romm-backup` yourself.
 
 ## Artwork Missing
 

--- a/main.py
+++ b/main.py
@@ -522,8 +522,12 @@ class Plugin:
         return await self._save_sync_service.get_save_setup_info(rom_id)
 
     @migration_blocked
-    async def confirm_slot_choice(self, rom_id, chosen_slot, migrate=False, migrate_from_slot=None):
-        return await self._save_sync_service.confirm_slot_choice(rom_id, chosen_slot, migrate, migrate_from_slot)
+    async def confirm_slot_choice(
+        self, rom_id, chosen_slot, migrate=False, migrate_from_slot=None, use_server_on_conflict=False
+    ):
+        return await self._save_sync_service.confirm_slot_choice(
+            rom_id, chosen_slot, migrate, migrate_from_slot, use_server_on_conflict
+        )
 
     @migration_blocked
     async def sync_all_saves(self):

--- a/py_modules/services/saves/_helpers.py
+++ b/py_modules/services/saves/_helpers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from domain.iso_time import parse_iso_to_epoch
 from domain.save_path import compute_local_save_target
 
 _logger = logging.getLogger(__name__)
@@ -26,3 +27,24 @@ def local_save_target(server_save: dict[str, Any], rom_name: str) -> str:
             server_save.get("file_extension", "srm"),
         )
     return result.filename
+
+
+def newest_server_saves_by_target(server_saves: list[dict[str, Any]], rom_name: str) -> dict[str, dict[str, Any]]:
+    """Pick the newest server save per canonical local target.
+
+    Groups *server_saves* by the canonical on-disk filename each would download
+    into (:func:`local_save_target` — ``<rom_name>.<ext>``, independent of the
+    server row's own filename) and keeps only the newest by ``updated_at`` per
+    target, so a target's carried save is deterministic rather than
+    server-list-order dependent (#1058). Keyed by the canonical target filename.
+    Shared by the slot-switch state sync and the setup wizard's legacy migration.
+    """
+    newest: dict[str, dict[str, Any]] = {}
+    for ss in server_saves:
+        target = local_save_target(ss, rom_name)
+        current = newest.get(target)
+        if current is None or (parse_iso_to_epoch(ss.get("updated_at")) or 0.0) > (
+            parse_iso_to_epoch(current.get("updated_at")) or 0.0
+        ):
+            newest[target] = ss
+    return newest

--- a/py_modules/services/saves/_messages.py
+++ b/py_modules/services/saves/_messages.py
@@ -15,6 +15,12 @@ DEVICE_NOT_REGISTERED = "Device not registered"
 # domain-specific skip/guard categories, not server-reachability failures.
 SAVE_SYNC_DISABLED_REASON = "sync_disabled"
 DEVICE_NOT_REGISTERED_REASON = "device_not_registered"
+# Wizard legacy-migration precheck: no device is registered yet, so the migration
+# can't upload into the slot. Refused before any local/server mutation so the
+# wizard just stays open and the user can retry (#1498 review).
+MIGRATION_DEVICE_NOT_REGISTERED = (
+    "This device isn't registered with RomM yet — retry in a moment (it registers automatically on the next save sync)."
+)
 # RomM's per-device ``sync_enabled`` switch is off server-side (the negotiate 400
 # policy stop, #1489). Distinct from ``sync_disabled``, which is the LOCAL toggle.
 DEVICE_SYNC_DISABLED_REASON = "device_sync_disabled"

--- a/py_modules/services/saves/service.py
+++ b/py_modules/services/saves/service.py
@@ -299,14 +299,20 @@ class SaveService:
         chosen_slot: str | None,
         migrate: bool = False,
         migrate_from_slot: str | None = None,
+        use_server_on_conflict: bool = False,
     ) -> dict[str, Any]:
         """Confirm which slot to use for a game's save sync.
 
-        ``chosen_slot`` is ``None`` for the legacy slot or the slot name. Migration
-        runs only when ``migrate`` is true, carrying saves from ``migrate_from_slot``
-        (``None`` = the legacy no-slot source) into ``chosen_slot``.
+        ``chosen_slot`` is the slot name. Migration runs only when ``migrate`` is
+        true, copying the newest legacy save per canonical target from
+        ``migrate_from_slot`` (``None`` = the legacy no-slot source) into
+        ``chosen_slot`` (#1498). A differing local save is held for the user's
+        decision unless ``use_server_on_conflict`` resolves it in the server's
+        favour.
         """
-        return await self._slots.confirm_slot_choice(rom_id, chosen_slot, migrate, migrate_from_slot)
+        return await self._slots.confirm_slot_choice(
+            rom_id, chosen_slot, migrate, migrate_from_slot, use_server_on_conflict
+        )
 
     async def get_slot_delete_info(self, rom_id: int, slot: str) -> dict[str, Any]:
         """Return info about what deleting a slot would do, for the confirmation modal."""

--- a/py_modules/services/saves/slots/service.py
+++ b/py_modules/services/saves/slots/service.py
@@ -174,9 +174,12 @@ class SlotsService:
         chosen_slot: str | None,
         migrate: bool = False,
         migrate_from_slot: str | None = None,
+        use_server_on_conflict: bool = False,
     ) -> dict[str, Any]:
         """Confirm which slot to use for a game's save sync."""
-        return await self._setup.confirm_slot_choice(rom_id, chosen_slot, migrate, migrate_from_slot)
+        return await self._setup.confirm_slot_choice(
+            rom_id, chosen_slot, migrate, migrate_from_slot, use_server_on_conflict
+        )
 
     # ------------------------------------------------------------------
     # Slot deletion — delegates to :class:`SlotDeleter`.

--- a/py_modules/services/saves/slots/setup.py
+++ b/py_modules/services/saves/slots/setup.py
@@ -18,8 +18,13 @@ from domain.iso_time import epoch_to_iso, parse_iso_to_epoch
 from domain.rom_save_sync_state import RomSaveSyncState
 from domain.save_layout import SAVE_SYNC_CONTENT_DIR_REASON
 from domain.save_slot import save_in_slot
+from lib.errors import classify_error
 from services.saves._helpers import newest_server_saves_by_target
-from services.saves._messages import SAVE_SYNC_IN_CONTENT_DIR
+from services.saves._messages import (
+    DEVICE_NOT_REGISTERED_REASON,
+    MIGRATION_DEVICE_NOT_REGISTERED,
+    SAVE_SYNC_IN_CONTENT_DIR,
+)
 from services.saves._settings import autocleanup_limit, resolve_default_slot
 
 if TYPE_CHECKING:
@@ -290,9 +295,31 @@ class SetupWizard:
                     "message": SAVE_SYNC_IN_CONTENT_DIR,
                 }
 
+            # Migration preconditions, checked BEFORE any confirm or mutation so
+            # a precondition failure holds the wizard open (no half-state) and the
+            # user can retry Track (#1498 review). A missing device would only
+            # surface as the #1478 upload guard AFTER local files were already
+            # touched, so it must be caught here first.
+            device_id = await self._loop.run_in_executor(None, self._device_registry.get_device_id)
+            if not device_id:
+                return {
+                    "success": False,
+                    "reason": DEVICE_NOT_REGISTERED_REASON,
+                    "needs_conflict_resolution": False,
+                    "message": MIGRATION_DEVICE_NOT_REGISTERED,
+                }
+            info = await self._loop.run_in_executor(None, self._rom_info.get_rom_save_info, rom_id)
+            if not info:
+                return {
+                    "success": False,
+                    "reason": "not_installed",
+                    "needs_conflict_resolution": False,
+                    "message": "ROM is not installed",
+                }
+
             # Confirm in memory so the migration uploads resolve to the chosen
-            # slot, but persist only once the migration resolves without an
-            # unanswered local-file conflict.
+            # slot, but persist only once the migration reaches the apply phase
+            # without an unanswered local-file conflict.
             save_state.confirm_slot(normalized_slot)
             try:
                 outcome = await self._loop.run_in_executor(
@@ -302,19 +329,24 @@ class SetupWizard:
                     migrate_from_slot,
                     use_server_on_conflict,
                     save_state,
+                    device_id,
+                    info,
                 )
             except Exception as e:
-                self._logger.warning(f"confirm_slot_choice({rom_id}): migration failed: {e}")
-                await self._loop.run_in_executor(None, self._write_save_state, rom_id, save_state)
+                # Wholesale failure BEFORE the apply phase (list_saves or a phase-1
+                # download threw) — nothing durable was mutated (only scratch
+                # temps, cleaned up). Do NOT confirm: return the canonical failure
+                # so the wizard stays open on the message and Track can be retried.
+                reason, message = classify_error(e)
+                self._logger.warning(f"confirm_slot_choice({rom_id}): migration failed before apply: {e}")
                 return {
-                    "success": True,
+                    "success": False,
+                    "reason": reason,
                     "needs_conflict_resolution": False,
-                    "message": f"Slot confirmed but migration failed: {e}",
-                    "migrated": 0,
-                    "failed": 0,
+                    "message": message,
                 }
 
-            if outcome["conflicts"]:
+            if outcome["status"] == "conflict":
                 # A local save differs — hold for the user. Do NOT persist the
                 # confirm; the wizard re-calls (keep-local → migrate=false;
                 # use-server → use_server_on_conflict=true).
@@ -326,7 +358,18 @@ class SetupWizard:
                     "conflicts": outcome["conflicts"],
                 }
 
+            # ``no_op`` (server had no legacy saves) and ``migrated`` (the apply
+            # phase ran) both confirm the slot. A partial per-target failure in
+            # the apply phase is counted, not fatal (confirm-with-warning).
             await self._loop.run_in_executor(None, self._write_save_state, rom_id, save_state)
+            if outcome["status"] == "no_op":
+                return {
+                    "success": True,
+                    "needs_conflict_resolution": False,
+                    "message": f"Slot '{normalized_slot}' confirmed",
+                    "migrated": 0,
+                    "failed": 0,
+                }
             return {
                 "success": True,
                 "needs_conflict_resolution": False,
@@ -341,45 +384,47 @@ class SetupWizard:
         migrate_from_slot: str | None,
         use_server_on_conflict: bool,
         save_state: RomSaveSyncState,
+        device_id: str,
+        info: dict[str, Any],
     ) -> dict[str, Any]:
         """Copy the newest legacy save per canonical target into the confirmed slot.
 
         Synchronous worker (run via ``run_in_executor``) — acquires no
         ``rom_lock``, so it is safe under the lock ``confirm_slot_choice`` holds.
-        Content-based: for each canonical target it downloads the newest legacy
-        save's content to a sibling temp, classifies it against the local file
-        (``no_local`` / ``identical`` / ``differs``), and either copies it into
-        the slot — adopting the per-file baseline via
+        ``device_id`` and ``info`` are the caller's already-validated
+        preconditions. Content-based: for each canonical target it downloads the
+        newest legacy save's content to a sibling temp, classifies it against the
+        local file (``no_local`` / ``identical`` / ``differs``), and either copies
+        it into the slot — adopting the per-file baseline via
         :meth:`SyncEngine.do_upload_save`, which uploads to the slot *save_state*
         was just confirmed with — or, for a differing local file with
         ``use_server_on_conflict`` unset, records a conflict for the wizard. The
         legacy source saves are never deleted; they stay in the read-only legacy
-        bucket (#1478). Returns ``{"conflicts": [...], "migrated": int,
-        "failed": int}``.
+        bucket (#1478).
+
+        Returns a discriminated result: ``{"status": "no_op"}`` (server had no
+        legacy saves), ``{"status": "conflict", "conflicts": [...]}`` (a differing
+        local save needs the user's decision), or ``{"status": "migrated",
+        "migrated": int, "failed": int}`` (the apply phase ran). The **wholesale**
+        pre-apply failures — a ``list_saves`` throw or a phase-1 download throw —
+        **propagate** so the caller returns a canonical failure without
+        confirming: phase 1 writes only scratch ``.tmp`` files (never the real
+        save files) and the ``finally`` clears them, so nothing durable is
+        mutated before the apply phase begins.
         """
-        device_id = self._device_registry.get_device_id()
+        rom_name = info["rom_name"]
+        saves_dir = info["saves_dir"]
+        system = info["system"]
+
         # The legacy source (None/"") can't be addressed by ``slot=`` (RomM
         # stores it as null), so list ALL saves and filter client-side via
-        # save_in_slot (#1061).
+        # save_in_slot (#1061). A throw here propagates → wholesale failure.
         all_saves = self._retry.with_retry(
             lambda: self._romm_api.list_saves(rom_id, device_id=device_id),
         )
         legacy_saves = [s for s in all_saves if save_in_slot(s, migrate_from_slot)]
         if not legacy_saves:
-            return {"conflicts": [], "migrated": 0, "failed": 0}
-
-        info = self._rom_info.get_rom_save_info(rom_id)
-        if not info:
-            # The wizard is reached from an installed game; a missing install
-            # here leaves no ``saves_dir`` to place the content, so nothing is
-            # migrated (the caller still confirms the slot).
-            self._logger.warning(
-                f"_migrate_slot_saves_io({rom_id}): ROM not installed — cannot migrate legacy saves",
-            )
-            return {"conflicts": [], "migrated": 0, "failed": 0}
-        rom_name = info["rom_name"]
-        saves_dir = info["saves_dir"]
-        system = info["system"]
+            return {"status": "no_op"}
 
         targets = newest_server_saves_by_target(legacy_saves, rom_name)
         core_so = self._resolve_core(rom_id)
@@ -387,60 +432,60 @@ class SetupWizard:
         cleanup_limit = autocleanup_limit(self._settings)
         self._save_file_store.make_dirs(saves_dir)
 
-        # Phase 1 — download + classify every target before touching any local
-        # file, so an unanswered conflict holds without having migrated anything.
-        plans: list[dict[str, Any]] = []
-        conflicts: list[dict[str, Any]] = []
-        for target, server_save in targets.items():
-            local_path = os.path.join(saves_dir, target)
-            tmp_path = local_path + ".tmp"
-            self._retry.with_retry(
-                lambda sid=server_save["id"], tp=tmp_path: self._romm_api.download_save(sid, tp),
-            )
-            server_hash = self._save_file_store.content_hash(tmp_path)
-            if not self._save_file_store.is_file(local_path):
-                kind = "no_local"
-            elif self._save_file_store.content_hash(local_path) == server_hash:
-                kind = "identical"
-            else:
-                kind = "differs"
-            plans.append(
-                {
-                    "target": target,
-                    "local_path": local_path,
-                    "tmp_path": tmp_path,
-                    "kind": kind,
-                }
-            )
-            if kind == "differs" and not use_server_on_conflict:
-                conflicts.append(self._build_migration_conflict(target, server_save, local_path))
+        # Every ``.tmp`` created below is scratch cleaned up on ANY exit: a
+        # mid-phase-1 download throw, a conflict hold, or the apply phase (whose
+        # rename/remove already consumes each temp, leaving the cleanup a no-op).
+        created_temps: list[str] = []
+        try:
+            # Phase 1 — download + classify every target before touching any local
+            # file, so an unanswered conflict (or a download throw) holds without
+            # having migrated anything.
+            plans: list[dict[str, Any]] = []
+            conflicts: list[dict[str, Any]] = []
+            for target, server_save in targets.items():
+                local_path = os.path.join(saves_dir, target)
+                tmp_path = local_path + ".tmp"
+                created_temps.append(tmp_path)
+                self._retry.with_retry(
+                    lambda sid=server_save["id"], tp=tmp_path: self._romm_api.download_save(sid, tp),
+                )
+                server_hash = self._save_file_store.content_hash(tmp_path)
+                if not self._save_file_store.is_file(local_path):
+                    kind = "no_local"
+                elif self._save_file_store.content_hash(local_path) == server_hash:
+                    kind = "identical"
+                else:
+                    kind = "differs"
+                plans.append({"target": target, "local_path": local_path, "tmp_path": tmp_path, "kind": kind})
+                if kind == "differs" and not use_server_on_conflict:
+                    conflicts.append(self._build_migration_conflict(target, server_save, local_path))
 
-        if conflicts:
-            # Hold for the user — discard every downloaded temp, migrate nothing.
+            if conflicts:
+                # Hold for the user — migrate nothing (temps cleared in finally).
+                return {"status": "conflict", "conflicts": conflicts}
+
+            # Phase 2 — apply. From here mutations begin; a per-target failure is
+            # counted, not fatal: the slot is still confirmed by the caller and the
+            # failed legacy source is left in place (never deleted), so no data
+            # that lives only there is lost.
+            migrated = 0
+            failed = 0
             for plan in plans:
+                try:
+                    self._apply_migration_plan(
+                        plan, rom_id, save_state, device_id, saves_dir, system, core_so, default_slot, cleanup_limit
+                    )
+                    migrated += 1
+                except Exception as e:
+                    self._logger.warning(
+                        f"_migrate_slot_saves_io({rom_id}): failed to migrate {plan['target']}: {e}",
+                    )
+                    failed += 1
+            return {"status": "migrated", "migrated": migrated, "failed": failed}
+        finally:
+            for tmp_path in created_temps:
                 with contextlib.suppress(OSError):
-                    self._save_file_store.remove_file(plan["tmp_path"])
-            return {"conflicts": conflicts, "migrated": 0, "failed": 0}
-
-        # Phase 2 — apply. A per-target failure is counted, not fatal: the slot
-        # is still confirmed by the caller and the failed legacy source is left
-        # in place (never deleted), so no data that lives only there is lost.
-        migrated = 0
-        failed = 0
-        for plan in plans:
-            try:
-                self._apply_migration_plan(
-                    plan, rom_id, save_state, device_id, saves_dir, system, core_so, default_slot, cleanup_limit
-                )
-                migrated += 1
-            except Exception as e:
-                self._logger.warning(
-                    f"_migrate_slot_saves_io({rom_id}): failed to migrate {plan['target']}: {e}",
-                )
-                failed += 1
-                with contextlib.suppress(OSError):
-                    self._save_file_store.remove_file(plan["tmp_path"])
-        return {"conflicts": [], "migrated": migrated, "failed": failed}
+                    self._save_file_store.remove_file(tmp_path)
 
     def _apply_migration_plan(
         self,

--- a/py_modules/services/saves/slots/setup.py
+++ b/py_modules/services/saves/slots/setup.py
@@ -10,13 +10,15 @@ operation's own narrow Unit of Work (ADR-0006).
 
 from __future__ import annotations
 
+import contextlib
+import os
 from typing import TYPE_CHECKING, Any
 
-from domain.emulator_tag import build_emulator_tag
-from domain.iso_time import parse_iso_to_epoch
+from domain.iso_time import epoch_to_iso, parse_iso_to_epoch
 from domain.rom_save_sync_state import RomSaveSyncState
 from domain.save_layout import SAVE_SYNC_CONTENT_DIR_REASON
-from domain.save_slot import save_in_slot, slot_query_param
+from domain.save_slot import save_in_slot
+from services.saves._helpers import newest_server_saves_by_target
 from services.saves._messages import SAVE_SYNC_IN_CONTENT_DIR
 from services.saves._settings import autocleanup_limit, resolve_default_slot
 
@@ -202,6 +204,7 @@ class SetupWizard:
         chosen_slot: str | None,
         migrate: bool = False,
         migrate_from_slot: str | None = None,
+        use_server_on_conflict: bool = False,
     ) -> dict[str, Any]:
         """Confirm which slot to use for a game's save sync.
 
@@ -212,17 +215,30 @@ class SetupWizard:
         legacy no-slot mode can no longer be confirmed as a target (#1276) — it
         survives only as a migration *source*.
 
-        When ``migrate`` is true, migrates saves from ``migrate_from_slot``
-        (``None`` = the legacy no-slot source) into ``chosen_slot``: upload local
-        files to ``chosen_slot``, then delete the old server saves. ``migrate``
-        defaults to false (no migration).
+        When ``migrate`` is true, the newest legacy (``migrate_from_slot``,
+        ``None`` = the legacy no-slot source) server save per canonical local
+        target is downloaded and copied into ``chosen_slot`` under the canonical
+        name — content-based, independent of the legacy row's own filename or of
+        any local file (#1498). The per-target collision matrix:
+
+        - **No local file** or a **byte-identical** local file → migrated
+          silently (content copied into the slot, baseline adopted).
+        - A **differing** local file → held for the user's decision unless
+          ``use_server_on_conflict`` is set. Without it, the slot is *not*
+          confirmed and the response carries ``needs_conflict_resolution=True`` +
+          a ``conflicts`` list (both sides' timestamp/size) so the wizard can ask.
+          With it, the differing local file is quarantined into ``.romm-backup``
+          (never deleted, #965) before the server content replaces it.
+
+        The legacy source saves are never deleted — a migration copies their
+        content into the slot and leaves the sources in the read-only legacy
+        bucket (#1478).
 
         When a migration is requested but RetroArch writes saves to the content
-        dir (#239), the migration is refused before any upload/delete (the local
-        files it would carry are not under ``saves_dir``); the response carries
-        ``success=False`` with ``reason="savefiles_in_content_dir"``. The slot
+        dir (#239), the migration is refused before any download; the slot
         confirmation itself — a non-destructive metadata flip — is still
-        persisted. The non-migration path is never gated (no file write).
+        persisted (``reason="savefiles_in_content_dir"``). The non-migration path
+        is never gated (no file write).
         """
         rom_id = int(rom_id)
         # Legacy ``slot:null`` confirmation is retired (#1276): a slot must carry
@@ -248,130 +264,246 @@ class SetupWizard:
 
         # The read→confirm→(migrate)→write of the RomSaveSyncState aggregate must
         # serialise against every other path that touches this ROM's state.
-        # content_dir_blocked and _migrate_slot_saves do NOT acquire rom_lock,
+        # content_dir_blocked and _migrate_slot_saves_io do NOT acquire rom_lock,
         # so calling them inside the held lock is safe (no re-entry).
         async with self._sync_engine.rom_lock(rom_id):
-            # Load → confirm in memory; migration I/O runs outside the txn.
             save_state = await self._loop.run_in_executor(None, self._read_save_state, rom_id) or RomSaveSyncState()
-            save_state.confirm_slot(normalized_slot)
 
-            # Migration: re-upload local files to new slot, delete old server saves
-            if migrate:
-                # #239: RetroArch writes saves to the content dir — the migration
-                # uploads local files read from ``saves_dir``, which holds nothing
-                # in content-dir mode, so the migration could not carry real saves.
-                # Refuse the migration before any upload/delete; the slot itself is
-                # still confirmed in state (a non-destructive metadata flip).
-                if await self._sync_engine.content_dir_blocked("confirm_slot_choice"):
-                    self._log_debug(f"confirm_slot_choice: content-dir layout for rom {rom_id}; skipping migration")
-                    await self._loop.run_in_executor(None, self._write_save_state, rom_id, save_state)
-                    return {
-                        "success": False,
-                        "reason": SAVE_SYNC_CONTENT_DIR_REASON,
-                        "needs_conflict_resolution": False,
-                        "message": SAVE_SYNC_IN_CONTENT_DIR,
-                    }
-                # normalized_slot is always a non-empty named target now (#1276);
-                # migrate_from_slot can be None (legacy no-slot source) or a named slot.
-                try:
-                    await self._migrate_slot_saves(rom_id, normalized_slot, migrate_from_slot)
-                except Exception as e:
-                    self._logger.warning(f"confirm_slot_choice({rom_id}): migration failed: {e}")
-                    await self._loop.run_in_executor(None, self._write_save_state, rom_id, save_state)
-                    return {
-                        "success": True,
-                        "needs_conflict_resolution": False,
-                        "message": f"Slot confirmed but migration failed: {e}",
-                    }
+            # Non-migration path: a plain, non-destructive metadata flip.
+            if not migrate:
+                save_state.confirm_slot(normalized_slot)
+                await self._loop.run_in_executor(None, self._write_save_state, rom_id, save_state)
+                return {"success": True, "needs_conflict_resolution": False, "message": "Slot confirmed"}
+
+            # #239: RetroArch writes saves to the content dir — the migration
+            # would write into ``saves_dir``, which RetroArch ignores in that
+            # layout. Refuse before any download; the slot itself is still
+            # confirmed (a non-destructive metadata flip).
+            if await self._sync_engine.content_dir_blocked("confirm_slot_choice"):
+                self._log_debug(f"confirm_slot_choice: content-dir layout for rom {rom_id}; skipping migration")
+                save_state.confirm_slot(normalized_slot)
+                await self._loop.run_in_executor(None, self._write_save_state, rom_id, save_state)
+                return {
+                    "success": False,
+                    "reason": SAVE_SYNC_CONTENT_DIR_REASON,
+                    "needs_conflict_resolution": False,
+                    "message": SAVE_SYNC_IN_CONTENT_DIR,
+                }
+
+            # Confirm in memory so the migration uploads resolve to the chosen
+            # slot, but persist only once the migration resolves without an
+            # unanswered local-file conflict.
+            save_state.confirm_slot(normalized_slot)
+            try:
+                outcome = await self._loop.run_in_executor(
+                    None,
+                    self._migrate_slot_saves_io,
+                    rom_id,
+                    migrate_from_slot,
+                    use_server_on_conflict,
+                    save_state,
+                )
+            except Exception as e:
+                self._logger.warning(f"confirm_slot_choice({rom_id}): migration failed: {e}")
+                await self._loop.run_in_executor(None, self._write_save_state, rom_id, save_state)
+                return {
+                    "success": True,
+                    "needs_conflict_resolution": False,
+                    "message": f"Slot confirmed but migration failed: {e}",
+                    "migrated": 0,
+                    "failed": 0,
+                }
+
+            if outcome["conflicts"]:
+                # A local save differs — hold for the user. Do NOT persist the
+                # confirm; the wizard re-calls (keep-local → migrate=false;
+                # use-server → use_server_on_conflict=true).
+                return {
+                    "success": False,
+                    "needs_conflict_resolution": True,
+                    "reason": "local_conflict",
+                    "message": f"A local save differs from the legacy save for slot '{normalized_slot}'",
+                    "conflicts": outcome["conflicts"],
+                }
 
             await self._loop.run_in_executor(None, self._write_save_state, rom_id, save_state)
-            return {"success": True, "needs_conflict_resolution": False, "message": "Slot confirmed"}
+            return {
+                "success": True,
+                "needs_conflict_resolution": False,
+                "message": f"Migrated {outcome['migrated']} save(s) into '{normalized_slot}'",
+                "migrated": outcome["migrated"],
+                "failed": outcome["failed"],
+            }
 
-    async def _migrate_slot_saves(
+    def _migrate_slot_saves_io(
         self,
         rom_id: int,
-        chosen_slot: str | None,
         migrate_from_slot: str | None,
-    ) -> None:
-        """Migrate server saves from one slot to another.
+        use_server_on_conflict: bool,
+        save_state: RomSaveSyncState,
+    ) -> dict[str, Any]:
+        """Copy the newest legacy save per canonical target into the confirmed slot.
 
-        Only saves that were actually re-uploaded (a local file matched the
-        save's ``file_name`` AND the upload succeeded) are deleted from the old
-        slot — #1005-safe: a save with no local counterpart is left untouched so
-        the migration never destroys data that exists nowhere else. Saves that
-        could not be carried over are collected and reported. Safe order for the
-        carried-over saves: POST first, DELETE after.
+        Synchronous worker (run via ``run_in_executor``) — acquires no
+        ``rom_lock``, so it is safe under the lock ``confirm_slot_choice`` holds.
+        Content-based: for each canonical target it downloads the newest legacy
+        save's content to a sibling temp, classifies it against the local file
+        (``no_local`` / ``identical`` / ``differs``), and either copies it into
+        the slot — adopting the per-file baseline via
+        :meth:`SyncEngine.do_upload_save`, which uploads to the slot *save_state*
+        was just confirmed with — or, for a differing local file with
+        ``use_server_on_conflict`` unset, records a conflict for the wizard. The
+        legacy source saves are never deleted; they stay in the read-only legacy
+        bucket (#1478). Returns ``{"conflicts": [...], "migrated": int,
+        "failed": int}``.
         """
-        device_id = await self._loop.run_in_executor(None, self._device_registry.get_device_id)
-
-        # Find server saves in the old slot. The legacy source (None/"") can't be
-        # addressed by ``slot=`` (RomM stores it as null), so list ALL saves and
-        # filter client-side via save_in_slot (#1061).
-        all_saves = await self._loop.run_in_executor(
-            None,
-            lambda: self._retry.with_retry(
-                lambda: self._romm_api.list_saves(rom_id, device_id=device_id),
-            ),
+        device_id = self._device_registry.get_device_id()
+        # The legacy source (None/"") can't be addressed by ``slot=`` (RomM
+        # stores it as null), so list ALL saves and filter client-side via
+        # save_in_slot (#1061).
+        all_saves = self._retry.with_retry(
+            lambda: self._romm_api.list_saves(rom_id, device_id=device_id),
         )
-        old_slot_saves = [s for s in all_saves if save_in_slot(s, migrate_from_slot)]
-        if not old_slot_saves:
-            return
+        legacy_saves = [s for s in all_saves if save_in_slot(s, migrate_from_slot)]
+        if not legacy_saves:
+            return {"conflicts": [], "migrated": 0, "failed": 0}
 
-        # Get local files for re-upload
-        local_files = self._rom_info.find_save_files(rom_id)
-        local_by_name = {lf["filename"]: lf for lf in local_files}
-
-        # Resolve emulator tag
-        core_so = await self._loop.run_in_executor(None, self._resolve_core, rom_id)
-        emulator = build_emulator_tag(core_so)
-
-        # Carry-over uploads POST a new entry into the chosen slot, so the user's
-        # retention cap applies here too (RomM autocleanup defaults off → without
-        # it, repeated migrations stack uncapped).
-        cleanup_limit = autocleanup_limit(self._settings)
-
-        ids_to_delete: list[int] = []
-        not_carried: list[str] = []
-
-        for old_save in old_slot_saves:
-            fname = old_save.get("file_name", "")
-            local_file = local_by_name.get(fname)
-            old_id = old_save.get("id")
-            if not (local_file and self._save_file_store.is_file(local_file["path"])):
-                # No local counterpart → cannot carry it over. Do NOT delete it
-                # (it would vanish from the server with no re-upload, #1005).
-                not_carried.append(fname)
-                continue
-            # Upload to new slot, then mark the old id for deletion. Only on a
-            # successful upload — a failed upload propagates and aborts the loop
-            # before its old id is queued, so nothing un-carried is deleted.
-            await self._loop.run_in_executor(
-                None,
-                lambda lf=local_file, em=emulator: self._retry.with_retry(
-                    lambda: self._romm_api.upload_save(
-                        rom_id,
-                        lf["path"],
-                        em,
-                        device_id=device_id,
-                        slot=slot_query_param(chosen_slot),
-                        autocleanup_limit=cleanup_limit,
-                    ),
-                ),
-            )
-            if old_id is not None:
-                ids_to_delete.append(old_id)
-
-        if not_carried:
+        info = self._rom_info.get_rom_save_info(rom_id)
+        if not info:
+            # The wizard is reached from an installed game; a missing install
+            # here leaves no ``saves_dir`` to place the content, so nothing is
+            # migrated (the caller still confirms the slot).
             self._logger.warning(
-                f"_migrate_slot_saves({rom_id}): {len(not_carried)} old save(s) had no local file to carry "
-                f"over and were left in place: {not_carried}",
+                f"_migrate_slot_saves_io({rom_id}): ROM not installed — cannot migrate legacy saves",
             )
+            return {"conflicts": [], "migrated": 0, "failed": 0}
+        rom_name = info["rom_name"]
+        saves_dir = info["saves_dir"]
+        system = info["system"]
 
-        # Delete only the carried-over saves
-        if ids_to_delete:
-            await self._loop.run_in_executor(
-                None,
-                lambda: self._retry.with_retry(
-                    lambda: self._romm_api.delete_server_saves(ids_to_delete),
-                ),
+        targets = newest_server_saves_by_target(legacy_saves, rom_name)
+        core_so = self._resolve_core(rom_id)
+        default_slot = resolve_default_slot(self._settings)
+        cleanup_limit = autocleanup_limit(self._settings)
+        self._save_file_store.make_dirs(saves_dir)
+
+        # Phase 1 — download + classify every target before touching any local
+        # file, so an unanswered conflict holds without having migrated anything.
+        plans: list[dict[str, Any]] = []
+        conflicts: list[dict[str, Any]] = []
+        for target, server_save in targets.items():
+            local_path = os.path.join(saves_dir, target)
+            tmp_path = local_path + ".tmp"
+            self._retry.with_retry(
+                lambda sid=server_save["id"], tp=tmp_path: self._romm_api.download_save(sid, tp),
             )
+            server_hash = self._save_file_store.content_hash(tmp_path)
+            if not self._save_file_store.is_file(local_path):
+                kind = "no_local"
+            elif self._save_file_store.content_hash(local_path) == server_hash:
+                kind = "identical"
+            else:
+                kind = "differs"
+            plans.append(
+                {
+                    "target": target,
+                    "local_path": local_path,
+                    "tmp_path": tmp_path,
+                    "kind": kind,
+                }
+            )
+            if kind == "differs" and not use_server_on_conflict:
+                conflicts.append(self._build_migration_conflict(target, server_save, local_path))
+
+        if conflicts:
+            # Hold for the user — discard every downloaded temp, migrate nothing.
+            for plan in plans:
+                with contextlib.suppress(OSError):
+                    self._save_file_store.remove_file(plan["tmp_path"])
+            return {"conflicts": conflicts, "migrated": 0, "failed": 0}
+
+        # Phase 2 — apply. A per-target failure is counted, not fatal: the slot
+        # is still confirmed by the caller and the failed legacy source is left
+        # in place (never deleted), so no data that lives only there is lost.
+        migrated = 0
+        failed = 0
+        for plan in plans:
+            try:
+                self._apply_migration_plan(
+                    plan, rom_id, save_state, device_id, saves_dir, system, core_so, default_slot, cleanup_limit
+                )
+                migrated += 1
+            except Exception as e:
+                self._logger.warning(
+                    f"_migrate_slot_saves_io({rom_id}): failed to migrate {plan['target']}: {e}",
+                )
+                failed += 1
+                with contextlib.suppress(OSError):
+                    self._save_file_store.remove_file(plan["tmp_path"])
+        return {"conflicts": [], "migrated": migrated, "failed": failed}
+
+    def _apply_migration_plan(
+        self,
+        plan: dict[str, Any],
+        rom_id: int,
+        save_state: RomSaveSyncState,
+        device_id: str | None,
+        saves_dir: str,
+        system: str,
+        core_so: str | None,
+        default_slot: str | None,
+        cleanup_limit: int | None,
+    ) -> None:
+        """Place one target's server content locally and upload it into the slot.
+
+        ``identical`` keeps the local file (the temp is redundant); ``no_local``
+        moves the downloaded content into place; ``differs`` — reached only with
+        ``use_server_on_conflict`` — quarantines the local file first (#965) then
+        replaces it. The final upload copies the local file into the confirmed
+        slot and adopts the per-file baseline (:meth:`SyncEngine.do_upload_save`).
+        """
+        target = plan["target"]
+        local_path = plan["local_path"]
+        tmp_path = plan["tmp_path"]
+        kind = plan["kind"]
+
+        if kind == "identical":
+            with contextlib.suppress(OSError):
+                self._save_file_store.remove_file(tmp_path)
+        else:
+            if kind == "differs":
+                self._sync_engine.quarantine_local_file(saves_dir, target)
+            self._save_file_store.rename(tmp_path, local_path)
+
+        self._sync_engine.do_upload_save(
+            rom_id,
+            local_path,
+            target,
+            save_state,
+            device_id,
+            system,
+            core_so,
+            default_slot=default_slot,
+            autocleanup_limit=cleanup_limit,
+        )
+
+    def _build_migration_conflict(
+        self,
+        target: str,
+        server_save: dict[str, Any],
+        local_path: str,
+    ) -> dict[str, Any]:
+        """Describe a legacy-vs-local collision for the wizard's resolution dialog.
+
+        Carries both sides' timestamp/size so the wizard can render them: the
+        server side from the legacy save row, the local side from the on-disk
+        file.
+        """
+        return {
+            "filename": target,
+            "server_save_id": server_save.get("id"),
+            "server_updated_at": server_save.get("updated_at", ""),
+            "server_size": server_save.get("file_size_bytes"),
+            "local_mtime": epoch_to_iso(self._save_file_store.get_mtime(local_path)),
+            "local_size": self._save_file_store.get_size(local_path),
+        }

--- a/py_modules/services/saves/slots/switching.py
+++ b/py_modules/services/saves/slots/switching.py
@@ -12,12 +12,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from domain.iso_time import parse_iso_to_epoch
 from domain.rom_save_sync_state import RomSaveSyncState
 from domain.save_layout import SAVE_SYNC_CONTENT_DIR_REASON
 from domain.save_slot import save_in_slot
 from lib.list_result import ErrorCode
-from services.saves._helpers import local_save_target
+from services.saves._helpers import newest_server_saves_by_target
 from services.saves._messages import SAVE_SYNC_IN_CONTENT_DIR
 from services.saves._settings import resolve_default_slot, save_sync_enabled
 
@@ -262,7 +261,7 @@ class SlotSwitcher:
 
             # 7. Make the saves dir + tracking coherent with the new slot:
             default_slot = resolve_default_slot(self._settings)
-            targets = self._newest_server_saves_by_target(slot_saves, info["rom_name"])
+            targets = newest_server_saves_by_target(slot_saves, info["rom_name"])
             switch_errors = await self._loop.run_in_executor(
                 None, self._apply_slot_switch, rom_id, saves_dir, system, save_state, device_id, targets, default_slot
             )
@@ -282,29 +281,6 @@ class SlotSwitcher:
         # get_save_status re-acquires rom_lock(rom_id), which would self-deadlock.
         save_status = await self._status_service.get_save_status(rom_id)
         return {"success": True, "save_status": save_status}
-
-    @staticmethod
-    def _newest_server_saves_by_target(slot_saves: list[dict[str, Any]], rom_name: str) -> dict[str, dict[str, Any]]:
-        """Pick the newest server save per canonical local target.
-
-        Two server saves mapping to one local target (e.g. both resolve to
-        ``<rom_name>.srm``) collapse to only the newest by ``updated_at``, so the
-        on-disk result + ``tracked_save_id`` are deterministic rather than
-        server-list-order dependent (#1058). Keyed by the canonical target
-        filename the save downloads into.
-        """
-        newest: dict[str, dict[str, Any]] = {}
-        for ss in slot_saves:
-            target = local_save_target(ss, rom_name)
-            current = newest.get(target)
-            if current is None:
-                newest[target] = ss
-                continue
-            if (parse_iso_to_epoch(ss.get("updated_at")) or 0.0) > (
-                parse_iso_to_epoch(current.get("updated_at")) or 0.0
-            ):
-                newest[target] = ss
-        return newest
 
     def _apply_slot_switch(
         self,

--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -32,6 +32,7 @@ import type {
   SwitchSlotResponse,
   LaunchVerdict,
   SlotDeleteInfo,
+  SlotMigrationConflict,
   DeleteSlotResult,
   MigrationStatus,
   MigrationResult,
@@ -583,15 +584,27 @@ export const isSaveTrackingConfigured = callable<[number], { configured: boolean
   "is_save_tracking_configured",
 );
 export const getSaveSetupInfo = callable<[number], SaveSetupInfo>("get_save_setup_info");
-// confirm_slot_choice(rom_id, chosen_slot, migrate, migrate_from_slot):
+// confirm_slot_choice(rom_id, chosen_slot, migrate, migrate_from_slot, use_server_on_conflict):
 // `chosen_slot` must be a non-empty named slot — legacy `slot:null` confirmation
 // is retired (#1276), so an empty/`null` target is rejected by the backend's
 // `invalid_slot_name` guard. `migrate` is an explicit boolean — the
 // non-destructive paths pass `false`; `migrate_from_slot` is `null` unless
 // migrating (then the source slot, with `null` meaning the legacy no-slot source).
+// A content-based migration (#1498) that finds a differing local save returns
+// `needs_conflict_resolution: true` + `conflicts` and confirms nothing — the
+// wizard asks; `use_server_on_conflict: true` resolves in the server's favour
+// (quarantine local, replace with the server content). On success the response
+// carries `migrated`/`failed` counts for the completion copy.
 export const confirmSlotChoice = callable<
-  [number, string, boolean, string | null],
-  { success: boolean; needs_conflict_resolution?: boolean; message: string }
+  [number, string, boolean, string | null, boolean],
+  {
+    success: boolean;
+    needs_conflict_resolution?: boolean;
+    message: string;
+    conflicts?: SlotMigrationConflict[];
+    migrated?: number;
+    failed?: number;
+  }
 >("confirm_slot_choice");
 export const checkCoreChange = callable<
   [number],

--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -600,6 +600,10 @@ export const confirmSlotChoice = callable<
   {
     success: boolean;
     needs_conflict_resolution?: boolean;
+    // Canonical failure slug on a wholesale (pre-apply) migration failure —
+    // e.g. "server_unreachable" / "device_not_registered" / "not_installed".
+    // The wizard surfaces `message`; `reason` is for routing/telemetry parity.
+    reason?: string;
     message: string;
     conflicts?: SlotMigrationConflict[];
     migrated?: number;

--- a/src/components/SlotSetupWizard.test.tsx
+++ b/src/components/SlotSetupWizard.test.tsx
@@ -3,6 +3,7 @@ import { render, fireEvent, act } from "@testing-library/react";
 import { createElement, type ChangeEvent, type ReactElement } from "react";
 import { SlotSetupWizard } from "./SlotSetupWizard";
 import * as backend from "../api/backend";
+import { toaster } from "@decky/api";
 import { showModal } from "@decky/ui";
 import {
   applyWizardInitialSetupResult,
@@ -60,6 +61,7 @@ vi.mock("@decky/ui", () => {
     );
   return {
     ConfirmModal,
+    ModalRoot: (p: AnyProps) => createElement("div", { "data-testid": "modal-root" }, p.children as never),
     DialogButton: ({ children, onClick, disabled }: AnyProps & { onClick?: () => void; disabled?: boolean }) =>
       createElement("button", { onClick, disabled }, children as never),
     TextField: (p: TextFieldProps) =>
@@ -442,7 +444,7 @@ describe("SlotSetupWizard", () => {
         await Promise.resolve();
       });
 
-      expect(vi.mocked(backend.confirmSlotChoice)).toHaveBeenCalledWith(5, "alpha", false, null);
+      expect(vi.mocked(backend.confirmSlotChoice)).toHaveBeenCalledWith(5, "alpha", false, null, false);
       expect(onComplete).toHaveBeenCalledOnce();
     });
 
@@ -473,9 +475,9 @@ describe("SlotSetupWizard", () => {
         await Promise.resolve();
       });
 
-      expect(vi.mocked(backend.confirmSlotChoice)).toHaveBeenCalledWith(5, "fallback", true, null);
+      expect(vi.mocked(backend.confirmSlotChoice)).toHaveBeenCalledWith(5, "fallback", true, null, false);
       // The legacy null slot is never confirmed as-is (retired, #1276).
-      expect(vi.mocked(backend.confirmSlotChoice)).not.toHaveBeenCalledWith(5, null, false, null);
+      expect(vi.mocked(backend.confirmSlotChoice)).not.toHaveBeenCalledWith(5, null, false, null, false);
     });
 
     it("surfaces a failed confirmSlotChoice via the inline error", async () => {
@@ -545,6 +547,159 @@ describe("SlotSetupWizard", () => {
     });
   });
 
+  describe("legacy migration content-based flow (#1498)", () => {
+    const legacyInfo = () =>
+      makeSetupInfo({
+        default_slot: "default",
+        server_slots: [{ slot: null, saves: [], count: 1, latest_updated_at: null }],
+      });
+
+    const conflictResult = () => ({
+      success: false,
+      needs_conflict_resolution: true,
+      message: "A local save differs",
+      conflicts: [
+        {
+          filename: "game.srm",
+          server_save_id: 1,
+          server_updated_at: "2026-01-01T00:00:00Z",
+          server_size: 200,
+          local_mtime: "2026-01-02T00:00:00Z",
+          local_size: 100,
+        },
+      ],
+    });
+
+    it("shows the legacy migration explainer before Track is clicked", async () => {
+      vi.mocked(applyWizardInitialSetupResult).mockImplementation(async (_r, deps) => {
+        deps.setInfo(legacyInfo());
+      });
+      const { container } = render(<SlotSetupWizard {...defaultProps()} />);
+      await flushAsync();
+      expect(container.textContent).toContain("Tracking copies the legacy save");
+    });
+
+    it("shows the start-fresh hint when there are local saves", async () => {
+      const info = makeSetupInfo({
+        default_slot: "fresh",
+        has_local_saves: true,
+        local_files: [{ filename: "game.srm", size: 100 }],
+        server_slots: [{ slot: "alpha", saves: [], count: 1, latest_updated_at: null }],
+      });
+      vi.mocked(applyWizardInitialSetupResult).mockImplementation(async (_r, deps) => {
+        deps.setInfo(info);
+      });
+      const { container } = render(<SlotSetupWizard {...defaultProps()} />);
+      await flushAsync();
+      expect(container.textContent).toContain("becomes the first save in ‘fresh’ on the next sync");
+    });
+
+    it("fires the migration outcome toast naming the slot on success", async () => {
+      vi.mocked(applyWizardInitialSetupResult).mockImplementation(async (_r, deps) => {
+        deps.setInfo(legacyInfo());
+      });
+      vi.mocked(backend.confirmSlotChoice).mockResolvedValue({ success: true, message: "", migrated: 1, failed: 0 });
+      const onComplete = vi.fn();
+      const { getByText } = render(<SlotSetupWizard {...defaultProps({ romId: 5, onComplete })} />);
+      await flushAsync();
+
+      fireEvent.click(getByText("Track"));
+      const migrateModal = confirmModalPropsAt(0);
+      await act(async () => {
+        await migrateModal?.onOK?.();
+        await Promise.resolve();
+      });
+
+      expect(vi.mocked(backend.confirmSlotChoice)).toHaveBeenCalledWith(5, "default", true, null, false);
+      expect(vi.mocked(toaster.toast)).toHaveBeenCalledWith({
+        title: "RomM Sync",
+        body: "Migrated 1 save into ‘default’",
+      });
+      expect(onComplete).toHaveBeenCalledOnce();
+    });
+
+    it("opens the conflict modal on needs_conflict_resolution and does not complete", async () => {
+      vi.mocked(applyWizardInitialSetupResult).mockImplementation(async (_r, deps) => {
+        deps.setInfo(legacyInfo());
+      });
+      vi.mocked(backend.confirmSlotChoice).mockResolvedValue(conflictResult());
+      const onComplete = vi.fn();
+      const { getByText } = render(<SlotSetupWizard {...defaultProps({ romId: 5, onComplete })} />);
+      await flushAsync();
+
+      fireEvent.click(getByText("Track"));
+      const migrateModal = confirmModalPropsAt(0);
+      await act(async () => {
+        await migrateModal?.onOK?.();
+        await Promise.resolve();
+      });
+
+      // The confirm modal (call 0) plus the conflict modal (call 1).
+      expect(vi.mocked(showModal)).toHaveBeenCalledTimes(2);
+      const conflictModal = modalElementAt(1);
+      if (!conflictModal) throw new Error("conflict modal not captured");
+      const sub = render(<>{conflictModal}</>);
+      expect(sub.container.textContent).toContain("game.srm");
+      expect(sub.container.textContent).toContain("Your local save");
+      expect(sub.container.textContent).toContain("Legacy save on server");
+      sub.unmount();
+      // Nothing completed — the user still has to choose.
+      expect(onComplete).not.toHaveBeenCalled();
+    });
+
+    it("'Use the server save' re-calls confirm with useServerOnConflict=true", async () => {
+      vi.mocked(applyWizardInitialSetupResult).mockImplementation(async (_r, deps) => {
+        deps.setInfo(legacyInfo());
+      });
+      vi.mocked(backend.confirmSlotChoice)
+        .mockResolvedValueOnce(conflictResult())
+        .mockResolvedValueOnce({ success: true, message: "", migrated: 1, failed: 0 });
+      const { getByText } = render(<SlotSetupWizard {...defaultProps({ romId: 5 })} />);
+      await flushAsync();
+
+      fireEvent.click(getByText("Track"));
+      const migrateModal = confirmModalPropsAt(0);
+      await act(async () => {
+        await migrateModal?.onOK?.();
+        await Promise.resolve();
+      });
+
+      const sub = render(<>{modalElementAt(1)}</>);
+      await act(async () => {
+        fireEvent.click(sub.getByText("Use the server save"));
+        await Promise.resolve();
+      });
+      expect(vi.mocked(backend.confirmSlotChoice)).toHaveBeenLastCalledWith(5, "default", true, null, true);
+      sub.unmount();
+    });
+
+    it("'Keep my local save' re-calls confirm without migrating", async () => {
+      vi.mocked(applyWizardInitialSetupResult).mockImplementation(async (_r, deps) => {
+        deps.setInfo(legacyInfo());
+      });
+      vi.mocked(backend.confirmSlotChoice)
+        .mockResolvedValueOnce(conflictResult())
+        .mockResolvedValueOnce({ success: true, message: "" });
+      const { getByText } = render(<SlotSetupWizard {...defaultProps({ romId: 5 })} />);
+      await flushAsync();
+
+      fireEvent.click(getByText("Track"));
+      const migrateModal = confirmModalPropsAt(0);
+      await act(async () => {
+        await migrateModal?.onOK?.();
+        await Promise.resolve();
+      });
+
+      const sub = render(<>{modalElementAt(1)}</>);
+      await act(async () => {
+        fireEvent.click(sub.getByText("Keep my local save"));
+        await Promise.resolve();
+      });
+      expect(vi.mocked(backend.confirmSlotChoice)).toHaveBeenLastCalledWith(5, "default", false, null, false);
+      sub.unmount();
+    });
+  });
+
   describe("default-slot button visibility", () => {
     it("renders the 'Use slot' button when the default is not in server_slots", async () => {
       const info = makeSetupInfo({
@@ -598,7 +753,7 @@ describe("SlotSetupWizard", () => {
         await Promise.resolve();
       });
 
-      expect(vi.mocked(backend.confirmSlotChoice)).toHaveBeenCalledWith(9, "fresh", false, null);
+      expect(vi.mocked(backend.confirmSlotChoice)).toHaveBeenCalledWith(9, "fresh", false, null, false);
     });
   });
 
@@ -650,7 +805,7 @@ describe("SlotSetupWizard", () => {
         await Promise.resolve();
       });
 
-      expect(vi.mocked(backend.confirmSlotChoice)).toHaveBeenCalledWith(21, "myslot", false, null);
+      expect(vi.mocked(backend.confirmSlotChoice)).toHaveBeenCalledWith(21, "myslot", false, null, false);
       // Non-empty submit must NOT open the legacy-mode prompt.
       expect(vi.mocked(showModal)).toHaveBeenCalledTimes(1);
       sub.unmount();
@@ -677,7 +832,7 @@ describe("SlotSetupWizard", () => {
         await Promise.resolve();
       });
 
-      expect(vi.mocked(backend.confirmSlotChoice)).toHaveBeenCalledWith(3, "padded", false, null);
+      expect(vi.mocked(backend.confirmSlotChoice)).toHaveBeenCalledWith(3, "padded", false, null, false);
       sub.unmount();
     });
 
@@ -704,7 +859,7 @@ describe("SlotSetupWizard", () => {
       });
 
       // The empty name goes straight to the backend guard; only the one modal opened.
-      expect(vi.mocked(backend.confirmSlotChoice)).toHaveBeenCalledWith(8, "", false, null);
+      expect(vi.mocked(backend.confirmSlotChoice)).toHaveBeenCalledWith(8, "", false, null, false);
       expect(vi.mocked(showModal)).toHaveBeenCalledTimes(1);
       sub.unmount();
     });
@@ -734,9 +889,9 @@ describe("SlotSetupWizard", () => {
         await Promise.resolve();
       });
 
-      expect(vi.mocked(backend.confirmSlotChoice)).toHaveBeenCalledWith(7, "", false, null);
+      expect(vi.mocked(backend.confirmSlotChoice)).toHaveBeenCalledWith(7, "", false, null, false);
       // Never confirms the retired legacy null slot, and no second modal opens.
-      expect(vi.mocked(backend.confirmSlotChoice)).not.toHaveBeenCalledWith(7, null, false, null);
+      expect(vi.mocked(backend.confirmSlotChoice)).not.toHaveBeenCalledWith(7, null, false, null, false);
       expect(vi.mocked(showModal)).toHaveBeenCalledTimes(1);
       sub.unmount();
     });

--- a/src/components/SlotSetupWizard.test.tsx
+++ b/src/components/SlotSetupWizard.test.tsx
@@ -570,13 +570,14 @@ describe("SlotSetupWizard", () => {
       ],
     });
 
-    it("shows the legacy migration explainer before Track is clicked", async () => {
+    it("shows the legacy migration explainer naming the target slot before Track is clicked", async () => {
       vi.mocked(applyWizardInitialSetupResult).mockImplementation(async (_r, deps) => {
         deps.setInfo(legacyInfo());
       });
       const { container } = render(<SlotSetupWizard {...defaultProps()} />);
       await flushAsync();
-      expect(container.textContent).toContain("Tracking copies the legacy save");
+      expect(container.textContent).toContain("Tracking copies the legacy save into ‘default’");
+      expect(container.textContent).not.toContain("into a named slot");
     });
 
     it("shows the start-fresh hint when there are local saves", async () => {
@@ -677,7 +678,7 @@ describe("SlotSetupWizard", () => {
       expect(onComplete).not.toHaveBeenCalled();
     });
 
-    it("'Use the server save' re-calls confirm with useServerOnConflict=true", async () => {
+    it("'Replace local save' re-calls confirm with useServerOnConflict=true", async () => {
       vi.mocked(applyWizardInitialSetupResult).mockImplementation(async (_r, deps) => {
         deps.setInfo(legacyInfo());
       });
@@ -696,21 +697,22 @@ describe("SlotSetupWizard", () => {
 
       const sub = render(<>{modalElementAt(1)}</>);
       await act(async () => {
-        fireEvent.click(sub.getByText("Use the server save"));
+        fireEvent.click(sub.getByText("Replace local save"));
         await Promise.resolve();
       });
       expect(vi.mocked(backend.confirmSlotChoice)).toHaveBeenLastCalledWith(5, "default", true, null, true);
       sub.unmount();
     });
 
-    it("'Keep my local save' re-calls confirm without migrating", async () => {
+    it("Cancel changes nothing — no second call, wizard still open with Track available", async () => {
+      // Cancelling the conflict dialog must leave the slot unconfirmed and the
+      // wizard usable, so the user can take the start-fresh route instead.
       vi.mocked(applyWizardInitialSetupResult).mockImplementation(async (_r, deps) => {
         deps.setInfo(legacyInfo());
       });
-      vi.mocked(backend.confirmSlotChoice)
-        .mockResolvedValueOnce(conflictResult())
-        .mockResolvedValueOnce({ success: true, message: "" });
-      const { getByText } = render(<SlotSetupWizard {...defaultProps({ romId: 5 })} />);
+      vi.mocked(backend.confirmSlotChoice).mockResolvedValue(conflictResult());
+      const onComplete = vi.fn();
+      const { getByText, container } = render(<SlotSetupWizard {...defaultProps({ romId: 5, onComplete })} />);
       await flushAsync();
 
       fireEvent.click(getByText("Track"));
@@ -720,12 +722,21 @@ describe("SlotSetupWizard", () => {
         await Promise.resolve();
       });
 
+      // One probe call so far (the Track click).
+      expect(vi.mocked(backend.confirmSlotChoice)).toHaveBeenCalledTimes(1);
+
       const sub = render(<>{modalElementAt(1)}</>);
       await act(async () => {
-        fireEvent.click(sub.getByText("Keep my local save"));
+        fireEvent.click(sub.getByText("Cancel"));
         await Promise.resolve();
       });
-      expect(vi.mocked(backend.confirmSlotChoice)).toHaveBeenLastCalledWith(5, "default", false, null, false);
+
+      // No second call — nothing was migrated and nothing was confirmed.
+      expect(vi.mocked(backend.confirmSlotChoice)).toHaveBeenCalledTimes(1);
+      expect(onComplete).not.toHaveBeenCalled();
+      // The wizard is still usable for the start-fresh route.
+      expect(getByText("Track")).toBeTruthy();
+      expect(container.textContent).toContain("Use slot");
       sub.unmount();
     });
   });

--- a/src/components/SlotSetupWizard.test.tsx
+++ b/src/components/SlotSetupWizard.test.tsx
@@ -580,7 +580,7 @@ describe("SlotSetupWizard", () => {
       expect(container.textContent).not.toContain("into a named slot");
     });
 
-    it("shows the start-fresh hint when there are local saves", async () => {
+    it("shows the start-fresh hint when there are local saves, without duplicating it for the custom route", async () => {
       const info = makeSetupInfo({
         default_slot: "fresh",
         has_local_saves: true,
@@ -593,6 +593,45 @@ describe("SlotSetupWizard", () => {
       const { container } = render(<SlotSetupWizard {...defaultProps()} />);
       await flushAsync();
       expect(container.textContent).toContain("becomes the first save in ‘fresh’ on the next sync");
+      // Both start-fresh routes are on screen — the hint must appear once, not twice.
+      expect(container.textContent).not.toContain("in the new slot on the next sync");
+    });
+
+    it("shows the slot-agnostic next-sync hint for the custom route when the start-fresh block is hidden", async () => {
+      // The default slot already exists on the server, so "Use slot ‘…’" (and its
+      // named hint) is gone and "Custom slot..." is the only start-fresh route —
+      // it still has to tell the user the local save uploads on the next sync.
+      const info = makeSetupInfo({
+        default_slot: "alpha",
+        has_local_saves: true,
+        local_files: [{ filename: "game.srm", size: 100 }],
+        server_slots: [{ slot: "alpha", saves: [], count: 1, latest_updated_at: null }],
+      });
+      vi.mocked(applyWizardInitialSetupResult).mockImplementation(async (_r, deps) => {
+        deps.setInfo(info);
+      });
+      const { container } = render(<SlotSetupWizard {...defaultProps()} />);
+      await flushAsync();
+      expect(container.textContent).not.toContain("Use slot");
+      expect(container.textContent).toContain("Custom slot...");
+      expect(container.textContent).toContain("becomes the first save in the new slot on the next sync");
+      // Never names a slot the user isn't choosing.
+      expect(container.textContent).not.toContain("in ‘alpha’ on the next sync");
+    });
+
+    it("shows no next-sync hint at all when there are no local saves", async () => {
+      const info = makeSetupInfo({
+        default_slot: "alpha",
+        has_local_saves: false,
+        local_files: [],
+        server_slots: [{ slot: "alpha", saves: [], count: 1, latest_updated_at: null }],
+      });
+      vi.mocked(applyWizardInitialSetupResult).mockImplementation(async (_r, deps) => {
+        deps.setInfo(info);
+      });
+      const { container } = render(<SlotSetupWizard {...defaultProps()} />);
+      await flushAsync();
+      expect(container.textContent).not.toContain("on the next sync");
     });
 
     it("fires the migration outcome toast naming the slot on success", async () => {

--- a/src/components/SlotSetupWizard.test.tsx
+++ b/src/components/SlotSetupWizard.test.tsx
@@ -618,6 +618,36 @@ describe("SlotSetupWizard", () => {
       expect(onComplete).toHaveBeenCalledOnce();
     });
 
+    it("shows the message and stays open (retryable) on a wholesale migration failure", async () => {
+      // A pre-apply failure (e.g. device not registered / server unreachable)
+      // returns the canonical failure; the wizard must surface it and stay
+      // usable — never confirm-and-close (#1498 review).
+      vi.mocked(applyWizardInitialSetupResult).mockImplementation(async (_r, deps) => {
+        deps.setInfo(legacyInfo());
+      });
+      vi.mocked(backend.confirmSlotChoice).mockResolvedValue({
+        success: false,
+        needs_conflict_resolution: false,
+        reason: "device_not_registered",
+        message: "This device isn't registered with RomM yet — retry in a moment.",
+      });
+      const onComplete = vi.fn();
+      const { getByText, container } = render(<SlotSetupWizard {...defaultProps({ romId: 5, onComplete })} />);
+      await flushAsync();
+
+      fireEvent.click(getByText("Track"));
+      const migrateModal = confirmModalPropsAt(0);
+      await act(async () => {
+        await migrateModal?.onOK?.();
+        await Promise.resolve();
+      });
+
+      expect(container.textContent).toContain("This device isn't registered");
+      expect(onComplete).not.toHaveBeenCalled();
+      // Wizard stays usable — the Track button is still rendered for a retry.
+      expect(getByText("Track")).toBeTruthy();
+    });
+
     it("opens the conflict modal on needs_conflict_resolution and does not complete", async () => {
       vi.mocked(applyWizardInitialSetupResult).mockImplementation(async (_r, deps) => {
         deps.setInfo(legacyInfo());

--- a/src/components/SlotSetupWizard.test.tsx
+++ b/src/components/SlotSetupWizard.test.tsx
@@ -613,7 +613,7 @@ describe("SlotSetupWizard", () => {
       expect(vi.mocked(backend.confirmSlotChoice)).toHaveBeenCalledWith(5, "default", true, null, false);
       expect(vi.mocked(toaster.toast)).toHaveBeenCalledWith({
         title: "RomM Sync",
-        body: "Migrated 1 save into ‘default’",
+        body: "Migrated 1 save into ‘default’. The legacy save stays in the read-only legacy bucket.",
       });
       expect(onComplete).toHaveBeenCalledOnce();
     });

--- a/src/components/SlotSetupWizard.tsx
+++ b/src/components/SlotSetupWizard.tsx
@@ -1,10 +1,15 @@
 import { useState, useEffect, useRef, FC, createElement, ChangeEvent } from "react";
-import { DialogButton, ConfirmModal, TextField, showModal } from "@decky/ui";
+import { toaster } from "@decky/api";
+import { DialogButton, ConfirmModal, ModalRoot, TextField, showModal } from "@decky/ui";
 import { getSaveSetupInfo, confirmSlotChoice, logError } from "../api/backend";
 import { scrollFocusedToCenter } from "../utils/scrollHelpers";
 import {
   applyWizardInitialSetupResult,
   applyWizardRetrySetupResult,
+  legacyMigrateConfirmDescription,
+  startFreshHint,
+  wizardMigrationOutcomeToastBody,
+  LEGACY_TRACK_EXPLAINER,
   SERVER_UNREACHABLE_WIZARD_MESSAGE,
 } from "../utils/saveSetup";
 import {
@@ -14,7 +19,7 @@ import {
   setServerRetryProgress,
 } from "../utils/connectionState";
 import { formatBytes } from "../utils/formatters";
-import type { SaveSetupInfo } from "../types";
+import type { SaveSetupInfo, SlotMigrationConflict } from "../types";
 import { detach } from "../utils/detach";
 import { ConnectingIndicator } from "./saves/ConnectingIndicator";
 import { displaySlot } from "./saves/helpers";
@@ -85,6 +90,95 @@ const CustomSlotModal: FC<{
       value,
       onChange: (e: ChangeEvent<HTMLInputElement>) => setValue(e.target.value),
     }),
+  );
+};
+
+/** "unknown" for a null/zero byte count; otherwise the shared byte formatter. */
+function formatSize(bytes: number | null): string {
+  if (bytes == null || bytes === 0) return "unknown";
+  return formatBytes(bytes);
+}
+
+/** Resolution dialog for a legacy migration whose target already has a differing
+ *  local save (#1498). Both sides are shown with size + timestamp; the choice is
+ *  global across every listed conflict (each one closes the modal, then fires the
+ *  matching backend re-call). "Use the server save" quarantines the local file
+ *  first; "Keep my local save" leaves the legacy save in the read-only bucket and
+ *  makes the local file the slot's first save on the next sync. */
+const LegacyMigrationConflictModal: FC<{
+  closeModal?: () => void;
+  conflicts: SlotMigrationConflict[];
+  slot: string;
+  onUseServer: () => void;
+  onKeepLocal: () => void;
+}> = ({ closeModal, conflicts, slot, onUseServer, onKeepLocal }) => {
+  const resolve = (choice: () => void) => {
+    closeModal?.();
+    choice();
+  };
+  return (
+    <ModalRoot {...(closeModal !== undefined ? { closeModal } : {})}>
+      <div style={{ padding: "8px 4px", minWidth: "360px" }}>
+        <div style={{ fontSize: "15px", fontWeight: "bold", color: "#fff", marginBottom: "4px" }}>
+          A local save differs from the legacy save
+        </div>
+        <div style={{ fontSize: "12px", color: "rgba(255, 255, 255, 0.6)", marginBottom: "12px", lineHeight: "1.4" }}>
+          Choose which save to keep in &lsquo;{slot}&rsquo;.
+        </div>
+        {conflicts.map((c) => (
+          <div key={c.filename} style={{ marginBottom: "10px" }}>
+            <div style={{ fontSize: "12px", color: "#fff", marginBottom: "4px" }}>{c.filename}</div>
+            <div style={{ display: "flex", gap: "8px" }}>
+              <div
+                style={{
+                  flex: 1,
+                  padding: "8px",
+                  background: "rgba(76, 175, 80, 0.15)",
+                  border: "1px solid rgba(76, 175, 80, 0.3)",
+                  borderRadius: "4px",
+                }}
+              >
+                <div style={{ fontSize: "11px", fontWeight: "bold", color: "#81c784", marginBottom: "2px" }}>
+                  Your local save
+                </div>
+                <div style={{ fontSize: "11px", color: "rgba(255, 255, 255, 0.7)" }}>
+                  {formatSize(c.local_size)} · modified {formatTimestamp(c.local_mtime)}
+                </div>
+              </div>
+              <div
+                style={{
+                  flex: 1,
+                  padding: "8px",
+                  background: "rgba(33, 150, 243, 0.15)",
+                  border: "1px solid rgba(33, 150, 243, 0.3)",
+                  borderRadius: "4px",
+                }}
+              >
+                <div style={{ fontSize: "11px", fontWeight: "bold", color: "#64b5f6", marginBottom: "2px" }}>
+                  Legacy save on server
+                </div>
+                <div style={{ fontSize: "11px", color: "rgba(255, 255, 255, 0.7)" }}>
+                  {formatSize(c.server_size)} · saved {formatTimestamp(c.server_updated_at)}
+                </div>
+              </div>
+            </div>
+          </div>
+        ))}
+        <div style={{ fontSize: "11px", color: "rgba(255, 255, 255, 0.5)", margin: "4px 0 12px", lineHeight: "1.4" }}>
+          &ldquo;Use the server save&rdquo; backs up your local file to .romm-backup first. &ldquo;Keep my local
+          save&rdquo; leaves the legacy save in the read-only legacy bucket and uploads your local file on the next
+          sync.
+        </div>
+        <div style={{ display: "flex", gap: "8px", justifyContent: "flex-end" }}>
+          <DialogButton style={btnStyle} onClick={() => resolve(onKeepLocal)} onFocus={scrollFocusedToCenter}>
+            Keep my local save
+          </DialogButton>
+          <DialogButton style={btnPrimaryStyle} onClick={() => resolve(onUseServer)} onFocus={scrollFocusedToCenter}>
+            Use the server save
+          </DialogButton>
+        </div>
+      </div>
+    </ModalRoot>
   );
 };
 
@@ -179,19 +273,48 @@ export const SlotSetupWizard: FC<SlotSetupWizardProps> = ({ romId, onComplete })
     [],
   );
 
-  const handleConfirm = async (slot: string, migrate = false, migrateFrom: string | null = null) => {
+  const handleConfirm = async (
+    slot: string,
+    migrate = false,
+    migrateFrom: string | null = null,
+    useServerOnConflict = false,
+  ) => {
     setConfirming(true);
     setError(null);
     try {
       // Confirm a non-empty named slot (legacy slot:null is retired, #1276).
       // Defaults are the non-destructive path (migrate=false, from=null); the
-      // legacy-group Track button passes migrate=true, from=null to carry the
-      // legacy saves into the target slot.
-      const result = await confirmSlotChoice(romId, slot, migrate, migrateFrom);
+      // legacy-group Track button passes migrate=true, from=null to copy the
+      // legacy saves into the target slot (#1498).
+      const result = await confirmSlotChoice(romId, slot, migrate, migrateFrom, useServerOnConflict);
+
+      // A content-based migration found a differing local save — nothing was
+      // confirmed. Ask the user, then re-call: "Use the server save" migrates
+      // (quarantine local), "Keep my local save" confirms without migrating.
+      if (result.needs_conflict_resolution) {
+        setConfirming(false);
+        showModal(
+          createElement(LegacyMigrationConflictModal, {
+            conflicts: result.conflicts ?? [],
+            slot,
+            onUseServer: () => detach(handleConfirm(slot, true, migrateFrom, true)),
+            onKeepLocal: () => detach(handleConfirm(slot, false, null, false)),
+          }),
+        );
+        return;
+      }
+
       if (!result.success) {
         setError(result.message || "Slot confirmation failed");
         setConfirming(false);
         return;
+      }
+
+      // Surface the migration outcome (names the slot + counts) so the copy is
+      // never log-only. Only a migration reports counts; a plain confirm doesn't.
+      if (migrate) {
+        const body = wizardMigrationOutcomeToastBody(result.migrated ?? 0, result.failed ?? 0, slot);
+        if (body) toaster.toast({ title: "RomM Sync", body });
       }
       onComplete();
     } catch (e) {
@@ -303,14 +426,13 @@ export const SlotSetupWizard: FC<SlotSetupWizardProps> = ({ romId, onComplete })
           key={`slot-${slotKey}`}
           style={{
             padding: "6px 0",
-            borderBottom: "1px solid rgba(255, 255, 255, 0.06)",
             display: "flex",
             alignItems: "center",
             justifyContent: "space-between",
             gap: "8px",
           }}
         >
-          <div>
+          <div style={{ minWidth: 0 }}>
             <div style={{ display: "flex", alignItems: "center", gap: "6px", fontSize: "13px", color: "#fff" }}>
               <span className="romm-status-dot" style={{ backgroundColor: "#1a9fff" }} />
               {displaySlot(s.slot)}
@@ -319,6 +441,13 @@ export const SlotSetupWizard: FC<SlotSetupWizardProps> = ({ romId, onComplete })
               {s.count} file{s.count === 1 ? "" : "s"}
               {s.latest_updated_at ? ` \u2014 ${formatTimestamp(s.latest_updated_at)}` : ""}
             </div>
+            {/* Pre-click explainer so the legacy "Track" reads as a migration
+                before it is clicked, not only inside the confirm modal (#1498). */}
+            {isLegacyGroup ? (
+              <div className="romm-panel-muted" style={{ fontSize: "11px", marginLeft: "18px", marginTop: "2px" }}>
+                {LEGACY_TRACK_EXPLAINER}
+              </div>
+            ) : null}
           </div>
           <DialogButton
             className="romm-wizard-btn"
@@ -326,12 +455,13 @@ export const SlotSetupWizard: FC<SlotSetupWizardProps> = ({ romId, onComplete })
             onClick={() => {
               if (isLegacyGroup) {
                 // Legacy (no-slot) saves can no longer be tracked as-is (#1276).
-                // Offer to migrate them into the default slot rather than
-                // confirming the retired legacy mode.
+                // Offer to copy them into the default slot rather than confirming
+                // the retired legacy mode. A differing local save is asked about
+                // by the backend after OK (#1498).
                 showModal(
                   createElement(ConfirmModal, {
                     strTitle: "Migrate Legacy Saves?",
-                    strDescription: `Migrate legacy saves into ‘${defaultSlot}’?`,
+                    strDescription: legacyMigrateConfirmDescription(defaultSlot),
                     onOK: () => {
                       detach(handleConfirm(defaultSlot, true, null));
                     },
@@ -379,6 +509,16 @@ export const SlotSetupWizard: FC<SlotSetupWizardProps> = ({ romId, onComplete })
         </DialogButton>
       </div>,
     );
+    // A fresh slot is not empty forever: the local save is uploaded into it on
+    // the next sync — spell that out so "the slot stays empty" never reads as a
+    // dead end (#1478/#1498). Only meaningful when a local save exists.
+    if (info.has_local_saves) {
+      rightChildren.push(
+        <div key="fresh-hint" className="romm-panel-muted" style={{ fontSize: "11px", marginBottom: "6px" }}>
+          {startFreshHint(defaultSlot)}
+        </div>,
+      );
+    }
   }
 
   rightChildren.push(

--- a/src/components/SlotSetupWizard.tsx
+++ b/src/components/SlotSetupWizard.tsx
@@ -10,6 +10,7 @@ import {
   legacyMigrateConfirmDescription,
   legacyTrackExplainer,
   startFreshHint,
+  startFreshHintNewSlot,
   wizardMigrationOutcomeToastBody,
   SERVER_UNREACHABLE_WIZARD_MESSAGE,
 } from "../utils/saveSetup";
@@ -544,6 +545,20 @@ export const SlotSetupWizard: FC<SlotSetupWizardProps> = ({ romId, onComplete })
       </DialogButton>
     </div>,
   );
+
+  // "Custom slot…" takes the same backend path as "Use slot ‘<default>’", so it
+  // needs the same next-sync expectation. The named hint above already carries it
+  // when the start-fresh block renders; when the default slot already exists on
+  // the server that block (and its hint) is gone and only this route remains, so
+  // render the slot-agnostic variant here instead — never both, and never naming
+  // a slot the user isn't choosing.
+  if (info.has_local_saves && defaultExistsOnServer) {
+    rightChildren.push(
+      <div key="custom-fresh-hint" className="romm-panel-muted" style={{ fontSize: "11px", marginTop: "6px" }}>
+        {startFreshHintNewSlot()}
+      </div>,
+    );
+  }
 
   return (
     <div style={{ padding: "12px 0" }}>

--- a/src/components/SlotSetupWizard.tsx
+++ b/src/components/SlotSetupWizard.tsx
@@ -190,6 +190,14 @@ interface ConfirmHandlerDeps {
   onComplete: () => void;
 }
 
+/** The wizard's slot-confirm entry point, as every action button calls it. */
+type ConfirmHandler = (
+  slot: string,
+  migrate?: boolean,
+  migrateFrom?: string | null,
+  useServerOnConflict?: boolean,
+) => Promise<void>;
+
 /** Build the wizard's slot-confirm handler.
  *
  *  Kept at module level rather than inline in the component so the whole confirm
@@ -252,7 +260,210 @@ function createConfirmHandler({ romId, setConfirming, setError, onComplete }: Co
   return handleConfirm;
 }
 
-export const SlotSetupWizard: FC<SlotSetupWizardProps> = ({ romId, onComplete }) => {
+/** Left column — what the device already has on disk. */
+function buildLocalSavesColumn(info: SaveSetupInfo): React.ReactNode[] {
+  const children: React.ReactNode[] = [
+    <div key="local-title" className="romm-panel-section-title" style={{ marginBottom: "8px" }}>
+      Local Saves
+    </div>,
+  ];
+
+  if (info.local_files.length > 0) {
+    children.push(
+      <div key="local-files">
+        {info.local_files.map((f) => (
+          <div
+            key={f.filename}
+            style={{ display: "flex", alignItems: "center", gap: "6px", padding: "4px 0", fontSize: "12px" }}
+          >
+            <span className="romm-status-dot" style={{ backgroundColor: "#5ba32b" }} />
+            <span style={{ color: "#fff" }}>{f.filename}</span>
+            <span className="romm-panel-muted">{formatBytes(f.size)}</span>
+          </div>
+        ))}
+      </div>,
+    );
+  } else {
+    children.push(
+      <div key="no-local" className="romm-panel-muted" style={{ fontSize: "12px" }}>
+        No local saves found
+      </div>,
+    );
+  }
+  return children;
+}
+
+/** One server-slot row: the slot summary plus its Track action. The legacy
+ *  (slot-less) group is the special case — it carries the migration explainer and
+ *  routes Track through the migrate-confirm modal instead of a plain confirm. */
+function buildSlotRow(
+  s: SaveSetupInfo["server_slots"][number],
+  defaultSlot: string,
+  handleConfirm: ConfirmHandler,
+): React.ReactNode {
+  const slotKey = s.slot ?? "__null__";
+  const isLegacyGroup = s.slot === null || s.slot === "";
+  return (
+    <div
+      key={`slot-${slotKey}`}
+      style={{
+        padding: "6px 0",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        gap: "8px",
+      }}
+    >
+      <div style={{ minWidth: 0 }}>
+        <div style={{ display: "flex", alignItems: "center", gap: "6px", fontSize: "13px", color: "#fff" }}>
+          <span className="romm-status-dot" style={{ backgroundColor: "#1a9fff" }} />
+          {displaySlot(s.slot)}
+        </div>
+        <div className="romm-panel-muted" style={{ fontSize: "11px", marginLeft: "18px" }}>
+          {s.count} file{s.count === 1 ? "" : "s"}
+          {s.latest_updated_at ? ` — ${formatTimestamp(s.latest_updated_at)}` : ""}
+        </div>
+        {/* Pre-click explainer so the legacy "Track" reads as a migration
+            before it is clicked, not only inside the confirm modal (#1498). */}
+        {isLegacyGroup ? (
+          <div className="romm-panel-muted" style={{ fontSize: "11px", marginLeft: "18px", marginTop: "2px" }}>
+            {legacyTrackExplainer(defaultSlot)}
+          </div>
+        ) : null}
+      </div>
+      <DialogButton
+        className="romm-wizard-btn"
+        style={btnStyle}
+        onClick={() => {
+          if (isLegacyGroup) {
+            // Legacy (no-slot) saves can no longer be tracked as-is (#1276).
+            // Offer to copy them into the default slot rather than confirming
+            // the retired legacy mode. A differing local save is asked about
+            // by the backend after OK (#1498).
+            showModal(
+              createElement(ConfirmModal, {
+                strTitle: "Migrate Legacy Saves?",
+                strDescription: legacyMigrateConfirmDescription(defaultSlot),
+                onOK: () => {
+                  detach(handleConfirm(defaultSlot, true, null));
+                },
+              }),
+            );
+          } else {
+            detach(handleConfirm(s.slot as string));
+          }
+        }}
+        onFocus={scrollFocusedToCenter}
+      >
+        Track
+      </DialogButton>
+    </div>
+  );
+}
+
+/** Right column — the server's slots plus the start-fresh actions. */
+function buildServerSlotsColumn(
+  info: SaveSetupInfo,
+  defaultSlot: string,
+  handleConfirm: ConfirmHandler,
+): React.ReactNode[] {
+  const children: React.ReactNode[] = [
+    <div key="server-title" className="romm-panel-section-title" style={{ marginBottom: "8px" }}>
+      Server Slots
+    </div>,
+  ];
+
+  if (info.server_slots.length > 0) {
+    info.server_slots.forEach((s) => children.push(buildSlotRow(s, defaultSlot, handleConfirm)));
+  } else {
+    children.push(
+      <div key="no-server" className="romm-panel-muted" style={{ fontSize: "12px" }}>
+        No saves on server
+      </div>,
+    );
+  }
+
+  // Divider + "Start fresh" section — only show "Use default" when it's not already in the server list
+  const defaultExistsOnServer = info.server_slots.some((s) => s.slot === defaultSlot);
+  children.push(
+    <div key="divider" style={{ borderTop: "1px solid rgba(255, 255, 255, 0.1)", margin: "10px 0 8px" }} />,
+  );
+  if (!defaultExistsOnServer) {
+    children.push(
+      <div key="fresh-label" className="romm-panel-muted" style={{ fontSize: "11px", marginBottom: "6px" }}>
+        Or start fresh:
+      </div>,
+      <div key="default-btn" style={{ marginBottom: "6px" }}>
+        <DialogButton
+          className="romm-wizard-btn romm-wizard-btn-primary"
+          style={btnPrimaryStyle}
+          onClick={() => {
+            detach(handleConfirm(defaultSlot));
+          }}
+          onFocus={scrollFocusedToCenter}
+        >
+          Use slot &lsquo;{defaultSlot}&rsquo;
+        </DialogButton>
+      </div>,
+    );
+    // A fresh slot is not empty forever: the local save is uploaded into it on
+    // the next sync — spell that out so "the slot stays empty" never reads as a
+    // dead end (#1478/#1498). Only meaningful when a local save exists.
+    if (info.has_local_saves) {
+      children.push(
+        <div key="fresh-hint" className="romm-panel-muted" style={{ fontSize: "11px", marginBottom: "6px" }}>
+          {startFreshHint(defaultSlot)}
+        </div>,
+      );
+    }
+  }
+
+  children.push(
+    <div key="custom-toggle">
+      <DialogButton
+        className="romm-wizard-btn"
+        style={btnStyle}
+        onFocus={scrollFocusedToCenter}
+        onClick={() => {
+          showModal(
+            createElement(CustomSlotModal, {
+              onSubmit: (trimmed: string) => {
+                // An empty custom name is rejected by the backend's
+                // invalid_slot_name guard — never reinterpret it as the retired
+                // legacy no-slot mode (#1276).
+                detach(handleConfirm(trimmed));
+              },
+            }),
+          );
+        }}
+      >
+        Custom slot...
+      </DialogButton>
+    </div>,
+  );
+
+  // "Custom slot…" takes the same backend path as "Use slot ‘<default>’", so it
+  // needs the same next-sync expectation. The named hint above already carries it
+  // when the start-fresh block renders; when the default slot already exists on
+  // the server that block (and its hint) is gone and only this route remains, so
+  // render the slot-agnostic variant here instead — never both, and never naming
+  // a slot the user isn't choosing.
+  if (info.has_local_saves && defaultExistsOnServer) {
+    children.push(
+      <div key="custom-fresh-hint" className="romm-panel-muted" style={{ fontSize: "11px", marginTop: "6px" }}>
+        {startFreshHintNewSlot()}
+      </div>,
+    );
+  }
+  return children;
+}
+
+/** Owns the wizard's setup-info lifecycle: the initial load, the reconnect
+ *  auto-reload, and the manual Retry — the three paths that share
+ *  `offlineHeldRef` and the loading/error state. Kept as a hook so the component
+ *  itself only renders; anything that fetches or re-fetches setup info belongs
+ *  here, not in the component body. */
+function useSaveSetupInfo(romId: number, onComplete: () => void) {
   const [info, setInfo] = useState<SaveSetupInfo | null>(null);
   const [loading, setLoading] = useState(true);
   const [confirming, setConfirming] = useState(false);
@@ -343,6 +554,36 @@ export const SlotSetupWizard: FC<SlotSetupWizardProps> = ({ romId, onComplete })
     [],
   );
 
+  // Manual Retry — user-initiated, so it never auto-confirms (see
+  // applyWizardRetrySetupResult); shares offlineHeldRef with the load above.
+  const retry = () => {
+    setError(null);
+    setLoading(true);
+    // Fresh load — drop any stale retry progress (see fetchInfo above).
+    setServerRetryProgress(null);
+    getSaveSetupInfo(romId).then(
+      (result) => {
+        // Same conservative feed as the initial load (#1345): the manual
+        // Retry re-probes reachability, so a server_unreachable result
+        // re-arms offline and any other result reports the server back.
+        const reachable = result.recommended_action !== "server_unreachable";
+        reportServerReachable(reachable);
+        offlineHeldRef.current = !reachable;
+        applyWizardRetrySetupResult(result, { setError, setLoading, setInfo });
+      },
+      (e) => {
+        setError(`Failed: ${e}`);
+        setLoading(false);
+      },
+    );
+  };
+
+  return { info, loading, confirming, error, setConfirming, setError, retry };
+}
+
+export const SlotSetupWizard: FC<SlotSetupWizardProps> = ({ romId, onComplete }) => {
+  const { info, loading, confirming, error, setConfirming, setError, retry } = useSaveSetupInfo(romId, onComplete);
+
   const handleConfirm = createConfirmHandler({ romId, setConfirming, setError, onComplete });
 
   // Loading / confirming — a spinner + live retry progress (#1345) instead of
@@ -362,31 +603,7 @@ export const SlotSetupWizard: FC<SlotSetupWizardProps> = ({ romId, onComplete })
       <div style={{ padding: "12px 0" }}>
         <div className="romm-panel-section-title">Save Slot Setup</div>
         <div style={{ color: "#d4513f", fontSize: "12px", marginBottom: "8px" }}>{error}</div>
-        <DialogButton
-          className="romm-wizard-btn"
-          style={btnStyle}
-          onClick={() => {
-            setError(null);
-            setLoading(true);
-            // Fresh load — drop any stale retry progress (see fetchInfo above).
-            setServerRetryProgress(null);
-            getSaveSetupInfo(romId).then(
-              (result) => {
-                // Same conservative feed as the initial load (#1345): the manual
-                // Retry re-probes reachability, so a server_unreachable result
-                // re-arms offline and any other result reports the server back.
-                const reachable = result.recommended_action !== "server_unreachable";
-                reportServerReachable(reachable);
-                offlineHeldRef.current = !reachable;
-                applyWizardRetrySetupResult(result, { setError, setLoading, setInfo });
-              },
-              (e) => {
-                setError(`Failed: ${e}`);
-                setLoading(false);
-              },
-            );
-          }}
-        >
+        <DialogButton className="romm-wizard-btn" style={btnStyle} onClick={retry}>
           Retry
         </DialogButton>
       </div>
@@ -397,188 +614,8 @@ export const SlotSetupWizard: FC<SlotSetupWizardProps> = ({ romId, onComplete })
 
   const defaultSlot = info.default_slot;
 
-  // ── Two-column layout ──────────────────────────────────────
-
-  // Left column: local saves info
-  const leftChildren: React.ReactNode[] = [];
-  leftChildren.push(
-    <div key="local-title" className="romm-panel-section-title" style={{ marginBottom: "8px" }}>
-      Local Saves
-    </div>,
-  );
-
-  if (info.local_files.length > 0) {
-    leftChildren.push(
-      <div key="local-files">
-        {info.local_files.map((f) => (
-          <div
-            key={f.filename}
-            style={{ display: "flex", alignItems: "center", gap: "6px", padding: "4px 0", fontSize: "12px" }}
-          >
-            <span className="romm-status-dot" style={{ backgroundColor: "#5ba32b" }} />
-            <span style={{ color: "#fff" }}>{f.filename}</span>
-            <span className="romm-panel-muted">{formatBytes(f.size)}</span>
-          </div>
-        ))}
-      </div>,
-    );
-  } else {
-    leftChildren.push(
-      <div key="no-local" className="romm-panel-muted" style={{ fontSize: "12px" }}>
-        No local saves found
-      </div>,
-    );
-  }
-
-  // Right column: server slots + actions
-  const rightChildren: React.ReactNode[] = [];
-  rightChildren.push(
-    <div key="server-title" className="romm-panel-section-title" style={{ marginBottom: "8px" }}>
-      Server Slots
-    </div>,
-  );
-
-  if (info.server_slots.length > 0) {
-    info.server_slots.forEach((s) => {
-      const slotKey = s.slot ?? "__null__";
-      const isLegacyGroup = s.slot === null || s.slot === "";
-      rightChildren.push(
-        <div
-          key={`slot-${slotKey}`}
-          style={{
-            padding: "6px 0",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "space-between",
-            gap: "8px",
-          }}
-        >
-          <div style={{ minWidth: 0 }}>
-            <div style={{ display: "flex", alignItems: "center", gap: "6px", fontSize: "13px", color: "#fff" }}>
-              <span className="romm-status-dot" style={{ backgroundColor: "#1a9fff" }} />
-              {displaySlot(s.slot)}
-            </div>
-            <div className="romm-panel-muted" style={{ fontSize: "11px", marginLeft: "18px" }}>
-              {s.count} file{s.count === 1 ? "" : "s"}
-              {s.latest_updated_at ? ` \u2014 ${formatTimestamp(s.latest_updated_at)}` : ""}
-            </div>
-            {/* Pre-click explainer so the legacy "Track" reads as a migration
-                before it is clicked, not only inside the confirm modal (#1498). */}
-            {isLegacyGroup ? (
-              <div className="romm-panel-muted" style={{ fontSize: "11px", marginLeft: "18px", marginTop: "2px" }}>
-                {legacyTrackExplainer(defaultSlot)}
-              </div>
-            ) : null}
-          </div>
-          <DialogButton
-            className="romm-wizard-btn"
-            style={btnStyle}
-            onClick={() => {
-              if (isLegacyGroup) {
-                // Legacy (no-slot) saves can no longer be tracked as-is (#1276).
-                // Offer to copy them into the default slot rather than confirming
-                // the retired legacy mode. A differing local save is asked about
-                // by the backend after OK (#1498).
-                showModal(
-                  createElement(ConfirmModal, {
-                    strTitle: "Migrate Legacy Saves?",
-                    strDescription: legacyMigrateConfirmDescription(defaultSlot),
-                    onOK: () => {
-                      detach(handleConfirm(defaultSlot, true, null));
-                    },
-                  }),
-                );
-              } else {
-                detach(handleConfirm(s.slot as string));
-              }
-            }}
-            onFocus={scrollFocusedToCenter}
-          >
-            Track
-          </DialogButton>
-        </div>,
-      );
-    });
-  } else {
-    rightChildren.push(
-      <div key="no-server" className="romm-panel-muted" style={{ fontSize: "12px" }}>
-        No saves on server
-      </div>,
-    );
-  }
-
-  // Divider + "Start fresh" section — only show "Use default" when it's not already in the server list
-  const defaultExistsOnServer = info.server_slots.some((s) => s.slot === defaultSlot);
-  rightChildren.push(
-    <div key="divider" style={{ borderTop: "1px solid rgba(255, 255, 255, 0.1)", margin: "10px 0 8px" }} />,
-  );
-  if (!defaultExistsOnServer) {
-    rightChildren.push(
-      <div key="fresh-label" className="romm-panel-muted" style={{ fontSize: "11px", marginBottom: "6px" }}>
-        Or start fresh:
-      </div>,
-      <div key="default-btn" style={{ marginBottom: "6px" }}>
-        <DialogButton
-          className="romm-wizard-btn romm-wizard-btn-primary"
-          style={btnPrimaryStyle}
-          onClick={() => {
-            detach(handleConfirm(defaultSlot));
-          }}
-          onFocus={scrollFocusedToCenter}
-        >
-          Use slot &lsquo;{defaultSlot}&rsquo;
-        </DialogButton>
-      </div>,
-    );
-    // A fresh slot is not empty forever: the local save is uploaded into it on
-    // the next sync — spell that out so "the slot stays empty" never reads as a
-    // dead end (#1478/#1498). Only meaningful when a local save exists.
-    if (info.has_local_saves) {
-      rightChildren.push(
-        <div key="fresh-hint" className="romm-panel-muted" style={{ fontSize: "11px", marginBottom: "6px" }}>
-          {startFreshHint(defaultSlot)}
-        </div>,
-      );
-    }
-  }
-
-  rightChildren.push(
-    <div key="custom-toggle">
-      <DialogButton
-        className="romm-wizard-btn"
-        style={btnStyle}
-        onFocus={scrollFocusedToCenter}
-        onClick={() => {
-          showModal(
-            createElement(CustomSlotModal, {
-              onSubmit: (trimmed: string) => {
-                // An empty custom name is rejected by the backend's
-                // invalid_slot_name guard — never reinterpret it as the retired
-                // legacy no-slot mode (#1276).
-                detach(handleConfirm(trimmed));
-              },
-            }),
-          );
-        }}
-      >
-        Custom slot...
-      </DialogButton>
-    </div>,
-  );
-
-  // "Custom slot…" takes the same backend path as "Use slot ‘<default>’", so it
-  // needs the same next-sync expectation. The named hint above already carries it
-  // when the start-fresh block renders; when the default slot already exists on
-  // the server that block (and its hint) is gone and only this route remains, so
-  // render the slot-agnostic variant here instead — never both, and never naming
-  // a slot the user isn't choosing.
-  if (info.has_local_saves && defaultExistsOnServer) {
-    rightChildren.push(
-      <div key="custom-fresh-hint" className="romm-panel-muted" style={{ fontSize: "11px", marginTop: "6px" }}>
-        {startFreshHintNewSlot()}
-      </div>,
-    );
-  }
+  const leftChildren = buildLocalSavesColumn(info);
+  const rightChildren = buildServerSlotsColumn(info, defaultSlot, handleConfirm);
 
   return (
     <div style={{ padding: "12px 0" }}>

--- a/src/components/SlotSetupWizard.tsx
+++ b/src/components/SlotSetupWizard.tsx
@@ -183,6 +183,75 @@ const LegacyMigrationConflictModal: FC<{
   );
 };
 
+interface ConfirmHandlerDeps {
+  romId: number;
+  setConfirming: (confirming: boolean) => void;
+  setError: (message: string | null) => void;
+  onComplete: () => void;
+}
+
+/** Build the wizard's slot-confirm handler.
+ *
+ *  Kept at module level rather than inline in the component so the whole confirm
+ *  flow reads as one unit — probe → conflict dialog → failure → outcome toast —
+ *  and so it can re-invoke itself for the "Replace local save" second call. The
+ *  deps are supplied fresh on every render, exactly as the inline closure read
+ *  them.
+ */
+function createConfirmHandler({ romId, setConfirming, setError, onComplete }: ConfirmHandlerDeps) {
+  const handleConfirm = async (
+    slot: string,
+    migrate = false,
+    migrateFrom: string | null = null,
+    useServerOnConflict = false,
+  ): Promise<void> => {
+    setConfirming(true);
+    setError(null);
+    try {
+      // Confirm a non-empty named slot (legacy slot:null is retired, #1276).
+      // Defaults are the non-destructive path (migrate=false, from=null); the
+      // legacy-group Track button passes migrate=true, from=null to copy the
+      // legacy saves into the target slot (#1498).
+      const result = await confirmSlotChoice(romId, slot, migrate, migrateFrom, useServerOnConflict);
+
+      // A content-based migration found a differing local save — nothing was
+      // confirmed. Show the comparison and let the user confirm the replacement;
+      // cancelling makes no second call, so the slot stays unconfirmed and the
+      // wizard's start-fresh route is still open.
+      if (result.needs_conflict_resolution) {
+        setConfirming(false);
+        showModal(
+          createElement(LegacyMigrationConflictModal, {
+            conflicts: result.conflicts ?? [],
+            slot,
+            onConfirm: () => detach(handleConfirm(slot, true, migrateFrom, true)),
+          }),
+        );
+        return;
+      }
+
+      if (!result.success) {
+        setError(result.message || "Slot confirmation failed");
+        setConfirming(false);
+        return;
+      }
+
+      // Surface the migration outcome (names the slot + counts) so the copy is
+      // never log-only. Only a migration reports counts; a plain confirm doesn't.
+      if (migrate) {
+        const body = wizardMigrationOutcomeToastBody(result.migrated ?? 0, result.failed ?? 0, slot);
+        if (body) toaster.toast({ title: "RomM Sync", body });
+      }
+      onComplete();
+    } catch (e) {
+      setError(`Failed to confirm slot: ${e}`);
+      logError(`SlotSetupWizard confirm failed: ${e}`);
+      setConfirming(false);
+    }
+  };
+  return handleConfirm;
+}
+
 export const SlotSetupWizard: FC<SlotSetupWizardProps> = ({ romId, onComplete }) => {
   const [info, setInfo] = useState<SaveSetupInfo | null>(null);
   const [loading, setLoading] = useState(true);
@@ -274,56 +343,7 @@ export const SlotSetupWizard: FC<SlotSetupWizardProps> = ({ romId, onComplete })
     [],
   );
 
-  const handleConfirm = async (
-    slot: string,
-    migrate = false,
-    migrateFrom: string | null = null,
-    useServerOnConflict = false,
-  ) => {
-    setConfirming(true);
-    setError(null);
-    try {
-      // Confirm a non-empty named slot (legacy slot:null is retired, #1276).
-      // Defaults are the non-destructive path (migrate=false, from=null); the
-      // legacy-group Track button passes migrate=true, from=null to copy the
-      // legacy saves into the target slot (#1498).
-      const result = await confirmSlotChoice(romId, slot, migrate, migrateFrom, useServerOnConflict);
-
-      // A content-based migration found a differing local save — nothing was
-      // confirmed. Show the comparison and let the user confirm the replacement;
-      // cancelling makes no second call, so the slot stays unconfirmed and the
-      // wizard's start-fresh route is still open.
-      if (result.needs_conflict_resolution) {
-        setConfirming(false);
-        showModal(
-          createElement(LegacyMigrationConflictModal, {
-            conflicts: result.conflicts ?? [],
-            slot,
-            onConfirm: () => detach(handleConfirm(slot, true, migrateFrom, true)),
-          }),
-        );
-        return;
-      }
-
-      if (!result.success) {
-        setError(result.message || "Slot confirmation failed");
-        setConfirming(false);
-        return;
-      }
-
-      // Surface the migration outcome (names the slot + counts) so the copy is
-      // never log-only. Only a migration reports counts; a plain confirm doesn't.
-      if (migrate) {
-        const body = wizardMigrationOutcomeToastBody(result.migrated ?? 0, result.failed ?? 0, slot);
-        if (body) toaster.toast({ title: "RomM Sync", body });
-      }
-      onComplete();
-    } catch (e) {
-      setError(`Failed to confirm slot: ${e}`);
-      logError(`SlotSetupWizard confirm failed: ${e}`);
-      setConfirming(false);
-    }
-  };
+  const handleConfirm = createConfirmHandler({ romId, setConfirming, setError, onComplete });
 
   // Loading / confirming — a spinner + live retry progress (#1345) instead of
   // bare italic text, so a load paying the backend retry ladder reads as busy.

--- a/src/components/SlotSetupWizard.tsx
+++ b/src/components/SlotSetupWizard.tsx
@@ -6,10 +6,11 @@ import { scrollFocusedToCenter } from "../utils/scrollHelpers";
 import {
   applyWizardInitialSetupResult,
   applyWizardRetrySetupResult,
+  legacyConflictReplaceNotice,
   legacyMigrateConfirmDescription,
+  legacyTrackExplainer,
   startFreshHint,
   wizardMigrationOutcomeToastBody,
-  LEGACY_TRACK_EXPLAINER,
   SERVER_UNREACHABLE_WIZARD_MESSAGE,
 } from "../utils/saveSetup";
 import {
@@ -99,22 +100,23 @@ function formatSize(bytes: number | null): string {
   return formatBytes(bytes);
 }
 
-/** Resolution dialog for a legacy migration whose target already has a differing
- *  local save (#1498). Both sides are shown with size + timestamp; the choice is
- *  global across every listed conflict (each one closes the modal, then fires the
- *  matching backend re-call). "Use the server save" quarantines the local file
- *  first; "Keep my local save" leaves the legacy save in the read-only bucket and
- *  makes the local file the slot's first save on the next sync. */
+/** Informed confirmation for a legacy migration whose target already has a
+ *  differing local save (#1498). Both sides are shown with size + timestamp —
+ *  that comparison is what stops a newer local save being buried unnoticed — and
+ *  the dialog offers exactly two ways out: confirm (proceed, quarantining the
+ *  local file) or Cancel, which changes nothing and leaves the slot unconfirmed
+ *  so the user can take the wizard's start-fresh route instead. There is no
+ *  "keep my local save" action: it would produce the same end state as the
+ *  wizard's own "Use slot" button. */
 const LegacyMigrationConflictModal: FC<{
   closeModal?: () => void;
   conflicts: SlotMigrationConflict[];
   slot: string;
-  onUseServer: () => void;
-  onKeepLocal: () => void;
-}> = ({ closeModal, conflicts, slot, onUseServer, onKeepLocal }) => {
-  const resolve = (choice: () => void) => {
+  onConfirm: () => void;
+}> = ({ closeModal, conflicts, slot, onConfirm }) => {
+  const confirm = () => {
     closeModal?.();
-    choice();
+    onConfirm();
   };
   return (
     <ModalRoot {...(closeModal !== undefined ? { closeModal } : {})}>
@@ -123,7 +125,7 @@ const LegacyMigrationConflictModal: FC<{
           A local save differs from the legacy save
         </div>
         <div style={{ fontSize: "12px", color: "rgba(255, 255, 255, 0.6)", marginBottom: "12px", lineHeight: "1.4" }}>
-          Choose which save to keep in &lsquo;{slot}&rsquo;.
+          Copying the legacy save into &lsquo;{slot}&rsquo; replaces your local save.
         </div>
         {conflicts.map((c) => (
           <div key={c.filename} style={{ marginBottom: "10px" }}>
@@ -165,16 +167,14 @@ const LegacyMigrationConflictModal: FC<{
           </div>
         ))}
         <div style={{ fontSize: "11px", color: "rgba(255, 255, 255, 0.5)", margin: "4px 0 12px", lineHeight: "1.4" }}>
-          &ldquo;Use the server save&rdquo; backs up your local file to .romm-backup first. &ldquo;Keep my local
-          save&rdquo; leaves the legacy save in the read-only legacy bucket and uploads your local file on the next
-          sync.
+          {legacyConflictReplaceNotice(slot)}
         </div>
         <div style={{ display: "flex", gap: "8px", justifyContent: "flex-end" }}>
-          <DialogButton style={btnStyle} onClick={() => resolve(onKeepLocal)} onFocus={scrollFocusedToCenter}>
-            Keep my local save
+          <DialogButton style={btnStyle} onClick={() => closeModal?.()} onFocus={scrollFocusedToCenter}>
+            Cancel
           </DialogButton>
-          <DialogButton style={btnPrimaryStyle} onClick={() => resolve(onUseServer)} onFocus={scrollFocusedToCenter}>
-            Use the server save
+          <DialogButton style={btnPrimaryStyle} onClick={confirm} onFocus={scrollFocusedToCenter}>
+            Replace local save
           </DialogButton>
         </div>
       </div>
@@ -289,16 +289,16 @@ export const SlotSetupWizard: FC<SlotSetupWizardProps> = ({ romId, onComplete })
       const result = await confirmSlotChoice(romId, slot, migrate, migrateFrom, useServerOnConflict);
 
       // A content-based migration found a differing local save — nothing was
-      // confirmed. Ask the user, then re-call: "Use the server save" migrates
-      // (quarantine local), "Keep my local save" confirms without migrating.
+      // confirmed. Show the comparison and let the user confirm the replacement;
+      // cancelling makes no second call, so the slot stays unconfirmed and the
+      // wizard's start-fresh route is still open.
       if (result.needs_conflict_resolution) {
         setConfirming(false);
         showModal(
           createElement(LegacyMigrationConflictModal, {
             conflicts: result.conflicts ?? [],
             slot,
-            onUseServer: () => detach(handleConfirm(slot, true, migrateFrom, true)),
-            onKeepLocal: () => detach(handleConfirm(slot, false, null, false)),
+            onConfirm: () => detach(handleConfirm(slot, true, migrateFrom, true)),
           }),
         );
         return;
@@ -445,7 +445,7 @@ export const SlotSetupWizard: FC<SlotSetupWizardProps> = ({ romId, onComplete })
                 before it is clicked, not only inside the confirm modal (#1498). */}
             {isLegacyGroup ? (
               <div className="romm-panel-muted" style={{ fontSize: "11px", marginLeft: "18px", marginTop: "2px" }}>
-                {LEGACY_TRACK_EXPLAINER}
+                {legacyTrackExplainer(defaultSlot)}
               </div>
             ) : null}
           </div>

--- a/src/types/saves.ts
+++ b/src/types/saves.ts
@@ -173,6 +173,19 @@ export interface SaveSetupInfo {
   server_query_failed?: boolean;
 }
 
+/** One legacy-vs-local collision surfaced by `confirm_slot_choice` when a
+ *  content-based migration finds a local save file that differs from the legacy
+ *  save it would copy into the chosen slot (#1498). Both sides carry a
+ *  timestamp + size so the wizard's resolution dialog can show them. */
+export interface SlotMigrationConflict {
+  filename: string;
+  server_save_id: number;
+  server_updated_at: string;
+  server_size: number | null;
+  local_mtime: string;
+  local_size: number;
+}
+
 export interface SlotDeleteInfo {
   success: boolean;
   slot?: string;

--- a/src/utils/launchInterceptor.test.ts
+++ b/src/utils/launchInterceptor.test.ts
@@ -669,7 +669,7 @@ describe("launchInterceptor — full funnel watcher", () => {
       handler(77, "1234", "LaunchApp", 0);
       await flush();
 
-      expect(backend.confirmSlotChoice).toHaveBeenCalledWith(42, "slot1", false, null);
+      expect(backend.confirmSlotChoice).toHaveBeenCalledWith(42, "slot1", false, null, false);
       expect(tabSwitch).not.toHaveBeenCalled();
       // The funnel still proceeds to a relaunch.
       expect(runGameMock()).toHaveBeenCalledWith("gid-7", "", -1, 100);

--- a/src/utils/saveSetup.test.ts
+++ b/src/utils/saveSetup.test.ts
@@ -3,11 +3,12 @@ import {
   applyLaunchGateSetupOutcome,
   applyWizardInitialSetupResult,
   applyWizardRetrySetupResult,
+  legacyConflictReplaceNotice,
   legacyMigrateConfirmDescription,
+  legacyTrackExplainer,
   resolveSaveSetupOutcome,
   startFreshHint,
   wizardMigrationOutcomeToastBody,
-  LEGACY_TRACK_EXPLAINER,
   SERVER_UNREACHABLE_WIZARD_MESSAGE,
   SERVER_UNREACHABLE_TOAST_BODY,
   type LaunchGateSetupDeps,
@@ -313,9 +314,21 @@ describe("applyWizardRetrySetupResult", () => {
 });
 
 describe("legacy-migration copy (#1498)", () => {
-  it("the Track explainer reads as a migration and says the legacy save is left untouched", () => {
-    expect(LEGACY_TRACK_EXPLAINER).toContain("copies the legacy save");
-    expect(LEGACY_TRACK_EXPLAINER).toContain("left untouched");
+  it("the Track explainer names the concrete target slot and says the legacy save is left untouched", () => {
+    const body = legacyTrackExplainer("default");
+    expect(body).toContain("copies the legacy save");
+    // Names the resolved slot — never "a named slot", which reads as still-open.
+    expect(body).toContain("‘default’");
+    expect(body).not.toContain("a named slot");
+    expect(body).toContain("left untouched");
+  });
+
+  it("the conflict notice states the backup-and-replace and that cancelling changes nothing", () => {
+    const body = legacyConflictReplaceNotice("default");
+    expect(body).toContain(".romm-backup");
+    expect(body).toContain("replaced with the legacy save");
+    expect(body).toContain("nothing changes");
+    expect(body).toContain("‘default’");
   });
 
   it("the migrate confirm description names the target slot and flags the differ-ask", () => {

--- a/src/utils/saveSetup.test.ts
+++ b/src/utils/saveSetup.test.ts
@@ -3,7 +3,11 @@ import {
   applyLaunchGateSetupOutcome,
   applyWizardInitialSetupResult,
   applyWizardRetrySetupResult,
+  legacyMigrateConfirmDescription,
   resolveSaveSetupOutcome,
+  startFreshHint,
+  wizardMigrationOutcomeToastBody,
+  LEGACY_TRACK_EXPLAINER,
   SERVER_UNREACHABLE_WIZARD_MESSAGE,
   SERVER_UNREACHABLE_TOAST_BODY,
   type LaunchGateSetupDeps,
@@ -94,7 +98,7 @@ describe("applyLaunchGateSetupOutcome", () => {
     const outcome: SaveSetupOutcome = { kind: "auto_confirm", slot: "main" };
     const result = await applyLaunchGateSetupOutcome(outcome, deps);
     expect(result).toBe("proceed");
-    expect(deps.confirmSlotChoice).toHaveBeenCalledWith(42, "main", false, null);
+    expect(deps.confirmSlotChoice).toHaveBeenCalledWith(42, "main", false, null, false);
     expect(deps.toast).not.toHaveBeenCalled();
     expect(deps.dispatchSavesTab).not.toHaveBeenCalled();
   });
@@ -108,7 +112,7 @@ describe("applyLaunchGateSetupOutcome", () => {
     });
     const result = await applyLaunchGateSetupOutcome({ kind: "auto_confirm", slot: "main" }, deps);
     expect(result).toBe("abort");
-    expect(deps.confirmSlotChoice).toHaveBeenCalledWith(42, "main", false, null);
+    expect(deps.confirmSlotChoice).toHaveBeenCalledWith(42, "main", false, null, false);
     expect(deps.toast).toHaveBeenCalledWith("slot taken");
     expect(deps.dispatchSavesTab).toHaveBeenCalledOnce();
   });
@@ -189,7 +193,7 @@ describe("applyWizardInitialSetupResult", () => {
     const result = makeInfo({ recommended_action: "auto_confirm_default", default_slot: "alpha" });
     await applyWizardInitialSetupResult(result, deps);
     expect(deps.setConfirming).toHaveBeenCalledWith(true);
-    expect(deps.confirmSlotChoice).toHaveBeenCalledWith(7, "alpha", false, null);
+    expect(deps.confirmSlotChoice).toHaveBeenCalledWith(7, "alpha", false, null, false);
     expect(deps.onComplete).toHaveBeenCalledOnce();
     expect(deps.setError).not.toHaveBeenCalled();
     expect(deps.setInfo).not.toHaveBeenCalled();
@@ -305,5 +309,47 @@ describe("applyWizardRetrySetupResult", () => {
     expect(deps.setInfo).toHaveBeenCalledWith(result);
     expect(deps.setLoading).toHaveBeenCalledWith(false);
     expect(deps.setError).not.toHaveBeenCalled();
+  });
+});
+
+describe("legacy-migration copy (#1498)", () => {
+  it("the Track explainer reads as a migration", () => {
+    expect(LEGACY_TRACK_EXPLAINER).toContain("copies the legacy save");
+  });
+
+  it("the migrate confirm description names the target slot and flags the differ-ask", () => {
+    const body = legacyMigrateConfirmDescription("default");
+    expect(body).toContain("‘default’");
+    expect(body).toContain("differs");
+  });
+
+  it("the start-fresh hint names the slot and points at the next sync", () => {
+    const body = startFreshHint("main");
+    expect(body).toContain("‘main’");
+    expect(body).toContain("next sync");
+  });
+
+  describe("wizardMigrationOutcomeToastBody", () => {
+    it("names the slot and count when only migrations succeeded (singular)", () => {
+      expect(wizardMigrationOutcomeToastBody(1, 0, "default")).toBe("Migrated 1 save into ‘default’");
+    });
+
+    it("pluralizes when more than one save migrated", () => {
+      expect(wizardMigrationOutcomeToastBody(2, 0, "default")).toBe("Migrated 2 saves into ‘default’");
+    });
+
+    it("reports failures alongside successes", () => {
+      expect(wizardMigrationOutcomeToastBody(1, 1, "slotA")).toBe(
+        "Migrated 1 save into ‘slotA’; 1 could not be migrated",
+      );
+    });
+
+    it("names the could-not-migrate count when nothing succeeded", () => {
+      expect(wizardMigrationOutcomeToastBody(0, 2, "slotA")).toBe("Could not migrate 2 saves into ‘slotA’");
+    });
+
+    it("returns null when nothing was attempted", () => {
+      expect(wizardMigrationOutcomeToastBody(0, 0, "default")).toBeNull();
+    });
   });
 });

--- a/src/utils/saveSetup.test.ts
+++ b/src/utils/saveSetup.test.ts
@@ -313,8 +313,9 @@ describe("applyWizardRetrySetupResult", () => {
 });
 
 describe("legacy-migration copy (#1498)", () => {
-  it("the Track explainer reads as a migration", () => {
+  it("the Track explainer reads as a migration and says the legacy save is left untouched", () => {
     expect(LEGACY_TRACK_EXPLAINER).toContain("copies the legacy save");
+    expect(LEGACY_TRACK_EXPLAINER).toContain("left untouched");
   });
 
   it("the migrate confirm description names the target slot and flags the differ-ask", () => {
@@ -330,21 +331,25 @@ describe("legacy-migration copy (#1498)", () => {
   });
 
   describe("wizardMigrationOutcomeToastBody", () => {
-    it("names the slot and count when only migrations succeeded (singular)", () => {
-      expect(wizardMigrationOutcomeToastBody(1, 0, "default")).toBe("Migrated 1 save into ‘default’");
-    });
-
-    it("pluralizes when more than one save migrated", () => {
-      expect(wizardMigrationOutcomeToastBody(2, 0, "default")).toBe("Migrated 2 saves into ‘default’");
-    });
-
-    it("reports failures alongside successes", () => {
-      expect(wizardMigrationOutcomeToastBody(1, 1, "slotA")).toBe(
-        "Migrated 1 save into ‘slotA’; 1 could not be migrated",
+    it("names the slot and count and reassures the legacy save stays (singular)", () => {
+      expect(wizardMigrationOutcomeToastBody(1, 0, "default")).toBe(
+        "Migrated 1 save into ‘default’. The legacy save stays in the read-only legacy bucket.",
       );
     });
 
-    it("names the could-not-migrate count when nothing succeeded", () => {
+    it("pluralizes the count and the legacy-stays clause when more than one save migrated", () => {
+      expect(wizardMigrationOutcomeToastBody(2, 0, "default")).toBe(
+        "Migrated 2 saves into ‘default’. The legacy saves stay in the read-only legacy bucket.",
+      );
+    });
+
+    it("reports failures alongside successes and still reassures", () => {
+      expect(wizardMigrationOutcomeToastBody(1, 1, "slotA")).toBe(
+        "Migrated 1 save into ‘slotA’; 1 could not be migrated. The legacy save stays in the read-only legacy bucket.",
+      );
+    });
+
+    it("names the could-not-migrate count when nothing succeeded (no legacy-stays clause needed)", () => {
       expect(wizardMigrationOutcomeToastBody(0, 2, "slotA")).toBe("Could not migrate 2 saves into ‘slotA’");
     });
 

--- a/src/utils/saveSetup.test.ts
+++ b/src/utils/saveSetup.test.ts
@@ -331,10 +331,13 @@ describe("legacy-migration copy (#1498)", () => {
     expect(body).toContain("‘default’");
   });
 
-  it("the migrate confirm description names the target slot and flags the differ-ask", () => {
+  it("the migrate confirm description names the slot and promises a confirmation, not a keep-choice", () => {
     const body = legacyMigrateConfirmDescription("default");
     expect(body).toContain("‘default’");
     expect(body).toContain("differs");
+    expect(body).toContain("confirm before anything is replaced");
+    // The dialog is confirm-or-cancel — never promise a choose-which-to-keep.
+    expect(body).not.toContain("which to keep");
   });
 
   it("the start-fresh hint names the slot and points at the next sync", () => {

--- a/src/utils/saveSetup.test.ts
+++ b/src/utils/saveSetup.test.ts
@@ -8,6 +8,7 @@ import {
   legacyTrackExplainer,
   resolveSaveSetupOutcome,
   startFreshHint,
+  startFreshHintNewSlot,
   wizardMigrationOutcomeToastBody,
   SERVER_UNREACHABLE_WIZARD_MESSAGE,
   SERVER_UNREACHABLE_TOAST_BODY,
@@ -344,6 +345,14 @@ describe("legacy-migration copy (#1498)", () => {
     const body = startFreshHint("main");
     expect(body).toContain("‘main’");
     expect(body).toContain("next sync");
+  });
+
+  it("the custom-slot variant makes the same promise without naming a slot", () => {
+    const body = startFreshHintNewSlot();
+    expect(body).toContain("the new slot");
+    expect(body).toContain("next sync");
+    // The custom name isn't known until submit — never name a concrete slot here.
+    expect(body).not.toContain("‘");
   });
 
   describe("wizardMigrationOutcomeToastBody", () => {

--- a/src/utils/saveSetup.ts
+++ b/src/utils/saveSetup.ts
@@ -219,10 +219,12 @@ export function legacyConflictReplaceNotice(slot: string): string {
 }
 
 /** Confirm-modal body for migrating the legacy group — names the target slot and
- *  states that a differing local save is asked about, never silently
- *  overwritten. */
+ *  promises that a differing local save is surfaced for an explicit confirmation
+ *  first, never silently overwritten. Deliberately does NOT promise a
+ *  choose-which-to-keep: the conflict dialog is confirm-or-cancel, and the
+ *  keep-local outcome is the wizard's own "Use slot" button. */
 export function legacyMigrateConfirmDescription(slot: string): string {
-  return `Copy the legacy save into ‘${slot}’? If a local save differs, you’ll choose which to keep.`;
+  return `Copy the legacy save into ‘${slot}’? If a local save differs, you’ll confirm before anything is replaced.`;
 }
 
 /** Hint under the "start fresh" buttons: a fresh slot holds no save until the

--- a/src/utils/saveSetup.ts
+++ b/src/utils/saveSetup.ts
@@ -235,6 +235,13 @@ export function startFreshHint(slot: string): string {
   return `Your local save becomes the first save in ‘${slot}’ on the next sync.`;
 }
 
+/** The same expectation for the "Custom slot…" route, where the slot name isn't
+ *  known until the user submits it — so the sentence stays slot-agnostic rather
+ *  than naming the default slot the user is not choosing. */
+export function startFreshHintNewSlot(): string {
+  return "Your local save becomes the first save in the new slot on the next sync.";
+}
+
 /** Completion toast after a legacy migration ran — names the target slot and the
  *  migrated / could-not-migrate counts. Whenever a save was actually copied it
  *  appends that the legacy source stays put, pre-empting the "why is the legacy

--- a/src/utils/saveSetup.ts
+++ b/src/utils/saveSetup.ts
@@ -201,11 +201,22 @@ export function applyWizardRetrySetupResult(result: SaveSetupInfo, deps: WizardR
 // Every surface names the target slot; nothing is log-only.
 
 /** Pre-click explainer shown under the legacy group so "Track" reads as a
- *  migration before it is clicked, not only inside the confirm modal. States that
- *  the legacy save itself is left untouched (it is copied, never moved) so the
- *  user isn't surprised to see it still there afterwards (#1498). */
-export const LEGACY_TRACK_EXPLAINER =
-  "Tracking copies the legacy save into a named slot — the legacy save itself is left untouched in the read-only legacy bucket.";
+ *  migration before it is clicked, not only inside the confirm modal. Names the
+ *  concrete target slot (the same one the confirm modal uses) so the target never
+ *  reads as still-open, and states that the legacy save itself is left untouched
+ *  (it is copied, never moved) so the user isn't surprised to see it afterwards. */
+export function legacyTrackExplainer(slot: string): string {
+  return `Tracking copies the legacy save into ‘${slot}’ — the legacy save itself is left untouched in the read-only legacy bucket.`;
+}
+
+/** What the legacy-migration conflict dialog promises before the user confirms:
+ *  the local save is backed up and replaced, and cancelling changes nothing so the
+ *  start-fresh route stays open. "Keep my local save" is deliberately NOT offered —
+ *  it would produce the same end state as the wizard's own "Use slot" button and
+ *  re-open a decision already made by clicking Track. */
+export function legacyConflictReplaceNotice(slot: string): string {
+  return `Your local save is moved to .romm-backup and replaced with the legacy save. Cancel to go back — nothing changes, and you can start fresh with ‘${slot}’ instead.`;
+}
 
 /** Confirm-modal body for migrating the legacy group — names the target slot and
  *  states that a differing local save is asked about, never silently

--- a/src/utils/saveSetup.ts
+++ b/src/utils/saveSetup.ts
@@ -201,8 +201,11 @@ export function applyWizardRetrySetupResult(result: SaveSetupInfo, deps: WizardR
 // Every surface names the target slot; nothing is log-only.
 
 /** Pre-click explainer shown under the legacy group so "Track" reads as a
- *  migration before it is clicked, not only inside the confirm modal. */
-export const LEGACY_TRACK_EXPLAINER = "Tracking copies the legacy save into a named slot so it keeps syncing.";
+ *  migration before it is clicked, not only inside the confirm modal. States that
+ *  the legacy save itself is left untouched (it is copied, never moved) so the
+ *  user isn't surprised to see it still there afterwards (#1498). */
+export const LEGACY_TRACK_EXPLAINER =
+  "Tracking copies the legacy save into a named slot — the legacy save itself is left untouched in the read-only legacy bucket.";
 
 /** Confirm-modal body for migrating the legacy group — names the target slot and
  *  states that a differing local save is asked about, never silently
@@ -220,15 +223,21 @@ export function startFreshHint(slot: string): string {
 }
 
 /** Completion toast after a legacy migration ran — names the target slot and the
- *  migrated / could-not-migrate counts. `null` only when nothing was attempted
- *  (the Track button is gated on a non-empty legacy group, so that is a
- *  defensive fallthrough, not a normal outcome). */
+ *  migrated / could-not-migrate counts. Whenever a save was actually copied it
+ *  appends that the legacy source stays put, pre-empting the "why is the legacy
+ *  save still there?" confusion (the migration copies, never deletes — #1498).
+ *  `null` only when nothing was attempted (the Track button is gated on a
+ *  non-empty legacy group, so that is a defensive fallthrough). */
 export function wizardMigrationOutcomeToastBody(migrated: number, failed: number, slot: string): string | null {
+  const legacyNote =
+    migrated === 1
+      ? " The legacy save stays in the read-only legacy bucket."
+      : " The legacy saves stay in the read-only legacy bucket.";
   if (migrated > 0 && failed > 0) {
-    return `Migrated ${migrated} save${migrated === 1 ? "" : "s"} into ‘${slot}’; ${failed} could not be migrated`;
+    return `Migrated ${migrated} save${migrated === 1 ? "" : "s"} into ‘${slot}’; ${failed} could not be migrated.${legacyNote}`;
   }
   if (migrated > 0) {
-    return `Migrated ${migrated} save${migrated === 1 ? "" : "s"} into ‘${slot}’`;
+    return `Migrated ${migrated} save${migrated === 1 ? "" : "s"} into ‘${slot}’.${legacyNote}`;
   }
   if (failed > 0) {
     return `Could not migrate ${failed} save${failed === 1 ? "" : "s"} into ‘${slot}’`;

--- a/src/utils/saveSetup.ts
+++ b/src/utils/saveSetup.ts
@@ -56,12 +56,15 @@ export interface LaunchGateSetupDeps {
   /** ROM id passed to `confirmSlotChoice` on the auto-confirm branch. */
   rid: number;
   /** Resolves the user's chosen save slot on the backend. `slot` is a non-empty
-   *  named slot — legacy `slot:null` confirmation is retired (#1276). */
+   *  named slot — legacy `slot:null` confirmation is retired (#1276). The launch
+   *  gate only ever auto-confirms (`migrate: false`), so `useServerOnConflict` is
+   *  always `false` here; it exists to match the callable's shape (#1498). */
   confirmSlotChoice: (
     rid: number,
     slot: string,
     migrate: boolean,
     migrateFrom: string | null,
+    useServerOnConflict: boolean,
   ) => Promise<{ success?: boolean; message?: string } | undefined>;
   /** Shows a Decky toast — wrapped as a callback so the helper is dispatch-agnostic. */
   toast: (body: string) => void;
@@ -83,8 +86,8 @@ export async function applyLaunchGateSetupOutcome(
     return "abort";
   }
   if (outcome.kind === "auto_confirm") {
-    // Auto-confirm of a named/default slot — never migrate.
-    const result = await deps.confirmSlotChoice(deps.rid, outcome.slot, false, null);
+    // Auto-confirm of a named/default slot — never migrate (so no conflict).
+    const result = await deps.confirmSlotChoice(deps.rid, outcome.slot, false, null, false);
     if (result?.success === false) {
       // A resolved failure (not a throw) must not let the launch proceed with
       // save tracking unconfigured — route to the Saves tab like the other
@@ -107,12 +110,15 @@ export async function applyLaunchGateSetupOutcome(
 export interface WizardSetupDeps {
   romId: number;
   /** `slot` is a non-empty named slot — legacy `slot:null` confirmation is
-   *  retired (#1276). */
+   *  retired (#1276). The wizard's auto-confirm path never migrates, so
+   *  `useServerOnConflict` is `false`; the interactive migration paths pass their
+   *  own value (#1498). */
   confirmSlotChoice: (
     rid: number,
     slot: string,
     migrate: boolean,
     migrateFrom: string | null,
+    useServerOnConflict: boolean,
   ) => Promise<{ success?: boolean; message?: string } | undefined>;
   setError: (message: string | null) => void;
   setConfirming: (confirming: boolean) => void;
@@ -140,8 +146,8 @@ export async function applyWizardInitialSetupResult(result: SaveSetupInfo, deps:
   if (result.recommended_action === "auto_confirm_default") {
     deps.setConfirming(true);
     try {
-      // Auto-confirm of the default slot — never migrate.
-      const confirmResult = await deps.confirmSlotChoice(deps.romId, result.default_slot, false, null);
+      // Auto-confirm of the default slot — never migrate (so no conflict).
+      const confirmResult = await deps.confirmSlotChoice(deps.romId, result.default_slot, false, null, false);
       if (deps.isCancelled()) return;
       if (confirmResult?.success === false) {
         // Resolved failure (not a throw): mirror the catch branch — surface the
@@ -187,4 +193,45 @@ export function applyWizardRetrySetupResult(result: SaveSetupInfo, deps: WizardR
   }
   deps.setInfo(result);
   deps.setLoading(false);
+}
+
+// ── First-sync wizard: legacy-migration copy (#1498) ─────────────────────────
+// The legacy "Track" action copies the newest legacy save per canonical target
+// into a named slot (content-based, independent of the legacy row's filename).
+// Every surface names the target slot; nothing is log-only.
+
+/** Pre-click explainer shown under the legacy group so "Track" reads as a
+ *  migration before it is clicked, not only inside the confirm modal. */
+export const LEGACY_TRACK_EXPLAINER = "Tracking copies the legacy save into a named slot so it keeps syncing.";
+
+/** Confirm-modal body for migrating the legacy group — names the target slot and
+ *  states that a differing local save is asked about, never silently
+ *  overwritten. */
+export function legacyMigrateConfirmDescription(slot: string): string {
+  return `Copy the legacy save into ‘${slot}’? If a local save differs, you’ll choose which to keep.`;
+}
+
+/** Hint under the "start fresh" buttons: a fresh slot holds no save until the
+ *  local one is uploaded — it becomes the slot's first save on the next sync,
+ *  not the moment the slot is chosen (the misleading "empty slot" moment #1478
+ *  reporters saw). */
+export function startFreshHint(slot: string): string {
+  return `Your local save becomes the first save in ‘${slot}’ on the next sync.`;
+}
+
+/** Completion toast after a legacy migration ran — names the target slot and the
+ *  migrated / could-not-migrate counts. `null` only when nothing was attempted
+ *  (the Track button is gated on a non-empty legacy group, so that is a
+ *  defensive fallthrough, not a normal outcome). */
+export function wizardMigrationOutcomeToastBody(migrated: number, failed: number, slot: string): string | null {
+  if (migrated > 0 && failed > 0) {
+    return `Migrated ${migrated} save${migrated === 1 ? "" : "s"} into ‘${slot}’; ${failed} could not be migrated`;
+  }
+  if (migrated > 0) {
+    return `Migrated ${migrated} save${migrated === 1 ? "" : "s"} into ‘${slot}’`;
+  }
+  if (failed > 0) {
+    return `Could not migrate ${failed} save${failed === 1 ? "" : "s"} into ‘${slot}’`;
+  }
+  return null;
 }

--- a/tests/contract/test_saves_slot_choice.py
+++ b/tests/contract/test_saves_slot_choice.py
@@ -15,7 +15,20 @@ canonical ``invalid_slot_name`` failure and never mutates state or hits the wire
 
 from __future__ import annotations
 
-from ._seed import enable_save_sync, seed_rom
+import os
+
+from ._seed import enable_save_sync, seed_install, seed_rom, seed_server_save
+
+
+def _write_local_save(harness, *, system: str = "gba", filename: str = "game.srm", content: bytes = b"x") -> str:
+    """Materialize a local save file under the harness saves tree."""
+    saves_dir = os.path.join(harness.plugin._retrodeck_paths.saves_path(), system)
+    os.makedirs(saves_dir, exist_ok=True)
+    path = os.path.join(saves_dir, filename)
+    with open(path, "wb") as fh:
+        fh.write(content)
+    return path
+
 
 # ── confirm_slot_choice ───────────────────────────────────────────────────
 
@@ -62,6 +75,117 @@ async def test_confirm_legacy_slot_none_rejected(harness):
     assert state is None
     # No migration delete fired.
     assert not any(c[0] == "delete_server_saves" for c in harness.romm.call_log)
+
+
+async def test_confirm_legacy_migration_content_based_timestamped_filename(harness):
+    """The #1498 repro: a timestamped legacy save + a byte-identical local save.
+
+    The old filename-equality migration left the ``default`` slot empty because
+    the web-player timestamped legacy filename never matched the canonical local
+    name. The content-based migration copies the legacy save's *content* into the
+    slot under the canonical name and confirms it; the legacy source is never
+    deleted (#1478/#1498).
+    """
+    enable_save_sync(harness)
+    seed_install(harness, 42, system="gba", file_name="game.gba")
+    _write_local_save(harness, filename="game.srm", content=b"progress")
+    seed_server_save(
+        harness,
+        save_id=700,
+        rom_id=42,
+        slot=None,
+        file_name="game [2026-07-19 13-41-44-611].srm",
+    )
+    harness.romm.set_server_save_content(700, b"progress")  # byte-identical to local
+
+    result = await harness.plugin.confirm_slot_choice(42, "default", True, None)
+
+    assert result["success"] is True
+    assert result["needs_conflict_resolution"] is False
+    assert result["migrated"] == 1
+    assert result["failed"] == 0
+    # Copied into the named slot — never as a slot:null upload.
+    upload_calls = [c for c in harness.romm.call_log if c[0] == "upload_save"]
+    assert len(upload_calls) == 1
+    assert upload_calls[0][2].get("slot") == "default"
+    # The legacy source stays in the read-only bucket.
+    assert not any(c[0] == "delete_server_saves" for c in harness.romm.call_log)
+    assert 700 in harness.romm.saves
+    with harness.uow_factory() as uow:
+        state = uow.rom_save_sync_states.get(42)
+    assert state is not None
+    assert state.slot_confirmed is True
+    assert state.active_slot == "default"
+
+
+async def test_confirm_legacy_migration_differing_local_needs_resolution(harness):
+    """A differing local save holds the migration: needs_conflict_resolution, nothing confirmed.
+
+    The response carries the ``local_conflict`` reason and a conflict entry (both
+    sides' shape) so the wizard can ask; nothing is uploaded/deleted and the slot
+    is not confirmed (#1498).
+    """
+    enable_save_sync(harness)
+    seed_install(harness, 42, system="gba", file_name="game.gba")
+    _write_local_save(harness, filename="game.srm", content=b"my-local-progress")
+    seed_server_save(
+        harness,
+        save_id=701,
+        rom_id=42,
+        slot=None,
+        file_name="game [2026-07-19 13-41-44-611].srm",
+    )
+    harness.romm.set_server_save_content(701, b"server-progress")
+
+    result = await harness.plugin.confirm_slot_choice(42, "default", True, None)
+
+    assert result["success"] is False
+    assert result["needs_conflict_resolution"] is True
+    assert result["reason"] == "local_conflict"
+    assert isinstance(result["message"], str)
+    conflicts = result["conflicts"]
+    assert len(conflicts) == 1
+    assert conflicts[0]["filename"] == "game.srm"
+    assert conflicts[0]["server_save_id"] == 701
+    # Nothing migrated, nothing deleted, slot not confirmed.
+    assert not any(c[0] == "upload_save" for c in harness.romm.call_log)
+    assert not any(c[0] == "delete_server_saves" for c in harness.romm.call_log)
+    with harness.uow_factory() as uow:
+        state = uow.rom_save_sync_states.get(42)
+    assert state is None
+
+
+async def test_confirm_legacy_migration_use_server_resolves_conflict(harness):
+    """ "Use the server save" resolves a differing-local conflict: quarantine local, copy server in."""
+    enable_save_sync(harness)
+    seed_install(harness, 42, system="gba", file_name="game.gba")
+    local_path = _write_local_save(harness, filename="game.srm", content=b"my-local-progress")
+    seed_server_save(
+        harness,
+        save_id=702,
+        rom_id=42,
+        slot=None,
+        file_name="game [2026-07-19 13-41-44-611].srm",
+    )
+    harness.romm.set_server_save_content(702, b"server-progress")
+
+    result = await harness.plugin.confirm_slot_choice(42, "default", True, None, True)
+
+    assert result["success"] is True
+    assert result["migrated"] == 1
+    # The local file now holds the server content; the original is backed up.
+    with open(local_path, "rb") as fh:
+        assert fh.read() == b"server-progress"
+    backup_dir = os.path.join(os.path.dirname(local_path), ".romm-backup")
+    backups = [n for n in os.listdir(backup_dir) if n.startswith("game")]
+    assert len(backups) == 1
+    upload_calls = [c for c in harness.romm.call_log if c[0] == "upload_save"]
+    assert len(upload_calls) == 1
+    assert upload_calls[0][2].get("slot") == "default"
+    with harness.uow_factory() as uow:
+        state = uow.rom_save_sync_states.get(42)
+    assert state is not None
+    assert state.slot_confirmed is True
 
 
 # ── switch_slot ───────────────────────────────────────────────────────────

--- a/tests/contract/test_saves_slot_choice.py
+++ b/tests/contract/test_saves_slot_choice.py
@@ -17,6 +17,9 @@ from __future__ import annotations
 
 import os
 
+from lib.errors import RommConnectionError
+from lib.list_result import ErrorCode
+
 from ._seed import enable_save_sync, seed_install, seed_rom, seed_server_save
 
 
@@ -186,6 +189,31 @@ async def test_confirm_legacy_migration_use_server_resolves_conflict(harness):
         state = uow.rom_save_sync_states.get(42)
     assert state is not None
     assert state.slot_confirmed is True
+
+
+async def test_confirm_legacy_migration_server_unreachable_holds_wizard(harness):
+    """A transient server failure before the apply phase returns the canonical failure and confirms nothing.
+
+    The wholesale (pre-apply) failure must NOT silently confirm-and-close — the
+    wizard stays open on the message so the user can retry Track (#1498 review).
+    """
+    enable_save_sync(harness)
+    seed_install(harness, 42, system="gba", file_name="game.gba")
+    _write_local_save(harness, filename="game.srm", content=b"progress")
+    seed_server_save(harness, save_id=703, rom_id=42, slot=None, file_name="game [ts].srm")
+    harness.romm.list_saves_side_effect = RommConnectionError("offline")
+
+    result = await harness.plugin.confirm_slot_choice(42, "default", True, None)
+
+    assert result["success"] is False
+    assert result["reason"] == ErrorCode.SERVER_UNREACHABLE.value
+    assert result["needs_conflict_resolution"] is False
+    assert isinstance(result["message"], str)
+    # Nothing confirmed, nothing uploaded — no half-state.
+    with harness.uow_factory() as uow:
+        state = uow.rom_save_sync_states.get(42)
+    assert state is None
+    assert not any(c[0] == "upload_save" for c in harness.romm.call_log)
 
 
 # ── switch_slot ───────────────────────────────────────────────────────────

--- a/tests/services/saves/test_slots.py
+++ b/tests/services/saves/test_slots.py
@@ -624,34 +624,115 @@ class TestConfirmSlotChoice:
         assert _require_save_state(svc, 42).slot_confirmed is True
 
     @pytest.mark.asyncio
-    async def test_confirm_with_legacy_no_slot_migration(self, tmp_path):
-        """Migrate from the legacy slot: re-upload to new slot, delete old.
+    async def test_confirm_legacy_migration_copies_content_into_slot(self, tmp_path):
+        """Content-based legacy migration: copy the newest legacy save into the slot.
 
-        ``migrate=True`` with ``migrate_from_slot=None`` migrates the legacy
-        no-slot server saves into ``chosen_slot``.
+        ``migrate=True`` with ``migrate_from_slot=None`` copies the newest legacy
+        (slot:null) save's *content* into ``chosen_slot`` under the canonical name
+        — independent of the legacy row's own (web-player timestamped) filename
+        (#1498). The legacy source is never deleted (#1478).
         """
         svc, fake = make_service(tmp_path)
         svc._config.settings["save_sync_enabled"] = True
         svc._config.settings["autocleanup_limit"] = 7
         _set_device_id(svc, "dev-1")
         _install_rom(svc, tmp_path)
-        _create_save(tmp_path)
-        # Old save on server with slot=None (legacy)
-        fake.saves[1] = _server_save(save_id=1, slot=None)
+        _create_save(tmp_path, content=b"S" * 1024)  # local pokemon.srm
+        # Legacy save with a web-player timestamped filename that never equals the
+        # canonical local name — the old filename-equality migration left it in
+        # place; the content-based one carries it (#1498).
+        fake.saves[1] = _server_save(save_id=1, filename="pokemon [2026-07-19 13-41-44-611].srm", slot=None)
+        fake.set_server_save_content(1, b"S" * 1024)  # byte-identical to local
 
         result = await svc.confirm_slot_choice(42, "default", True, None)
         assert result["success"] is True
-        # New save should have been uploaded
+        assert result["migrated"] == 1
+        assert result["failed"] == 0
+        # Uploaded into the named slot, retention cap riding along on the POST.
         upload_calls = [c for c in fake.call_log if c[0] == "upload_save"]
-        assert len(upload_calls) >= 1
-        # Check it was uploaded with the new slot
+        assert len(upload_calls) == 1
         assert upload_calls[0][2].get("slot") == "default"
-        # Carry-over POST creates a new entry, so the user's retention cap rides along.
         assert upload_calls[0][2].get("autocleanup_limit") == 7
-        # Old save should have been deleted
-        delete_calls = [c for c in fake.call_log if c[0] == "delete_server_saves"]
-        assert len(delete_calls) == 1
-        assert 1 in delete_calls[0][1][0]  # save_id 1 in the list
+        # The legacy source is never deleted — it stays in the read-only bucket.
+        assert not any(c[0] == "delete_server_saves" for c in fake.call_log)
+        assert 1 in fake.saves
+        assert _require_save_state(svc, 42).slot_confirmed is True
+
+    @pytest.mark.asyncio
+    async def test_confirm_migration_no_local_file_writes_content(self, tmp_path):
+        """No local file → server content is written to disk and copied into the slot."""
+        svc, fake = make_service(tmp_path)
+        svc._config.settings["save_sync_enabled"] = True
+        _set_device_id(svc, "dev-1")
+        _install_rom(svc, tmp_path)
+        # No local save file on disk.
+        fake.saves[1] = _server_save(save_id=1, filename="pokemon [ts].srm", slot=None)
+        fake.set_server_save_content(1, b"SERVER-CONTENT")
+
+        result = await svc.confirm_slot_choice(42, "default", True, None)
+        assert result["success"] is True
+        assert result["migrated"] == 1
+        # The content landed on disk under the canonical name.
+        assert (tmp_path / "saves" / "gba" / "pokemon.srm").read_bytes() == b"SERVER-CONTENT"
+        upload_calls = [c for c in fake.call_log if c[0] == "upload_save"]
+        assert len(upload_calls) == 1
+        assert upload_calls[0][2].get("slot") == "default"
+        assert not any(c[0] == "delete_server_saves" for c in fake.call_log)
+
+    @pytest.mark.asyncio
+    async def test_confirm_migration_differing_local_holds_for_conflict(self, tmp_path):
+        """A differing local file holds the migration for the user's decision.
+
+        The response carries ``needs_conflict_resolution=True`` + a conflict
+        entry, nothing is uploaded/deleted, the local file is untouched, and the
+        slot is NOT confirmed (#1498).
+        """
+        svc, fake = make_service(tmp_path)
+        svc._config.settings["save_sync_enabled"] = True
+        _set_device_id(svc, "dev-1")
+        _install_rom(svc, tmp_path)
+        _create_save(tmp_path, content=b"LOCAL" * 10)
+        fake.saves[1] = _server_save(save_id=1, filename="pokemon [ts].srm", slot=None)
+        fake.set_server_save_content(1, b"SERVER" * 10)
+
+        result = await svc.confirm_slot_choice(42, "default", True, None)
+        assert result["success"] is False
+        assert result["needs_conflict_resolution"] is True
+        assert result["reason"] == "local_conflict"
+        conflicts = result["conflicts"]
+        assert len(conflicts) == 1
+        assert conflicts[0]["filename"] == "pokemon.srm"
+        assert conflicts[0]["server_save_id"] == 1
+        # Nothing migrated, nothing deleted, local untouched, slot unconfirmed.
+        assert not any(c[0] == "upload_save" for c in fake.call_log)
+        assert not any(c[0] == "delete_server_saves" for c in fake.call_log)
+        assert (tmp_path / "saves" / "gba" / "pokemon.srm").read_bytes() == b"LOCAL" * 10
+        assert _get_save_state(svc, 42) is None
+
+    @pytest.mark.asyncio
+    async def test_confirm_migration_use_server_quarantines_local(self, tmp_path):
+        """ "Use the server save": the differing local file is quarantined, then replaced."""
+        svc, fake = make_service(tmp_path)
+        svc._config.settings["save_sync_enabled"] = True
+        _set_device_id(svc, "dev-1")
+        _install_rom(svc, tmp_path)
+        _create_save(tmp_path, content=b"LOCAL" * 10)
+        fake.saves[1] = _server_save(save_id=1, filename="pokemon [ts].srm", slot=None)
+        fake.set_server_save_content(1, b"SERVER" * 10)
+
+        result = await svc.confirm_slot_choice(42, "default", True, None, True)
+        assert result["success"] is True
+        assert result["migrated"] == 1
+        local_dir = tmp_path / "saves" / "gba"
+        # Local replaced with server content; the original backed up (never deleted).
+        assert (local_dir / "pokemon.srm").read_bytes() == b"SERVER" * 10
+        backups = list((local_dir / ".romm-backup").glob("pokemon*"))
+        assert len(backups) == 1
+        assert backups[0].read_bytes() == b"LOCAL" * 10
+        upload_calls = [c for c in fake.call_log if c[0] == "upload_save"]
+        assert len(upload_calls) == 1
+        assert upload_calls[0][2].get("slot") == "default"
+        assert _require_save_state(svc, 42).slot_confirmed is True
 
     @pytest.mark.asyncio
     async def test_confirm_migration_no_old_saves(self, tmp_path):
@@ -673,16 +754,16 @@ class TestConfirmSlotChoice:
         assert len(delete_calls) == 0
 
     @pytest.mark.asyncio
-    async def test_confirm_migration_failure_still_confirms_slot(self, tmp_path):
-        """Migration failure should still confirm the slot but report the issue."""
+    async def test_confirm_migration_upload_failure_counts_and_confirms(self, tmp_path):
+        """An upload failure during migration is counted (not fatal); the slot is still confirmed."""
         svc, fake = make_service(tmp_path)
         svc._config.settings["save_sync_enabled"] = True
         _set_device_id(svc, "dev-1")
         _install_rom(svc, tmp_path)
-        _create_save(tmp_path)
-        fake.saves[1] = _server_save(save_id=1, slot=None)
+        _create_save(tmp_path, content=b"X" * 512)
+        fake.saves[1] = _server_save(save_id=1, filename="pokemon [ts].srm", slot=None)
+        fake.set_server_save_content(1, b"X" * 512)  # identical → migrate path
 
-        # Make upload_save fail during migration
         def failing_upload(*args, **kwargs):
             raise RommApiError(500, "Server error")
 
@@ -690,39 +771,61 @@ class TestConfirmSlotChoice:
 
         result = await svc.confirm_slot_choice(42, "default", True, None)
         assert result["success"] is True
-        assert "migration failed" in result["message"].lower()
-        # Slot is still confirmed despite migration failure
+        assert result["migrated"] == 0
+        assert result["failed"] == 1
+        # Slot is still confirmed despite the migration failure.
         assert _require_save_state(svc, 42).slot_confirmed is True
 
     @pytest.mark.asyncio
-    async def test_confirm_migration_skips_delete_for_save_without_local_file(self, tmp_path):
-        """#1005: an old-slot save with NO matching local file is NOT deleted.
+    async def test_confirm_migration_download_failure_confirms_with_warning(self, tmp_path):
+        """A download failure during detection confirms the slot with a warning."""
+        svc, fake = make_service(tmp_path)
+        svc._config.settings["save_sync_enabled"] = True
+        _set_device_id(svc, "dev-1")
+        _install_rom(svc, tmp_path)
+        _create_save(tmp_path)
+        fake.saves[1] = _server_save(save_id=1, filename="pokemon [ts].srm", slot=None)
 
-        One old save has a local counterpart (re-uploaded, then its old id
-        deleted); the other has none (left in place, excluded from the delete).
+        def failing_download(save_id, dest_path):
+            raise RommApiError(500, "boom")
+
+        fake.download_save = failing_download
+
+        result = await svc.confirm_slot_choice(42, "default", True, None)
+        assert result["success"] is True
+        assert "migration failed" in result["message"].lower()
+        assert _require_save_state(svc, 42).slot_confirmed is True
+        assert not any(c[0] == "delete_server_saves" for c in fake.call_log)
+
+    @pytest.mark.asyncio
+    async def test_confirm_migration_collapses_duplicate_targets_no_delete(self, tmp_path):
+        """Two legacy saves mapping to one canonical target collapse to the newest; neither is deleted.
+
+        The content-based grouping keys by the canonical local target, so two
+        legacy saves that both resolve to ``pokemon.srm`` collapse to the newest
+        by ``updated_at`` — the older one is neither carried nor deleted, so no
+        data that lives only in the legacy bucket is lost (#1005/#1498).
         """
         svc, fake = make_service(tmp_path)
         svc._config.settings["save_sync_enabled"] = True
         _set_device_id(svc, "dev-1")
         _install_rom(svc, tmp_path)
-        # Local file matches "pokemon.srm" only.
-        _create_save(tmp_path)
-        # Two legacy server saves: one with a local match, one orphaned.
-        fake.saves[1] = _server_save(save_id=1, filename="pokemon.srm", slot=None)
-        fake.saves[2] = _server_save(save_id=2, filename="orphan.srm", slot=None)
+        _create_save(tmp_path, content=b"NEW" * 100)
+        fake.saves[1] = _server_save(save_id=1, filename="old [ts1].srm", slot=None, updated_at="2026-01-01T00:00:00Z")
+        fake.saves[2] = _server_save(save_id=2, filename="new [ts2].srm", slot=None, updated_at="2026-06-01T00:00:00Z")
+        fake.set_server_save_content(1, b"OLD" * 100)
+        fake.set_server_save_content(2, b"NEW" * 100)  # newest == local → identical
 
         result = await svc.confirm_slot_choice(42, "default", True, None)
         assert result["success"] is True
-        # Only the matched save was re-uploaded.
+        assert result["migrated"] == 1
+        # Only the newest was carried — exactly one upload.
         upload_calls = [c for c in fake.call_log if c[0] == "upload_save"]
         assert len(upload_calls) == 1
-        # Only the carried-over save id (1) is deleted; the orphan (2) survives.
-        delete_calls = [c for c in fake.call_log if c[0] == "delete_server_saves"]
-        assert len(delete_calls) == 1
-        deleted_ids = delete_calls[0][1][0]
-        assert 1 in deleted_ids
-        assert 2 not in deleted_ids
-        assert 2 in fake.saves  # orphan still on the server
+        # Neither legacy source is deleted.
+        assert not any(c[0] == "delete_server_saves" for c in fake.call_log)
+        assert 1 in fake.saves
+        assert 2 in fake.saves
 
     @pytest.mark.asyncio
     async def test_is_configured_after_confirm(self, tmp_path):

--- a/tests/services/saves/test_slots.py
+++ b/tests/services/saves/test_slots.py
@@ -8,7 +8,8 @@ import pytest
 
 from domain.rom_save_sync_state import FileSyncState, RomSaveSyncState
 from domain.save_layout import ContentDir
-from lib.errors import RommApiError
+from lib.errors import RommApiError, RommConnectionError
+from lib.list_result import ErrorCode
 from tests.services.saves._helpers import (
     _create_save,
     _file_md5,
@@ -777,25 +778,149 @@ class TestConfirmSlotChoice:
         assert _require_save_state(svc, 42).slot_confirmed is True
 
     @pytest.mark.asyncio
-    async def test_confirm_migration_download_failure_confirms_with_warning(self, tmp_path):
-        """A download failure during detection confirms the slot with a warning."""
+    async def test_confirm_migration_download_failure_holds_wizard(self, tmp_path):
+        """A phase-1 download failure is wholesale (pre-apply): canonical failure, slot NOT confirmed.
+
+        No durable state was mutated (only scratch temps, which are cleaned up),
+        so the migration must not silently confirm-and-close — it returns the
+        canonical failure and the wizard stays open for a retry (#1498 review).
+        """
         svc, fake = make_service(tmp_path)
         svc._config.settings["save_sync_enabled"] = True
         _set_device_id(svc, "dev-1")
         _install_rom(svc, tmp_path)
-        _create_save(tmp_path)
+        _create_save(tmp_path, content=b"L" * 100)
         fake.saves[1] = _server_save(save_id=1, filename="pokemon [ts].srm", slot=None)
 
         def failing_download(save_id, dest_path):
-            raise RommApiError(500, "boom")
+            raise RommConnectionError("offline")
 
         fake.download_save = failing_download
 
         result = await svc.confirm_slot_choice(42, "default", True, None)
-        assert result["success"] is True
-        assert "migration failed" in result["message"].lower()
-        assert _require_save_state(svc, 42).slot_confirmed is True
+        assert result["success"] is False
+        assert result["reason"] == ErrorCode.SERVER_UNREACHABLE.value
+        assert result["needs_conflict_resolution"] is False
+        # Slot NOT confirmed, local file untouched, no scratch temp left behind.
+        assert _get_save_state(svc, 42) is None
+        assert (tmp_path / "saves" / "gba" / "pokemon.srm").read_bytes() == b"L" * 100
+        assert not (tmp_path / "saves" / "gba" / "pokemon.srm.tmp").exists()
+        assert not any(c[0] == "upload_save" for c in fake.call_log)
         assert not any(c[0] == "delete_server_saves" for c in fake.call_log)
+
+    @pytest.mark.asyncio
+    async def test_confirm_migration_list_saves_failure_holds_then_retry_works(self, tmp_path):
+        """The reviewer's scenario: a transient list_saves throw holds the wizard; a retry migrates.
+
+        First attempt: list_saves throws → canonical failure, slot NOT confirmed,
+        no local mutation (migrated=0/failed=0 must NEVER be a silent success).
+        Second attempt (server back): the migration runs and the slot is confirmed.
+        """
+        svc, fake = make_service(tmp_path)
+        svc._config.settings["save_sync_enabled"] = True
+        _set_device_id(svc, "dev-1")
+        _install_rom(svc, tmp_path)
+        _create_save(tmp_path, content=b"L" * 100)
+        fake.saves[1] = _server_save(save_id=1, filename="pokemon [ts].srm", slot=None)
+        fake.set_server_save_content(1, b"L" * 100)  # identical → the retry migrates silently
+
+        orig_list = fake.list_saves
+        calls = {"n": 0}
+
+        def flaky_list(*args, **kwargs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RommConnectionError("offline")
+            return orig_list(*args, **kwargs)
+
+        fake.list_saves = flaky_list
+
+        result = await svc.confirm_slot_choice(42, "default", True, None)
+        assert result["success"] is False
+        assert result["reason"] == ErrorCode.SERVER_UNREACHABLE.value
+        assert result["needs_conflict_resolution"] is False
+        # Nothing confirmed, nothing uploaded, local untouched.
+        assert _get_save_state(svc, 42) is None
+        assert not any(c[0] == "upload_save" for c in fake.call_log)
+        assert (tmp_path / "saves" / "gba" / "pokemon.srm").read_bytes() == b"L" * 100
+
+        # Retry: server is back → the migration runs and the slot is confirmed.
+        result2 = await svc.confirm_slot_choice(42, "default", True, None)
+        assert result2["success"] is True
+        assert result2["migrated"] == 1
+        assert _require_save_state(svc, 42).slot_confirmed is True
+
+    @pytest.mark.asyncio
+    async def test_confirm_migration_phase1_throw_cleans_earlier_temp(self, tmp_path):
+        """A mid-phase-1 download throw removes the earlier target's .tmp (no scratch residue)."""
+        svc, fake = make_service(tmp_path)
+        svc._config.settings["save_sync_enabled"] = True
+        _set_device_id(svc, "dev-1")
+        _install_rom(svc, tmp_path)
+        # Two legacy saves mapping to two distinct canonical targets (different
+        # extensions) so phase 1 downloads two temps before the second throws.
+        fake.saves[1] = _server_save(save_id=1, filename="a [ts].srm", slot=None)
+        fake.saves[1]["file_extension"] = "srm"
+        fake.saves[2] = _server_save(save_id=2, filename="b [ts].rtc", slot=None)
+        fake.saves[2]["file_extension"] = "rtc"
+
+        orig_download = fake.download_save
+
+        def selective_download(save_id, dest_path):
+            if save_id == 2:
+                raise RommConnectionError("offline")
+            return orig_download(save_id, dest_path)
+
+        fake.download_save = selective_download
+
+        result = await svc.confirm_slot_choice(42, "default", True, None)
+        assert result["success"] is False
+        assert result["reason"] == ErrorCode.SERVER_UNREACHABLE.value
+        # The first target's downloaded temp was cleaned up by the finally.
+        saves_dir = tmp_path / "saves" / "gba"
+        assert not (saves_dir / "pokemon.srm.tmp").exists()
+        assert not (saves_dir / "pokemon.rtc.tmp").exists()
+        assert _get_save_state(svc, 42) is None
+
+    @pytest.mark.asyncio
+    async def test_confirm_migration_no_device_holds_wizard(self, tmp_path):
+        """No registered device → the migration is refused before any mutation (#1494/#1498).
+
+        The #1478 upload guard would otherwise fire only AFTER local files were
+        touched; prechecking the device at the top keeps the wizard clean.
+        """
+        svc, fake = make_service(tmp_path)
+        svc._config.settings["save_sync_enabled"] = True
+        # No device registered (no _set_device_id).
+        _install_rom(svc, tmp_path)
+        _create_save(tmp_path, content=b"L" * 100)
+        fake.saves[1] = _server_save(save_id=1, slot=None)
+
+        result = await svc.confirm_slot_choice(42, "default", True, None)
+        assert result["success"] is False
+        assert result["reason"] == "device_not_registered"
+        assert result["needs_conflict_resolution"] is False
+        # No mutation, no server traffic (the precheck runs before list_saves).
+        assert _get_save_state(svc, 42) is None
+        assert (tmp_path / "saves" / "gba" / "pokemon.srm").read_bytes() == b"L" * 100
+        assert not any(c[0] == "list_saves" for c in fake.call_log)
+        assert not any(c[0] == "upload_save" for c in fake.call_log)
+
+    @pytest.mark.asyncio
+    async def test_confirm_migration_not_installed_holds_wizard(self, tmp_path):
+        """ROM not installed → canonical failure, slot NOT confirmed (never a silent 0/0 success)."""
+        svc, fake = make_service(tmp_path)
+        svc._config.settings["save_sync_enabled"] = True
+        _set_device_id(svc, "dev-1")
+        # No _install_rom — the ROM has no install row.
+        fake.saves[1] = _server_save(save_id=1, slot=None)
+
+        result = await svc.confirm_slot_choice(42, "default", True, None)
+        assert result["success"] is False
+        assert result["reason"] == "not_installed"
+        assert result["needs_conflict_resolution"] is False
+        assert _get_save_state(svc, 42) is None
+        assert not any(c[0] == "upload_save" for c in fake.call_log)
 
     @pytest.mark.asyncio
     async def test_confirm_migration_collapses_duplicate_targets_no_delete(self, tmp_path):

--- a/tests/test_plugin_callable_delegation.py
+++ b/tests/test_plugin_callable_delegation.py
@@ -607,8 +607,8 @@ class TestSavesCallableDelegation:
     @pytest.mark.asyncio
     async def test_confirm_slot_choice_delegates(self, plugin):
         plugin._save_sync_service.confirm_slot_choice = AsyncMock(return_value={"ok": True})
-        result = await plugin.confirm_slot_choice(42, "default", True, "slot_1")
-        plugin._save_sync_service.confirm_slot_choice.assert_awaited_once_with(42, "default", True, "slot_1")
+        result = await plugin.confirm_slot_choice(42, "default", True, "slot_1", True)
+        plugin._save_sync_service.confirm_slot_choice.assert_awaited_once_with(42, "default", True, "slot_1", True)
         assert result == {"ok": True}
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #1498 — part of the #1478 triage (does not close #1478).

## Problem

The setup wizard's legacy migration matched legacy server saves against local files by filename equality. Web-player-created legacy saves carry timestamped filenames that never match the canonical local name, so "Migrate legacy saves into '<slot>'" silently migrated nothing (log-only warning) and left an empty confirmed slot — reproduced live on device.

## Change

- Migration is now content-based per canonical target: the newest legacy save per target is downloaded from the server and copied into the chosen slot under the canonical name — independent of the legacy row's filename and of any local file. The legacy source is never deleted (the bucket stays read-only, #1496).
- A differing local save is surfaced before anything is replaced: the wizard shows both sides (size + timestamp) and offers **Replace local save** (quarantines the local file into `.romm-backup`, then writes the migrated content) or **Cancel** (nothing changes, the slot stays unconfirmed, and the wizard's start-fresh route is right there). No local file or byte-identical content migrates silently.
- Failures split by whether anything happened yet: a wholesale failure before any mutation (server unreachable, device not registered, ROM not installed) returns the canonical failure and confirms nothing — the wizard stays open for retry. Per-target failures after the apply phase confirm with a visible "Could not migrate N" warning. A requested migration can no longer end in silent success with nothing migrated.
- Wizard copy: the target slot is named in every path; the pre-click explainer states that tracking *copies* the legacy save and leaves it untouched in the read-only bucket; both start-fresh routes state that the local save becomes the slot's first save on the next sync; the completion toast reports the outcome. Cosmetic double divider removed.
- User guide: `.romm-backup` retention (newest 10 per save file) and the other quarantine triggers (slot switch, wizard migration) are now documented.

## Tests

Contract + unit repro with the exact timestamped-filename case; all collision branches; probe-writes-no-state assertions; wholesale-failure/retry, temp-cleanup and device/not-installed precheck tests; frontend tests for the dialog, the cancel path, the copy, and hint placement. Verified on device (Steam Deck, Game Mode): migration into the named slot, legacy source untouched, local file quarantined into `.romm-backup`, clean baseline. Full gates green (5578 backend + 2033 frontend tests).

Bundle: the new dialog and copy raise the build to 760.67 kB; the size-limit budget is bumped 750 → 775 kB in this PR.

Docs: `docs/architecture/save-file-sync-architecture.md` and `docs/user-guide/troubleshooting.md` updated in this PR.
