### PR TITLE
fix(sync): price the time estimate by composition and separate cover downloads

### DIFF
--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -579,28 +579,37 @@ weights + planned totals, via `sync_plan`) and the applying frames.
   `list_roms_updated_after` server check is deliberately not replayed — no network at plan time) — and
   `collapsed_count`, the persisted post-collapse shortcut count, mirroring the collapse's lane selection (ADR-0021):
   `max(1, bound rows)` per sibling group — so a grandfathered legacy group with multiple independently-bound duplicates
-  (§5) prices one shortcut per bound sibling, not one per group — plus one per keyless row. Both ride the `sync_plan`
-  payload conditionally-present (absent on collections, never-synced platforms, and failed reads); `collapsed_count` is
-  additionally **gated on the platform's completion stamp** (#1412, mirroring the `get_platforms` garnish below) — a
-  never-synced platform holds only PARTIAL collection-sibling rows (ADR-0021), so an ungated count would weight the ETA
-  below the true work, and without a stamp the frontend falls back to the raw `rom_count`. The payload's `total_roms`
-  stays the raw pre-collapse total (backward compat); an additive `total_estimated_items` sums `0` for predicted skips,
-  else `collapsed_count ?? rom_count`. A third rider, `bound_count` (#1511), counts the unit's rows that already carry a
-  `shortcut_app_id` — read in the same short UoW, since the skip prediction already needed that count. Unlike
-  `collapsed_count` it is **not** stamp-gated: a bound row genuinely has a Steam shortcut whether or not the platform's
-  mirror is complete, and zero persisted rows honestly means "every planned item is a create". **Hard constraint
-  (ADR-0023): the prediction never feeds the actual skip decision** — `_try_unit_incremental_skip` at fetch time remains
-  the sole skip authority, so a mis-prediction can only make the estimate read long or short, never mis-apply. A Force
-  Full Sync needs no special case: `clear_sync_cache` deletes every stamp before the run, so a forced plan predicts no
-  skips and drops every `collapsed_count` (the forced re-apply is priced at the full `rom_count`). The same collapsed
-  counts also garnish `get_platforms` (an optional per-platform `collapsed_count`), so the platform toggles show the
-  number of games a synced platform actually produces rather than the raw server file count. That garnish is **gated on
-  the platform's completion stamp** (`_read_collapsed_counts`, #1412): the count is emitted only for slugs that
-  currently carry a `PlatformSyncState` stamp — the stamp exists iff the local mirror is complete, which is exactly when
-  a post-collapse count is meaningful. A never-synced platform legitimately holds only PARTIAL rows (cross-platform
-  collection siblings persist per ADR-0021), so an ungated count would shadow the true server total; with no stamp the
-  field is absent and the toggle label falls back to the raw `rom_count`. Clearing the stamp (local removal / Force Full
-  Sync) reverts the label to the server total until the next completed sync re-stamps.
+  (§5) prices one shortcut per bound sibling, not one per group — plus one per keyless row. Both of **those two** ride
+  the `sync_plan` payload conditionally-present (absent on collections, never-synced platforms, and failed reads);
+  `collapsed_count` is additionally **gated on the platform's completion stamp** (#1412, mirroring the `get_platforms`
+  garnish below) — a never-synced platform holds only PARTIAL collection-sibling rows (ADR-0021), so an ungated count
+  would weight the ETA below the true work, and without a stamp the frontend falls back to the raw `rom_count`. The
+  payload's `total_roms` stays the raw pre-collapse total (backward compat); an additive `total_estimated_items` sums
+  `0` for predicted skips, else `collapsed_count ?? rom_count`. A third rider, `bound_count` (#1511), counts the unit's
+  known ROMs that already carry a `shortcut_app_id`, and is the one rider that rides **both** unit kinds. On a
+  **platform** it counts the persisted rows, read in the same short UoW the skip prediction already needed that count
+  for, and is **not** stamp-gated: a bound row genuinely has a Steam shortcut whether or not the mirror is complete, and
+  zero persisted rows honestly means "every planned item is a create". On a **collection** it counts the bound members
+  of the completion stamp's stored `member_rom_ids` (the same member set the skip replays), in one short read UoW
+  covering every collection unit — no ROM fetch. The two sides are deliberately **asymmetric** on the empty case: a
+  platform reports `0`, an unstamped or franchise collection is **omitted**. A collection's membership exists only in
+  its stamp, and franchise collections are never stampable (`CollectionSyncState.stamp` accepts only `user`/`smart`), so
+  `0` there would claim knowledge that does not exist. Absent and `0` price identically today; the distinction keeps the
+  field honest for later consumers, so do not collapse it into consistency. A collection's stored member set may be
+  **stale** if membership changed since the stamp — accepted and bounded, since this is estimate-only and a freshness
+  probe would mean network I/O at plan time. **Hard constraint (ADR-0023): the prediction never feeds the actual skip
+  decision** — `_try_unit_incremental_skip` at fetch time remains the sole skip authority, so a mis-prediction can only
+  make the estimate read long or short, never mis-apply. A Force Full Sync needs no special case: `clear_sync_cache`
+  deletes every stamp before the run, so a forced plan predicts no skips and drops every `collapsed_count` (the forced
+  re-apply is priced at the full `rom_count`). The same collapsed counts also garnish `get_platforms` (an optional
+  per-platform `collapsed_count`), so the platform toggles show the number of games a synced platform actually produces
+  rather than the raw server file count. That garnish is **gated on the platform's completion stamp**
+  (`_read_collapsed_counts`, #1412): the count is emitted only for slugs that currently carry a `PlatformSyncState`
+  stamp — the stamp exists iff the local mirror is complete, which is exactly when a post-collapse count is meaningful.
+  A never-synced platform legitimately holds only PARTIAL rows (cross-platform collection siblings persist per
+  ADR-0021), so an ungated count would shadow the true server total; with no stamp the field is absent and the toggle
+  label falls back to the raw `rom_count`. Clearing the stamp (local removal / Force Full Sync) reverts the label to the
+  server total until the next completed sync re-stamps.
 - **Static walk-cost ceiling (pre-run seed).** Before a run — in the preview, and again as the initial "up to X min" the
   instant a skip-preview run starts — the estimate is a pure cost model over **three independent terms** (#1511),
   because a run is three independent phases and one blended per-item rate cannot describe a mix of them:
@@ -617,9 +626,11 @@ weights + planned totals, via `sync_plan`) and the applying frames.
   blended item count (#1511): a predicted-skip unit costs nothing, and of the remainder's items
   (`collapsed_count ?? rom_count`) the ones already bound (`bound_count`) take the update rate, the rest the create
   rate. Pricing every planned item as a create over-read by ~4x on the common case — any re-sync, and **every Force Full
-  Sync**, which clears the completion stamps but unbinds nothing and is therefore an all-updates run. A unit from a
-  backend that omits `bound_count` still prices as all creates, the pre-#1511 behaviour. The live-countdown weights are
-  unaffected and stay `predicted_skip ? 0 : (collapsed_count ?? rom_count)`.
+  Sync**, which clears the completion stamps but unbinds nothing and is therefore an all-updates run. Platform and
+  collection units are priced the same way, so a collection-heavy library does not reinstate the over-read through its
+  collections. A unit whose `bound_count` is absent (older backend, unstamped or franchise collection) still prices as
+  all creates, the pre-#1511 behaviour. The live-countdown weights are unaffected and stay
+  `predicted_skip ? 0 : (collapsed_count ?? rom_count)`.
 - **Measured live countdown (takes over within seconds).** Once the apply is underway, `syncEta.ts` measures the
   **real** rate from the applying frames — one throttled sample per second over a ~30 s sliding window — and projects
   `remaining = (planned_total − processed) / rate`, rendered rounded **up** ("9 min left") so it never promises less

--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -627,10 +627,14 @@ weights + planned totals, via `sync_plan`) and the applying frames.
   (`collapsed_count ?? rom_count`) the ones already bound (`bound_count`) take the update rate, the rest the create
   rate. Pricing every planned item as a create over-read by ~4x on the common case — any re-sync, and **every Force Full
   Sync**, which clears the completion stamps but unbinds nothing and is therefore an all-updates run. Platform and
-  collection units are priced the same way, so a collection-heavy library does not reinstate the over-read through its
-  collections. A unit whose `bound_count` is absent (older backend, unstamped or franchise collection) still prices as
-  all creates, the pre-#1511 behaviour. The live-countdown weights are unaffected and stay
-  `predicted_skip ? 0 : (collapsed_count ?? rom_count)`.
+  collection units are priced the same way on an ordinary re-sync, so a collection-heavy library does not reinstate the
+  over-read through its collections. **A Force Full Sync is the exception for collections**: `clear_sync_cache` clears
+  `collection_sync_state` wholesale, and a collection's member set lives _only_ in that stamp, so every collection unit
+  is unstamped for that run and reverts to create pricing. Platforms are unaffected — their `bound_count` is
+  deliberately not stamp-gated. This follows directly from the `None`-not-`0` rule above and errs **long**, the safe
+  direction; correcting it would mean asserting membership the plan does not have. A unit whose `bound_count` is absent
+  (older backend, unstamped or franchise collection) prices as all creates, the pre-#1511 behaviour. The live-countdown
+  weights are unaffected and stay `predicted_skip ? 0 : (collapsed_count ?? rom_count)`.
 - **Measured live countdown (takes over within seconds).** Once the apply is underway, `syncEta.ts` measures the
   **real** rate from the applying frames — one throttled sample per second over a ~30 s sliding window — and projects
   `remaining = (planned_total − processed) / rate`, rendered rounded **up** ("9 min left") so it never promises less

--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -585,29 +585,41 @@ weights + planned totals, via `sync_plan`) and the applying frames.
   never-synced platform holds only PARTIAL collection-sibling rows (ADR-0021), so an ungated count would weight the ETA
   below the true work, and without a stamp the frontend falls back to the raw `rom_count`. The payload's `total_roms`
   stays the raw pre-collapse total (backward compat); an additive `total_estimated_items` sums `0` for predicted skips,
-  else `collapsed_count ?? rom_count`. **Hard constraint (ADR-0023): the prediction never feeds the actual skip
-  decision** — `_try_unit_incremental_skip` at fetch time remains the sole skip authority, so a mis-prediction can only
-  make the estimate read long or short, never mis-apply. A Force Full Sync needs no special case: `clear_sync_cache`
-  deletes every stamp before the run, so a forced plan predicts no skips and drops every `collapsed_count` (the forced
-  re-apply is priced at the full `rom_count`). The same collapsed counts also garnish `get_platforms` (an optional
-  per-platform `collapsed_count`), so the platform toggles show the number of games a synced platform actually produces
-  rather than the raw server file count. That garnish is **gated on the platform's completion stamp**
-  (`_read_collapsed_counts`, #1412): the count is emitted only for slugs that currently carry a `PlatformSyncState`
-  stamp — the stamp exists iff the local mirror is complete, which is exactly when a post-collapse count is meaningful.
-  A never-synced platform legitimately holds only PARTIAL rows (cross-platform collection siblings persist per
-  ADR-0021), so an ungated count would shadow the true server total; with no stamp the field is absent and the toggle
-  label falls back to the raw `rom_count`. Clearing the stamp (local removal / Force Full Sync) reverts the label to the
-  server total until the next completed sync re-stamps.
+  else `collapsed_count ?? rom_count`. A third rider, `bound_count` (#1511), counts the unit's rows that already carry a
+  `shortcut_app_id` — read in the same short UoW, since the skip prediction already needed that count. Unlike
+  `collapsed_count` it is **not** stamp-gated: a bound row genuinely has a Steam shortcut whether or not the platform's
+  mirror is complete, and zero persisted rows honestly means "every planned item is a create". **Hard constraint
+  (ADR-0023): the prediction never feeds the actual skip decision** — `_try_unit_incremental_skip` at fetch time remains
+  the sole skip authority, so a mis-prediction can only make the estimate read long or short, never mis-apply. A Force
+  Full Sync needs no special case: `clear_sync_cache` deletes every stamp before the run, so a forced plan predicts no
+  skips and drops every `collapsed_count` (the forced re-apply is priced at the full `rom_count`). The same collapsed
+  counts also garnish `get_platforms` (an optional per-platform `collapsed_count`), so the platform toggles show the
+  number of games a synced platform actually produces rather than the raw server file count. That garnish is **gated on
+  the platform's completion stamp** (`_read_collapsed_counts`, #1412): the count is emitted only for slugs that
+  currently carry a `PlatformSyncState` stamp — the stamp exists iff the local mirror is complete, which is exactly when
+  a post-collapse count is meaningful. A never-synced platform legitimately holds only PARTIAL rows (cross-platform
+  collection siblings persist per ADR-0021), so an ungated count would shadow the true server total; with no stamp the
+  field is absent and the toggle label falls back to the raw `rom_count`. Clearing the stamp (local removal / Force Full
+  Sync) reverts the label to the server total until the next completed sync re-stamps.
 - **Static walk-cost ceiling (pre-run seed).** Before a run — in the preview, and again as the initial "up to X min" the
-  instant a skip-preview run starts — the estimate is a pure cost model: `new_count × NEW_ITEM_SEC` +
-  `changed_count × UPDATED_ITEM_SEC` + a flat fetch allowance. The per-item constants (currently ~0.45 s for a created
-  shortcut, ~0.20 s for an updated one) sit **deliberately above** the measured on-device apply rates and the allowance
-  (~90 s) covers the multi-page ROM/save fetch phases the per-item model ignores, so the seed is an honest **upper
-  bound** that reads long, never short. It is priced at **walk cost** (every unit the run will actually touch), not at
-  the delta only — a resume walks thousands of already-applied games through the cheap update path, so a delta-only
-  price would badly undershoot the real work. The skip-preview seed prices `total_estimated_items ?? total_roms`, so an
-  incremental re-sync whose platforms are all predicted skips seeds near the flat allowance instead of a whole-library
-  ceiling; the live-countdown weights are seeded per unit as `predicted_skip ? 0 : (collapsed_count ?? rom_count)`.
+  instant a skip-preview run starts — the estimate is a pure cost model over **three independent terms** (#1511),
+  because a run is three independent phases and one blended per-item rate cannot describe a mix of them:
+  `created × NEW_ITEM_SEC` + `changed × UPDATED_ITEM_SEC` + `(created + cover_refresh_count) × COVER_DOWNLOAD_SEC` + a
+  flat fixed-overhead allowance. Each constant is calibrated to its own measured mean with a ~15% ceiling margin (0.36 s
+  per created shortcut against a measured 0.314; 0.13 s per update against 0.109; 0.15 s per cover download against
+  0.132 cold), and the allowance (45 s) covers the run's genuinely fixed cost — the one-time shortcut scan, the
+  multi-page ROM/save fetches, the inter-chunk gaps, finalize (measured 17–24 s). So the seed still reads long, never
+  short, but it now reads long by a margin rather than by a factor. Two consequences worth stating: an **update carries
+  no artwork cost** (the apply loop gates cover application on `created`), and a **cached cover is not a term** — warm
+  covers cost 0.0018 s, 73x cheaper than cold, and pricing them would need a backend cache probe in the preview path
+  that is deliberately not added, so every create is priced as needing a cold download.
+- **Composition-priced plan seed.** The skip-preview seed prices the plan **per unit by composition**, not as one
+  blended item count (#1511): a predicted-skip unit costs nothing, and of the remainder's items
+  (`collapsed_count ?? rom_count`) the ones already bound (`bound_count`) take the update rate, the rest the create
+  rate. Pricing every planned item as a create over-read by ~4x on the common case — any re-sync, and **every Force Full
+  Sync**, which clears the completion stamps but unbinds nothing and is therefore an all-updates run. A unit from a
+  backend that omits `bound_count` still prices as all creates, the pre-#1511 behaviour. The live-countdown weights are
+  unaffected and stay `predicted_skip ? 0 : (collapsed_count ?? rom_count)`.
 - **Measured live countdown (takes over within seconds).** Once the apply is underway, `syncEta.ts` measures the
   **real** rate from the applying frames — one throttled sample per second over a ~30 s sliding window — and projects
   `remaining = (planned_total − processed) / rate`, rendered rounded **up** ("9 min left") so it never promises less
@@ -624,6 +636,16 @@ weights + planned totals, via `sync_plan`) and the applying frames.
   segment** (the prior samples are discarded), so the slope is never measured across the gap — pairing a pre-gap sample
   with a post-gap one would be a tiny item delta over a long span, an absurd rate that would briefly spike the
   countdown.
+- **Stalled-prefix trim (shorter stalls).** A stall too short to break the segment used to poison the window head
+  instead (#1511). The applying stage is entered — and its first frame emitted — **before** the one-time shortcut scan,
+  which then blocks for ~9–14 s (it scales with the existing library, not the delta). That frame became sample #1 and
+  paired with the first post-scan sample: a couple of items across the whole scan, a rate ~10x below the real one, which
+  the sticky deadline then held until the 30 s window slid past — the reported "6 min → 2 min" collapse. Leading samples
+  are therefore dropped when the head gap is both **wide** (> 3 s, several sampling cadences) and **unproductive**
+  (fewer than one item per sampling interval, below anything the 50 ms-paced apply loop produces). Both conditions are
+  required: a wide gap that carried real throughput is slow work, not a stall, and discarding it would measure only the
+  fastest stretch. Trimming can legitimately leave a single sample — "no measurement yet" is the honest answer while a
+  stall is all the window has seen, so the static seed keeps standing until clean samples accumulate.
 
 The coarse QAM progress bar reuses the same run weights (`weightedCoarseFraction`, `syncEta.ts`): each unit's bar width
 is its item-weight share — skip-aware at plan time, corrected to the real delta as units dispatch — with the within-unit

--- a/docs/user-guide/syncing-your-library.md
+++ b/docs/user-guide/syncing-your-library.md
@@ -53,10 +53,13 @@ skips it without re-listing its contents — so a large, collection-heavy librar
 
 The estimate also knows the **difference between adding a game and updating one**. Creating a shortcut is roughly three
 times the work of refreshing one that already exists, and it also has to pull down a cover; updating an existing
-shortcut does neither. So a run over games your library already has — any re-sync, and in particular a **Force Full
-Sync**, which re-applies everything but keeps your existing shortcuts — is estimated at the cheaper update rate rather
-than as though it were building your library from scratch. Cover updates are counted on their own, so a run that only
-refreshes cover art is estimated from how many covers changed instead of falling back to a fixed number.
+shortcut does neither. So a re-sync over games your library already has is estimated at the cheaper update rate rather
+than as though it were building your library from scratch. One exception: after a **Force Full Sync**, your collections
+are estimated at the dearer "adding" rate for that run. The plugin only knows which games are in a collection from the
+record it keeps when that collection last finished syncing, and Force Full Sync deliberately wipes those records — so
+for that one run it can't tell that your collections' games are already in Steam. The run itself is unaffected, and the
+estimate only ever reads too long, never too short. Cover updates are counted on their own, so a run that only refreshes
+cover art is estimated from how many covers changed instead of falling back to a fixed number.
 
 Once the sync has been creating shortcuts for a few seconds, that "up to" ceiling is replaced by a **live countdown** —
 "2 min left" — measured from the actual speed on your device and updated as the run proceeds. The countdown waits until

--- a/docs/user-guide/syncing-your-library.md
+++ b/docs/user-guide/syncing-your-library.md
@@ -51,15 +51,25 @@ the readout run long or short for a moment, but it never changes what the sync a
 the same way a platform is: if a collection's membership hasn't changed and none of its games did either, the plugin
 skips it without re-listing its contents — so a large, collection-heavy library re-syncs quickly.
 
+The estimate also knows the **difference between adding a game and updating one**. Creating a shortcut is roughly three
+times the work of refreshing one that already exists, and it also has to pull down a cover; updating an existing
+shortcut does neither. So a run over games your library already has — any re-sync, and in particular a **Force Full
+Sync**, which re-applies everything but keeps your existing shortcuts — is estimated at the cheaper update rate rather
+than as though it were building your library from scratch. Cover updates are counted on their own, so a run that only
+refreshes cover art is estimated from how many covers changed instead of falling back to a fixed number.
+
 Once the sync has been creating shortcuts for a few seconds, that "up to" ceiling is replaced by a **live countdown** —
-"2 min left" — measured from the actual speed on your device and updated as the run proceeds. Both the countdown and the
-progress counter show **net** progress: they count the games this run actually needs to add or update (say "100/801"),
-not every game in your library. It holds steady across the short pauses where the sync fetches the next platform's game
-list, rather than jumping around. The main progress bar apportions its width the same way — a platform expected to skip
-takes no space, and a huge platform fills the bar in proportion to its real work instead of an equal slice per platform.
-The one exception is a run that _opens_ with platforms that have nothing to add: those still refresh cover art, so they
-would leave the bar sitting at empty for as long as they work. Each of them therefore claims an ordinary equal slice,
-and the platforms that do have games to add fill the rest of the bar between them.
+"2 min left" — measured from the actual speed on your device and updated as the run proceeds. The countdown waits until
+it has genuinely measured the apply speed before it appears: at the very start of a run the plugin takes a one-off look
+at the shortcuts already in Steam, which can take ten seconds or so on a large library, and readings taken across that
+pause would make the first countdown read several times too long. Both the countdown and the progress counter show
+**net** progress: they count the games this run actually needs to add or update (say "100/801"), not every game in your
+library. It holds steady across the short pauses where the sync fetches the next platform's game list, rather than
+jumping around. The main progress bar apportions its width the same way — a platform expected to skip takes no space,
+and a huge platform fills the bar in proportion to its real work instead of an equal slice per platform. The one
+exception is a run that _opens_ with platforms that have nothing to add: those still refresh cover art, so they would
+leave the bar sitting at empty for as long as they work. Each of them therefore claims an ordinary equal slice, and the
+platforms that do have games to add fill the rest of the bar between them.
 
 A few things worth knowing for a large library:
 

--- a/py_modules/domain/work_unit.py
+++ b/py_modules/domain/work_unit.py
@@ -38,17 +38,18 @@ class WorkUnit:
     # membership-stable signal. ``None`` when the listing omits it (e.g. a
     # franchise collection, which is never stamped) — skip-internal, off the wire.
     collection_updated_at: str | None = None
-    # Plan-time estimate riders (#1382), platform-only. ``predicted_skip`` is
-    # the plan's local-conditions guess at the fetch-time wholesale-skip gate's
-    # outcome; ``collapsed_count`` the persisted post-collapse shortcut count;
-    # ``bound_count`` how many of the unit's persisted rows already carry a
-    # Steam shortcut, which is what lets the frontend price them at the cheap
-    # UPDATE rate instead of the create rate.
+    # Plan-time estimate riders (#1382 / #1511). ``predicted_skip`` is the
+    # plan's local-conditions guess at the fetch-time wholesale-skip gate's
+    # outcome and ``collapsed_count`` the persisted post-collapse shortcut
+    # count — both platform-only. ``bound_count`` carries on BOTH unit types:
+    # how many of the unit's known ROMs already hold a Steam shortcut, which is
+    # what lets the frontend price them at the cheap UPDATE rate instead of the
+    # create rate (a platform reads its persisted rows; a collection reads its
+    # stamped member set).
     # Estimate-ONLY: they price the ``sync_plan`` payload and must never feed
     # the actual skip decision — ``_try_unit_incremental_skip`` remains the
-    # sole skip authority (ADR-0023). ``None`` means unknown (collections,
-    # never-synced platforms, failed estimate read) and is omitted from the
-    # event payload.
+    # sole skip authority (ADR-0023). ``None`` means unknown and is omitted
+    # from the event payload.
     predicted_skip: bool | None = None
     collapsed_count: int | None = None
     bound_count: int | None = None

--- a/py_modules/domain/work_unit.py
+++ b/py_modules/domain/work_unit.py
@@ -40,7 +40,10 @@ class WorkUnit:
     collection_updated_at: str | None = None
     # Plan-time estimate riders (#1382), platform-only. ``predicted_skip`` is
     # the plan's local-conditions guess at the fetch-time wholesale-skip gate's
-    # outcome; ``collapsed_count`` the persisted post-collapse shortcut count.
+    # outcome; ``collapsed_count`` the persisted post-collapse shortcut count;
+    # ``bound_count`` how many of the unit's persisted rows already carry a
+    # Steam shortcut, which is what lets the frontend price them at the cheap
+    # UPDATE rate instead of the create rate.
     # Estimate-ONLY: they price the ``sync_plan`` payload and must never feed
     # the actual skip decision — ``_try_unit_incremental_skip`` remains the
     # sole skip authority (ADR-0023). ``None`` means unknown (collections,
@@ -48,6 +51,7 @@ class WorkUnit:
     # event payload.
     predicted_skip: bool | None = None
     collapsed_count: int | None = None
+    bound_count: int | None = None
 
     def estimated_items(self) -> int:
         """This unit's weight in the plan's skip-aware estimate total.
@@ -76,4 +80,6 @@ class WorkUnit:
             payload["predicted_skip"] = self.predicted_skip
         if self.collapsed_count is not None:
             payload["collapsed_count"] = self.collapsed_count
+        if self.bound_count is not None:
+            payload["bound_count"] = self.bound_count
         return payload

--- a/py_modules/services/library/fetcher.py
+++ b/py_modules/services/library/fetcher.py
@@ -569,6 +569,13 @@ class LibraryFetcher:
         all-creates — but the distinction keeps the field honest for any later
         consumer. Do not "simplify" this into consistency with the platform side.
 
+        Consequence worth knowing before re-tuning the estimate: ``clear_sync_cache``
+        clears ``collection_sync_state`` wholesale, so a **Force Full Sync** leaves
+        every collection unstamped and its units revert to create pricing for that
+        run — even though the shortcuts themselves survive. Platform units are
+        unaffected (their bound count reads the rows directly, no stamp gate). The
+        estimate reads long, never short, which is the safe direction.
+
         The member set may be STALE (membership can have changed since the
         stamp). That is accepted and bounded: estimate-only (ADR-0023), and a
         freshness probe would mean network I/O at plan time.
@@ -614,8 +621,9 @@ class LibraryFetcher:
         create". The gate's server-delta check (``list_roms_updated_after``) is
         deliberately NOT replayed — no network at plan time. A Force Full Sync clears every
         stamp before the run, so its plan predicts no skips AND drops every
-        collapsed count (the forced re-apply is priced at the full ``rom_count``)
-        without a special case. One short read UoW for the whole plan.
+        collapsed count — the forced re-apply is WEIGHED at the full ``rom_count``,
+        though the bound count survives the clear and still splits those items
+        between the update and create rates. One short read UoW for the whole plan.
 
         Estimate-ONLY (ADR-0023): the result rides the ``sync_plan`` payload
         and must never feed the actual skip decision —

--- a/py_modules/services/library/fetcher.py
+++ b/py_modules/services/library/fetcher.py
@@ -433,10 +433,11 @@ class LibraryFetcher:
         first, then user collections, then smart collections, then
         franchise collections) with ROM counts pulled from the listing
         endpoints. No ROMs are fetched here — the queue is a dispatch
-        plan, not a payload. Platform units additionally carry the
-        plan-time estimate riders (``predicted_skip`` / ``collapsed_count``,
-        #1382) — estimate-only fields for the ``sync_plan`` payload that
-        never feed the actual skip decision (ADR-0023).
+        plan, not a payload. Units additionally carry the plan-time estimate
+        riders for the ``sync_plan`` payload — ``predicted_skip`` /
+        ``collapsed_count`` on platform units (#1382), ``bound_count`` on both
+        kinds (#1511). Estimate-only: they never feed the actual skip decision
+        (ADR-0023).
         """
         units: list[WorkUnit] = []
 
@@ -460,9 +461,13 @@ class LibraryFetcher:
         if not (enabled_user_ids or enabled_smart_ids or enabled_franchise_ids):
             return units
 
-        units.extend(await self._build_user_collection_units(enabled_user_ids))
-        units.extend(await self._build_smart_collection_units(enabled_smart_ids))
-        units.extend(await self._build_franchise_collection_units(enabled_franchise_ids))
+        collection_units: list[WorkUnit] = []
+        collection_units.extend(await self._build_user_collection_units(enabled_user_ids))
+        collection_units.extend(await self._build_smart_collection_units(enabled_smart_ids))
+        collection_units.extend(await self._build_franchise_collection_units(enabled_franchise_ids))
+        # One short read UoW for every collection at once — after the listing
+        # fetches, never across them.
+        units.extend(await self._attach_collection_bound_counts(collection_units))
 
         return units
 
@@ -524,6 +529,64 @@ class LibraryFetcher:
             else unit
             for unit in platform_units
         ]
+
+    async def _attach_collection_bound_counts(self, collection_units: list[WorkUnit]) -> list[WorkUnit]:
+        """Stamp each collection unit with its ``bound_count`` estimate rider (#1511).
+
+        Fail-open like the platform sibling: a failed read leaves the field
+        ``None``, so the frontend prices the unit exactly as it did before the
+        rider existed rather than the plan failing.
+        """
+        if not collection_units:
+            return collection_units
+        try:
+            counts = await self._loop.run_in_executor(None, self._read_collection_bound_counts, collection_units)
+        except Exception as e:
+            self._logger.warning(f"Plan-time collection bound-count read failed, pricing as creates: {e}")
+            return collection_units
+        return [
+            replace(unit, bound_count=counts[key]) if (key := (str(unit.id), unit.collection_kind)) in counts else unit
+            for unit in collection_units
+        ]
+
+    def _read_collection_bound_counts(self, units: list[WorkUnit]) -> dict[tuple[str, str | None], int]:
+        """Bound-member count per stamped collection, keyed ``(id, kind)`` (#1511).
+
+        A collection has no local membership column — membership lives on the
+        server — so the count comes from the completion stamp's
+        ``member_rom_ids`` (the same stored member set the skip replays),
+        counting those whose ``roms`` row carries a ``shortcut_app_id``. No ROM
+        fetch, one short read UoW for every collection unit at once.
+
+        Deliberately ASYMMETRIC with the platform rider: a platform with no
+        persisted rows reports ``0`` (real knowledge — nothing is mirrored, so
+        every item is a create), whereas an unstamped collection is omitted
+        entirely. A collection's member set exists ONLY in its stamp, so without
+        one there is no membership to count; franchise collections are never
+        stampable at all (``CollectionSyncState.stamp`` accepts only
+        ``user``/``smart``). Reporting ``0`` there would claim knowledge we do
+        not have. Absent and ``0`` price identically today — both read as
+        all-creates — but the distinction keeps the field honest for any later
+        consumer. Do not "simplify" this into consistency with the platform side.
+
+        The member set may be STALE (membership can have changed since the
+        stamp). That is accepted and bounded: estimate-only (ADR-0023), and a
+        freshness probe would mean network I/O at plan time.
+        """
+        counts: dict[tuple[str, str | None], int] = {}
+        with self._uow_factory() as uow:
+            for unit in units:
+                if unit.collection_kind is None:
+                    continue
+                stamp = uow.collection_sync_state.get(str(unit.id), unit.collection_kind)
+                if stamp is None:
+                    continue
+                counts[(str(unit.id), unit.collection_kind)] = sum(
+                    1
+                    for rom_id in stamp.member_rom_ids
+                    if (rom := uow.roms.get(rom_id)) is not None and rom.shortcut_app_id is not None
+                )
+        return counts
 
     def _read_plan_estimates(self, units: list[WorkUnit]) -> dict[str, _PlanEstimate]:
         """Read the plan-time estimate baseline for platform units (#1382).

--- a/py_modules/services/library/fetcher.py
+++ b/py_modules/services/library/fetcher.py
@@ -48,6 +48,19 @@ if TYPE_CHECKING:
 _SYNC_CANCELLED = "Sync cancelled"
 
 
+class _PlanEstimate(NamedTuple):
+    """One platform's plan-time estimate riders for the ``sync_plan`` payload.
+
+    Estimate-ONLY (ADR-0023) — these price the frontend's time readout and
+    never feed the actual skip decision. ``None`` counts mean "unknown" and
+    ride the payload absent.
+    """
+
+    predicted_skip: bool
+    collapsed_count: int | None
+    bound_count: int | None
+
+
 class _SkipBaseline(NamedTuple):
     """One platform's locally persisted inputs to the incremental-skip gate."""
 
@@ -501,13 +514,18 @@ class LibraryFetcher:
             self._logger.warning(f"Plan-time skip-estimate read failed, using raw ROM counts: {e}")
             return platform_units
         return [
-            replace(unit, predicted_skip=estimates[unit.slug][0], collapsed_count=estimates[unit.slug][1])
+            replace(
+                unit,
+                predicted_skip=estimates[unit.slug].predicted_skip,
+                collapsed_count=estimates[unit.slug].collapsed_count,
+                bound_count=estimates[unit.slug].bound_count,
+            )
             if unit.slug in estimates
             else unit
             for unit in platform_units
         ]
 
-    def _read_plan_estimates(self, units: list[WorkUnit]) -> dict[str, tuple[bool, int | None]]:
+    def _read_plan_estimates(self, units: list[WorkUnit]) -> dict[str, _PlanEstimate]:
         """Read the plan-time estimate baseline for platform units (#1382).
 
         Per unit slug: replay the wholesale-skip gate's LOCAL conditions
@@ -523,9 +541,15 @@ class LibraryFetcher:
         (cross-platform collection siblings, ADR-0021) would mis-weight the ETA
         below the true work. ``None`` (no stamp, or no persisted rows) rides the
         payload absent, so the frontend weights the unit at its raw ``rom_count``
-        (``predicted_skip ? 0 : collapsed_count ?? rom_count``). The gate's
-        server-delta check (``list_roms_updated_after``) is deliberately NOT
-        replayed — no network at plan time. A Force Full Sync clears every
+        (``predicted_skip ? 0 : collapsed_count ?? rom_count``). Also count the
+        unit's BOUND rows — those already carrying a ``shortcut_app_id`` — which
+        the frontend prices at the cheap update rate rather than the create rate,
+        so a re-sync of an already-mirrored platform stops reading as a fresh
+        import. Unlike the collapsed count this needs no stamp gate: a bound row
+        genuinely has a Steam shortcut whether or not the platform's mirror is
+        complete, and zero persisted rows honestly means "every item is a
+        create". The gate's server-delta check (``list_roms_updated_after``) is
+        deliberately NOT replayed — no network at plan time. A Force Full Sync clears every
         stamp before the run, so its plan predicts no skips AND drops every
         collapsed count (the forced re-apply is priced at the full ``rom_count``)
         without a special case. One short read UoW for the whole plan.
@@ -535,11 +559,12 @@ class LibraryFetcher:
         ``_try_unit_incremental_skip`` at fetch time remains the sole skip
         authority.
         """
-        estimates: dict[str, tuple[bool, int | None]] = {}
+        estimates: dict[str, _PlanEstimate] = {}
         with self._uow_factory() as uow:
             for unit in units:
                 stamp = uow.platform_sync_state.get(unit.slug)
                 all_rows = list(uow.roms.iter_by_platform(unit.slug))
+                bound_count = sum(1 for rom in all_rows if rom.shortcut_app_id is not None)
                 predicted = predict_unit_skip(
                     stamp_completed_at=stamp.completed_at if stamp is not None else None,
                     stamp_rom_count=stamp.rom_count if stamp is not None else None,
@@ -547,7 +572,7 @@ class LibraryFetcher:
                     # The same fetch-generation count the real gate uses (#1504),
                     # so the estimate keeps replaying the gate's local conditions.
                     fetched_count=count_rows_for_skip(all_rows, stamp.fetch_id if stamp is not None else None),
-                    registry_count=sum(1 for rom in all_rows if rom.shortcut_app_id is not None),
+                    registry_count=bound_count,
                     needs_backfill=any(rom.sibling_group_key is None for rom in all_rows),
                 )
                 collapsed = (
@@ -557,7 +582,7 @@ class LibraryFetcher:
                     if stamp is not None and all_rows
                     else None
                 )
-                estimates[unit.slug] = (predicted, collapsed)
+                estimates[unit.slug] = _PlanEstimate(predicted, collapsed, bound_count)
         return estimates
 
     def _read_collapsed_counts(self) -> dict[str, int]:

--- a/src/components/MainPage.test.tsx
+++ b/src/components/MainPage.test.tsx
@@ -51,7 +51,7 @@ import {
 } from "../utils/syncProgress";
 import { beginEtaRun, resetEta, liveEtaSeconds } from "../utils/syncEta";
 import * as syncEta from "../utils/syncEta";
-import { NEW_ITEM_SEC, UPDATED_ITEM_SEC } from "../utils/syncEstimate";
+import { NEW_ITEM_SEC, UPDATED_ITEM_SEC, COVER_DOWNLOAD_SEC, FETCH_ALLOWANCE_SEC } from "../utils/syncEstimate";
 import { setDownloads } from "../utils/downloadStore";
 import { showModal } from "@decky/ui";
 import * as syncManager from "../utils/syncManager";
@@ -1210,12 +1210,12 @@ describe("MainPage", () => {
 
     // Coverage and duration each own a label-less line under the "Changes"
     // block ("Scope" and "Preview" as competing labels read as duplicate info).
-    // These summaries have one new item, so the estimate is the fetch allowance
-    // rounding to "2 min".
+    // These summaries have one new item, so the estimate is essentially the flat
+    // fixed-overhead allowance (45s) and reads "< 1 min".
     it("reads 'Syncing N platforms · M collections' with both counts", async () => {
       const c = await renderPreviewScope(3, 2);
       expect(c.querySelector('[data-testid="sync-scope"]')?.textContent).toBe("Syncing 3 platforms · 2 collections");
-      expect(c.querySelector('[data-testid="sync-estimate"]')?.textContent).toBe("Estimated duration: 2 min");
+      expect(c.querySelector('[data-testid="sync-estimate"]')?.textContent).toBe("Estimated duration: < 1 min");
     });
 
     it("omits the collections part when the run syncs none, and singularizes", async () => {
@@ -1231,7 +1231,7 @@ describe("MainPage", () => {
     it("shows the duration alone when the backend omits both scope counts (empty scope)", async () => {
       const c = await renderPreviewScope(0, 0);
       expect(c.querySelector('[data-testid="sync-scope"]')).toBeNull();
-      expect(c.querySelector('[data-testid="sync-estimate"]')?.textContent).toBe("Estimated duration: 2 min");
+      expect(c.querySelector('[data-testid="sync-estimate"]')?.textContent).toBe("Estimated duration: < 1 min");
     });
 
     it("hides the scope line and the progress hint on an empty delta (nothing to apply)", async () => {
@@ -2380,7 +2380,9 @@ describe("MainPage", () => {
   });
 
   describe("always-on sync estimate (#1025 UX)", () => {
-    function previewWithCounts(newCount: number, changedCount: number): SyncPreview {
+    // ``coverRefreshCount`` is left OFF the summary when zero, so the default
+    // fixtures keep exercising the absent-field (older backend) path.
+    function previewWithCounts(newCount: number, changedCount: number, coverRefreshCount = 0): SyncPreview {
       return {
         success: true,
         summary: {
@@ -2389,6 +2391,7 @@ describe("MainPage", () => {
           unchanged_count: 0,
           remove_count: 0,
           disabled_platform_remove_count: 0,
+          ...(coverRefreshCount > 0 ? { cover_refresh_count: coverRefreshCount } : {}),
         },
         new_names: [],
         changed_names: [],
@@ -2396,8 +2399,12 @@ describe("MainPage", () => {
       };
     }
 
-    async function renderPreviewWithCounts(newCount: number, changedCount: number): Promise<HTMLElement> {
-      vi.mocked(backend.syncPreview).mockResolvedValue(previewWithCounts(newCount, changedCount));
+    async function renderPreviewWithCounts(
+      newCount: number,
+      changedCount: number,
+      coverRefreshCount = 0,
+    ): Promise<HTMLElement> {
+      vi.mocked(backend.syncPreview).mockResolvedValue(previewWithCounts(newCount, changedCount, coverRefreshCount));
       const { container } = render(<MainPage onNavigate={vi.fn()} />);
       await flushAsync();
       const sync = buttonByExactText(container, "Sync Library");
@@ -2422,21 +2429,30 @@ describe("MainPage", () => {
     }
 
     it("renders an estimate on its own line for a small preview", async () => {
-      // 3 new * 0.45s + 90s fetch allowance = 91.35s → ~2 min (small libraries
-      // overshoot; the allowance covers the fetch/prep phase).
+      // 3 new * (0.36s walk + 0.15s cover) + 45s allowance = 46.53s → "< 1 min".
+      // A handful of creates really is dominated by the run's fixed overhead.
       const c = await renderPreviewWithCounts(3, 0);
-      expect(estimateLine(c)).toBe("Estimated duration: 2 min");
+      expect(estimateLine(c)).toBe("Estimated duration: < 1 min");
     });
 
     it("renders an estimate on its own line for a large preview", async () => {
-      // 1000 new * 0.45s + 90s = 540s → ~9 min.
+      // 1000 new * (0.36s walk + 0.15s cover) + 45s = 555s → ~9 min.
       const c = await renderPreviewWithCounts(1000, 0);
       expect(estimateLine(c)).toBe("Estimated duration: 9 min");
     });
 
     it("prices updated items into the preview estimate", async () => {
-      // 100 updated * 0.20s + 90s = 110s → ~2 min.
+      // 100 updated * 0.13s + 45s = 58s → "< 1 min". Updates carry no cover
+      // download — the apply loop applies artwork only to created shortcuts.
       const c = await renderPreviewWithCounts(0, 100);
+      expect(estimateLine(c)).toBe("Estimated duration: < 1 min");
+    });
+
+    it("prices cover refreshes, so a cover-only preview no longer reads the flat allowance (#1511)", async () => {
+      // No shortcut delta at all, 400 covers changed server-side: 400 * 0.15s +
+      // 45s = 105s → ~2 min. Under the old model this read a flat 90s ("2 min")
+      // whether one cover or four thousand had changed.
+      const c = await renderPreviewWithCounts(0, 0, 400);
       expect(estimateLine(c)).toBe("Estimated duration: 2 min");
     });
 
@@ -2448,7 +2464,9 @@ describe("MainPage", () => {
     });
 
     it("appends the sleep-pause caveat only when the estimate is ≥ 10 min", async () => {
-      // 1200 new * 0.45s + 90s = 630s ≥ 600s (10 min) → the caveat sentence appears.
+      // 1200 new * (0.36s walk + 0.15s cover) + 45s = 657s ≥ 600s (10 min) → the
+      // caveat sentence appears. Pricing cover downloads separately is what keeps
+      // this fixture above the threshold after the walk rate came down (#1511).
       const c = await renderPreviewWithCounts(1200, 0);
       expect(c.textContent).toContain("Progress is saved about every 200 games — cancelling is safe.");
       expect(c.textContent).toContain("Long syncs pause during sleep; keep the Deck powered.");
@@ -2458,8 +2476,8 @@ describe("MainPage", () => {
       // Resume-shaped: 153 real creates and ~3000 content-unchanged items. The
       // delta-restricted apply (#1383) skips the unchanged entirely (no Set* walk,
       // no confirm poll), so they cost nothing and no longer inflate the estimate:
-      // 153*NEW_ITEM_SEC + 90s fetch allowance = 158.85s → ~3 min. The 3000
-      // unchanged priced the old walk model at ~13 min; that overshoot is gone.
+      // 153*(NEW_ITEM_SEC + COVER_DOWNLOAD_SEC) + 45s allowance = 123s → ~2 min.
+      // The 3000 unchanged priced the old walk model at ~13 min; that overshoot is gone.
       vi.mocked(backend.syncPreview).mockResolvedValue({
         success: true,
         summary: {
@@ -2480,7 +2498,7 @@ describe("MainPage", () => {
         await Promise.resolve();
         await Promise.resolve();
       });
-      expect(estimateLine(container)).toBe("Estimated duration: 3 min");
+      expect(estimateLine(container)).toBe("Estimated duration: 2 min");
       // The 3000 unchanged items must NOT be priced — the walk-model overshoot is gone.
       expect(estimateLine(container)).not.toBe("Estimated duration: 13 min");
     });
@@ -2545,25 +2563,29 @@ describe("MainPage", () => {
     }
 
     it("handleApply seeds the apply ETA from the DELTA (new + changed), unchanged priced at zero", async () => {
-      // The delta apply touches only new + changed — creates at the new rate,
-      // changed at the update rate — and skips unchanged entirely (#1383). new=100,
-      // changed=200, unchanged=600 → 100*NEW_ITEM_SEC + 200*UPDATED_ITEM_SEC + 90s
-      // allowance = 175s; the 600 unchanged add nothing.
+      // The delta apply touches only new + changed — creates at the new rate plus
+      // their cover download, changed at the bare update rate — and skips unchanged
+      // entirely (#1383). new=100, changed=200, unchanged=600 → 36 + 26 + 15 + 45 =
+      // 122s; the 600 unchanged add nothing.
       const container = await applyPreviewSummary({ new_count: 100, changed_count: 200, unchanged_count: 600 });
-      expect(getSyncProgress().etaSeconds).toBe(100 * NEW_ITEM_SEC + 200 * UPDATED_ITEM_SEC + 90 /* fetch allowance */);
-      // Surfaced as the "up to ~X" upper bound (175s → ~3 min) until the live
+      expect(getSyncProgress().etaSeconds).toBeCloseTo(
+        100 * NEW_ITEM_SEC + 200 * UPDATED_ITEM_SEC + 100 * COVER_DOWNLOAD_SEC + FETCH_ALLOWANCE_SEC,
+      );
+      // Surfaced as the "up to ~X" upper bound (122s → ~2 min) until the live
       // countdown takes over.
-      expect(container.querySelector('[data-testid="estimate-time"]')?.textContent).toBe("up to 3 min");
+      expect(container.querySelector('[data-testid="estimate-time"]')?.textContent).toBe("up to 2 min");
     });
 
     it("prices a resume-shaped preview (few creates, many unchanged) by its DELTA — unchanged skipped", async () => {
       // The #1382-M3 fix: a resume with ~90 real creates and ~3000 content-unchanged
       // items now SKIPS the 3000 (delta-restricted apply), so the seed prices only
-      // the 90 creates: 90*NEW_ITEM_SEC + 90s allowance = 130.5s → ~2 min. The old
-      // walk model priced the 3000 unchanged at ~12 min; that overshoot is gone, and
-      // the small delta is the true, fast cost.
+      // the 90 creates: 90*(NEW_ITEM_SEC + COVER_DOWNLOAD_SEC) + 45s allowance =
+      // 90.9s → ~2 min. The old walk model priced the 3000 unchanged at ~12 min;
+      // that overshoot is gone, and the small delta is the true, fast cost.
       const container = await applyPreviewSummary({ new_count: 90, changed_count: 0, unchanged_count: 3000 });
-      expect(getSyncProgress().etaSeconds).toBe(90 * NEW_ITEM_SEC + 90 /* fetch allowance */);
+      expect(getSyncProgress().etaSeconds).toBeCloseTo(
+        90 * NEW_ITEM_SEC + 90 * COVER_DOWNLOAD_SEC + FETCH_ALLOWANCE_SEC,
+      );
       const text = container.querySelector('[data-testid="estimate-time"]')?.textContent;
       expect(text).toBe("up to 2 min");
       // The 3000 unchanged items must NOT be priced — the walk-model overshoot is gone.

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -365,15 +365,19 @@ function formatLibraryLine(stats: SyncStats): string {
  * apply (#1383) touches only new + changed shortcuts; content-unchanged items are
  * skipped entirely (no Set* walk, no confirm poll), so they cost nothing and are
  * no longer priced. Creates run at the new-shortcut rate, changed at the lighter
- * update rate, plus the flat fetch allowance. This is now a tight estimate rather
- * than an inflated upper bound — the old model priced every unchanged item as an
- * update because a resume re-walked them, which the skip has eliminated. Used for
- * BOTH the preview "Estimated time" row and the handleApply seed, so the number
- * the user approves is the number the run starts with; the live countdown still
- * corrects it against the measured apply rate.
+ * update rate, plus the flat fixed-overhead allowance. This is now a tight
+ * estimate rather than an inflated upper bound — the old model priced every
+ * unchanged item as an update because a resume re-walked them, which the skip has
+ * eliminated. Cover refreshes are their own term (#1511): they are backend
+ * downloads on already-bound shortcuts, so they carry no shortcut-walk cost, and
+ * a cover-only preview must price its covers rather than read the flat allowance.
+ * Absent on older backends, where zero is the right reading. Used for BOTH the
+ * preview "Estimated time" row and the handleApply seed, so the number the user
+ * approves is the number the run starts with; the live countdown still corrects
+ * it against the measured apply rate.
  */
 function previewApplySeconds(s: SyncPreviewSummary): number {
-  return estimateApplySeconds(s.new_count, s.changed_count);
+  return estimateApplySeconds(s.new_count, s.changed_count, s.cover_refresh_count ?? 0);
 }
 
 /** Preview apply-time (seconds) at/above which the hint appends the sleep-pause

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -1222,16 +1222,52 @@ describe("index.tsx — sync_complete toast shows the true delta (#744)", () => 
 });
 
 describe("index.tsx — sync_plan seeds the applying-phase ETA (always-on estimate)", () => {
-  it("writes the walk-cost seed (estimateApplySeconds all-as-new) into the sync progress store", async () => {
+  it("writes the composition-priced seed (unbound rows as creates) into the sync progress store", async () => {
     const plugin = pluginFactory();
 
     act(() => {
-      emitDeckyEvent<[SyncPlanData]>("sync_plan", { run_id: "run-eta", units: [], total_units: 3, total_roms: 120 });
+      emitDeckyEvent<[SyncPlanData]>("sync_plan", {
+        run_id: "run-eta",
+        units: [{ type: "platform", id: 1, name: "N64", slug: "n64", rom_count: 120, bound_count: 0 }],
+        total_units: 3,
+        total_roms: 120,
+      });
     });
 
-    // Walk-cost upper bound: every planned ROM priced as a new shortcut, plus the
-    // flat fetch allowance — the same estimateApplySeconds model the preview uses.
-    expect(getSyncProgress().etaSeconds).toBe(estimateApplySeconds(120, 0));
+    // Nothing bound yet, so every planned item is a create — the fresh-import
+    // shape, priced exactly as the preview would price it.
+    expect(getSyncProgress().etaSeconds).toBeCloseTo(estimateApplySeconds(120, 0));
+    plugin.onDismount();
+  });
+
+  it("prices already-bound rows as cheap updates, not as fresh creates (#1511)", async () => {
+    const plugin = pluginFactory();
+
+    act(() => {
+      emitDeckyEvent<[SyncPlanData]>("sync_plan", {
+        run_id: "run-eta",
+        units: [
+          // A fully-mirrored platform re-syncing: every row already carries a
+          // shortcut, so the run is all updates. Priced as creates this read ~16
+          // min against a real ~4.5 — the over-read #1511 was opened for.
+          {
+            type: "platform",
+            id: 1,
+            name: "N64",
+            slug: "n64",
+            rom_count: 2000,
+            collapsed_count: 2000,
+            bound_count: 2000,
+          },
+        ],
+        total_units: 1,
+        total_roms: 2000,
+        total_estimated_items: 2000,
+      });
+    });
+
+    expect(getSyncProgress().etaSeconds).toBeCloseTo(estimateApplySeconds(0, 2000));
+    resetEta();
     plugin.onDismount();
   });
 
@@ -1239,7 +1275,12 @@ describe("index.tsx — sync_plan seeds the applying-phase ETA (always-on estima
     const plugin = pluginFactory();
 
     act(() => {
-      emitDeckyEvent<[SyncPlanData]>("sync_plan", { run_id: "run-eta", units: [], total_units: 1, total_roms: 200 });
+      emitDeckyEvent<[SyncPlanData]>("sync_plan", {
+        run_id: "run-eta",
+        units: [{ type: "platform", id: 1, name: "N64", slug: "n64", rom_count: 200, bound_count: 0 }],
+        total_units: 1,
+        total_roms: 200,
+      });
     });
     // A backend frame carries no etaSeconds — the listener must not wipe it.
     act(() => {
@@ -1252,7 +1293,7 @@ describe("index.tsx — sync_plan seeds the applying-phase ETA (always-on estima
       });
     });
 
-    expect(getSyncProgress().etaSeconds).toBe(estimateApplySeconds(200, 0));
+    expect(getSyncProgress().etaSeconds).toBeCloseTo(estimateApplySeconds(200, 0));
     expect(getSyncProgress().stage).toBe("applying");
     plugin.onDismount();
   });
@@ -1283,20 +1324,37 @@ describe("index.tsx — sync_plan seeds the applying-phase ETA (always-on estima
     // the etaSeconds-undefined gate.
     expect(getSyncProgress().etaSeconds).toBeUndefined();
     act(() => {
-      emitDeckyEvent<[SyncPlanData]>("sync_plan", { run_id: "run-eta", units: [], total_units: 2, total_roms: 80 });
+      emitDeckyEvent<[SyncPlanData]>("sync_plan", {
+        run_id: "run-eta",
+        units: [{ type: "platform", id: 1, name: "N64", slug: "n64", rom_count: 80, bound_count: 0 }],
+        total_units: 2,
+        total_roms: 80,
+      });
     });
 
-    expect(getSyncProgress().etaSeconds).toBe(estimateApplySeconds(80, 0));
+    expect(getSyncProgress().etaSeconds).toBeCloseTo(estimateApplySeconds(80, 0));
     plugin.onDismount();
   });
 
-  it("prefers total_estimated_items over total_roms for the seed (#1382 skip-aware)", async () => {
+  it("excludes predicted-skip units from the seed (#1382 skip-aware)", async () => {
     const plugin = pluginFactory();
 
     act(() => {
       emitDeckyEvent<[SyncPlanData]>("sync_plan", {
         run_id: "run-eta",
-        units: [],
+        units: [
+          {
+            type: "platform",
+            id: 1,
+            name: "N64",
+            slug: "n64",
+            rom_count: 115,
+            collapsed_count: 115,
+            bound_count: 115,
+            predicted_skip: true,
+          },
+          { type: "platform", id: 2, name: "GBA", slug: "gba", rom_count: 5, bound_count: 0 },
+        ],
         total_units: 3,
         total_roms: 120,
         total_estimated_items: 5,
@@ -1304,7 +1362,7 @@ describe("index.tsx — sync_plan seeds the applying-phase ETA (always-on estima
     });
 
     // An incremental re-sync prices only the predicted work, not the library.
-    expect(getSyncProgress().etaSeconds).toBe(estimateApplySeconds(5, 0));
+    expect(getSyncProgress().etaSeconds).toBeCloseTo(estimateApplySeconds(5, 0));
     resetEta();
     plugin.onDismount();
   });
@@ -1370,7 +1428,7 @@ describe("index.tsx — sync_plan seeds the applying-phase ETA (always-on estima
       });
     });
 
-    expect(getSyncProgress().etaSeconds).toBe(estimateApplySeconds(80, 0));
+    expect(getSyncProgress().etaSeconds).toBeCloseTo(estimateApplySeconds(80, 0));
     // Raw rom_count weights: unit 1 done (60) plus half of unit 2 (10) → 70/80.
     expect(weightedCoarseFraction(1, 0.5, 2)).toBeCloseTo(70 / 80, 10);
     resetEta();

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -1248,25 +1248,25 @@ describe("index.tsx — sync_plan seeds the applying-phase ETA (always-on estima
         run_id: "run-eta",
         units: [
           // A fully-mirrored platform re-syncing: every row already carries a
-          // shortcut, so the run is all updates. Priced as creates this read ~16
-          // min against a real ~4.5 — the over-read #1511 was opened for.
+          // shortcut, so the run is all updates. Pricing it as creates is the
+          // over-read #1511 was opened for; the seed must price it as updates.
           {
             type: "platform",
             id: 1,
             name: "N64",
             slug: "n64",
-            rom_count: 2000,
-            collapsed_count: 2000,
-            bound_count: 2000,
+            rom_count: 1000,
+            collapsed_count: 1000,
+            bound_count: 1000,
           },
         ],
         total_units: 1,
-        total_roms: 2000,
-        total_estimated_items: 2000,
+        total_roms: 1000,
+        total_estimated_items: 1000,
       });
     });
 
-    expect(getSyncProgress().etaSeconds).toBeCloseTo(estimateApplySeconds(0, 2000));
+    expect(getSyncProgress().etaSeconds).toBeCloseTo(estimateApplySeconds(0, 1000));
     resetEta();
     plugin.onDismount();
   });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -559,10 +559,12 @@ export default definePlugin(() => {
     // persisted collapsed (post-sibling-group) shortcut count — and of those
     // items, the ones already bound to a Steam shortcut (``bound_count``) take
     // the cheap update path. Pricing every planned item as a create over-read
-    // by ~4x on the common case: any re-sync, and every Force Full Sync (which
-    // clears the completion stamps but unbinds nothing, so it is all updates).
-    // A unit from a backend that omits ``bound_count`` still prices as all
-    // creates. The delta-restricted apply skips unchanged items and the live
+    // by ~4x on the common case: any re-sync, and — for platforms — every Force
+    // Full Sync (which clears the completion stamps but unbinds nothing, so it
+    // is all updates). A unit that omits ``bound_count`` still prices as all
+    // creates: an older backend, or a collection with no stamped member set,
+    // which is every collection on a forced run since that clears the stamps
+    // membership is read from. The delta-restricted apply skips unchanged items and the live
     // rate estimator corrects the readout within seconds of applying (#1382-M3).
     // Merged (not replaced) so the running/stage the click set survives, and the
     // sync_progress listener below preserves it across backend frames. Shown as

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,7 +9,7 @@ import { DangerZone } from "./components/DangerZone";
 import { DownloadQueue } from "./components/DownloadQueue";
 import { initUnitSyncManager, resetSyncCancel } from "./utils/syncManager";
 import { setSyncProgress, getSyncProgress, updateSyncProgress } from "./utils/syncProgress";
-import { estimateApplySeconds } from "./utils/syncEstimate";
+import { estimatePlanSeconds } from "./utils/syncEstimate";
 import { beginEtaRun } from "./utils/syncEta";
 import { updateDownload, getDownloadState, removeDownload } from "./utils/downloadStore";
 import { handleGlobalDownloadFailure } from "./utils/downloadFailure";
@@ -553,14 +553,16 @@ export default definePlugin(() => {
     // a Cancel click comes from the backend-fed sync_progress store now (#1202).
     resetSyncCancel();
     // Seed the applying-phase estimate on the walk-cost model (the same
-    // ``estimateApplySeconds`` the preview row uses): an honest upper bound that
-    // prices every planned item as a new shortcut plus the flat fetch allowance.
-    // The plan is skip-aware (#1382): ``total_estimated_items`` zero-weights the
-    // platforms the backend predicts its wholesale-skip gate will skip and prices
-    // the rest at their persisted collapsed (post-sibling-group) shortcut count,
-    // so an incremental re-sync no longer seeds a whole-library ceiling. The raw
-    // ``total_roms`` stays the fallback for an older backend that doesn't send
-    // the field. The delta-restricted apply skips unchanged items and the live
+    // constants the preview row uses), priced per unit by COMPOSITION rather
+    // than as one blended item count (#1511). The plan is skip-aware (#1382):
+    // a predicted-skip unit costs nothing and the rest are weighed at their
+    // persisted collapsed (post-sibling-group) shortcut count — and of those
+    // items, the ones already bound to a Steam shortcut (``bound_count``) take
+    // the cheap update path. Pricing every planned item as a create over-read
+    // by ~4x on the common case: any re-sync, and every Force Full Sync (which
+    // clears the completion stamps but unbinds nothing, so it is all updates).
+    // A unit from a backend that omits ``bound_count`` still prices as all
+    // creates. The delta-restricted apply skips unchanged items and the live
     // rate estimator corrects the readout within seconds of applying (#1382-M3).
     // Merged (not replaced) so the running/stage the click set survives, and the
     // sync_progress listener below preserves it across backend frames. Shown as
@@ -574,7 +576,7 @@ export default definePlugin(() => {
     // seed, never a stale prior-run value. The skip-preview path never sets one,
     // so it still gets this bound.
     if (getSyncProgress().etaSeconds === undefined) {
-      updateSyncProgress({ etaSeconds: estimateApplySeconds(data.total_estimated_items ?? data.total_roms, 0) });
+      updateSyncProgress({ etaSeconds: estimatePlanSeconds(data.units) });
     }
     // Begin the run-scoped live-ETA estimator with the plan's per-unit weights
     // and total. Weights are skip-aware (#1382): 0 for a predicted-skip unit,

--- a/src/types/sync.ts
+++ b/src/types/sync.ts
@@ -247,12 +247,15 @@ export interface SyncPlanUnit {
    */
   collapsed_count?: number;
   /**
-   * Persisted rows for this platform that already carry a Steam shortcut
-   * (#1511). Those items take the cheap UPDATE path in the apply loop, so the
-   * seed prices them at `UPDATED_ITEM_SEC` and only the remainder at the create
-   * rate — without it a re-sync (and every Force Full Sync, which unbinds
-   * nothing) is priced as a fresh import. Absent on collections and older
-   * backends; the seed then prices every item as a create, as before.
+   * This unit's known ROMs that already carry a Steam shortcut (#1511) — a
+   * platform's persisted rows, or a collection's stamped member set. Those
+   * items take the cheap UPDATE path in the apply loop, so the seed prices them
+   * at `UPDATED_ITEM_SEC` and only the remainder at the create rate — without it
+   * a re-sync (and every Force Full Sync, which unbinds nothing) is priced as a
+   * fresh import. Unlike its sibling riders this rides BOTH unit kinds. Absent
+   * on older backends, on never-stamped collections (a collection's membership
+   * is known only from its stamp), and on franchise collections (never
+   * stampable); the seed then prices every item as a create, as before.
    */
   bound_count?: number;
 }

--- a/src/types/sync.ts
+++ b/src/types/sync.ts
@@ -256,6 +256,10 @@ export interface SyncPlanUnit {
    * on older backends, on never-stamped collections (a collection's membership
    * is known only from its stamp), and on franchise collections (never
    * stampable); the seed then prices every item as a create, as before.
+   *
+   * Note the asymmetry a Force Full Sync exposes: it clears every stamp, so its
+   * PLATFORM units keep this field (read from the rows, no stamp gate) while its
+   * COLLECTION units lose it and price as creates for that run.
    */
   bound_count?: number;
 }

--- a/src/types/sync.ts
+++ b/src/types/sync.ts
@@ -224,7 +224,7 @@ export interface SyncPreview {
   pause_likely?: boolean;
 }
 
-interface SyncPlanUnit {
+export interface SyncPlanUnit {
   type: "platform" | "collection";
   id: number | string;
   name: string;
@@ -246,6 +246,15 @@ interface SyncPlanUnit {
    * raw `rom_count`.
    */
   collapsed_count?: number;
+  /**
+   * Persisted rows for this platform that already carry a Steam shortcut
+   * (#1511). Those items take the cheap UPDATE path in the apply loop, so the
+   * seed prices them at `UPDATED_ITEM_SEC` and only the remainder at the create
+   * rate — without it a re-sync (and every Force Full Sync, which unbinds
+   * nothing) is priced as a fresh import. Absent on collections and older
+   * backends; the seed then prices every item as a create, as before.
+   */
+  bound_count?: number;
 }
 
 export interface SyncPlanData {

--- a/src/utils/syncEstimate.test.ts
+++ b/src/utils/syncEstimate.test.ts
@@ -50,14 +50,14 @@ describe("estimateApplySeconds", () => {
     expect(NEW_ITEM_SEC).toBeGreaterThan(UPDATED_ITEM_SEC);
   });
 
-  // Calibration guards against the on-device measurements (2026-07, #1511). These
-  // pin the model's OUTPUT at the shapes that were actually timed, so a future
-  // constant tweak cannot silently drift the readout away from reality.
-  it("reads close to the measured runs it was calibrated against", () => {
-    // 684 creates with cold covers — measured 323 s (5.4 min).
-    expect(formatDuration(estimateApplySeconds(684, 0))).toBe("7 min");
-    // 1315 updates, warm covers (a Force Full Sync) — measured ~174 s (2.9 min).
-    expect(formatDuration(estimateApplySeconds(0, 1315))).toBe("4 min");
+  // Calibration guards for the model's OUTPUT at representative run shapes, so a
+  // future constant tweak cannot silently drift the readout away from the
+  // on-device rates the constants were fitted to (2026-07, #1511).
+  it("prices representative create-heavy and update-heavy runs into sane buckets", () => {
+    // A create-heavy run: each item pays the create walk plus a cover download.
+    expect(formatDuration(estimateApplySeconds(700, 0))).toBe("7 min");
+    // An update-heavy run (e.g. a Force Full Sync): cheap Set* walks, no covers.
+    expect(formatDuration(estimateApplySeconds(0, 1300))).toBe("4 min");
   });
 });
 
@@ -130,11 +130,11 @@ describe("estimatePlanSeconds", () => {
   });
 
   // The seed shape #1511 was opened for: a fully-mirrored library re-syncing.
-  // Every row is bound, so the whole plan is cheap updates — it used to be
-  // priced as 2000 fresh creates and read 16 min.
+  // Every row is bound, so the whole plan is cheap updates — pricing it as fresh
+  // creates (0.36 + 0.15 each) is the ceiling the over-read came from.
   it("reads minutes, not a fresh-import ceiling, for an all-bound re-sync", () => {
-    const seconds = estimatePlanSeconds([unit({ rom_count: 2000, collapsed_count: 2000, bound_count: 2000 })]);
-    expect(formatDuration(seconds)).toBe("5 min");
+    const seconds = estimatePlanSeconds([unit({ rom_count: 1000, collapsed_count: 1000, bound_count: 1000 })]);
+    expect(formatDuration(seconds)).toBe("3 min");
   });
 });
 

--- a/src/utils/syncEstimate.test.ts
+++ b/src/utils/syncEstimate.test.ts
@@ -1,29 +1,110 @@
 import { describe, it, expect } from "vitest";
-import { NEW_ITEM_SEC, UPDATED_ITEM_SEC, estimateApplySeconds, formatDuration } from "./syncEstimate";
+import {
+  NEW_ITEM_SEC,
+  UPDATED_ITEM_SEC,
+  COVER_DOWNLOAD_SEC,
+  FETCH_ALLOWANCE_SEC,
+  estimateApplySeconds,
+  estimatePlanSeconds,
+  formatDuration,
+} from "./syncEstimate";
+import type { SyncPlanUnit } from "../types/sync";
 
-// The flat fetch allowance folded into every estimate (see FETCH_ALLOWANCE_SEC
-// in syncEstimate.ts). Not exported — the constant is internal to
-// estimateApplySeconds — so the tests pin it as a literal.
-const FETCH_ALLOWANCE = 90;
+/** A platform plan unit; every estimate rider is opt-in per test. */
+function unit(overrides: Partial<SyncPlanUnit> = {}): SyncPlanUnit {
+  return { type: "platform", id: 1, name: "Platform", slug: "platform", rom_count: 0, ...overrides };
+}
 
 describe("estimateApplySeconds", () => {
-  it("prices new and updated items with their per-item costs plus the fetch allowance", () => {
-    expect(estimateApplySeconds(10, 0)).toBe(10 * NEW_ITEM_SEC + FETCH_ALLOWANCE);
-    expect(estimateApplySeconds(0, 10)).toBe(10 * UPDATED_ITEM_SEC + FETCH_ALLOWANCE);
-    expect(estimateApplySeconds(4, 6)).toBe(4 * NEW_ITEM_SEC + 6 * UPDATED_ITEM_SEC + FETCH_ALLOWANCE);
+  it("prices new and updated items with their per-item costs plus the fixed-overhead allowance", () => {
+    // A create carries its own cover download; an update never does.
+    expect(estimateApplySeconds(10, 0)).toBeCloseTo(10 * NEW_ITEM_SEC + 10 * COVER_DOWNLOAD_SEC + FETCH_ALLOWANCE_SEC);
+    expect(estimateApplySeconds(0, 10)).toBeCloseTo(10 * UPDATED_ITEM_SEC + FETCH_ALLOWANCE_SEC);
+    expect(estimateApplySeconds(4, 6)).toBeCloseTo(
+      4 * NEW_ITEM_SEC + 6 * UPDATED_ITEM_SEC + 4 * COVER_DOWNLOAD_SEC + FETCH_ALLOWANCE_SEC,
+    );
   });
 
-  it("returns the flat fetch allowance for zero counts (fetch/prep still runs)", () => {
-    expect(estimateApplySeconds(0, 0)).toBe(FETCH_ALLOWANCE);
+  it("prices cover refreshes as their own term, so a cover-only run is no longer a flat allowance", () => {
+    expect(estimateApplySeconds(0, 0, 140)).toBeCloseTo(140 * COVER_DOWNLOAD_SEC + FETCH_ALLOWANCE_SEC);
+    // The refresh term is additive to the creates' own downloads.
+    expect(estimateApplySeconds(10, 0, 5)).toBeCloseTo(
+      10 * NEW_ITEM_SEC + 15 * COVER_DOWNLOAD_SEC + FETCH_ALLOWANCE_SEC,
+    );
+  });
+
+  it("defaults the cover count to zero, so an older backend's preview prices as before", () => {
+    expect(estimateApplySeconds(7, 3)).toBe(estimateApplySeconds(7, 3, 0));
+  });
+
+  it("returns the flat allowance for zero counts (fixed overhead still runs)", () => {
+    expect(estimateApplySeconds(0, 0)).toBe(FETCH_ALLOWANCE_SEC);
   });
 
   it("clamps negative counts to zero, but the allowance still applies (never below the allowance)", () => {
-    expect(estimateApplySeconds(-5, -3)).toBe(FETCH_ALLOWANCE);
-    expect(estimateApplySeconds(-5, 2)).toBe(2 * UPDATED_ITEM_SEC + FETCH_ALLOWANCE);
+    expect(estimateApplySeconds(-5, -3, -2)).toBe(FETCH_ALLOWANCE_SEC);
+    expect(estimateApplySeconds(-5, 2)).toBeCloseTo(2 * UPDATED_ITEM_SEC + FETCH_ALLOWANCE_SEC);
   });
 
   it("prices a new item higher than an updated one (create is dearer than update)", () => {
     expect(NEW_ITEM_SEC).toBeGreaterThan(UPDATED_ITEM_SEC);
+  });
+
+  // Calibration guards against the on-device measurements (2026-07, #1511). These
+  // pin the model's OUTPUT at the shapes that were actually timed, so a future
+  // constant tweak cannot silently drift the readout away from reality.
+  it("reads close to the measured runs it was calibrated against", () => {
+    // 684 creates with cold covers — measured 323 s (5.4 min).
+    expect(formatDuration(estimateApplySeconds(684, 0))).toBe("7 min");
+    // 1315 updates, warm covers (a Force Full Sync) — measured ~174 s (2.9 min).
+    expect(formatDuration(estimateApplySeconds(0, 1315))).toBe("4 min");
+  });
+});
+
+describe("estimatePlanSeconds", () => {
+  it("prices already-bound rows as updates and the remainder as creates", () => {
+    const seconds = estimatePlanSeconds([unit({ rom_count: 100, collapsed_count: 100, bound_count: 40 })]);
+    expect(seconds).toBeCloseTo(estimateApplySeconds(60, 40));
+  });
+
+  it("prices every item as a create when the backend omits bound_count (older backend)", () => {
+    const seconds = estimatePlanSeconds([unit({ rom_count: 100, collapsed_count: 100 })]);
+    expect(seconds).toBeCloseTo(estimateApplySeconds(100, 0));
+  });
+
+  it("skips predicted-skip units entirely, however large", () => {
+    const seconds = estimatePlanSeconds([
+      unit({ rom_count: 5000, collapsed_count: 5000, bound_count: 5000, predicted_skip: true }),
+      unit({ id: 2, slug: "b", rom_count: 10, collapsed_count: 10, bound_count: 4 }),
+    ]);
+    expect(seconds).toBeCloseTo(estimateApplySeconds(6, 4));
+  });
+
+  it("weighs a unit by rom_count when no collapsed count is known", () => {
+    const seconds = estimatePlanSeconds([unit({ rom_count: 30, bound_count: 10 })]);
+    expect(seconds).toBeCloseTo(estimateApplySeconds(20, 10));
+  });
+
+  it("clamps bound rows to the unit's item total (pre-collapse rows can exceed it)", () => {
+    const seconds = estimatePlanSeconds([unit({ rom_count: 10, collapsed_count: 10, bound_count: 40 })]);
+    expect(seconds).toBeCloseTo(estimateApplySeconds(0, 10));
+  });
+
+  it("sums across units and reads the flat allowance for an empty plan", () => {
+    expect(estimatePlanSeconds([])).toBe(FETCH_ALLOWANCE_SEC);
+    const seconds = estimatePlanSeconds([
+      unit({ rom_count: 10, collapsed_count: 10, bound_count: 10 }),
+      unit({ id: 2, slug: "b", rom_count: 20, collapsed_count: 20 }),
+    ]);
+    expect(seconds).toBeCloseTo(estimateApplySeconds(20, 10));
+  });
+
+  // The seed shape #1511 was opened for: a fully-mirrored library re-syncing.
+  // Every row is bound, so the whole plan is cheap updates — it used to be
+  // priced as 2000 fresh creates and read 16 min.
+  it("reads minutes, not a fresh-import ceiling, for an all-bound re-sync", () => {
+    const seconds = estimatePlanSeconds([unit({ rom_count: 2000, collapsed_count: 2000, bound_count: 2000 })]);
+    expect(formatDuration(seconds)).toBe("5 min");
   });
 });
 

--- a/src/utils/syncEstimate.test.ts
+++ b/src/utils/syncEstimate.test.ts
@@ -99,6 +99,36 @@ describe("estimatePlanSeconds", () => {
     expect(seconds).toBeCloseTo(estimateApplySeconds(20, 10));
   });
 
+  it("prices a collection unit's bound members as updates, same as a platform's", () => {
+    // Collections carry no collapsed_count, so items come from rom_count. A
+    // stamped collection whose members are already bound is an all-updates unit;
+    // pricing it as creates over-read it ~4x for collection-heavy libraries.
+    const collection: SyncPlanUnit = {
+      type: "collection",
+      id: "7",
+      name: "Faves",
+      slug: "",
+      rom_count: 300,
+      collection_kind: "user",
+      bound_count: 300,
+    };
+    expect(estimatePlanSeconds([collection])).toBeCloseTo(estimateApplySeconds(0, 300));
+    // Guard the regression directly: the all-creates reading is far dearer.
+    expect(estimatePlanSeconds([collection])).toBeLessThan(estimateApplySeconds(300, 0));
+  });
+
+  it("prices an unstamped or franchise collection as all creates (bound_count absent)", () => {
+    const collection: SyncPlanUnit = {
+      type: "collection",
+      id: "fr-1",
+      name: "Zelda",
+      slug: "zelda",
+      rom_count: 40,
+      collection_kind: "franchise",
+    };
+    expect(estimatePlanSeconds([collection])).toBeCloseTo(estimateApplySeconds(40, 0));
+  });
+
   // The seed shape #1511 was opened for: a fully-mirrored library re-syncing.
   // Every row is bound, so the whole plan is cheap updates — it used to be
   // priced as 2000 fresh creates and read 16 min.

--- a/src/utils/syncEstimate.ts
+++ b/src/utils/syncEstimate.ts
@@ -84,13 +84,19 @@ export function estimateApplySeconds(newCount: number, changedCount: number, cov
  * a create: a predicted-skip unit costs nothing, and of the remainder's items
  * (``collapsed_count ?? rom_count``) the ones already bound to a Steam shortcut
  * (``bound_count``) take the cheap update path. This is what stops a re-sync —
- * and every Force Full Sync, which clears the completion stamps but unbinds
- * nothing — from being seeded at fresh-import prices. Applies to platform AND
- * collection units alike; a unit whose backend omits ``bound_count`` (an older
- * backend, or a collection with no stamped member set) prices all of its items
- * as creates, the pre-#1511 behaviour. Cover downloads ride the create term; the
- * plan carries no cover-refresh count, and a refresh-only unit's covers are the
- * cheap warm case.
+ * and, for platforms, every Force Full Sync, which clears the completion stamps
+ * but unbinds nothing — from being seeded at fresh-import prices. Applies to
+ * platform AND collection units alike; a unit whose backend omits
+ * ``bound_count`` prices all of its items as creates, the pre-#1511 behaviour.
+ *
+ * That fallback is not rare for collections: a collection's membership is known
+ * only from its completion stamp, and a Force Full Sync clears every stamp, so a
+ * forced run prices its collections as creates even though their shortcuts
+ * survive. Deliberate — the alternative is asserting membership the plan does
+ * not have — and it errs long, the safe direction.
+ *
+ * Cover downloads ride the create term; the plan carries no cover-refresh count,
+ * and a refresh-only unit's covers are the cheap warm case.
  */
 export function estimatePlanSeconds(units: readonly SyncPlanUnit[]): number {
   let created = 0;

--- a/src/utils/syncEstimate.ts
+++ b/src/utils/syncEstimate.ts
@@ -1,49 +1,108 @@
 /**
  * Sync-time estimate — the pure cost model behind the always-on "Estimated
- * time" readout. Given a count of new and updated shortcuts it returns an
- * expected apply duration; anything that turns item counts into a
+ * time" readout. Given counts of new, updated and cover-refreshed shortcuts it
+ * returns an expected apply duration; anything that turns item counts into a
  * human-readable duration for the sync UI lives here. No I/O, no React.
  *
- * The per-item constants are calibrated to the measured post-poll apply rates
- * (2026-07 on-device, after the AddShortcut overview-poll replaced the blind
- * ~500ms settle wait): a new shortcut runs ~0.30–0.36 s/item, an updated one
- * ~0.15 s/item. The constants sit deliberately above those means so the preview
- * estimate and the skip-preview upper bound never read short. A flat fetch
- * allowance folded into ``estimateApplySeconds`` covers the multi-page
- * fetch/prep phases the per-item model would otherwise ignore.
+ * The model prices three INDEPENDENT terms, because they are three independent
+ * phases of a run and a single blended per-item rate cannot describe a mix of
+ * them: the per-item create walk, the per-item update walk, and the backend's
+ * cover-download pass that runs between a unit's fetch and its first apply
+ * chunk. Each constant is calibrated to its own measured mean with a ceiling
+ * margin, so the estimate reads long rather than short whatever the mix. A flat
+ * allowance covers the run's fixed overhead (the one-time shortcut scan, the
+ * multi-page fetch, inter-chunk gaps, finalize).
  */
 
-/**
- * Seconds per newly created shortcut — calibrated to the measured ~0.30–0.36
- * s/item post-poll create rate (2026-07 on-device), with a deliberate ceiling
- * margin. Covers the AddShortcut + overview poll, the Set* calls, the confirm
- * poll, the inter-op cadence, and amortized artwork fetch/apply.
- */
-export const NEW_ITEM_SEC = 0.45;
+import type { SyncPlanUnit } from "../types/sync";
 
 /**
- * Seconds per updated shortcut — calibrated to the measured ~0.15 s/item update
- * rate (2026-07 on-device), with a deliberate ceiling margin. The update path
- * reuses the existing shortcut (no AddShortcut), so it is just the Set* calls
- * and confirm poll.
+ * Seconds per newly created shortcut — the AddShortcut + overview poll, the
+ * Set* calls, the confirm poll, the inter-op cadence, and the per-item artwork
+ * leg (DB read → file read → base64 → IPC → SetCustomArtworkForApp). Measured
+ * 0.314 s/item over 684 creates (2026-07 on-device); carries a ~15% margin.
+ * Excludes the backend cover DOWNLOAD, which is priced separately by
+ * {@link COVER_DOWNLOAD_SEC} — it is a distinct phase, not part of the walk.
  */
-export const UPDATED_ITEM_SEC = 0.2;
+export const NEW_ITEM_SEC = 0.36;
+
+/**
+ * Seconds per updated shortcut — the update path reuses the existing shortcut
+ * (no AddShortcut, no overview poll, and no artwork: the apply loop gates cover
+ * application on ``created``), so it is just the Set* calls and the confirm
+ * poll. Measured 0.109 s/item over 1315 updates (2026-07 on-device); carries a
+ * ~15% margin.
+ */
+export const UPDATED_ITEM_SEC = 0.13;
+
+/**
+ * Seconds per cover the backend must DOWNLOAD, in the per-unit cover pass that
+ * runs before the unit's first apply chunk. Measured 0.132 s/cover cold
+ * (2026-07 on-device). A cover already in the cache costs 0.0018 s — 73x
+ * cheaper, and deliberately NOT a term: pricing warm covers would require a
+ * backend cache probe in the preview path that we are not adding, and treating
+ * every cover as cold is the safe direction.
+ */
+export const COVER_DOWNLOAD_SEC = 0.15;
+
+/**
+ * Flat allowance for the run's FIXED overhead — the one-time shortcut scan
+ * (which scales with the existing library, not the delta), the multi-page ROM +
+ * save fetches, the inter-chunk gaps, and finalize. Measured 17–24 s on-device
+ * across a 684-create and a 1315-update run; the margin here is wide because
+ * the scan grows with library size.
+ */
+export const FETCH_ALLOWANCE_SEC = 45;
 
 /**
  * Expected apply duration in seconds for *newCount* created and *changedCount*
- * updated shortcuts, plus a flat fetch allowance for the multi-page fetch/prep
- * phases that precede and interleave the apply. Negative counts are clamped to
- * zero (the allowance still applies).
+ * updated shortcuts, plus *coverRefreshCount* covers refreshed on already-bound
+ * shortcuts, plus the flat fixed-overhead allowance.
+ *
+ * Every create is priced as needing a cover download on top of the refreshes —
+ * a deliberate upper bound: a create usually does need one, and the cache state
+ * is not knowable without a backend probe, so over-reading is the safe
+ * direction. Negative counts are clamped to zero (the allowance still applies).
  */
-export function estimateApplySeconds(newCount: number, changedCount: number): number {
-  // Flat allowance for the fetch/prep phases the per-item model ignores (the
-  // multi-page ROM + save fetches a resume re-runs, ~1–1.5 min on-device).
-  // Small libraries overshoot slightly; the "up to X min" wording covers it and the
-  // live countdown corrects downward within seconds of applying.
-  const FETCH_ALLOWANCE_SEC = 90;
+export function estimateApplySeconds(newCount: number, changedCount: number, coverRefreshCount = 0): number {
   const created = Math.max(0, newCount);
   const updated = Math.max(0, changedCount);
-  return created * NEW_ITEM_SEC + updated * UPDATED_ITEM_SEC + FETCH_ALLOWANCE_SEC;
+  const refreshed = Math.max(0, coverRefreshCount);
+  return (
+    created * NEW_ITEM_SEC +
+    updated * UPDATED_ITEM_SEC +
+    (created + refreshed) * COVER_DOWNLOAD_SEC +
+    FETCH_ALLOWANCE_SEC
+  );
+}
+
+/**
+ * Expected apply duration in seconds for a whole ``sync_plan`` — the seed the
+ * skip-preview path shows before any preview delta exists.
+ *
+ * Prices each unit by its COMPOSITION rather than pricing every planned item as
+ * a create: a predicted-skip unit costs nothing, and of the remainder's items
+ * (``collapsed_count ?? rom_count``) the ones already bound to a Steam shortcut
+ * (``bound_count``) take the cheap update path. This is what stops a re-sync —
+ * and every Force Full Sync, which clears the completion stamps but unbinds
+ * nothing — from being seeded at fresh-import prices. A unit whose backend
+ * omits ``bound_count`` prices all of its items as creates, the pre-#1511
+ * behaviour. Cover downloads ride the create term; the plan carries no
+ * cover-refresh count, and a refresh-only unit's covers are the cheap warm case.
+ */
+export function estimatePlanSeconds(units: readonly SyncPlanUnit[]): number {
+  let created = 0;
+  let updated = 0;
+  for (const unit of units) {
+    if (unit.predicted_skip) continue;
+    const items = Math.max(0, unit.collapsed_count ?? unit.rom_count);
+    // Clamp: bound rows are counted pre-collapse, so a sibling-heavy platform
+    // could report more bound rows than the collapsed item total.
+    const bound = Math.min(items, Math.max(0, unit.bound_count ?? 0));
+    updated += bound;
+    created += items - bound;
+  }
+  return estimateApplySeconds(created, updated);
 }
 
 /**

--- a/src/utils/syncEstimate.ts
+++ b/src/utils/syncEstimate.ts
@@ -85,10 +85,12 @@ export function estimateApplySeconds(newCount: number, changedCount: number, cov
  * (``collapsed_count ?? rom_count``) the ones already bound to a Steam shortcut
  * (``bound_count``) take the cheap update path. This is what stops a re-sync —
  * and every Force Full Sync, which clears the completion stamps but unbinds
- * nothing — from being seeded at fresh-import prices. A unit whose backend
- * omits ``bound_count`` prices all of its items as creates, the pre-#1511
- * behaviour. Cover downloads ride the create term; the plan carries no
- * cover-refresh count, and a refresh-only unit's covers are the cheap warm case.
+ * nothing — from being seeded at fresh-import prices. Applies to platform AND
+ * collection units alike; a unit whose backend omits ``bound_count`` (an older
+ * backend, or a collection with no stamped member set) prices all of its items
+ * as creates, the pre-#1511 behaviour. Cover downloads ride the create term; the
+ * plan carries no cover-refresh count, and a refresh-only unit's covers are the
+ * cheap warm case.
  */
 export function estimatePlanSeconds(units: readonly SyncPlanUnit[]): number {
   let created = 0;

--- a/src/utils/syncEstimate.ts
+++ b/src/utils/syncEstimate.ts
@@ -20,7 +20,7 @@ import type { SyncPlanUnit } from "../types/sync";
  * Seconds per newly created shortcut — the AddShortcut + overview poll, the
  * Set* calls, the confirm poll, the inter-op cadence, and the per-item artwork
  * leg (DB read → file read → base64 → IPC → SetCustomArtworkForApp). Measured
- * 0.314 s/item over 684 creates (2026-07 on-device); carries a ~15% margin.
+ * at ~0.314 s/item (2026-07 on-device); carries a ~15% margin.
  * Excludes the backend cover DOWNLOAD, which is priced separately by
  * {@link COVER_DOWNLOAD_SEC} — it is a distinct phase, not part of the walk.
  */
@@ -30,8 +30,7 @@ export const NEW_ITEM_SEC = 0.36;
  * Seconds per updated shortcut — the update path reuses the existing shortcut
  * (no AddShortcut, no overview poll, and no artwork: the apply loop gates cover
  * application on ``created``), so it is just the Set* calls and the confirm
- * poll. Measured 0.109 s/item over 1315 updates (2026-07 on-device); carries a
- * ~15% margin.
+ * poll. Measured at ~0.109 s/item (2026-07 on-device); carries a ~15% margin.
  */
 export const UPDATED_ITEM_SEC = 0.13;
 
@@ -49,7 +48,7 @@ export const COVER_DOWNLOAD_SEC = 0.15;
  * Flat allowance for the run's FIXED overhead — the one-time shortcut scan
  * (which scales with the existing library, not the delta), the multi-page ROM +
  * save fetches, the inter-chunk gaps, and finalize. Measured 17–24 s on-device
- * across a 684-create and a 1315-update run; the margin here is wide because
+ * across a create-heavy and an update-heavy run; the margin here is wide because
  * the scan grows with library size.
  */
 export const FETCH_ALLOWANCE_SEC = 45;

--- a/src/utils/syncEta.test.ts
+++ b/src/utils/syncEta.test.ts
@@ -286,7 +286,7 @@ describe("run-scoped estimator", () => {
   // first reading was ~10x pessimistic and the sticky deadline held it until the
   // 30s window slid past the scan (the reported "6 min → 2 min" collapse).
   it("ignores the pre-scan frame that a sub-segment-break stall stranded at the window head (#1511)", () => {
-    beginEtaRun("run-1", [684], 684);
+    beginEtaRun("run-1", [800], 800);
     // Stage-entry frame at the unit's chunk offset — emitted before the scan.
     observeApplyProgress(1, 0, 0);
     // The scan blocks ~8.9s. The apply loop's first frame lands just after it,
@@ -300,12 +300,12 @@ describe("run-scoped estimator", () => {
     observeApplyProgress(1, 4, 9930);
     observeApplyProgress(1, 100, 19000);
     // Measured from post-scan samples only: 99 items over 10.07s = 9.83 items/s,
-    // leaving (684-100)/9.83 ≈ 59s. Had the pre-scan frame survived the slope
+    // leaving (800-100)/9.83 ≈ 71s. Had the pre-scan frame survived the slope
     // would be 100 items / 19s = 5.26 items/s and the readout would nearly double.
     const seconds = liveEtaSeconds();
     expect(seconds).not.toBeNull();
-    expect(seconds).toBeCloseTo((684 - 100) / (99 / 10.07), 0);
-    expect(seconds).toBeLessThan((684 - 100) / (100 / 19));
+    expect(seconds).toBeCloseTo((800 - 100) / (99 / 10.07), 0);
+    expect(seconds).toBeLessThan((800 - 100) / (100 / 19));
   });
 
   it("keeps a wide head gap that carried real throughput (slow work is not a stall, #1511)", () => {

--- a/src/utils/syncEta.test.ts
+++ b/src/utils/syncEta.test.ts
@@ -11,6 +11,7 @@ import {
   displayedEtaSeconds,
   resetEta,
   weightedCoarseFraction,
+  trimStalledPrefix,
   type EtaSample,
 } from "./syncEta";
 
@@ -277,6 +278,85 @@ describe("run-scoped estimator", () => {
     observeApplyProgress(1, 700, 6000);
     // totalRoms grew 1000 → 1300; remaining = (1300 - 700) / 100 = 6s.
     expect(liveEtaSeconds()).toBe(6);
+  });
+
+  // #1511: the applying stage is entered — and its first frame emitted — BEFORE
+  // the one-time shortcut scan, which then blocks for ~9s. That frame used to
+  // anchor the slope against the first post-scan sample, so the countdown's very
+  // first reading was ~10x pessimistic and the sticky deadline held it until the
+  // 30s window slid past the scan (the reported "6 min → 2 min" collapse).
+  it("ignores the pre-scan frame that a sub-segment-break stall stranded at the window head (#1511)", () => {
+    beginEtaRun("run-1", [684], 684);
+    // Stage-entry frame at the unit's chunk offset — emitted before the scan.
+    observeApplyProgress(1, 0, 0);
+    // The scan blocks ~8.9s. The apply loop's first frame lands just after it,
+    // one nominal item in: a stall, not throughput.
+    observeApplyProgress(1, 1, 8930);
+    // Nothing measurable yet — the stalled head is trimmed, leaving one sample.
+    // The static seed keeps standing rather than a 10x-slow countdown replacing it.
+    expect(liveEtaSeconds()).toBeNull();
+    expect(displayedEtaSeconds(8930)).toBeNull();
+    // Real apply work now proceeds, staying inside the segment-break threshold.
+    observeApplyProgress(1, 4, 9930);
+    observeApplyProgress(1, 100, 19000);
+    // Measured from post-scan samples only: 99 items over 10.07s = 9.83 items/s,
+    // leaving (684-100)/9.83 ≈ 59s. Had the pre-scan frame survived the slope
+    // would be 100 items / 19s = 5.26 items/s and the readout would nearly double.
+    const seconds = liveEtaSeconds();
+    expect(seconds).not.toBeNull();
+    expect(seconds).toBeCloseTo((684 - 100) / (99 / 10.07), 0);
+    expect(seconds).toBeLessThan((684 - 100) / (100 / 19));
+  });
+
+  it("keeps a wide head gap that carried real throughput (slow work is not a stall, #1511)", () => {
+    beginEtaRun("run-1", [100000], 100000);
+    // 6s between samples is far wider than the sampling cadence, but 600 items
+    // crossed it — that is real apply work being measured, not a parked stream.
+    observeApplyProgress(1, 100, 0);
+    observeApplyProgress(1, 700, 6000);
+    expect(liveEtaSeconds()).toBe(993);
+  });
+});
+
+describe("trimStalledPrefix", () => {
+  it("drops leading samples stranded behind a stall, leaving the post-stall window", () => {
+    const samples: EtaSample[] = [
+      { tMs: 0, processed: 0 },
+      { tMs: 8930, processed: 1 },
+      { tMs: 9930, processed: 4 },
+    ];
+    expect(trimStalledPrefix(samples)).toEqual([
+      { tMs: 8930, processed: 1 },
+      { tMs: 9930, processed: 4 },
+    ]);
+  });
+
+  it("can trim down to the newest sample alone (no measurement is the honest answer)", () => {
+    const samples: EtaSample[] = [
+      { tMs: 0, processed: 0 },
+      { tMs: 8930, processed: 1 },
+    ];
+    expect(trimStalledPrefix(samples)).toEqual([{ tMs: 8930, processed: 1 }]);
+  });
+
+  it("keeps a wide gap that carried throughput, and a narrow gap that carried none", () => {
+    // Wide but productive — real (slow) apply work.
+    const productive: EtaSample[] = [
+      { tMs: 0, processed: 0 },
+      { tMs: 6000, processed: 600 },
+    ];
+    expect(trimStalledPrefix(productive)).toEqual(productive);
+    // Flat but within the cadence — an ordinary throttled sample, not a stall.
+    const brief: EtaSample[] = [
+      { tMs: 0, processed: 500 },
+      { tMs: 1000, processed: 500 },
+    ];
+    expect(trimStalledPrefix(brief)).toEqual(brief);
+  });
+
+  it("leaves a window of fewer than two samples untouched", () => {
+    expect(trimStalledPrefix([])).toEqual([]);
+    expect(trimStalledPrefix([{ tMs: 0, processed: 5 }])).toEqual([{ tMs: 0, processed: 5 }]);
   });
 });
 

--- a/src/utils/syncEta.ts
+++ b/src/utils/syncEta.ts
@@ -46,6 +46,15 @@ const WINDOW_MS = 30_000;
 // one is a tiny item delta over a long span, an absurd rate that briefly spikes the
 // countdown before it settles.
 const SEGMENT_BREAK_MS = 10_000;
+// Stall threshold for the WINDOW HEAD. The apply loop emits a frame per item at
+// its ~50ms cadence, so admitted samples sit one throttle interval (~1s) apart
+// while real apply work is running. A leading gap of several cadences is
+// therefore a suspect: it may span a stall (the one-time shortcut scan, a fetch,
+// an ack round-trip) that the head sample predates. Below SEGMENT_BREAK_MS such
+// a stall leaves the whole segment intact, so the stale head would anchor the
+// oldest→newest slope. Suspicion alone does not trim — see trimStalledPrefix,
+// which also requires the interval to carry no real throughput.
+const STALL_GAP_MS = 3_000;
 // Readiness gate: the live countdown replaces the static "up to X" seed only
 // once the window spans enough real time to trust the slope. ~5s of applying
 // (≥2 throttled samples) is well inside the "measured within ~20s" target while
@@ -83,6 +92,42 @@ export function windowedRate(samples: readonly EtaSample[]): number | null {
   const delta = last.processed - first.processed;
   if (spanMs <= 0 || delta <= 0) return null;
   return delta / (spanMs / 1000);
+}
+
+/**
+ * Drop leading samples that sit on the far side of a STALL — a wide head gap
+ * that carried no real throughput. The applying stage is entered, and its first
+ * frame emitted, BEFORE the one-time shortcut scan blocks for ~9–14 s, so that
+ * frame becomes sample #1 and pairs with the first post-scan sample: a couple of
+ * items across the whole scan, a rate ~10x below the real one, which the sticky
+ * deadline then holds until the window slides past the scan.
+ *
+ * A wide gap alone does not qualify — slow-but-real work also spaces samples out,
+ * and discarding it would measure only the fastest stretch. The interval must ALSO
+ * carry less than one item per sampling interval, which is below anything the apply
+ * loop produces (it paces at ~50ms per item, and the slowest measured create rate
+ * is ~3 items/s). Both conditions together isolate "the frame stream was parked",
+ * which is what makes the head sample unfit to anchor the slope.
+ *
+ * Trimming can legitimately leave a SINGLE sample: while a stall is all the window
+ * has seen, "no measurement yet" is the honest answer, so the caller falls back to
+ * the static seed until clean samples accumulate (~5 s of applying). The newest
+ * sample always survives to anchor the next segment. Consistent with the module's
+ * premise — it measures apply throughput, not wall-clock including boundaries,
+ * the same reason ``SEGMENT_BREAK_MS`` discards a segment across a long fetch gap.
+ */
+export function trimStalledPrefix(samples: readonly EtaSample[]): EtaSample[] {
+  let start = 0;
+  while (start + 1 < samples.length) {
+    const head = samples[start];
+    const next = samples[start + 1];
+    if (head === undefined || next === undefined) break;
+    const spanMs = next.tMs - head.tMs;
+    if (spanMs <= STALL_GAP_MS) break;
+    if (next.processed - head.processed >= spanMs / SAMPLE_MIN_INTERVAL_MS) break;
+    start++;
+  }
+  return samples.slice(start);
 }
 
 /** Remaining seconds to process ``totalRoms - processed`` items at *rate* items/sec; clamped to ``≥ 0``. */
@@ -195,9 +240,10 @@ export function observeUnitTotal(unitIndex: number, unitTotal: number): void {
  * samples are discarded and a fresh measurement segment begins (this sample
  * bypasses the throttle), so no slope is ever measured across the gap — pairing a
  * pre-gap sample with a post-gap one yields an absurd rate. The estimator re-arms
- * to ``null`` until the new segment spans the readiness window. A no-op when no run
- * is being measured. Feed ONLY applying frames — fetch frames carry page/cover
- * counters, not item progress.
+ * to ``null`` until the new segment spans the readiness window. A shorter stall
+ * that leaves the segment standing is handled at the window head instead, by
+ * {@link trimStalledPrefix}. A no-op when no run is being measured. Feed ONLY
+ * applying frames — fetch frames carry page/cover counters, not item progress.
  */
 export function observeApplyProgress(step: number, current: number, tMs: number): void {
   if (_run === null) return;
@@ -213,7 +259,9 @@ export function observeApplyProgress(step: number, current: number, tMs: number)
   _run.lastSampleMs = tMs;
   const cutoff = tMs - WINDOW_MS;
   const recent = _run.samples.filter((s) => s.tMs >= cutoff);
-  _run.samples = recent.length >= 2 ? recent : _run.samples.slice(-2);
+  // Trim at admission, not at read time, so the span gate, the slope and the
+  // ``processed`` anchor all see one coherent window.
+  _run.samples = trimStalledPrefix(recent.length >= 2 ? recent : _run.samples.slice(-2));
   // Re-anchor the sticky countdown deadline from the fresh measurement. The
   // readiness gate re-arms liveEtaSeconds() to null ~5s after every inter-unit
   // fetch gap, and a run's tail of small units each applies in <5s and so never

--- a/tests/domain/test_work_unit.py
+++ b/tests/domain/test_work_unit.py
@@ -17,18 +17,27 @@ class TestToEventPayload:
         assert payload == {"type": "platform", "id": 1, "name": "N64", "slug": "n64", "rom_count": 5}
         assert "predicted_skip" not in payload
         assert "collapsed_count" not in payload
+        assert "bound_count" not in payload
         assert "collection_kind" not in payload
 
     def test_platform_payload_carries_estimate_fields_when_set(self):
-        payload = _platform_unit(predicted_skip=True, collapsed_count=3).to_event_payload()
+        payload = _platform_unit(predicted_skip=True, collapsed_count=3, bound_count=2).to_event_payload()
         assert payload["predicted_skip"] is True
         assert payload["collapsed_count"] == 3
+        assert payload["bound_count"] == 2
+
+    def test_zero_bound_count_is_still_emitted(self):
+        """0 is knowledge ("nothing mirrored yet, price it all as creates"),
+        distinct from absent ("unknown, fall back to the old all-creates read")."""
+        payload = _platform_unit(bound_count=0).to_event_payload()
+        assert payload["bound_count"] == 0
 
     def test_predicted_skip_false_is_still_emitted(self):
         """False is knowledge ("will not skip"), distinct from absent ("unknown")."""
         payload = _platform_unit(predicted_skip=False).to_event_payload()
         assert payload["predicted_skip"] is False
         assert "collapsed_count" not in payload
+        assert "bound_count" not in payload
 
     def test_collection_payload_carries_kind_but_no_estimate_fields(self):
         unit = WorkUnit(type="collection", id="7", name="Faves", slug="", rom_count=4, collection_kind="user")
@@ -36,6 +45,7 @@ class TestToEventPayload:
         assert payload["collection_kind"] == "user"
         assert "predicted_skip" not in payload
         assert "collapsed_count" not in payload
+        assert "bound_count" not in payload
 
 
 class TestEstimatedItems:

--- a/tests/services/library/test_fetcher.py
+++ b/tests/services/library/test_fetcher.py
@@ -1675,30 +1675,61 @@ class TestPlanEstimates:
 
     @pytest.mark.asyncio
     async def test_force_full_sync_clears_stamps_so_plan_predicts_no_skips(self, plugin, fake_romm_api):
-        """clear_sync_cache runs BEFORE the run, so a forced plan reads no stamps."""
+        """clear_sync_cache runs BEFORE the run, so a forced plan reads no stamps.
+
+        Pins the PLATFORM-vs-COLLECTION asymmetry the clear exposes (#1511): a
+        platform keeps its ``bound_count`` (read straight from the rows, no stamp
+        gate) while a collection loses its — a collection's membership is knowable
+        only from the stamp the clear just deleted, so its unit reverts to create
+        pricing for that run. The estimate reads long, never short.
+        """
         _wire_fake(plugin, fake_romm_api)
         uow = plugin._uow
         fake_romm_api.platforms = [{"id": 1, "name": "N64", "slug": "n64", "rom_count": 1}]
         plugin.settings["enabled_platforms"] = {"1": True}
         _seed_platform_stamp(uow, "n64", at="2025-01-01T00:00:00", rom_count=1)
         _seed_persisted_rom(uow, 10, app_id=1001, group_key="igdb:100:1")
+        # A stamped collection with one bound member. Its member row sits on
+        # another platform so it cannot perturb the N64 unit's own counts.
+        fake_romm_api.collections = [{"id": 7, "name": "Faves", "slug": "faves", "rom_count": 1}]
+        plugin.settings["enabled_collections"] = {"user": {"7": True}, "smart": {}, "franchise": {}}
+        _seed_persisted_rom(uow, 20, app_id=2001, group_key="igdb:200:1", platform_slug="snes")
+        _seed_collection_stamp(
+            uow,
+            "7",
+            "user",
+            updated_at="2026-01-01T00:00:00",
+            completed_at="2026-01-01T00:00:00",
+            rom_count=1,
+            member_rom_ids=(20,),
+        )
 
-        before = await plugin._sync_service._fetcher.build_work_queue()
-        assert before[0].predicted_skip is True
-        assert before[0].collapsed_count == 1
+        before = {u.name: u for u in await plugin._sync_service._fetcher.build_work_queue()}
+        assert before["N64"].predicted_skip is True
+        assert before["N64"].collapsed_count == 1
+        assert before["Faves"].bound_count == 1
 
         plugin._sync_service.clear_sync_cache()
 
-        after = await plugin._sync_service._fetcher.build_work_queue()
-        assert after[0].predicted_skip is False
+        after = {u.name: u for u in await plugin._sync_service._fetcher.build_work_queue()}
+        assert after["N64"].predicted_skip is False
         # The stamp clear also drops the collapsed count (#1412 gate): the forced
         # re-apply recreates every shortcut, so the ETA is priced at the full
         # server rom_count, not the (now stale) persisted collapse. The rows
         # survive the clear, but without a stamp the count is not emitted.
-        assert after[0].collapsed_count is None
-        # The BINDING survives the clear, though — so the re-apply is a walk of
-        # cheap updates and the seed prices it as such (#1511).
-        assert after[0].bound_count == 1
+        assert after["N64"].collapsed_count is None
+        # The platform's BINDING survives the clear, and so does its bound_count —
+        # it reads the rows directly, so the re-apply is priced as a walk of cheap
+        # updates (#1511).
+        assert after["N64"].bound_count == 1
+        # The collection is the opposite case, and this pairing is the point: its
+        # shortcut is just as intact, but the clear deleted the ONLY record of
+        # which ROMs are members, so the count is absent — not 0, which would
+        # assert a membership the plan can no longer see. Absent means the seed
+        # prices the unit's items as creates for this run.
+        assert after["Faves"].bound_count is None
+        with uow:
+            assert uow.roms.get(20).shortcut_app_id == 2001
 
     @pytest.mark.asyncio
     async def test_estimate_read_failure_leaves_fields_none_and_plan_intact(self, plugin, fake_romm_api):

--- a/tests/services/library/test_fetcher.py
+++ b/tests/services/library/test_fetcher.py
@@ -1563,8 +1563,9 @@ class TestPlanEstimates:
         assert units[0].predicted_skip is False
 
     @pytest.mark.asyncio
-    async def test_collection_units_carry_no_estimate_fields(self, plugin, fake_romm_api):
-        """Collection membership isn't locally derivable — the scope guard leaves both fields None."""
+    async def test_unstamped_collection_carries_no_estimate_fields(self, plugin, fake_romm_api):
+        """Without a stamp a collection's membership is unknown — every rider
+        stays None, and the seed prices the unit exactly as it did pre-#1511."""
         _wire_fake(plugin, fake_romm_api)
         fake_romm_api.platforms = []
         fake_romm_api.collections = [{"id": 7, "name": "Faves", "slug": "faves", "rom_count": 4}]
@@ -1576,6 +1577,100 @@ class TestPlanEstimates:
         assert [u.type for u in units] == ["collection"]
         assert units[0].predicted_skip is None
         assert units[0].collapsed_count is None
+        # None, NOT 0 — the platform side reports 0 for "nothing mirrored", but a
+        # collection with no stamp has no member set to count at all (#1511).
+        assert units[0].bound_count is None
+
+    @pytest.mark.asyncio
+    async def test_stamped_collection_counts_its_bound_members(self, plugin, fake_romm_api):
+        """#1511: a stamped collection's member set comes from the stamp (no ROM
+        fetch), so its already-bound members price at the cheap update rate."""
+        _wire_fake(plugin, fake_romm_api)
+        uow = plugin._uow
+        fake_romm_api.platforms = []
+        fake_romm_api.collections = [{"id": 7, "name": "Faves", "slug": "faves", "rom_count": 3}]
+        plugin.settings["enabled_platforms"] = {}
+        plugin.settings["enabled_collections"] = {"user": {"7": True}, "smart": {}, "franchise": {}}
+        # Three members; two already hold a Steam shortcut.
+        _seed_persisted_rom(uow, 10, app_id=1001, group_key="igdb:100:1")
+        _seed_persisted_rom(uow, 11, app_id=1002, group_key="igdb:101:1")
+        _seed_persisted_rom(uow, 12, app_id=None, group_key="igdb:102:1")
+        _seed_collection_stamp(
+            uow,
+            "7",
+            "user",
+            updated_at="2026-01-01T00:00:00",
+            completed_at="2026-01-01T00:00:00",
+            rom_count=3,
+            member_rom_ids=(10, 11, 12),
+        )
+
+        units = await plugin._sync_service._fetcher.build_work_queue()
+
+        assert units[0].bound_count == 2
+
+    @pytest.mark.asyncio
+    async def test_stamped_collection_ignores_members_with_no_persisted_row(self, plugin, fake_romm_api):
+        """A stale member set can name ROMs no longer persisted locally; those
+        are not bound and must not be counted (estimate-only, no freshness probe)."""
+        _wire_fake(plugin, fake_romm_api)
+        uow = plugin._uow
+        fake_romm_api.platforms = []
+        fake_romm_api.collections = [{"id": 7, "name": "Faves", "slug": "faves", "rom_count": 2}]
+        plugin.settings["enabled_platforms"] = {}
+        plugin.settings["enabled_collections"] = {"user": {"7": True}, "smart": {}, "franchise": {}}
+        _seed_persisted_rom(uow, 10, app_id=1001, group_key="igdb:100:1")
+        _seed_collection_stamp(
+            uow,
+            "7",
+            "user",
+            updated_at="2026-01-01T00:00:00",
+            completed_at="2026-01-01T00:00:00",
+            rom_count=2,
+            member_rom_ids=(10, 999),
+        )
+
+        units = await plugin._sync_service._fetcher.build_work_queue()
+
+        assert units[0].bound_count == 1
+
+    @pytest.mark.asyncio
+    async def test_franchise_collection_never_carries_a_bound_count(self, plugin, fake_romm_api):
+        """Franchise collections are never stampable (CollectionSyncState.stamp
+        takes only user/smart), so they have no member set — the field stays absent."""
+        _wire_fake(plugin, fake_romm_api)
+        uow = plugin._uow
+        fake_romm_api.platforms = []
+        fake_romm_api.virtual_collections = {
+            "franchise": [{"id": "fr-1", "name": "Zelda", "slug": "zelda", "rom_count": 5}]
+        }
+        plugin.settings["enabled_platforms"] = {}
+        plugin.settings["enabled_collections"] = {"user": {}, "smart": {}, "franchise": {"fr-1": True}}
+        _seed_persisted_rom(uow, 10, app_id=1001, group_key="igdb:100:1")
+
+        units = await plugin._sync_service._fetcher.build_work_queue()
+
+        assert [u.collection_kind for u in units] == ["franchise"]
+        assert units[0].bound_count is None
+
+    @pytest.mark.asyncio
+    async def test_collection_bound_count_read_failure_leaves_the_field_none(self, plugin, fake_romm_api):
+        """Fail-open, like the platform sibling: a DB failure degrades the
+        estimate to its pre-#1511 reading, never the plan."""
+        _wire_fake(plugin, fake_romm_api)
+        fake_romm_api.platforms = []
+        fake_romm_api.collections = [{"id": 7, "name": "Faves", "slug": "faves", "rom_count": 3}]
+        plugin.settings["enabled_platforms"] = {}
+        plugin.settings["enabled_collections"] = {"user": {"7": True}, "smart": {}, "franchise": {}}
+
+        def _boom():
+            raise RuntimeError("db down")
+
+        plugin._sync_service._fetcher._uow_factory = _boom
+
+        units = await plugin._sync_service._fetcher.build_work_queue()
+
+        assert len(units) == 1
         assert units[0].bound_count is None
 
     @pytest.mark.asyncio

--- a/tests/services/library/test_fetcher.py
+++ b/tests/services/library/test_fetcher.py
@@ -1385,9 +1385,9 @@ class TestFetchProgressNarration:
 class TestPlanEstimates:
     """build_work_queue's plan-time estimate riders (#1382).
 
-    ``predicted_skip`` / ``collapsed_count`` are estimate-only fields that
-    price the ``sync_plan`` payload — the fetch-time gate
-    (``_try_unit_incremental_skip``) stays the sole skip authority
+    ``predicted_skip`` / ``collapsed_count`` / ``bound_count`` are
+    estimate-only fields that price the ``sync_plan`` payload — the fetch-time
+    gate (``_try_unit_incremental_skip``) stays the sole skip authority
     (ADR-0023); see :class:`TestPredictionNeverFeedsSkipGate` for the guard.
     """
 
@@ -1458,6 +1458,60 @@ class TestPlanEstimates:
 
         assert units[0].predicted_skip is False
         assert units[0].collapsed_count is None
+        # bound_count is NOT stamp-gated: those two favorited siblings really do
+        # have Steam shortcuts, so they are genuinely updates, not creates.
+        assert units[0].bound_count == 2
+
+    @pytest.mark.asyncio
+    async def test_bound_count_counts_rows_carrying_a_shortcut(self, plugin, fake_romm_api):
+        """#1511: the count of rows already bound to a Steam shortcut, which the
+        frontend prices at the cheap update rate instead of the create rate."""
+        _wire_fake(plugin, fake_romm_api)
+        uow = plugin._uow
+        fake_romm_api.platforms = [{"id": 1, "name": "N64", "slug": "n64", "rom_count": 3}]
+        plugin.settings["enabled_platforms"] = {"1": True}
+        _seed_platform_stamp(uow, "n64", at="2025-01-01T00:00:00", rom_count=3)
+        _seed_persisted_rom(uow, 10, app_id=1001, group_key="igdb:100:1")
+        _seed_persisted_rom(uow, 11, app_id=1002, group_key="igdb:101:1")
+        _seed_persisted_rom(uow, 12, app_id=None, group_key="igdb:102:1")
+
+        units = await plugin._sync_service._fetcher.build_work_queue()
+
+        assert units[0].bound_count == 2
+
+    @pytest.mark.asyncio
+    async def test_bound_count_is_zero_for_a_platform_with_no_persisted_rows(self, plugin, fake_romm_api):
+        """Zero is knowledge, not absence: a never-synced platform mirrors
+        nothing, so every planned item really is a create."""
+        _wire_fake(plugin, fake_romm_api)
+        fake_romm_api.platforms = [{"id": 1, "name": "N64", "slug": "n64", "rom_count": 3}]
+        plugin.settings["enabled_platforms"] = {"1": True}
+
+        units = await plugin._sync_service._fetcher.build_work_queue()
+
+        assert units[0].bound_count == 0
+
+    @pytest.mark.asyncio
+    async def test_force_full_sync_shape_keeps_bound_count_so_the_re_apply_prices_as_updates(
+        self, plugin, fake_romm_api
+    ):
+        """The #1511 over-read: a Force Full Sync clears every completion stamp
+        but unbinds nothing, so the run is all cheap updates. Without
+        bound_count the plan prices it as a fresh import (~4x the real cost)."""
+        _wire_fake(plugin, fake_romm_api)
+        uow = plugin._uow
+        fake_romm_api.platforms = [{"id": 1, "name": "N64", "slug": "n64", "rom_count": 2}]
+        plugin.settings["enabled_platforms"] = {"1": True}
+        # No stamp — exactly what clear_sync_cache leaves behind — but the rows
+        # keep their shortcut_app_id.
+        _seed_persisted_rom(uow, 10, app_id=1001, group_key="igdb:100:1")
+        _seed_persisted_rom(uow, 11, app_id=1002, group_key="igdb:101:1")
+
+        units = await plugin._sync_service._fetcher.build_work_queue()
+
+        assert units[0].predicted_skip is False
+        assert units[0].collapsed_count is None
+        assert units[0].bound_count == 2
 
     @pytest.mark.asyncio
     async def test_stamp_count_mismatch_predicts_no_skip_but_keeps_collapsed_count(self, plugin, fake_romm_api):
@@ -1522,6 +1576,7 @@ class TestPlanEstimates:
         assert [u.type for u in units] == ["collection"]
         assert units[0].predicted_skip is None
         assert units[0].collapsed_count is None
+        assert units[0].bound_count is None
 
     @pytest.mark.asyncio
     async def test_force_full_sync_clears_stamps_so_plan_predicts_no_skips(self, plugin, fake_romm_api):
@@ -1546,6 +1601,9 @@ class TestPlanEstimates:
         # server rom_count, not the (now stale) persisted collapse. The rows
         # survive the clear, but without a stamp the count is not emitted.
         assert after[0].collapsed_count is None
+        # The BINDING survives the clear, though — so the re-apply is a walk of
+        # cheap updates and the seed prices it as such (#1511).
+        assert after[0].bound_count == 1
 
     @pytest.mark.asyncio
     async def test_estimate_read_failure_leaves_fields_none_and_plan_intact(self, plugin, fake_romm_api):
@@ -1564,6 +1622,7 @@ class TestPlanEstimates:
         assert len(units) == 1
         assert units[0].predicted_skip is None
         assert units[0].collapsed_count is None
+        assert units[0].bound_count is None
 
 
 class TestGetPlatformsCollapsedCount:

--- a/tests/services/library/test_sync_orchestrator.py
+++ b/tests/services/library/test_sync_orchestrator.py
@@ -1395,8 +1395,10 @@ class TestDoSyncPerUnit:
         _seed_platform_stamp(plugin, "n64", at="2025-01-01T00:00:00", rom_count=2)
         _seed_rom_row(plugin, 10, app_id=1001, platform_slug="n64", sibling_group_key="igdb:100:1")
         _seed_rom_row(plugin, 11, app_id=None, platform_slug="n64", sibling_group_key="igdb:100:1")
-        # A collection unit: membership isn't locally derivable, so it carries
-        # neither estimate field and weighs its raw rom_count.
+        # A collection unit, left UNSTAMPED here: its membership is knowable only
+        # from a completion stamp, so it carries no estimate field at all and
+        # weighs its raw rom_count. (A stamped collection does ride bound_count,
+        # #1511 — covered in test_fetcher.)
         _seed_collection(fake_romm_api, collection_id=7, name="Faves", rom_ids=[20, 21, 22])
         plugin.settings["enabled_collections"] = {"user": {"7": True}, "smart": {}, "franchise": {}}
 
@@ -1421,6 +1423,7 @@ class TestDoSyncPerUnit:
         assert "collapsed_count" not in units["GBA"]
         assert "predicted_skip" not in units["Faves"]
         assert "collapsed_count" not in units["Faves"]
+        assert "bound_count" not in units["Faves"]
 
     @pytest.mark.asyncio
     async def test_unstamped_zero_delta_platform_restamps_and_records_run(self, plugin, fake_romm_api):


### PR DESCRIPTION
The pre-sync time estimate over-reads by up to 5.5x on update-heavy runs. A full-library Force Full Sync opens at "up to 16 min" and finishes in under 3.

**The issue's original diagnosis was wrong.** It attributed the over-read to artwork being priced into every item and wasted on a warm cover cache. On-device measurement disproves that: `clear_sync_cache` never touches `roms.shortcut_app_id`, so a Force Full Sync produces zero creates and everything-changed; `applyCoverArtwork` is gated on `created`, so updated shortcuts apply no artwork at all. On the run that produced the reported number, artwork cost was ~zero — nothing was wasted on anything.

The real cause is composition blindness. When a sync starts without a preview, the seed priced _every_ planned item at the create rate. That path had no idea the run was all cheap updates.

**Measured on-device** (Steam Deck, 2026-07), per-item rates:

| | modelled before | measured | after |
|---|---|---|---|
| create | 0.45 s | 0.314 s | 0.36 s |
| update | 0.20 s | 0.109 s | 0.13 s |
| cover download | folded into create | 0.132 s | 0.15 s |
| fixed allowance | 90 s | 17–24 s | 45 s |

The cover cache does matter, but in the backend download phase rather than per item — the same covers cost ~130 ms each cold and under 2 ms warm, a ~70x difference. That is now its own term instead of being amortised into the per-item constant.

## Changes

- The cost model prices creates, updates and cover downloads as independent terms, with constants recalibrated against the measurements above.
- `sync_plan` carries a per-unit `bound_count` — how many of a unit's rows already have a Steam shortcut — read in the existing plan-estimates transaction at no extra cost. The seed prices those at the update rate. Additive and optional; an older backend falls back to the previous behaviour.
- Collection units carry it too, counted from the persisted member set so no ROM fetch is needed. Unstamped and franchise collections report "unknown" rather than zero — their member set lives only in the stamp, and asserting zero would claim knowledge we don't have. (Consequence: after a Force Full Sync, which wipes those stamps, collections revert to create pricing for that one run — the estimate reads long, never short.)
- Cover-refresh work is priced instead of being free, so a cover-only preview no longer reads a flat 90 s whether it refreshes one cover or thousands.
- The live countdown no longer opens ~10x pessimistic. An `applying` frame is emitted before the one-time shortcut scan, which then blocks for several seconds; since the rate is a two-point slope, that stalled sample sat at the head of the window and dragged the first measurement down until the window slid past it. The stalled prefix is now trimmed.

## Effect

| run shape | before | after | actual |
|---|---|---|---|
| create-heavy, cold covers | 7 min | 7 min | ~5 min |
| full-library update pass | 4 min | 4 min | ~3 min |
| full-library re-sync, no preview | **16 min** | **5 min** | ~4.5 min |

A uniform ~1.2x margin instead of 1.3x for creates and 5.5x for updates. The estimate still reads long, never short.

Closes #1511
