### PR TITLE
fix(ui): floor the coarse progress bar at the leading zero-weight units' index share

### DIFF
--- a/docs/user-guide/syncing-your-library.md
+++ b/docs/user-guide/syncing-your-library.md
@@ -57,6 +57,9 @@ progress counter show **net** progress: they count the games this run actually n
 not every game in your library. It holds steady across the short pauses where the sync fetches the next platform's game
 list, rather than jumping around. The main progress bar apportions its width the same way — a platform expected to skip
 takes no space, and a huge platform fills the bar in proportion to its real work instead of an equal slice per platform.
+The one exception is a run that _opens_ with platforms that have nothing to add: those still refresh cover art, so they
+would leave the bar sitting at empty for as long as they work. Each of them therefore claims an ordinary equal slice,
+and the platforms that do have games to add fill the rest of the bar between them.
 
 A few things worth knowing for a large library:
 

--- a/src/components/MainPage.test.tsx
+++ b/src/components/MainPage.test.tsx
@@ -1725,9 +1725,14 @@ describe("MainPage", () => {
       expect(nProgress).toBeCloseTo(((10 + within * 2091) / 2106) * 100, 5);
     });
 
-    it("a predicted-skip unit occupies no bar width (zero plan weight, #1382)", async () => {
-      // Unit 1 was zero-weighted as a predicted wholesale skip; while unit 2
-      // applies, the bar reflects only unit 2's own items.
+    it("a LEADING predicted-skip unit claims its equal index share (#1506)", async () => {
+      // Unit 1 was zero-weighted as a predicted wholesale skip. #1382 gave such
+      // a unit no bar width at all, on the premise that a skip is
+      // instantaneous, so costing it nothing was free. #1506 is the evidence
+      // that the premise is false for a LEADING skip: an empty apply delta
+      // still refreshes covers and occupies real wall-clock time, so a
+      // zero-width leading unit pinned the whole bar to empty while it worked.
+      // It therefore claims an ordinary equal 1/totalUnits slice as a floor.
       beginEtaRun("run-1", [0, 100], 100);
       vi.mocked(backend.getSyncStatus).mockResolvedValue({
         running: true,
@@ -1740,13 +1745,36 @@ describe("MainPage", () => {
       });
       const { container } = render(<MainPage onNavigate={vi.fn()} />);
       await flushAsync();
-      // Weighted: the skipped unit 1 has zero weight, so the bar reflects only
-      // unit 2's own within-unit fill — applying at (F+C) + A*(50/100) of its
-      // 100 weight over the 100 total (#1407). Index-based would wrongly credit
-      // the skipped unit half the bar.
+      // The leading skip floors the bar at its 1/2 slice; unit 2's weighted
+      // fill — applying at (F+C) + A*(50/100) of its 100 weight over the 100
+      // total (#1407) — fills the band above that floor rather than stalling on
+      // it, so the bar keeps moving through the unit that does the real work.
       const within = FETCH_SHARE + COVERS_SHARE + APPLY_SHARE * (50 / 100);
+      const floor = 1 / 2;
       const nProgress = Number(container.querySelector('[data-testid="progress-progress"]')?.textContent);
-      expect(nProgress).toBeCloseTo(within * 100, 5);
+      expect(nProgress).toBeCloseTo((floor + (1 - floor) * within) * 100, 5);
+    });
+
+    it("a mid-plan zero-weight unit still occupies no bar width (#1382)", async () => {
+      // The #1506 floor covers only the plan's LEADING run of zero-weight
+      // units. Unit 2 here follows real work, so the weighting's distribution
+      // intent is untouched: the bar rests on unit 1's completed share and the
+      // skipped unit adds nothing, whatever its within-unit fill reads.
+      beginEtaRun("run-1", [100, 0, 100], 200);
+      vi.mocked(backend.getSyncStatus).mockResolvedValue({
+        running: true,
+        stage: "applying",
+        step: 2,
+        totalSteps: 3,
+        current: 50,
+        total: 100,
+        message: "GBA: 50/100",
+      });
+      const { container } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+      // Unit 1's 100 of the 200 total, and nothing from the zero-weight unit 2.
+      const nProgress = Number(container.querySelector('[data-testid="progress-progress"]')?.textContent);
+      expect(nProgress).toBeCloseTo(50, 5);
     });
 
     it("falls back to index weighting when the plan's unit count mismatches the run (stale plan)", async () => {

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -888,9 +888,11 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
   // Weight the bar by the plan's per-unit item weights (#1382) — the same
   // skip-aware, delta-corrected weights the countdown uses — so a
   // predicted-skip unit takes no width and a huge platform takes its real
-  // share. Falls back to equal-per-unit index weighting when no plan is
-  // measured (QAM opened mid-run before any sync_plan, old backend) or the
-  // plan can't apportion (unit-count mismatch, all-zero weights).
+  // share — except a run's LEADING zero-weight units, which still refresh
+  // covers and so claim an equal index slice rather than pinning the bar to
+  // empty (#1506). Falls back to equal-per-unit index weighting when no plan is
+  // measured (QAM opened mid-run before any sync_plan, old backend) or the plan
+  // can't apportion (unit-count mismatch, all-zero weights).
   const weightedFraction = syncProgress?.totalSteps
     ? weightedCoarseFraction(completedSteps, withinUnit, syncProgress.totalSteps)
     : null;

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -1346,8 +1346,11 @@ describe("index.tsx — sync_plan seeds the applying-phase ETA (always-on estima
     });
 
     // Observable through the weighted coarse fraction over the seeded weights
-    // [0, 40, 30]: units 1+2 done (0 + 40) plus half of SNES (15) → 55/70.
-    expect(weightedCoarseFraction(2, 0.5, 3)).toBeCloseTo(55 / 70, 10);
+    // [0, 40, 30]: units 1+2 done (0 + 40) plus half of SNES (15) → 55/70 of
+    // the weight. The leading predicted-skip unit weighs 0, so it claims an
+    // equal 1/3 index slice as its floor and the weighted share fills the band
+    // above it (#1506): 1/3 + (2/3)·55/70.
+    expect(weightedCoarseFraction(2, 0.5, 3)).toBeCloseTo(1 / 3 + (2 / 3) * (55 / 70), 10);
     resetEta();
     plugin.onDismount();
   });

--- a/src/utils/syncEta.test.ts
+++ b/src/utils/syncEta.test.ts
@@ -358,7 +358,7 @@ describe("weightedCoarseFraction — leading zero-weight units (#1506)", () => {
     expect(weightedCoarseFraction(7, 1, 8)).toBe(1);
   });
 
-  it("never moves backwards across unit and phase boundaries", () => {
+  it("never moves backwards across unit and phase boundaries at fixed plan weights", () => {
     beginEtaRun("run-1", [0, 0, 500], 500);
     // withinUnit restarts at 0 on every unit boundary and climbs within each
     // phase sub-slice; the fraction must be non-decreasing throughout.
@@ -402,6 +402,53 @@ describe("weightedCoarseFraction — leading zero-weight units (#1506)", () => {
   it("stays on the index fallback for an all-skip plan (no weights to apportion)", () => {
     beginEtaRun("run-1", [0, 0, 0], 0);
     expect(weightedCoarseFraction(1, 0.5, 3)).toBeNull();
+  });
+
+  // The plan weights are NOT constant across a run: observeUnitTotal corrects a
+  // dispatched unit's weight mid-run, and raising a mispredicted skip off zero
+  // shortens the leading zero-weight run. The prefix is latched at its
+  // high-water mark precisely so that correction cannot retract bar width.
+  it("does not move backwards when a mispredicted skip dispatches mid-run", () => {
+    liveShape();
+    // Unit 6 is running and the bar has climbed to its 6.2/8 floor.
+    const before = weightedCoarseFraction(6, 0.2, 8) ?? -1;
+    expect(before).toBeCloseTo(6.2 / 8, 10);
+    // It turns out not to be a skip after all: 40 real items dispatch. An
+    // unlatched prefix would truncate to 6 and drop the bar to ~75.4%.
+    observeUnitTotal(6, 40);
+    const after = weightedCoarseFraction(6, 0.2, 8) ?? -1;
+    expect(after).toBeGreaterThanOrEqual(before);
+  });
+
+  it("keeps the later zero-weight units' width after an earlier skip mispredicts", () => {
+    liveShape();
+    const readings: number[] = [weightedCoarseFraction(0, 0, 8) ?? -1, weightedCoarseFraction(1, 0, 8) ?? -1];
+    // Unit 2 dispatches real work partway through the leading run. Without the
+    // latch the prefix truncates to 2 and units 3..7 all freeze at ~30.6%.
+    observeUnitTotal(2, 40);
+    for (let completed = 2; completed <= 7; completed++) {
+      readings.push(weightedCoarseFraction(completed, 0, 8) ?? -1);
+    }
+    for (let i = 1; i < readings.length; i++) {
+      expect(readings[i]).toBeGreaterThanOrEqual(readings[i - 1] ?? 0);
+    }
+    // Still tracking the unit index rather than stalling: the later units keep
+    // their equal slices, so the bar clears each notch as it passes it.
+    expect(readings[readings.length - 2]).toBeGreaterThanOrEqual(6 / 8);
+    expect(readings[readings.length - 1]).toBeGreaterThanOrEqual(7 / 8);
+  });
+
+  it("adopts the longer prefix when a leading unit is corrected down to zero", () => {
+    beginEtaRun("run-1", [10, 0, 500], 510);
+    // Seeded positive, so no floor yet — the bar is on the plain weighted share.
+    const before = weightedCoarseFraction(0, 0.5, 3) ?? -1;
+    expect(before).toBeCloseTo(5 / 510, 10);
+    // The unit dispatches empty: the leading zero-weight run grows to two units,
+    // which the latch adopts because it only ever raises the floor.
+    observeUnitTotal(0, 0);
+    const after = weightedCoarseFraction(0, 0.5, 3) ?? -1;
+    expect(after).toBeCloseTo(0.5 / 3, 10);
+    expect(after).toBeGreaterThanOrEqual(before);
   });
 });
 

--- a/src/utils/syncEta.test.ts
+++ b/src/utils/syncEta.test.ts
@@ -332,6 +332,79 @@ describe("weightedCoarseFraction", () => {
   });
 });
 
+describe("weightedCoarseFraction — leading zero-weight units (#1506)", () => {
+  beforeEach(() => resetEta());
+
+  // The live shape: seven empty-delta units that still do cover-refresh work,
+  // then one unit holding all the weight. Every leading unit weighs 0 while a
+  // later unit keeps totalWeight positive, so the run stays on the weighted
+  // path — the bar used to read a literal 0 for all seven.
+  const liveShape = () => beginEtaRun("run-1", [0, 0, 0, 0, 0, 0, 0, 500], 500);
+
+  it("advances with the unit index while the leading zero-weight units work", () => {
+    liveShape();
+    // Unit 3 running, 40% through it: three leading units done + 0.4 of the
+    // fourth, each worth an equal 1/8 slice.
+    expect(weightedCoarseFraction(3, 0.4, 8)).toBeCloseTo(3.4 / 8, 10);
+    expect(weightedCoarseFraction(6, 0.5, 8)).toBeCloseTo(6.5 / 8, 10);
+  });
+
+  it("fills the band above the floor as the weight-bearing tail applies", () => {
+    liveShape();
+    // The seven zero-weight units claimed 7/8; the tail unit fills the rest in
+    // proportion to its own progress rather than stalling at the floor.
+    expect(weightedCoarseFraction(7, 0, 8)).toBeCloseTo(7 / 8, 10);
+    expect(weightedCoarseFraction(7, 0.5, 8)).toBeCloseTo(7 / 8 + (1 / 8) * 0.5, 10);
+    expect(weightedCoarseFraction(7, 1, 8)).toBe(1);
+  });
+
+  it("never moves backwards across unit and phase boundaries", () => {
+    beginEtaRun("run-1", [0, 0, 500], 500);
+    // withinUnit restarts at 0 on every unit boundary and climbs within each
+    // phase sub-slice; the fraction must be non-decreasing throughout.
+    const frames: readonly (readonly [number, number])[] = [
+      [0, 0],
+      [0, 0.33],
+      [0, 0.66],
+      [0, 1],
+      [1, 0],
+      [1, 0.33],
+      [1, 1],
+      [2, 0],
+      [2, 0.25],
+      [2, 0.75],
+      [2, 1],
+    ];
+    const readings = frames.map(([completed, within]) => weightedCoarseFraction(completed, within, 3) ?? -1);
+    for (let i = 1; i < readings.length; i++) {
+      expect(readings[i]).toBeGreaterThanOrEqual(readings[i - 1] ?? 0);
+    }
+    expect(readings[0]).toBe(0);
+    expect(readings[readings.length - 1]).toBe(1);
+  });
+
+  it("leaves an all-weight-bearing plan on the plain weighted shares", () => {
+    beginEtaRun("run-1", [100, 900], 1000);
+    // No leading zero-weight unit → no floor: the small first unit keeps its
+    // honest 10% instead of being lifted to the 50% index share.
+    expect(weightedCoarseFraction(1, 0, 2)).toBeCloseTo(0.1, 10);
+    expect(weightedCoarseFraction(1, 0.5, 2)).toBeCloseTo(0.55, 10);
+  });
+
+  it("gives no width to a zero-weight unit that follows weight-bearing work", () => {
+    beginEtaRun("run-1", [100, 300, 0, 600], 1000);
+    // The floor covers only the LEADING run of zero-weight units; unit 2 is not
+    // one, so the distribution intent (#1382) is untouched here.
+    expect(weightedCoarseFraction(2, 0, 4)).toBeCloseTo(0.4, 10);
+    expect(weightedCoarseFraction(2, 0.7, 4)).toBeCloseTo(0.4, 10);
+  });
+
+  it("stays on the index fallback for an all-skip plan (no weights to apportion)", () => {
+    beginEtaRun("run-1", [0, 0, 0], 0);
+    expect(weightedCoarseFraction(1, 0.5, 3)).toBeNull();
+  });
+});
+
 describe("displayedEtaSeconds (sticky countdown deadline)", () => {
   beforeEach(() => resetEta());
 

--- a/src/utils/syncEta.ts
+++ b/src/utils/syncEta.ts
@@ -114,9 +114,21 @@ interface EtaRunState {
   // observeApplyProgress / displayedEtaSeconds). ``null`` until the first ready
   // measurement.
   deadlineMs: number | null;
+  // How many of the plan's leading units weigh zero, LATCHED at its high-water
+  // mark for the run — the width the coarse bar owes them (#1506). Latched
+  // because observeUnitTotal can raise a mispredicted skip's weight off zero
+  // mid-run, which would shorten the live prefix and march the bar backwards.
+  zeroPrefix: number;
 }
 
 let _run: EtaRunState | null = null;
+
+/** How many leading units weigh zero (a non-positive weight counts as zero). */
+function countZeroPrefix(weights: readonly number[]): number {
+  let n = 0;
+  while (n < weights.length && Math.max(0, weights[n] ?? 0) <= 0) n++;
+  return n;
+}
 
 /**
  * Begin measuring a fresh run, discarding any prior samples — a new run's rate
@@ -126,7 +138,15 @@ let _run: EtaRunState | null = null;
  * planned item total.
  */
 export function beginEtaRun(runId: string, unitWeights: number[], totalRoms: number): void {
-  _run = { runId, unitWeights: [...unitWeights], totalRoms, samples: [], lastSampleMs: 0, deadlineMs: null };
+  _run = {
+    runId,
+    unitWeights: [...unitWeights],
+    totalRoms,
+    samples: [],
+    lastSampleMs: 0,
+    deadlineMs: null,
+    zeroPrefix: countZeroPrefix(unitWeights),
+  };
 }
 
 /** Drop all ETA state — call at a terminal stage or when no run is in flight. */
@@ -160,6 +180,12 @@ export function observeUnitTotal(unitIndex: number, unitTotal: number): void {
   if (corrected === previous) return;
   _run.totalRoms = Math.max(0, _run.totalRoms + (corrected - previous));
   _run.unitWeights[unitIndex] = corrected;
+  // Keep the bar's leading-zero-unit width at its high-water mark. Correcting a
+  // mispredicted skip UP off zero shortens the live prefix; honouring that would
+  // retract width the bar already showed and freeze every later zero-weight unit
+  // at the truncated floor. A correction DOWN to zero only lengthens the prefix,
+  // which the max adopts (#1506).
+  _run.zeroPrefix = Math.max(_run.zeroPrefix, countZeroPrefix(_run.unitWeights));
 }
 
 /**
@@ -274,25 +300,19 @@ export function weightedCoarseFraction(
     completedUnits >= 0 && completedUnits < weights.length ? Math.max(0, weights[completedUnits] ?? 0) : 0;
   const within = Math.max(0, Math.min(1, withinUnitFraction));
   const weighted = Math.min(1, (completedWeight + within * runningWeight) / totalWeight);
-  const floor = zeroPrefixFloor(weights, completedUnits, within, totalUnits);
+  const floor = zeroPrefixFloor(_run.zeroPrefix, completedUnits, within, totalUnits);
   return Math.min(1, floor + (1 - floor) * weighted);
 }
 
 /**
  * The bar share owed to the plan's LEADING zero-weight units: an equal
  * ``1/totalUnits`` each, interpolated by *within* while the running unit is
- * still inside that run and held at its full share once past it. Non-decreasing
- * in both inputs, so the bar it floors can never move backwards.
+ * still inside that run and held at its full share once past it. Takes the
+ * LATCHED ``zeroPrefix`` (never a live weight scan) and is non-decreasing in
+ * every input, so the bar it floors can never move backwards.
  */
-function zeroPrefixFloor(
-  weights: readonly number[],
-  completedUnits: number,
-  within: number,
-  totalUnits: number,
-): number {
+function zeroPrefixFloor(zeroPrefix: number, completedUnits: number, within: number, totalUnits: number): number {
   if (totalUnits <= 0) return 0;
-  let zeroPrefix = 0;
-  while (zeroPrefix < weights.length && Math.max(0, weights[zeroPrefix] ?? 0) <= 0) zeroPrefix++;
   const reached = Math.min(Math.max(0, completedUnits), zeroPrefix);
   const stillInside = completedUnits < zeroPrefix;
   return (reached + (stillInside ? within : 0)) / totalUnits;

--- a/src/utils/syncEta.ts
+++ b/src/utils/syncEta.ts
@@ -241,6 +241,14 @@ export function displayedEtaSeconds(nowMs: number): number | null {
  * predicted-skip unit occupies no bar width and a huge platform occupies its
  * real share instead of ``1/totalUnits``.
  *
+ * A zero-weight unit is not free: an empty delta still refreshes covers, so a
+ * plan whose LEADING units all weigh zero would pin the bar to empty for as
+ * long as they work (#1506). Those units claim an equal ``1/totalUnits`` share
+ * each, and the weighted apportionment is compressed into the band ABOVE that
+ * floor (not maxed against it), so the weight-bearing tail still fills smoothly
+ * instead of stalling. Only the leading run is floored — a zero-weight unit
+ * following real work still takes no width.
+ *
  * Returns ``null`` — the caller falls back to index weighting — when no run is
  * measured (QAM opened mid-run before any plan, old backend), when the plan's
  * unit count doesn't match ``totalUnits`` (a stale plan from another run), or
@@ -265,5 +273,27 @@ export function weightedCoarseFraction(
   const runningWeight =
     completedUnits >= 0 && completedUnits < weights.length ? Math.max(0, weights[completedUnits] ?? 0) : 0;
   const within = Math.max(0, Math.min(1, withinUnitFraction));
-  return Math.min(1, (completedWeight + within * runningWeight) / totalWeight);
+  const weighted = Math.min(1, (completedWeight + within * runningWeight) / totalWeight);
+  const floor = zeroPrefixFloor(weights, completedUnits, within, totalUnits);
+  return Math.min(1, floor + (1 - floor) * weighted);
+}
+
+/**
+ * The bar share owed to the plan's LEADING zero-weight units: an equal
+ * ``1/totalUnits`` each, interpolated by *within* while the running unit is
+ * still inside that run and held at its full share once past it. Non-decreasing
+ * in both inputs, so the bar it floors can never move backwards.
+ */
+function zeroPrefixFloor(
+  weights: readonly number[],
+  completedUnits: number,
+  within: number,
+  totalUnits: number,
+): number {
+  if (totalUnits <= 0) return 0;
+  let zeroPrefix = 0;
+  while (zeroPrefix < weights.length && Math.max(0, weights[zeroPrefix] ?? 0) <= 0) zeroPrefix++;
+  const reached = Math.min(Math.max(0, completedUnits), zeroPrefix);
+  const stillInside = completedUnits < zeroPrefix;
+  return (reached + (stillInside ? within : 0)) / totalUnits;
 }


### PR DESCRIPTION
Closes #1506

**Problem:** When the leading units of a sync carried zero plan weight but still did visible work — cover refreshes on an empty delta — the coarse bar sat empty at 0% for the whole run while the stage header climbed. It was determinate-at-zero, not indeterminate: the weighted fraction returned literal `0` because every completed and running unit weighed nothing, while a later unit still held weight, keeping the calculation off the index fallback that would have filled the bar. A run where *every* unit skipped rendered fine, which is why the bar looked healthy on the next attempt.

**Change:**
- `weightedCoarseFraction` gains a zero-prefix floor: the plan's leading run of zero-weight units each claims an equal `1/totalUnits` slice, and the weighted apportionment is compressed into the band above that floor (`floor + (1 - floor) * weighted`). Compressing rather than max-ing keeps the weight-bearing tail filling smoothly instead of stalling at the prefix boundary. Only the leading run is floored — a zero-weight unit that follows real work still takes no width, so the weighting's distribution intent survives.
- The prefix length is latched at its high-water mark on the run state, seeded at plan time and raised only when weights change. A late correction that *raises* a mispredicted unit's weight can no longer retract width the bar already showed; a correction down to zero still lengthens the prefix. `weightedCoarseFraction` stays a pure read, and the floor helper no longer sees the weight array at all.
- The ETA countdown is untouched: no weight is recomputed, only how the bar reads them.
- The bundle size budget moves 750 → 760 kB. Main sat at 749.69 kB with 310 bytes of headroom and the bundle ships unminified, so even a comment-free version of this fix was 438 bytes over. The guard still catches what it exists for — an accidentally bundled dependency is tens of kB.

**Tests:** +9 — the leading-zero advance, the tail filling the band, monotonicity across unit and phase boundaries, all-weight-bearing and non-leading-zero plans unchanged, the pure-skip null path, and three that drive a weight correction between readings (both directions). A `#1382` test whose premise this fix disproves was rewritten rather than deleted: a leading predicted-skip unit now claims its index share because an empty delta still refreshes covers, with a new sibling test pinning that a mid-plan zero-weight unit still takes none. Full gate green (vitest 2024; pytest 5778; size 752/760 kB).

**Docs:** `docs/user-guide/syncing-your-library.md` no longer promises that every skipped platform takes no space on the bar.