### PR TITLE
fix(ui): latch the coarse progress bar at its run high-water mark so a weight correction can't retract it

### DIFF
--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -692,6 +692,17 @@ bar in proportion to its real work. It falls back to the old equal-per-unit inde
 (QAM opened mid-run before any `sync_plan`, an older backend) or the plan can't apportion (unit-count mismatch, all-zero
 weights).
 
+Two run-scoped latches keep the coarse fraction monotonic so the bar only ever moves forward. A run's **leading**
+zero-weight units still refresh covers, so rather than pinning the bar to zero they each claim an equal `1/totalUnits`
+slice as a floor, with the weighted shares compressed into the band above it (#1506); that floor is held at its
+high-water mark, so raising a mispredicted skip off zero can't shorten the prefix and retract it. On top of that, the
+returned fraction itself is latched at the run's high-water mark by `latchedCoarseFraction` — the wrapper MainPage
+actually calls, keeping `weightedCoarseFraction` a pure reader (#1509): when `observeUnitTotal` corrects a mispredicted
+**trailing** skip up (0 → its real delta) it correctly grows the countdown's `totalRoms` (the run really is longer), but
+that shrinks the bar's completed/total ratio and would retract width already shown, so the bar holds while the countdown
+lengthens. Both latches touch only the bar output; the live ETA still reads the corrected total. The `null` fallbacks
+(no run, unit-count mismatch, zero total weight) pass through the wrapper un-latched.
+
 The **within-unit fill is itself split into three monotonic sub-slices** (#1407, `withinUnitFraction` in
 `src/utils/syncProgress.ts`): fetch (`FETCH_SHARE` 15%) → covers (`COVERS_SHARE` 25%) → apply (`APPLY_SHARE` 60%). A
 unit is worked in that order — paginate the ROM list, download/refresh cover art, then create the shortcuts — and each

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -37,7 +37,7 @@ import {
   displayedEtaSeconds,
   resetEta,
   formatEtaCountdown,
-  weightedCoarseFraction,
+  latchedCoarseFraction,
 } from "../utils/syncEta";
 import {
   getSyncProgress,
@@ -894,11 +894,14 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
   // predicted-skip unit takes no width and a huge platform takes its real
   // share — except a run's LEADING zero-weight units, which still refresh
   // covers and so claim an equal index slice rather than pinning the bar to
-  // empty (#1506). Falls back to equal-per-unit index weighting when no plan is
-  // measured (QAM opened mid-run before any sync_plan, old backend) or the plan
-  // can't apportion (unit-count mismatch, all-zero weights).
+  // empty (#1506). The latched wrapper adds a run-scoped high-water floor so a
+  // mid-run upward weight correction (observeUnitTotal on a mispredicted
+  // trailing skip) can't retract shown width (#1509). Falls back to
+  // equal-per-unit index weighting when no plan is measured (QAM opened mid-run
+  // before any sync_plan, old backend) or the plan can't apportion (unit-count
+  // mismatch, all-zero weights).
   const weightedFraction = syncProgress?.totalSteps
-    ? weightedCoarseFraction(completedSteps, withinUnit, syncProgress.totalSteps)
+    ? latchedCoarseFraction(completedSteps, withinUnit, syncProgress.totalSteps)
     : null;
   const coarseFraction = syncProgress?.totalSteps
     ? Math.max(0, Math.min(100, (weightedFraction ?? (completedSteps + withinUnit) / syncProgress.totalSteps) * 100))

--- a/src/utils/syncEta.test.ts
+++ b/src/utils/syncEta.test.ts
@@ -11,6 +11,7 @@ import {
   displayedEtaSeconds,
   resetEta,
   weightedCoarseFraction,
+  latchedCoarseFraction,
   trimStalledPrefix,
   type EtaSample,
 } from "./syncEta";
@@ -580,5 +581,93 @@ describe("displayedEtaSeconds (sticky countdown deadline)", () => {
     expect(displayedEtaSeconds(6000)).not.toBeNull();
     resetEta();
     expect(displayedEtaSeconds(6000)).toBeNull();
+  });
+});
+
+describe("latchedCoarseFraction — monotonic high-water bar latch (#1509)", () => {
+  beforeEach(() => resetEta());
+
+  // The confirmed repro, driven through a correction BETWEEN two reads — a single
+  // read cannot catch this class, which is how the dip survived #1506's first
+  // review. Same test proves the HARD scope boundary: the correction that holds
+  // the bar still grows totalRoms for the countdown.
+  it("holds the bar on an upward weight correction while the countdown still grows totalRoms", () => {
+    beginEtaRun("run-1", [100, 0], 100);
+    // Unit 0's 100 over the whole 100-weight plan → the bar reads full.
+    const before = latchedCoarseFraction(1, 0, 2);
+    expect(before).toBe(1);
+
+    // The trailing unit the plan zero-weighted actually dispatches: 0 → 400. That
+    // grows totalRoms 100 → 500 (correct — real work lengthens the countdown),
+    // which would drop the pure fraction to 100/500 = 0.2.
+    observeUnitTotal(1, 400);
+
+    // BAR: the latch floors it at the high-water mark instead of retracting.
+    const after = latchedCoarseFraction(1, 0, 2);
+    expect(after).toBe(1);
+    expect(after).toBeGreaterThanOrEqual(before ?? 0);
+
+    // COUNTDOWN: the very same correction is visible to the live ETA. Measure unit
+    // 1 at 25 items/s over a 6s window; remaining reads against the grown total 500.
+    observeApplyProgress(2, 50, 0); // processed = 100 (unit 0) + 50 = 150
+    observeApplyProgress(2, 200, 6000); // processed = 300, rate = (300-150)/6s = 25/s
+    // remaining = (500 - 300) / 25 = 8s. With the un-grown total of 100 the
+    // countdown would have clamped to 0 — proof totalRoms still grew.
+    expect(liveEtaSeconds()).toBe(8);
+  });
+
+  // Non-vacuous guard: the un-latched pure reader DOES dip across the exact same
+  // correction, so reverting MainPage to it (the pre-#1509 state) reintroduces the
+  // bug and the test above would fail. The latch is load-bearing.
+  it("the un-latched reader dips on the same upward correction (latch is load-bearing)", () => {
+    beginEtaRun("run-1", [100, 0], 100);
+    const before = weightedCoarseFraction(1, 0, 2) ?? -1;
+    expect(before).toBe(1);
+    observeUnitTotal(1, 400);
+    const after = weightedCoarseFraction(1, 0, 2) ?? -1;
+    expect(after).toBeCloseTo(0.2, 10);
+    expect(after).toBeLessThan(before);
+  });
+
+  // The latch is a floor, not a freeze: a DOWNWARD correction (raw rom_count seeded
+  // high, corrected to a smaller real delta) must still let the bar climb.
+  it("a downward weight correction still lets the bar climb", () => {
+    beginEtaRun("run-1", [100, 900], 1000);
+    const start = latchedCoarseFraction(1, 0, 2) ?? -1; // 100 / 1000 = 0.1
+    expect(start).toBeCloseTo(0.1, 10);
+    observeUnitTotal(1, 100); // total shrinks 1000 → 200, weights [100, 100]
+    // The bar keeps RISING as unit 1 progresses — never pinned at the 0.1 start.
+    const readings = [0, 0.25, 0.5, 0.75, 1].map((w) => latchedCoarseFraction(1, w, 2) ?? -1);
+    for (let i = 1; i < readings.length; i++) {
+      expect(readings[i]).toBeGreaterThanOrEqual(readings[i - 1] ?? 0);
+    }
+    expect(readings[0]).toBeGreaterThanOrEqual(start); // 0.5 ≥ 0.1, moved forward
+    expect(readings[readings.length - 1]).toBe(1);
+  });
+
+  it("passes the reader's null fallbacks through untouched", () => {
+    // no run
+    expect(latchedCoarseFraction(1, 0.5, 2)).toBeNull();
+    // unit-count mismatch (stale plan)
+    beginEtaRun("run-1", [100, 300], 400);
+    expect(latchedCoarseFraction(1, 0.5, 4)).toBeNull();
+    // zero total weight (all-predicted-skip plan)
+    beginEtaRun("run-2", [0, 0], 0);
+    expect(latchedCoarseFraction(1, 0.5, 2)).toBeNull();
+  });
+
+  it("does not leak the latched value into a following null fallback", () => {
+    beginEtaRun("run-1", [100, 300], 400);
+    expect(latchedCoarseFraction(2, 0, 2)).toBe(1); // real read latches high-water = 1
+    // A stale-plan read (unit-count mismatch) must return null, not the latched 1.
+    expect(latchedCoarseFraction(1, 0.5, 4)).toBeNull();
+  });
+
+  it("starts a fresh latch per run — a second run does not inherit the first's high-water", () => {
+    beginEtaRun("run-1", [100, 300], 400);
+    expect(latchedCoarseFraction(2, 0, 2)).toBe(1); // run 1 latches to full
+    // Run 2's honest 10% must not be floored to 1 by run 1's high-water.
+    beginEtaRun("run-2", [100, 900], 1000);
+    expect(latchedCoarseFraction(1, 0, 2)).toBeCloseTo(0.1, 10);
   });
 });

--- a/src/utils/syncEta.ts
+++ b/src/utils/syncEta.ts
@@ -164,6 +164,15 @@ interface EtaRunState {
   // because observeUnitTotal can raise a mispredicted skip's weight off zero
   // mid-run, which would shorten the live prefix and march the bar backwards.
   zeroPrefix: number;
+  // The highest coarse-bar fraction shown this run, LATCHED at its high-water
+  // mark (#1509). observeUnitTotal grows totalRoms when a mispredicted TRAILING
+  // skip actually dispatches — correct for the countdown (real work lengthens
+  // it), but it grows weightedCoarseFraction's denominator while the completed
+  // numerator stands, so an upward weight correction would retract bar width
+  // already shown. latchedCoarseFraction floors the bar at this mark so it only
+  // ever moves forward; the countdown still sees the grown total. The zeroPrefix
+  // floor covers only LEADING zero-weight units, so it can't guard a tail one.
+  coarseHighWater: number;
 }
 
 let _run: EtaRunState | null = null;
@@ -191,6 +200,7 @@ export function beginEtaRun(runId: string, unitWeights: number[], totalRoms: num
     lastSampleMs: 0,
     deadlineMs: null,
     zeroPrefix: countZeroPrefix(unitWeights),
+    coarseHighWater: 0,
   };
 }
 
@@ -328,6 +338,10 @@ export function displayedEtaSeconds(nowMs: number): number | null {
  * unit count doesn't match ``totalUnits`` (a stale plan from another run), or
  * when the total weight is zero (an all-predicted-skip plan has no widths to
  * apportion).
+ *
+ * A pure reader of the run snapshot. The monotonic bar latch that keeps an
+ * upward weight correction from retracting shown width lives in
+ * {@link latchedCoarseFraction}, the wrapper MainPage actually calls.
  */
 export function weightedCoarseFraction(
   completedUnits: number,
@@ -350,6 +364,35 @@ export function weightedCoarseFraction(
   const weighted = Math.min(1, (completedWeight + within * runningWeight) / totalWeight);
   const floor = zeroPrefixFloor(_run.zeroPrefix, completedUnits, within, totalUnits);
   return Math.min(1, floor + (1 - floor) * weighted);
+}
+
+/**
+ * {@link weightedCoarseFraction} with a run-scoped monotonic high-water latch —
+ * the fraction MainPage renders, never below the highest it has already shown
+ * this run (#1509). The pure reader can dip when {@link observeUnitTotal}
+ * corrects a mispredicted TRAILING skip UP: totalRoms grows (correct — the
+ * countdown must lengthen for the real work) while the completed numerator
+ * stands, shrinking the ratio, so the bar would retract width it already showed.
+ * Flooring at the high-water mark holds the bar there instead; the countdown
+ * still reads the grown total, since the latch touches only this output. Composes
+ * ON TOP of the value the reader returns (the #1506 leading-zero floor included).
+ *
+ * The latch fires ONLY on a real numeric fraction. The reader's three ``null``
+ * fallbacks (no run, unit-count mismatch, zero total weight) pass through
+ * untouched — ``null`` means "fall back to index weighting", and latching across
+ * it would leak a stale value into the fallback. The high-water lives in ``_run``
+ * and is reset per run by {@link beginEtaRun} / {@link resetEta}.
+ */
+export function latchedCoarseFraction(
+  completedUnits: number,
+  withinUnitFraction: number,
+  totalUnits: number,
+): number | null {
+  const fraction = weightedCoarseFraction(completedUnits, withinUnitFraction, totalUnits);
+  if (fraction === null || _run === null) return fraction;
+  const latched = Math.max(fraction, _run.coarseHighWater);
+  _run.coarseHighWater = latched;
+  return latched;
 }
 
 /**


### PR DESCRIPTION
The coarse QAM progress bar could jump backwards. When `observeUnitTotal` corrects a not-yet-completed unit's weight *upward* — a platform the plan predicted as a skip that actually dispatches — the weighted fraction's denominator grows while the numerator stands, so the bar retracts width it already showed, then climbs again. On a two-unit plan the drop was as sharp as 100% → 20%.

Only upward corrections cause it; the common case (the real delta is smaller than the seeded raw count) shrinks the denominator and moves the bar forward. The #1506 zero-prefix floor doesn't cover this — it only guards *leading* zero-weight units, and here the mispredicted unit is at the tail.

**Fix.** A run-scoped monotonic high-water latch on the coarse-bar fraction, composed on top of the existing #1506 floor: the bar never returns a value below the highest it has already shown this run. It's a floor, not a freeze — a downward correction still lets the bar rise. Implemented as a thin `latchedCoarseFraction` wrapper so `weightedCoarseFraction` stays a pure reader (existing callers read it multiple times per run at decreasing inputs and rely on the raw value).

**Scope.** Bar only. The live ETA countdown is byte-for-byte unchanged: `observeUnitTotal` still grows the run's item total, so a mispredicted skip that dispatches correctly lengthens the countdown — the latch touches only the coarse-fraction output. A regression test drives the correction *between* two fraction reads (the gap that let this survive #1506's first review) and asserts both halves at once: the bar holds while the countdown's total still grows.

Closes #1509
