### PR TITLE
fix(sync): price a Force Full Sync's sibling duplicates as updates, not phantom creates

### DIFF
--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -597,19 +597,28 @@ weights + planned totals, via `sync_plan`) and the applying frames.
   `0` there would claim knowledge that does not exist. Absent and `0` price identically today; the distinction keeps the
   field honest for later consumers, so do not collapse it into consistency. A collection's stored member set may be
   **stale** if membership changed since the stamp — accepted and bounded, since this is estimate-only and a freshness
-  probe would mean network I/O at plan time. **Hard constraint (ADR-0023): the prediction never feeds the actual skip
-  decision** — `_try_unit_incremental_skip` at fetch time remains the sole skip authority, so a mis-prediction can only
-  make the estimate read long or short, never mis-apply. A Force Full Sync needs no special case: `clear_sync_cache`
-  deletes every stamp before the run, so a forced plan predicts no skips and drops every `collapsed_count` (the forced
-  re-apply is priced at the full `rom_count`). The same collapsed counts also garnish `get_platforms` (an optional
-  per-platform `collapsed_count`), so the platform toggles show the number of games a synced platform actually produces
-  rather than the raw server file count. That garnish is **gated on the platform's completion stamp**
-  (`_read_collapsed_counts`, #1412): the count is emitted only for slugs that currently carry a `PlatformSyncState`
-  stamp — the stamp exists iff the local mirror is complete, which is exactly when a post-collapse count is meaningful.
-  A never-synced platform legitimately holds only PARTIAL rows (cross-platform collection siblings persist per
-  ADR-0021), so an ungated count would shadow the true server total; with no stamp the field is absent and the toggle
-  label falls back to the raw `rom_count`. Clearing the stamp (local removal / Force Full Sync) reverts the label to the
-  server total until the next completed sync re-stamps.
+  probe would mean network I/O at plan time. A fourth rider, `new_shortcut_count` (#1517), is the create-side complement
+  of `collapsed_count`: the shortcuts the next apply must **mint** rather than update — sibling groups with no binding
+  anywhere, unbound keyless rows, and every server ROM the local mirror holds no row for (`rom_count − persisted rows`,
+  clamped at zero). It is **platform-only** — a collection's rows belong to their platform's unit, so counting creates
+  on a collection too would price the same shortcuts twice — and like `bound_count` it is **not** stamp-gated: an
+  unbound group genuinely has no shortcut and a ROM with no local row genuinely has to be created, whether or not the
+  mirror is complete. The frontend takes it as its create term directly instead of deriving creates by subtracting
+  `bound_count` from the unit's weight (see the composition-priced seed below). **Hard constraint (ADR-0023): the
+  prediction never feeds the actual skip decision** — `_try_unit_incremental_skip` at fetch time remains the sole skip
+  authority, so a mis-prediction can only make the estimate read long or short, never mis-apply. A Force Full Sync needs
+  no special case: `clear_sync_cache` deletes every stamp before the run, so a forced plan predicts no skips and drops
+  every `collapsed_count` — the unit is then weighed at the full pre-collapse `rom_count`, but `bound_count` and
+  `new_shortcut_count` both survive the clear (they read the rows, not the stamp) and keep the forced re-apply priced by
+  composition (#1517). The same collapsed counts also garnish `get_platforms` (an optional per-platform
+  `collapsed_count`), so the platform toggles show the number of games a synced platform actually produces rather than
+  the raw server file count. That garnish is **gated on the platform's completion stamp** (`_read_collapsed_counts`,
+  #1412): the count is emitted only for slugs that currently carry a `PlatformSyncState` stamp — the stamp exists iff
+  the local mirror is complete, which is exactly when a post-collapse count is meaningful. A never-synced platform
+  legitimately holds only PARTIAL rows (cross-platform collection siblings persist per ADR-0021), so an ungated count
+  would shadow the true server total; with no stamp the field is absent and the toggle label falls back to the raw
+  `rom_count`. Clearing the stamp (local removal / Force Full Sync) reverts the label to the server total until the next
+  completed sync re-stamps.
 - **Static walk-cost ceiling (pre-run seed).** Before a run — in the preview, and again as the initial "up to X min" the
   instant a skip-preview run starts — the estimate is a pure cost model over **three independent terms** (#1511),
   because a run is three independent phases and one blended per-item rate cannot describe a mix of them:
@@ -623,18 +632,32 @@ weights + planned totals, via `sync_plan`) and the applying frames.
   covers cost 0.0018 s, 73x cheaper than cold, and pricing them would need a backend cache probe in the preview path
   that is deliberately not added, so every create is priced as needing a cold download.
 - **Composition-priced plan seed.** The skip-preview seed prices the plan **per unit by composition**, not as one
-  blended item count (#1511): a predicted-skip unit costs nothing, and of the remainder's items
-  (`collapsed_count ?? rom_count`) the ones already bound (`bound_count`) take the update rate, the rest the create
-  rate. Pricing every planned item as a create over-read by ~4x on the common case — any re-sync, and **every Force Full
-  Sync**, which clears the completion stamps but unbinds nothing and is therefore an all-updates run. Platform and
-  collection units are priced the same way on an ordinary re-sync, so a collection-heavy library does not reinstate the
-  over-read through its collections. **A Force Full Sync is the exception for collections**: `clear_sync_cache` clears
-  `collection_sync_state` wholesale, and a collection's member set lives _only_ in that stamp, so every collection unit
-  is unstamped for that run and reverts to create pricing. Platforms are unaffected — their `bound_count` is
-  deliberately not stamp-gated. This follows directly from the `None`-not-`0` rule above and errs **long**, the safe
-  direction; correcting it would mean asserting membership the plan does not have. A unit whose `bound_count` is absent
-  (older backend, unstamped or franchise collection) prices as all creates, the pre-#1511 behaviour. The live-countdown
-  weights are unaffected and stay `predicted_skip ? 0 : (collapsed_count ?? rom_count)`.
+  blended item count (#1511): a predicted-skip unit costs nothing, the unit's already-bound ROMs (`bound_count`) take
+  the update rate, and the shortcuts that genuinely have to be minted (`new_shortcut_count`) take the create rate.
+  Pricing every planned item as a create over-read by ~4x on the common case — any re-sync, and **every Force Full
+  Sync**, which clears the completion stamps but unbinds nothing and is therefore an all-updates run.
+- **Why the create term is read, not subtracted (#1517).** The two rates are priced from **independent** counts; the
+  create term is `new_shortcut_count` directly, never `items − bound_count`. The subtraction over-read a **Force Full
+  Sync of a sibling-heavy platform** by ~2.5x: a forced run drops `collapsed_count`, so the unit is weighed at its
+  pre-collapse `rom_count`, and on a platform carrying sibling groups (ADR-0021) that raw count exceeds the real
+  shortcut count — one row per group is bound, its duplicates are not. Subtracting the bound rows priced every unbound
+  duplicate as a phantom new shortcut, at the dear create rate **plus** a cover download it would never perform, even
+  though a sibling duplicate never produces a shortcut. `new_shortcut_count` reports no creates there instead, because
+  the clear takes the stamps and not the bindings, so no group is left without one. The symmetric hazard is a **never-
+  synced platform holding only PARTIAL collection-sibling rows** (ADR-0021): counting creates from the known rows alone
+  would price a handful of items for a whole platform — a **short** read, the one direction this estimate may not err
+  in. The `rom_count − persisted rows` term prices those unmirrored ROMs as creates, so the seed stays at (or above) the
+  full platform. A unit whose `new_shortcut_count` is absent (collections, older backends) falls back to the
+  `items − bound_count` subtraction, the pre-#1517 behaviour.
+- **Collections still price by bound members.** Platform and collection units are priced the same way on an ordinary
+  re-sync, so a collection-heavy library does not reinstate the over-read through its collections. **A Force Full Sync
+  is the exception for collections**: `clear_sync_cache` clears `collection_sync_state` wholesale, and a collection's
+  member set lives _only_ in that stamp, so every collection unit is unstamped for that run and reverts to create
+  pricing. Platforms are unaffected — their `bound_count` and `new_shortcut_count` are deliberately not stamp-gated.
+  This follows directly from the `None`-not-`0` rule above and errs **long**, the safe direction; correcting it would
+  mean asserting membership the plan does not have. A unit whose `bound_count` is absent (older backend, unstamped or
+  franchise collection) prices as all creates, the pre-#1511 behaviour. The live-countdown weights are unaffected and
+  stay `predicted_skip ? 0 : (collapsed_count ?? rom_count)`.
 - **Measured live countdown (takes over within seconds).** Once the apply is underway, `syncEta.ts` measures the
   **real** rate from the applying frames — one throttled sample per second over a ~30 s sliding window — and projects
   `remaining = (planned_total − processed) / rate`, rendered rounded **up** ("9 min left") so it never promises less

--- a/docs/user-guide/syncing-your-library.md
+++ b/docs/user-guide/syncing-your-library.md
@@ -54,12 +54,14 @@ skips it without re-listing its contents — so a large, collection-heavy librar
 The estimate also knows the **difference between adding a game and updating one**. Creating a shortcut is roughly three
 times the work of refreshing one that already exists, and it also has to pull down a cover; updating an existing
 shortcut does neither. So a re-sync over games your library already has is estimated at the cheaper update rate rather
-than as though it were building your library from scratch. One exception: after a **Force Full Sync**, your collections
-are estimated at the dearer "adding" rate for that run. The plugin only knows which games are in a collection from the
-record it keeps when that collection last finished syncing, and Force Full Sync deliberately wipes those records — so
-for that one run it can't tell that your collections' games are already in Steam. The run itself is unaffected, and the
-estimate only ever reads too long, never too short. Cover updates are counted on their own, so a run that only refreshes
-cover art is estimated from how many covers changed instead of falling back to a fixed number.
+than as though it were building your library from scratch — including a **Force Full Sync**, which re-applies every game
+your platforms already hold but adds none, so its platforms are estimated at that cheaper rate too. One exception
+remains: after a Force Full Sync, your **collections** are estimated at the dearer "adding" rate for that run. The
+plugin only knows which games are in a collection from the record it keeps when that collection last finished syncing,
+and Force Full Sync deliberately wipes those records — so for that one run it can't tell that your collections' games
+are already in Steam. The run itself is unaffected, and the estimate only ever reads too long, never too short. Cover
+updates are counted on their own, so a run that only refreshes cover art is estimated from how many covers changed
+instead of falling back to a fixed number.
 
 Once the sync has been creating shortcuts for a few seconds, that "up to" ceiling is replaced by a **live countdown** —
 "2 min left" — measured from the actual speed on your device and updated as the run proceeds. The countdown waits until

--- a/py_modules/domain/skip_prediction.py
+++ b/py_modules/domain/skip_prediction.py
@@ -1,10 +1,11 @@
 """Plan-time estimate kernels for the skip-aware sync time estimate.
 
 Pure predictions derived from locally persisted state: whether the
-fetch-time wholesale-skip gate is expected to skip a platform unit, and
-how many Steam shortcuts a platform's persisted rows collapse into.
-Both exist ONLY to price the ``sync_plan`` estimate payload
-(``predicted_skip`` / ``collapsed_count`` / ``total_estimated_items``).
+fetch-time wholesale-skip gate is expected to skip a platform unit, how
+many Steam shortcuts a platform's persisted rows collapse into, and how
+many of those shortcuts do not exist yet. They exist ONLY to price the
+``sync_plan`` estimate payload (``predicted_skip`` / ``collapsed_count``
+/ ``new_shortcut_count`` / ``total_estimated_items``).
 
 Hard constraint (ADR-0023): the fetch-time gate
 (``LibraryFetcher._try_unit_incremental_skip``) remains the SOLE skip
@@ -86,3 +87,41 @@ def collapsed_shortcut_count(rows: Iterable[tuple[str | None, bool]]) -> int:
         else:
             bound_by_key[key] = bound_by_key.get(key, 0) + (1 if is_bound else 0)
     return sum(max(1, bound) for bound in bound_by_key.values()) + singletons
+
+
+def new_shortcut_count(rows: Iterable[tuple[str | None, bool]], *, unit_rom_count: int) -> int:
+    """Shortcuts a platform's next apply is expected to CREATE rather than update.
+
+    The complement of :func:`collapsed_shortcut_count`: that one counts the
+    shortcuts a platform ends up with, this one the subset of them that has
+    to be minted. A sibling group (ADR-0021) with any bound row already owns
+    its shortcut — every further row in it is a duplicate the collapse drops,
+    never a create — so only a group with no binding anywhere counts, plus
+    each unbound keyless row (its real group is unknown until the backfill
+    fetch computes the key, so it must be assumed to be its own creation).
+
+    *unit_rom_count* is the server's ROM count for the platform. Rows the
+    local mirror does not hold yet — ``unit_rom_count`` beyond the number of
+    persisted rows — each count as a create, which is what keeps a
+    never-synced platform honest: it may hold PARTIAL rows (cross-platform
+    collection siblings persist per ADR-0021) whose groups say nothing about
+    the ROMs never fetched. Without that term the estimate would read short
+    by the entire unfetched remainder, and reading short is the one direction
+    this estimate may not err in. A local mirror that is ahead of the server
+    (retained rows for dropped rom_ids, ADR-0007) clamps the term at zero.
+
+    Estimate-only (ADR-0023): the result prices the ``sync_plan`` payload's
+    create term and must never feed the actual skip decision.
+    """
+    bound_by_key: dict[str, bool] = {}
+    unbound_singletons = 0
+    row_count = 0
+    for key, is_bound in rows:
+        row_count += 1
+        if key is None:
+            if not is_bound:
+                unbound_singletons += 1
+        else:
+            bound_by_key[key] = bound_by_key.get(key, False) or is_bound
+    unmirrored = max(0, unit_rom_count - row_count)
+    return sum(1 for bound in bound_by_key.values() if not bound) + unbound_singletons + unmirrored

--- a/py_modules/domain/work_unit.py
+++ b/py_modules/domain/work_unit.py
@@ -38,10 +38,11 @@ class WorkUnit:
     # membership-stable signal. ``None`` when the listing omits it (e.g. a
     # franchise collection, which is never stamped) — skip-internal, off the wire.
     collection_updated_at: str | None = None
-    # Plan-time estimate riders (#1382 / #1511). ``predicted_skip`` is the
-    # plan's local-conditions guess at the fetch-time wholesale-skip gate's
-    # outcome and ``collapsed_count`` the persisted post-collapse shortcut
-    # count — both platform-only. ``bound_count`` carries on BOTH unit types:
+    # Plan-time estimate riders (#1382 / #1511 / #1517). ``predicted_skip`` is
+    # the plan's local-conditions guess at the fetch-time wholesale-skip gate's
+    # outcome, ``collapsed_count`` the persisted post-collapse shortcut count
+    # and ``new_shortcut_count`` how many of those shortcuts do not exist yet —
+    # all three platform-only. ``bound_count`` carries on BOTH unit types:
     # how many of the unit's known ROMs already hold a Steam shortcut, which is
     # what lets the frontend price them at the cheap UPDATE rate instead of the
     # create rate (a platform reads its persisted rows; a collection reads its
@@ -53,6 +54,7 @@ class WorkUnit:
     predicted_skip: bool | None = None
     collapsed_count: int | None = None
     bound_count: int | None = None
+    new_shortcut_count: int | None = None
 
     def estimated_items(self) -> int:
         """This unit's weight in the plan's skip-aware estimate total.
@@ -83,4 +85,6 @@ class WorkUnit:
             payload["collapsed_count"] = self.collapsed_count
         if self.bound_count is not None:
             payload["bound_count"] = self.bound_count
+        if self.new_shortcut_count is not None:
+            payload["new_shortcut_count"] = self.new_shortcut_count
         return payload

--- a/py_modules/services/library/fetcher.py
+++ b/py_modules/services/library/fetcher.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING, Any, NamedTuple
 
 from domain.fetch_generation import count_rows_for_skip
 from domain.platform_prefs import materialize_enabled_platforms, resolve_sync_enabled
-from domain.skip_prediction import collapsed_shortcut_count, predict_unit_skip
+from domain.skip_prediction import collapsed_shortcut_count, new_shortcut_count, predict_unit_skip
 from domain.sync_stage import SyncStage
 from domain.sync_state import SyncCancelled, SyncState
 from domain.work_unit import CollectionKind, WorkUnit
@@ -59,6 +59,7 @@ class _PlanEstimate(NamedTuple):
     predicted_skip: bool
     collapsed_count: int | None
     bound_count: int | None
+    new_shortcut_count: int | None
 
 
 class _SkipBaseline(NamedTuple):
@@ -435,9 +436,9 @@ class LibraryFetcher:
         endpoints. No ROMs are fetched here — the queue is a dispatch
         plan, not a payload. Units additionally carry the plan-time estimate
         riders for the ``sync_plan`` payload — ``predicted_skip`` /
-        ``collapsed_count`` on platform units (#1382), ``bound_count`` on both
-        kinds (#1511). Estimate-only: they never feed the actual skip decision
-        (ADR-0023).
+        ``collapsed_count`` (#1382) and ``new_shortcut_count`` (#1517) on
+        platform units, ``bound_count`` on both kinds (#1511). Estimate-only:
+        they never feed the actual skip decision (ADR-0023).
         """
         units: list[WorkUnit] = []
 
@@ -524,6 +525,7 @@ class LibraryFetcher:
                 predicted_skip=estimates[unit.slug].predicted_skip,
                 collapsed_count=estimates[unit.slug].collapsed_count,
                 bound_count=estimates[unit.slug].bound_count,
+                new_shortcut_count=estimates[unit.slug].new_shortcut_count,
             )
             if unit.slug in estimates
             else unit
@@ -611,19 +613,32 @@ class LibraryFetcher:
         (cross-platform collection siblings, ADR-0021) would mis-weight the ETA
         below the true work. ``None`` (no stamp, or no persisted rows) rides the
         payload absent, so the frontend weights the unit at its raw ``rom_count``
-        (``predicted_skip ? 0 : collapsed_count ?? rom_count``). Also count the
-        unit's BOUND rows — those already carrying a ``shortcut_app_id`` — which
-        the frontend prices at the cheap update rate rather than the create rate,
+        (``predicted_skip ? 0 : collapsed_count ?? rom_count``). Also split the
+        unit by what the apply will actually do to it: count its BOUND rows —
+        those already carrying a ``shortcut_app_id`` — which the frontend
+        prices at the cheap update rate rather than the create rate,
         so a re-sync of an already-mirrored platform stops reading as a fresh
-        import. Unlike the collapsed count this needs no stamp gate: a bound row
-        genuinely has a Steam shortcut whether or not the platform's mirror is
-        complete, and zero persisted rows honestly means "every item is a
-        create". The gate's server-delta check (``list_roms_updated_after``) is
-        deliberately NOT replayed — no network at plan time. A Force Full Sync clears every
-        stamp before the run, so its plan predicts no skips AND drops every
-        collapsed count — the forced re-apply is WEIGHED at the full ``rom_count``,
-        though the bound count survives the clear and still splits those items
-        between the update and create rates. One short read UoW for the whole plan.
+        import, and count the shortcuts still to be MINTED
+        (``new_shortcut_count``), which the frontend takes as its create term
+        directly instead of subtracting the bound rows from the unit's weight.
+        Neither is stamp-gated, unlike the collapsed count: both describe the
+        rows and the server count as they stand, not the completeness of the
+        mirror: a bound row genuinely has a Steam shortcut whether or not the
+        platform's mirror is complete, and a ROM the mirror holds no row for
+        genuinely has to be created. The gate's server-delta check (``list_roms_updated_after``) is
+        deliberately NOT replayed — no network at plan time.
+
+        A Force Full Sync clears every stamp before the run, so its plan predicts
+        no skips AND drops every collapsed count, leaving the unit WEIGHED at the
+        full pre-collapse ``rom_count``. Both composition counts survive that
+        clear, which is what keeps the forced re-apply priced honestly: on a
+        platform carrying sibling groups (ADR-0021) the raw ``rom_count`` exceeds
+        the real shortcut count, so deriving creates by subtracting the bound rows
+        from it would price every collapsed duplicate as a phantom new shortcut —
+        at the dear create rate, plus a cover download it will never perform.
+        ``new_shortcut_count`` reports no creates there instead, because the clear
+        takes away the stamps and not the bindings, so no sibling group is left
+        without one (#1517). One short read UoW for the whole plan.
 
         Estimate-ONLY (ADR-0023): the result rides the ``sync_plan`` payload
         and must never feed the actual skip decision —
@@ -653,7 +668,11 @@ class LibraryFetcher:
                     if stamp is not None and all_rows
                     else None
                 )
-                estimates[unit.slug] = _PlanEstimate(predicted, collapsed, bound_count)
+                new_shortcuts = new_shortcut_count(
+                    ((rom.sibling_group_key, rom.shortcut_app_id is not None) for rom in all_rows),
+                    unit_rom_count=unit.rom_count,
+                )
+                estimates[unit.slug] = _PlanEstimate(predicted, collapsed, bound_count, new_shortcuts)
         return estimates
 
     def _read_collapsed_counts(self) -> dict[str, int]:

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -1271,6 +1271,38 @@ describe("index.tsx — sync_plan seeds the applying-phase ETA (always-on estima
     plugin.onDismount();
   });
 
+  it("prices a Force Full Sync's sibling duplicates as nothing, not as phantom creates (#1517)", async () => {
+    const plugin = pluginFactory();
+
+    act(() => {
+      emitDeckyEvent<[SyncPlanData]>("sync_plan", {
+        run_id: "run-eta",
+        units: [
+          // A Force Full Sync clears the completion stamps, so collapsed_count is
+          // absent and the unit weighs its pre-collapse rom_count — sibling
+          // duplicates included. Only new_shortcut_count knows those duplicates
+          // are not new shortcuts; the bound-row subtraction would price 400 of
+          // them as creates, each with a cover download it never performs.
+          {
+            type: "platform",
+            id: 1,
+            name: "N64",
+            slug: "n64",
+            rom_count: 1000,
+            bound_count: 600,
+            new_shortcut_count: 0,
+          },
+        ],
+        total_units: 1,
+        total_roms: 1000,
+      });
+    });
+
+    expect(getSyncProgress().etaSeconds).toBeCloseTo(estimateApplySeconds(0, 600));
+    resetEta();
+    plugin.onDismount();
+  });
+
   it("preserves etaSeconds across a subsequent backend sync_progress frame", async () => {
     const plugin = pluginFactory();
 

--- a/src/types/sync.ts
+++ b/src/types/sync.ts
@@ -262,6 +262,23 @@ export interface SyncPlanUnit {
    * COLLECTION units lose it and price as creates for that run.
    */
   bound_count?: number;
+  /**
+   * Shortcuts this platform's apply is expected to CREATE rather than update
+   * (#1517) — sibling groups (ADR-0021) with no binding anywhere, unbound rows
+   * with no group key, and every server ROM the local mirror holds no row for.
+   * The seed uses it as the create term directly, because deriving creates by
+   * subtracting `bound_count` from the unit's weight over-reads whenever that
+   * weight is the pre-collapse `rom_count`: a sibling group's duplicates are
+   * unbound rows that will never become shortcuts, and the subtraction prices
+   * each of them as a new shortcut plus a cover download. That is precisely a
+   * Force Full Sync, which drops `collapsed_count` (stamp-gated) while leaving
+   * the bindings intact.
+   *
+   * Platform units only; absent on collections and older backends, where the
+   * seed falls back to the subtraction. `0` is real knowledge, not absence — a
+   * fully-mirrored platform genuinely creates nothing.
+   */
+  new_shortcut_count?: number;
 }
 
 export interface SyncPlanData {

--- a/src/utils/syncEstimate.test.ts
+++ b/src/utils/syncEstimate.test.ts
@@ -129,6 +129,55 @@ describe("estimatePlanSeconds", () => {
     expect(estimatePlanSeconds([collection])).toBeCloseTo(estimateApplySeconds(40, 0));
   });
 
+  it("takes new_shortcut_count as the create term instead of subtracting the bound rows", () => {
+    // The unit weighs 100 pre-collapse, but only 25 shortcuts are actually new.
+    const seconds = estimatePlanSeconds([unit({ rom_count: 100, bound_count: 60, new_shortcut_count: 25 })]);
+    expect(seconds).toBeCloseTo(estimateApplySeconds(25, 60));
+  });
+
+  // The seed shape #1517 was opened for. A Force Full Sync clears the completion
+  // stamps, so collapsed_count is absent and the unit weighs its PRE-COLLAPSE
+  // rom_count — every sibling duplicate included. Subtracting the bound rows
+  // from that weight prices each duplicate as a phantom create plus a cover
+  // download, which is where the ~2.5x over-read came from.
+  it("prices a Force Full Sync of a sibling-heavy platform entirely at the update rate", () => {
+    const forced = unit({ rom_count: 100, bound_count: 60, new_shortcut_count: 0 });
+
+    expect(estimatePlanSeconds([forced])).toBeCloseTo(estimateApplySeconds(0, 60));
+    // Guard the regression directly: the subtraction reading is far dearer.
+    expect(estimatePlanSeconds([forced])).toBeLessThan(estimateApplySeconds(40, 60));
+  });
+
+  // The safety-critical shape: a never-synced platform holding only partial
+  // collection-sibling rows (ADR-0021). Its create count covers the server ROMs
+  // the mirror knows nothing about, so the seed must NOT collapse to the
+  // handful of known rows — reading short is the one direction it may not err in.
+  it("does not read short for a never-synced platform holding partial rows", () => {
+    const partial = unit({ rom_count: 100, bound_count: 2, new_shortcut_count: 98 });
+
+    expect(estimatePlanSeconds([partial])).toBeCloseTo(estimateApplySeconds(98, 2));
+    // A rows-only create count would have priced 1 create + 2 updates here.
+    expect(estimatePlanSeconds([partial])).toBeGreaterThan(estimateApplySeconds(1, 2));
+    // Still at least as dear as pricing the whole platform at the update rate.
+    expect(estimatePlanSeconds([partial])).toBeGreaterThan(estimateApplySeconds(0, 100));
+  });
+
+  it("prices a first-ever platform sync as all creates", () => {
+    const seconds = estimatePlanSeconds([unit({ rom_count: 40, bound_count: 0, new_shortcut_count: 40 })]);
+    expect(seconds).toBeCloseTo(estimateApplySeconds(40, 0));
+  });
+
+  it("falls back to the bound-row subtraction when the backend omits new_shortcut_count", () => {
+    // Collections never carry the rider, and neither does an older backend.
+    const seconds = estimatePlanSeconds([unit({ rom_count: 100, collapsed_count: 100, bound_count: 40 })]);
+    expect(seconds).toBeCloseTo(estimateApplySeconds(60, 40));
+  });
+
+  it("prices a zero create count as knowledge, not as a missing rider", () => {
+    const allBound = unit({ rom_count: 50, bound_count: 50, new_shortcut_count: 0 });
+    expect(estimatePlanSeconds([allBound])).toBeCloseTo(estimateApplySeconds(0, 50));
+  });
+
   // The seed shape #1511 was opened for: a fully-mirrored library re-syncing.
   // Every row is bound, so the whole plan is cheap updates — pricing it as fresh
   // creates (0.36 + 0.15 each) is the ceiling the over-read came from.

--- a/src/utils/syncEstimate.ts
+++ b/src/utils/syncEstimate.ts
@@ -80,19 +80,28 @@ export function estimateApplySeconds(newCount: number, changedCount: number, cov
  * skip-preview path shows before any preview delta exists.
  *
  * Prices each unit by its COMPOSITION rather than pricing every planned item as
- * a create: a predicted-skip unit costs nothing, and of the remainder's items
- * (``collapsed_count ?? rom_count``) the ones already bound to a Steam shortcut
- * (``bound_count``) take the cheap update path. This is what stops a re-sync —
- * and, for platforms, every Force Full Sync, which clears the completion stamps
- * but unbinds nothing — from being seeded at fresh-import prices. Applies to
- * platform AND collection units alike; a unit whose backend omits
- * ``bound_count`` prices all of its items as creates, the pre-#1511 behaviour.
+ * a create: a predicted-skip unit costs nothing, the unit's ROMs already bound
+ * to a Steam shortcut (``bound_count``) take the cheap update path, and the
+ * shortcuts that genuinely have to be minted (``new_shortcut_count``) take the
+ * create path. This is what stops a re-sync — and, for platforms, every Force
+ * Full Sync, which clears the completion stamps but unbinds nothing — from being
+ * seeded at fresh-import prices.
  *
- * That fallback is not rare for collections: a collection's membership is known
- * only from its completion stamp, and a Force Full Sync clears every stamp, so a
- * forced run prices its collections as creates even though their shortcuts
- * survive. Deliberate — the alternative is asserting membership the plan does
- * not have — and it errs long, the safe direction.
+ * The two terms are read INDEPENDENTLY, never derived from each other by
+ * subtracting from the unit's item weight (``collapsed_count ?? rom_count``).
+ * That weight falls back to the pre-collapse ``rom_count`` whenever the platform
+ * carries no completion stamp — exactly what a Force Full Sync leaves behind —
+ * and on a platform with sibling groups (ADR-0021) the pre-collapse count
+ * exceeds the real shortcut count, so the subtraction would price each collapsed
+ * duplicate as a phantom create plus a cover download (#1517). A unit whose
+ * backend omits ``new_shortcut_count`` (collections, older backends) keeps the
+ * subtraction, which is the pre-#1517 behaviour.
+ *
+ * The ``bound_count`` fallback is not rare for collections: a collection's
+ * membership is known only from its completion stamp, and a Force Full Sync
+ * clears every stamp, so a forced run prices its collections as creates even
+ * though their shortcuts survive. Deliberate — the alternative is asserting
+ * membership the plan does not have — and it errs long, the safe direction.
  *
  * Cover downloads ride the create term; the plan carries no cover-refresh count,
  * and a refresh-only unit's covers are the cheap warm case.
@@ -107,7 +116,7 @@ export function estimatePlanSeconds(units: readonly SyncPlanUnit[]): number {
     // could report more bound rows than the collapsed item total.
     const bound = Math.min(items, Math.max(0, unit.bound_count ?? 0));
     updated += bound;
-    created += items - bound;
+    created += unit.new_shortcut_count !== undefined ? Math.max(0, unit.new_shortcut_count) : items - bound;
   }
   return estimateApplySeconds(created, updated);
 }

--- a/tests/domain/test_skip_prediction.py
+++ b/tests/domain/test_skip_prediction.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from domain.skip_prediction import collapsed_shortcut_count, predict_unit_skip
+from domain.skip_prediction import collapsed_shortcut_count, new_shortcut_count, predict_unit_skip
 
 
 def _kwargs(**overrides):
@@ -108,3 +108,63 @@ class TestCollapsedShortcutCount:
         # rows (1 each, bound or not).
         rows = [("g:a", True), ("g:a", True), ("g:b", False), ("g:b", False), (None, True), (None, False)]
         assert collapsed_shortcut_count(rows) == 5
+
+
+class TestNewShortcutCount:
+    """A group with any binding owns its shortcut; everything else is a create.
+
+    Rows are ``(sibling_group_key, is_bound)`` and *unit_rom_count* is the
+    server's count for the platform, so ROMs the mirror holds no row for count
+    as creates too.
+    """
+
+    def test_nothing_known_and_nothing_on_the_server_creates_nothing(self):
+        assert new_shortcut_count([], unit_rom_count=0) == 0
+
+    def test_never_synced_platform_creates_every_server_rom(self):
+        assert new_shortcut_count([], unit_rom_count=25) == 25
+
+    def test_group_with_a_bound_sibling_creates_nothing(self):
+        # The duplicates collapse away — they are not new shortcuts.
+        rows = [("g:a", True), ("g:a", False), ("g:a", False)]
+        assert new_shortcut_count(rows, unit_rom_count=3) == 0
+
+    def test_grandfathered_group_creates_nothing(self):
+        # Two independently-bound duplicates (ADR-0021 §5) keep both shortcuts;
+        # neither is new.
+        rows = [("g:a", True), ("g:a", True), ("g:a", False)]
+        assert new_shortcut_count(rows, unit_rom_count=3) == 0
+
+    def test_group_with_no_binding_anywhere_creates_one_representative(self):
+        rows = [("g:a", False), ("g:a", False), ("g:b", False)]
+        assert new_shortcut_count(rows, unit_rom_count=3) == 2
+
+    def test_keyless_rows_create_only_while_unbound(self):
+        # A keyless row's real group is unknown until the backfill fetch, so an
+        # unbound one must be assumed to be its own creation.
+        assert new_shortcut_count([(None, False), (None, False), (None, True)], unit_rom_count=3) == 2
+
+    def test_partial_mirror_creates_the_unmirrored_remainder_too(self):
+        """The safety-critical shape: a never-synced platform holding only a
+        few collection-sibling rows (ADR-0021). Counting the known rows alone
+        would price the run at a handful of items instead of the whole
+        platform — a short read, the one direction this estimate may not err in.
+        """
+        rows = [("g:a", True), ("g:b", True), ("g:c", False)]
+        # 1 unbound group + the 97 server ROMs no row is held for.
+        assert new_shortcut_count(rows, unit_rom_count=100) == 98
+
+    def test_mirror_ahead_of_the_server_never_goes_negative(self):
+        # Retained rows for rom_ids the server dropped (ADR-0007) leave more
+        # rows than the server reports; the unmirrored term clamps at zero.
+        rows = [("g:a", True), ("g:b", True), ("g:c", True)]
+        assert new_shortcut_count(rows, unit_rom_count=1) == 0
+
+    def test_creates_and_bound_rows_partition_the_collapsed_count(self):
+        """The two terms the seed prices are disjoint and complete: over a fully
+        mirrored platform, creates + bound rows is exactly the shortcut count
+        the collapse emits — no item priced twice, none dropped.
+        """
+        rows = [("g:a", True), ("g:a", False), ("g:b", False), ("g:b", False), (None, True), (None, False)]
+        bound_rows = sum(1 for _key, is_bound in rows if is_bound)
+        assert new_shortcut_count(rows, unit_rom_count=len(rows)) + bound_rows == collapsed_shortcut_count(rows)

--- a/tests/domain/test_skip_prediction_property.py
+++ b/tests/domain/test_skip_prediction_property.py
@@ -1,4 +1,6 @@
-"""Property-based tests for ``domain.skip_prediction.collapsed_shortcut_count``.
+"""Property-based tests for the plan-time collapse kernels in
+``domain.skip_prediction`` — ``collapsed_shortcut_count`` and its
+create-side complement ``new_shortcut_count``.
 
 The plan-time estimate kernel must mirror the LANE SELECTION of the real
 collapse (``domain.sync_diff.collapse_sibling_groups``, ADR-0021) — a group
@@ -22,7 +24,7 @@ from typing import Any
 from hypothesis import given
 from hypothesis import strategies as st
 
-from domain.skip_prediction import collapsed_shortcut_count
+from domain.skip_prediction import collapsed_shortcut_count, new_shortcut_count
 from domain.sync_diff import collapse_sibling_groups
 
 # One persisted row: (group key, bound?, installed?). A handful of key values
@@ -80,3 +82,26 @@ def test_keyless_rows_add_one_singleton_each(rows, keyless):
     base = [(key, bound) for key, bound, _installed in rows]
     with_keyless = base + [(None, bound) for bound in keyless]
     assert collapsed_shortcut_count(with_keyless) == collapsed_shortcut_count(base) + len(keyless)
+
+
+@given(rows=_rows, keyless=st.lists(st.booleans(), max_size=5), rom_count=st.integers(min_value=0, max_value=40))
+def test_creates_and_bound_rows_price_every_shortcut_exactly_once(rows, keyless, rom_count):
+    """The seed's two terms partition the work: ``new_shortcut_count`` (creates)
+    plus the bound rows (updates) is exactly the shortcut count the persisted
+    rows collapse into, plus one create per server ROM no row is held for.
+
+    This is what makes the seed safe in both directions at once. It cannot read
+    SHORT — an unmirrored remainder is priced, so a never-synced platform
+    holding partial collection-sibling rows (ADR-0021) is still priced at the
+    whole platform. And it cannot read LONG on a sibling-heavy platform — a
+    collapsed duplicate lands in neither term, whereas deriving creates by
+    subtracting the bound rows from a pre-collapse ``rom_count`` prices every
+    one of them as a phantom new shortcut (#1517).
+    """
+    all_rows = [(key, bound) for key, bound, _installed in rows] + [(None, bound) for bound in keyless]
+    bound_rows = sum(1 for _key, is_bound in all_rows if is_bound)
+    unmirrored = max(0, rom_count - len(all_rows))
+
+    creates = new_shortcut_count(all_rows, unit_rom_count=rom_count)
+
+    assert creates + bound_rows == collapsed_shortcut_count(all_rows) + unmirrored

--- a/tests/domain/test_work_unit.py
+++ b/tests/domain/test_work_unit.py
@@ -18,13 +18,17 @@ class TestToEventPayload:
         assert "predicted_skip" not in payload
         assert "collapsed_count" not in payload
         assert "bound_count" not in payload
+        assert "new_shortcut_count" not in payload
         assert "collection_kind" not in payload
 
     def test_platform_payload_carries_estimate_fields_when_set(self):
-        payload = _platform_unit(predicted_skip=True, collapsed_count=3, bound_count=2).to_event_payload()
+        payload = _platform_unit(
+            predicted_skip=True, collapsed_count=3, bound_count=2, new_shortcut_count=1
+        ).to_event_payload()
         assert payload["predicted_skip"] is True
         assert payload["collapsed_count"] == 3
         assert payload["bound_count"] == 2
+        assert payload["new_shortcut_count"] == 1
 
     def test_zero_bound_count_is_still_emitted(self):
         """0 is knowledge ("nothing mirrored yet, price it all as creates"),
@@ -32,12 +36,20 @@ class TestToEventPayload:
         payload = _platform_unit(bound_count=0).to_event_payload()
         assert payload["bound_count"] == 0
 
+    def test_zero_new_shortcut_count_is_still_emitted(self):
+        """0 is knowledge ("nothing left to mint, price it all as updates") —
+        exactly the Force Full Sync shape. Absent means "unknown", which prices
+        creates by subtraction instead and over-reads a sibling-heavy platform."""
+        payload = _platform_unit(new_shortcut_count=0).to_event_payload()
+        assert payload["new_shortcut_count"] == 0
+
     def test_predicted_skip_false_is_still_emitted(self):
         """False is knowledge ("will not skip"), distinct from absent ("unknown")."""
         payload = _platform_unit(predicted_skip=False).to_event_payload()
         assert payload["predicted_skip"] is False
         assert "collapsed_count" not in payload
         assert "bound_count" not in payload
+        assert "new_shortcut_count" not in payload
 
     def test_collection_payload_carries_kind_but_no_estimate_fields(self):
         unit = WorkUnit(type="collection", id="7", name="Faves", slug="", rom_count=4, collection_kind="user")
@@ -46,6 +58,7 @@ class TestToEventPayload:
         assert "predicted_skip" not in payload
         assert "collapsed_count" not in payload
         assert "bound_count" not in payload
+        assert "new_shortcut_count" not in payload
 
 
 class TestEstimatedItems:

--- a/tests/services/library/test_fetcher.py
+++ b/tests/services/library/test_fetcher.py
@@ -1385,7 +1385,8 @@ class TestFetchProgressNarration:
 class TestPlanEstimates:
     """build_work_queue's plan-time estimate riders (#1382).
 
-    ``predicted_skip`` / ``collapsed_count`` / ``bound_count`` are
+    ``predicted_skip`` / ``collapsed_count`` / ``bound_count`` /
+    ``new_shortcut_count`` are
     estimate-only fields that price the ``sync_plan`` payload — the fetch-time
     gate (``_try_unit_incremental_skip``) stays the sole skip authority
     (ADR-0023); see :class:`TestPredictionNeverFeedsSkipGate` for the guard.
@@ -1514,6 +1515,88 @@ class TestPlanEstimates:
         assert units[0].bound_count == 2
 
     @pytest.mark.asyncio
+    async def test_force_full_sync_of_a_sibling_heavy_platform_mints_nothing(self, plugin, fake_romm_api):
+        """The #1517 over-read: a Force Full Sync drops the collapsed count, so
+        the unit is weighed at the pre-collapse rom_count — which counts each
+        sibling duplicate. Deriving creates by subtracting the bound rows from
+        that weight prices every duplicate as a phantom new shortcut (plus a
+        cover download it never performs); new_shortcut_count reports none,
+        because the clear takes the stamps and not the bindings.
+        """
+        _wire_fake(plugin, fake_romm_api)
+        uow = plugin._uow
+        fake_romm_api.platforms = [{"id": 1, "name": "N64", "slug": "n64", "rom_count": 4}]
+        plugin.settings["enabled_platforms"] = {"1": True}
+        # No stamp — what clear_sync_cache leaves behind. Two sibling groups
+        # (ADR-0021), each a bound representative plus an unbound duplicate.
+        _seed_persisted_rom(uow, 10, app_id=1001, group_key="igdb:100:1")
+        _seed_persisted_rom(uow, 11, app_id=None, group_key="igdb:100:1")
+        _seed_persisted_rom(uow, 12, app_id=1002, group_key="igdb:200:1")
+        _seed_persisted_rom(uow, 13, app_id=None, group_key="igdb:200:1")
+
+        units = await plugin._sync_service._fetcher.build_work_queue()
+
+        assert units[0].collapsed_count is None
+        assert units[0].bound_count == 2
+        assert units[0].new_shortcut_count == 0
+
+    @pytest.mark.asyncio
+    async def test_never_synced_partial_platform_counts_the_unmirrored_remainder(self, plugin, fake_romm_api):
+        """The safety-critical shape (#1412 / #1517): a never-synced platform
+        whose only local rows are collection siblings (ADR-0021). Counting
+        creates from the known rows alone would price a handful of items for a
+        whole platform — a short read. The unmirrored server ROMs count too, so
+        creates + bound rows still cover the full rom_count.
+        """
+        _wire_fake(plugin, fake_romm_api)
+        uow = plugin._uow
+        fake_romm_api.platforms = [{"id": 1, "name": "SNES", "slug": "snes", "rom_count": 100}]
+        plugin.settings["enabled_platforms"] = {"1": True}
+        _seed_persisted_rom(uow, 10, app_id=1001, group_key="igdb:100:1", platform_slug="snes")
+        _seed_persisted_rom(uow, 11, app_id=1002, group_key="igdb:101:1", platform_slug="snes")
+        _seed_persisted_rom(uow, 12, app_id=None, group_key="igdb:102:1", platform_slug="snes")
+
+        units = await plugin._sync_service._fetcher.build_work_queue()
+
+        # One unbound group + the 97 server ROMs no row is held for.
+        assert units[0].new_shortcut_count == 98
+        assert units[0].bound_count == 2
+        assert units[0].new_shortcut_count + units[0].bound_count == units[0].rom_count
+
+    @pytest.mark.asyncio
+    async def test_first_ever_sync_counts_every_server_rom_as_a_create(self, plugin, fake_romm_api):
+        """Nothing persisted, nothing bound — the whole platform is new work."""
+        _wire_fake(plugin, fake_romm_api)
+        fake_romm_api.platforms = [{"id": 1, "name": "N64", "slug": "n64", "rom_count": 3}]
+        plugin.settings["enabled_platforms"] = {"1": True}
+
+        units = await plugin._sync_service._fetcher.build_work_queue()
+
+        assert units[0].new_shortcut_count == 3
+        assert units[0].bound_count == 0
+
+    @pytest.mark.asyncio
+    async def test_partially_applied_platform_mints_only_its_unbound_groups(self, plugin, fake_romm_api):
+        """A fetched-but-not-fully-applied platform: the groups that never got a
+        shortcut are the creates, the bound rows the updates."""
+        _wire_fake(plugin, fake_romm_api)
+        uow = plugin._uow
+        fake_romm_api.platforms = [{"id": 1, "name": "N64", "slug": "n64", "rom_count": 4}]
+        plugin.settings["enabled_platforms"] = {"1": True}
+        _seed_platform_stamp(uow, "n64", at="2025-01-01T00:00:00", rom_count=4)
+        _seed_persisted_rom(uow, 10, app_id=1001, group_key="igdb:100:1")
+        _seed_persisted_rom(uow, 11, app_id=None, group_key="igdb:100:1")
+        _seed_persisted_rom(uow, 12, app_id=None, group_key="igdb:200:1")
+        _seed_persisted_rom(uow, 13, app_id=None, group_key="igdb:300:1")
+
+        units = await plugin._sync_service._fetcher.build_work_queue()
+
+        assert units[0].new_shortcut_count == 2
+        assert units[0].bound_count == 1
+        # The two terms partition the collapsed count — no item priced twice.
+        assert units[0].new_shortcut_count + units[0].bound_count == units[0].collapsed_count
+
+    @pytest.mark.asyncio
     async def test_stamp_count_mismatch_predicts_no_skip_but_keeps_collapsed_count(self, plugin, fake_romm_api):
         _wire_fake(plugin, fake_romm_api)
         uow = plugin._uow
@@ -1580,6 +1663,9 @@ class TestPlanEstimates:
         # None, NOT 0 — the platform side reports 0 for "nothing mirrored", but a
         # collection with no stamp has no member set to count at all (#1511).
         assert units[0].bound_count is None
+        # Platform-only: a collection's rows belong to their platform's unit, so
+        # counting creates here would price the same shortcuts twice (#1517).
+        assert units[0].new_shortcut_count is None
 
     @pytest.mark.asyncio
     async def test_stamped_collection_counts_its_bound_members(self, plugin, fake_romm_api):
@@ -1608,6 +1694,7 @@ class TestPlanEstimates:
         units = await plugin._sync_service._fetcher.build_work_queue()
 
         assert units[0].bound_count == 2
+        assert units[0].new_shortcut_count is None
 
     @pytest.mark.asyncio
     async def test_stamped_collection_ignores_members_with_no_persisted_row(self, plugin, fake_romm_api):


### PR DESCRIPTION
Follow-up to #1511. After that change the skip-preview seed prices already-bound rows at the update rate, but a **Force Full Sync** still over-read — a full re-sync opened at "up to 12 min" for a run that finishes in ~5.

**Cause.** `clear_sync_cache` deletes the platform completion stamps. `collapsed_count` is stamp-gated (#1412), so it falls to absent, and the seed dropped back to the raw pre-collapse `rom_count`. On platforms with sibling groups (ADR-0021) one row per group is bound and its duplicates are not, so `rom_count` exceeds the real shortcut count — and the difference got priced as new shortcuts at the create rate plus a cover download. The run itself was never affected; a sibling duplicate produces no shortcut.

**Fix.** The plan now carries a per-unit `new_shortcut_count` — the count of genuine new shortcuts: sibling groups with no bound member, plus unbound keyless rows, plus the server ROMs the local mirror holds no row for yet. The seed uses it as the create term directly instead of subtracting bound rows from `rom_count`. It's computed in the existing plan-estimate transaction with no extra query, is additive and optional (an older backend falls back to the previous subtraction), and never feeds the real skip decision (ADR-0023).

This reads correctly across all three shapes:

| shape | new shortcuts | effect |
|---|---|---|
| Force Full Sync (stamps cleared, bindings intact) | 0 | every group keeps its bound active version → priced entirely at the update rate |
| never-synced platform with only partial collection-sibling rows | the true create count, including the unfetched server remainder | never reads short |
| first-ever sync | every server ROM | priced entirely at the create rate |

The never-synced-partial row is the safety-critical one: the estimate must never read short, and the unfetched-remainder term is what keeps it honest there. A Hypothesis partition property (`new_shortcut_count + bound_rows == collapsed_shortcut_count + unmirrored`) backs the two-directional count.

Closes #1517
