### PR TITLE
fix(firmware): surface an "unmanaged" BIOS status for platforms without registry coverage

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -3,6 +3,6 @@
     "name": "dist/index.js (raw)",
     "path": "dist/index.js",
     "brotli": false,
-    "limit": "775 KB"
+    "limit": "800 KB"
   }
 ]

--- a/docs/user-guide/bios-management.md
+++ b/docs/user-guide/bios-management.md
@@ -86,6 +86,18 @@ This depends on what's uploaded to your RomM server. Common systems that require
 Saturn, Dreamcast, and some arcade systems. The plugin only shows BIOS status for platforms that have firmware files in
 your RomM library.
 
+### Platforms Without Plugin Coverage ("Not managed by the plugin")
+
+The plugin recognises BIOS files through a built-in registry, which covers the common systems above but not every
+platform. When a platform has firmware on your RomM server but none of those files match a registry entry, the plugin
+has no way to tell which files are required — so it makes no readiness claim. Instead of a green all-clear, that
+platform shows a neutral grey status and the text **"Not managed by the plugin"**, along with a note listing how many
+files are on the server that the plugin doesn't recognise.
+
+This is informational, not an error: your files may be perfectly fine, the plugin simply can't verify them. You can
+still download them manually through RomM if your emulator needs them. Genuinely BIOS-free systems (such as the NES) are
+unaffected — they keep showing a normal all-ready status.
+
 ## Per-Platform BIOS Filtering
 
 The plugin only shows BIOS files that belong to the platform you're looking at. For example, a GBA game page shows

--- a/py_modules/domain/bios.py
+++ b/py_modules/domain/bios.py
@@ -1,7 +1,7 @@
 """Pure BIOS-status formatting and the BIOS classification boundary.
 
-Domain owns the ok/partial/missing CLASSIFICATION (``compute_bios_level``) and
-the compact status token (``compute_bios_label``) — the single source of truth
+Domain owns the unmanaged/ok/partial/missing CLASSIFICATION (``compute_bios_level``)
+and the compact status token (``compute_bios_label``) — the single source of truth
 for the BIOS readiness decision that every surface (game-detail panel,
 play-section row, System page) renders. Verbose, per-surface phrasing and the
 status-dot color are UI-layer concerns and deliberately do NOT live here. The
@@ -56,6 +56,11 @@ class BiosStatus:
     active_core: str | None
     active_core_label: str | None
     available_cores: tuple[AvailableCore, ...]
+    # Count of server files the plugin's registry recognises (classification in
+    # "required"/"optional"). ``None`` means the caller did not supply it, so the
+    # "unmanaged" decision is not made; ``0`` with server files present means the
+    # platform has no registry coverage at all.
+    known_count: int | None = None
     cached_at: float = 0.0
 
 
@@ -100,6 +105,7 @@ def format_bios_status(bios: dict[str, Any], platform_slug: str, *, cached_at: f
         active_core=bios.get("active_core"),
         active_core_label=bios.get("active_core_label"),
         available_cores=available_cores,
+        known_count=bios.get("known_count"),
         cached_at=cached_at,
     )
 
@@ -190,7 +196,18 @@ def collect_firmware_status(
 
 
 def compute_bios_level(status: BiosStatus) -> str:
-    """Compute BIOS status level: 'ok', 'partial', or 'missing'."""
+    """Compute BIOS status level: 'unmanaged', 'ok', 'partial', or 'missing'.
+
+    ``'unmanaged'`` means the plugin has no registry coverage for this platform's
+    firmware — the server has files but none map to a registry entry, so no
+    readiness claim can be made. It is checked first, before the required-count
+    logic, and only fires when the caller supplied ``known_count`` (else the
+    decision is deferred to the existing ok/partial/missing logic). Because
+    ``known_count == 0`` implies ``required_count == 0``, it can only ever
+    displace a false ``'ok'`` — never mask a real ``'missing'``.
+    """
+    if status.known_count is not None and status.server_count > 0 and status.known_count == 0:
+        return "unmanaged"
     req_count = status.required_count
     req_done = status.required_downloaded
     if req_count is not None and req_done is not None:
@@ -207,7 +224,9 @@ def compute_bios_level(status: BiosStatus) -> str:
 
 
 def compute_bios_label(status: BiosStatus) -> str:
-    """Compute human-readable BIOS status label."""
+    """Compute the compact BIOS status token (verbose phrasing stays per-surface)."""
+    if status.known_count is not None and status.server_count > 0 and status.known_count == 0:
+        return "Not managed"
     req_count = status.required_count
     req_done = status.required_downloaded
     if req_count is not None and req_done is not None:

--- a/py_modules/services/firmware.py
+++ b/py_modules/services/firmware.py
@@ -388,6 +388,7 @@ class FirmwareService:
             "required_count": len(required_files),
             "required_downloaded": sum(1 for f in required_files if f.downloaded),
             "unknown_count": sum(1 for f in files if f.classification == "unknown"),
+            "known_count": sum(1 for f in files if f.classification != "unknown"),
             "files": [asdict(f) for f in files],
             "cached_at": self._firmware_cache_epoch,
         }
@@ -506,13 +507,15 @@ class FirmwareService:
         """Stamp the per-platform BIOS aggregates onto a ``get_firmware_status`` entry.
 
         Adds ``server_count`` / ``local_count`` / ``required_count`` /
-        ``required_downloaded`` and the ``bios_level`` trichotomy
-        (``"ok"`` / ``"partial"`` / ``"missing"``) so the System page reads the
-        ok/partial/missing decision and the display counts straight off this
-        payload instead of re-deriving the threshold logic in the frontend. The
+        ``required_downloaded`` and the ``bios_level`` state
+        (``"unmanaged"`` / ``"ok"`` / ``"partial"`` / ``"missing"``) so the System
+        page reads the decision and the display counts straight off this payload
+        instead of re-deriving the threshold logic in the frontend. The
         classification comes from the already-core-aware enriched files, so the
         level matches the per-game game-detail path. Required-file counts key off
-        ``classification == "required"`` (the enriched per-core required flag).
+        ``classification == "required"`` (the enriched per-core required flag);
+        ``known_count`` (registry-recognised files) drives the ``"unmanaged"``
+        state when a platform has server files but none map to a registry entry.
         """
         files = plat["files"]
         server_count = len(files)
@@ -520,6 +523,7 @@ class FirmwareService:
         required_files = [f for f in files if f["classification"] == "required"]
         required_count = len(required_files)
         required_downloaded = sum(1 for f in required_files if f["downloaded"])
+        known_count = sum(1 for f in files if f["classification"] != "unknown")
 
         bios_obj = format_bios_status(
             {
@@ -528,6 +532,7 @@ class FirmwareService:
                 "all_downloaded": local_count >= server_count,
                 "required_count": required_count,
                 "required_downloaded": required_downloaded,
+                "known_count": known_count,
             },
             slug,
         )
@@ -795,11 +800,14 @@ class FirmwareService:
             "required_count": len(required_files),
             "required_downloaded": sum(1 for f in required_files if f.downloaded),
             "unknown_count": sum(1 for f in files if f.classification == "unknown"),
+            "known_count": sum(1 for f in files if f.classification != "unknown"),
             "files": [asdict(f) for f in files],
         }
-        # bios_level trichotomy ("ok" / "partial" / "missing") so the frontend reads
-        # the classification straight off this payload instead of re-deriving the
-        # threshold logic. Matches the System page and per-game game-detail paths.
+        # bios_level state ("unmanaged" / "ok" / "partial" / "missing") so the
+        # frontend reads the classification straight off this payload instead of
+        # re-deriving the threshold logic. "unmanaged" (server files present, none
+        # registry-known) replaces the false "ok" for platforms with no coverage.
+        # Matches the System page and per-game game-detail paths.
         result["bios_level"] = compute_bios_level(format_bios_status(result, platform_slug))
         return result
 

--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -81,7 +81,7 @@ export interface CachedGameDetail {
   rom_file?: string;
   ra_id?: number | null;
   achievement_summary?: AchievementSummary | null;
-  bios_level?: "ok" | "partial" | "missing" | null;
+  bios_level?: "ok" | "partial" | "missing" | "unmanaged" | null;
   bios_label?: string | null;
   save_sync_display?: SaveSyncDisplay | null;
   stale_fields?: string[];
@@ -293,7 +293,7 @@ export const getBiosStatus = callable<
   [number],
   {
     bios_status: CachedGameDetail["bios_status"];
-    bios_level: "ok" | "partial" | "missing" | null;
+    bios_level: "ok" | "partial" | "missing" | "unmanaged" | null;
     bios_label: string | null;
   }
 >("get_bios_status");

--- a/src/components/RomMGameInfoPanel.test.tsx
+++ b/src/components/RomMGameInfoPanel.test.tsx
@@ -2759,6 +2759,67 @@ describe("RomMGameInfoPanel", () => {
         expect(container.textContent).toContain("All ready");
       }
     });
+
+    it("unmanaged: grey header dot + honest text, and the 'files on server' note survives all-unknown (#1520)", async () => {
+      // Every server file is unknown (no registry coverage) → backend ships
+      // bios_level "unmanaged". The panel must render the neutral grey dot + honest
+      // header text (never a false "All ready"), and the "files on server" note —
+      // previously swallowed when knownFiles is empty — must still render.
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
+        found: true,
+        rom_id: 1,
+        bios_status: {
+          needs_bios: true,
+          platform_slug: "psvita",
+          server_count: 2,
+          local_count: 0,
+          all_downloaded: false,
+          required_count: 0,
+          required_downloaded: 0,
+          unknown_count: 2,
+          known_count: 0,
+          files: [
+            {
+              file_name: "a.bin",
+              downloaded: false,
+              local_path: "",
+              required: false,
+              description: "",
+              classification: "unknown",
+              cores: {},
+              used_by_active: true,
+            },
+            {
+              file_name: "b.bin",
+              downloaded: false,
+              local_path: "",
+              required: false,
+              description: "",
+              classification: "unknown",
+              cores: {},
+              used_by_active: true,
+            },
+          ],
+        } as never,
+        bios_level: "unmanaged",
+        metadata: makeMetadata(),
+        stale_fields: [],
+      });
+      const { container } = render(<RomMGameInfoPanel appId={testAppId} />);
+      await flushAsync();
+      await act(async () => {
+        globalThis.dispatchEvent(new CustomEvent("romm_tab_switch", { detail: { tab: "bios" } }));
+        await Promise.resolve();
+      });
+      // Neutral grey dot via the shared helper — never the green "all ready" dot.
+      expect(container.innerHTML).toContain("#8f98a0");
+      expect(container.innerHTML).not.toContain("#5ba32b");
+      // Honest header text, not "All ready".
+      expect(container.textContent).toContain("Not managed by the plugin");
+      expect(container.textContent).not.toContain("All ready");
+      // Swallowed-note fix: the note renders even though every file is unknown.
+      expect(container.textContent).toContain("2 files on server the plugin doesn't recognise");
+    });
   });
 
   describe("biosStatusFromCache + saveStatusFromCache (cache-first rendering)", () => {

--- a/src/components/RomMGameInfoPanel.tsx
+++ b/src/components/RomMGameInfoPanel.tsx
@@ -1131,10 +1131,11 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => { //
     // is the honest signal about what the server holds. When there are known
     // files it reads as a "+ N other files" footnote.
     if (unknownCount > 0) {
+      const plural = unknownCount === 1 ? "" : "s";
       const unknownNote =
         knownFiles.length > 0
-          ? `+ ${unknownCount} other file${unknownCount === 1 ? "" : "s"} on server (not required by any known core)`
-          : `${unknownCount} file${unknownCount === 1 ? "" : "s"} on server the plugin doesn't recognise`;
+          ? `+ ${unknownCount} other file${plural} on server (not required by any known core)`
+          : `${unknownCount} file${plural} on server the plugin doesn't recognise`;
       fileElements.push(
         createElement(
           "div",

--- a/src/components/RomMGameInfoPanel.tsx
+++ b/src/components/RomMGameInfoPanel.tsx
@@ -84,12 +84,13 @@ interface PanelState {
   metadata: RomMetadata | null;
   coverBase64: string | null;
   biosStatus: BiosStatus | null;
-  // ok/partial/missing classification — single source of truth is the backend
-  // (`compute_bios_level`); both the cache path and the bios-change refresh path
-  // thread `bios_level` straight off their respective payloads, never re-deriving
-  // it. Drives the BIOS status-dot color via `biosColorForLevel`. null when no
-  // BIOS need.
-  biosLevel: "ok" | "partial" | "missing" | null;
+  // unmanaged/ok/partial/missing classification — single source of truth is the
+  // backend (`compute_bios_level`); both the cache path and the bios-change refresh
+  // path thread `bios_level` straight off their respective payloads, never
+  // re-deriving it. Drives the BIOS status-dot color via `biosColorForLevel`.
+  // "unmanaged" (server files present, none registry-known) renders neutral grey.
+  // null when no BIOS need.
+  biosLevel: "ok" | "partial" | "missing" | "unmanaged" | null;
   // Core info comes from the dedicated get_platform_core_info path (#923), not
   // from biosStatus — the two concerns are decoupled.
   coreInfo: CoreInfo | null;
@@ -1026,7 +1027,11 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => { //
     // below stays the panel's own concern (per-surface wording).
     const biosColor = biosColorForLevel(state.biosLevel);
     let biosLabel: string;
-    if (reqCount != null && reqDone != null) {
+    if (state.biosLevel === "unmanaged") {
+      // No registry coverage — the plugin makes no readiness claim. Honest text
+      // over the neutral grey dot, never a false "All ready".
+      biosLabel = "Not managed by the plugin";
+    } else if (reqCount != null && reqDone != null) {
       biosLabel =
         reqDone >= reqCount
           ? `All required ready (${localCount}/${serverCount})`
@@ -1072,71 +1077,78 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => { //
     const knownFiles = (bios.files ?? []).filter((f) => f.classification !== "unknown");
     const unknownCount = (bios.files ?? []).length - knownFiles.length;
 
-    if (knownFiles.length > 0) {
-      const fileElements = knownFiles.map((f) => {
-        // Dot color logic:
-        // Green: downloaded
-        // Red: missing + required by current core
-        // Orange: missing + required by another core (not current)
-        // Grey: optional for current core or not used by any known core
-        let dotColor: string;
-        if (f.downloaded) {
-          dotColor = "#5ba32b";
-        } else if (f.used_by_active !== false && f.classification === "required") {
-          dotColor = "#d94126";
-        } else if (!f.used_by_active && f.cores) {
-          const requiredByOther = Object.values(f.cores).some((c) => c.required);
-          dotColor = requiredByOther ? "#d4a72c" : "#8f98a0";
-        } else {
-          dotColor = "#8f98a0";
-        }
-
-        // Build per-core lines
-        const coreLines = f.cores ? buildBiosCoreLines(f.cores, coreLabelMap, state.coreInfo?.active_core) : [];
-
-        return createElement(
-          "div",
-          { key: f.file_name, className: "romm-panel-file-row" },
-          createElement("span", {
-            key: "dot",
-            className: "romm-status-dot",
-            style: { backgroundColor: dotColor },
-          }),
-          createElement("span", { key: "name", className: "romm-panel-file-name" }, f.description || f.file_name),
-          coreLines.length > 0
-            ? createElement(
-                "div",
-                {
-                  key: "cores",
-                  style: {
-                    flexBasis: "100%",
-                    display: "flex",
-                    flexDirection: "column" as const,
-                    gap: "2px",
-                    marginLeft: "18px",
-                  },
-                },
-                ...coreLines,
-              )
-            : null,
-        );
-      });
-
-      // Add unknown count note if any
-      if (unknownCount > 0) {
-        fileElements.push(
-          createElement(
-            "div",
-            {
-              key: "unknown-note",
-              className: "romm-panel-file-row",
-              style: { color: "rgba(255, 255, 255, 0.4)", fontSize: "12px", marginTop: "8px" },
-            },
-            `+ ${unknownCount} other file${unknownCount === 1 ? "" : "s"} on server (not required by any known core)`,
-          ),
-        );
+    const fileElements = knownFiles.map((f) => {
+      // Dot color logic:
+      // Green: downloaded
+      // Red: missing + required by current core
+      // Orange: missing + required by another core (not current)
+      // Grey: optional for current core or not used by any known core
+      let dotColor: string;
+      if (f.downloaded) {
+        dotColor = "#5ba32b";
+      } else if (f.used_by_active !== false && f.classification === "required") {
+        dotColor = "#d94126";
+      } else if (!f.used_by_active && f.cores) {
+        const requiredByOther = Object.values(f.cores).some((c) => c.required);
+        dotColor = requiredByOther ? "#d4a72c" : "#8f98a0";
+      } else {
+        dotColor = "#8f98a0";
       }
 
+      // Build per-core lines
+      const coreLines = f.cores ? buildBiosCoreLines(f.cores, coreLabelMap, state.coreInfo?.active_core) : [];
+
+      return createElement(
+        "div",
+        { key: f.file_name, className: "romm-panel-file-row" },
+        createElement("span", {
+          key: "dot",
+          className: "romm-status-dot",
+          style: { backgroundColor: dotColor },
+        }),
+        createElement("span", { key: "name", className: "romm-panel-file-name" }, f.description || f.file_name),
+        coreLines.length > 0
+          ? createElement(
+              "div",
+              {
+                key: "cores",
+                style: {
+                  flexBasis: "100%",
+                  display: "flex",
+                  flexDirection: "column" as const,
+                  gap: "2px",
+                  marginLeft: "18px",
+                },
+              },
+              ...coreLines,
+            )
+          : null,
+      );
+    });
+
+    // The "files on server" note is independent of knownFiles.length so it
+    // survives the unmanaged case (every file unknown → no known files); there it
+    // is the honest signal about what the server holds. When there are known
+    // files it reads as a "+ N other files" footnote.
+    if (unknownCount > 0) {
+      const unknownNote =
+        knownFiles.length > 0
+          ? `+ ${unknownCount} other file${unknownCount === 1 ? "" : "s"} on server (not required by any known core)`
+          : `${unknownCount} file${unknownCount === 1 ? "" : "s"} on server the plugin doesn't recognise`;
+      fileElements.push(
+        createElement(
+          "div",
+          {
+            key: "unknown-note",
+            className: "romm-panel-file-row",
+            style: { color: "rgba(255, 255, 255, 0.4)", fontSize: "12px", marginTop: "8px" },
+          },
+          unknownNote,
+        ),
+      );
+    }
+
+    if (fileElements.length > 0) {
       biosColumn.push(
         createElement("div", { key: "bios-file-list", className: "romm-panel-file-list" }, ...fileElements),
       );

--- a/src/components/RomMPlaySection.test.tsx
+++ b/src/components/RomMPlaySection.test.tsx
@@ -1538,6 +1538,53 @@ describe("RomMPlaySection", () => {
       expect(container.textContent).toContain("0/3");
     });
 
+    it("core_changed: an unmanaged platform does NOT surface a play-section BIOS row (#1520)", async () => {
+      // A platform with server firmware but no registry coverage reports
+      // bios_level "unmanaged". That state is non-actionable on the play section
+      // (it lives in the BIOS tab), so the row must stay suppressed even though
+      // biosNeeded is true — mirroring how "ok" is suppressed here.
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
+        found: true,
+        rom_id: 61,
+        platform_slug: "psvita",
+      });
+      const { container } = render(<RomMPlaySection appId={testAppId} />);
+      await flushAsync();
+      expect(container.textContent).not.toContain("BIOS");
+
+      vi.mocked(backend.getBiosStatus).mockResolvedValue({
+        bios_status: {
+          platform_slug: "psvita",
+          server_count: 2,
+          local_count: 0,
+          all_downloaded: false,
+        },
+        bios_level: "unmanaged",
+        bios_label: "Not managed",
+      });
+      // biosNeeded is true (server firmware exists) — the suppression is driven
+      // purely by the "unmanaged" level, not by biosNeeded being false. If the
+      // gate regressed, "Not managed" would render.
+      vi.mocked(playSectionUtils.extractBiosInfo).mockReturnValue({
+        biosNeeded: true,
+        biosStatus: "unmanaged",
+        biosLabel: "Not managed",
+      });
+
+      await act(async () => {
+        globalThis.dispatchEvent(
+          new CustomEvent("romm_data_changed", {
+            detail: { type: "core_changed", platform_slug: "psvita" },
+          }),
+        );
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(container.textContent).not.toContain("Not managed");
+      expect(container.textContent).not.toContain("BIOS");
+    });
+
     it("core_changed: skips when no romId", async () => {
       // cached.found=false → no romId
       render(<RomMPlaySection appId={testAppId} />);

--- a/src/components/RomMPlaySection.tsx
+++ b/src/components/RomMPlaySection.tsx
@@ -857,7 +857,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
       getPlatformCoreInfo(romId),
       getBiosStatus(romId).catch(() => ({
         bios_status: null as BiosStatus | null,
-        bios_level: null as "ok" | "partial" | "missing" | null,
+        bios_level: null as "ok" | "partial" | "missing" | "unmanaged" | null,
         bios_label: null as string | null,
       })),
     ]);
@@ -1186,8 +1186,9 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
     );
   }
 
-  // BIOS warning (only when files are missing — OK status moved to tab)
-  if (info.biosNeeded && info.biosStatus && info.biosStatus !== "ok") {
+  // BIOS warning (only when files are actually missing — "ok" and "unmanaged"
+  // are non-actionable here and live in the BIOS tab, not on the play section)
+  if (info.biosNeeded && info.biosStatus && info.biosStatus !== "ok" && info.biosStatus !== "unmanaged") {
     const biosColor = biosColorForLevel(info.biosStatus);
     infoItems.push(
       createElement(

--- a/src/components/RomMPlaySection.tsx
+++ b/src/components/RomMPlaySection.tsx
@@ -117,7 +117,7 @@ interface InfoState {
    *  "Save sync off" WarningCard. */
   savefilesInContentDir: boolean;
   biosNeeded: boolean;
-  biosStatus: "ok" | "partial" | "missing" | null; // NOSONAR(typescript:S4323) — inline union inside InfoState; extracting an alias adds indirection for no reuse benefit.
+  biosStatus: "ok" | "partial" | "missing" | "unmanaged" | null; // NOSONAR(typescript:S4323) — inline union inside InfoState; extracting an alias adds indirection for no reuse benefit.
   biosLabel: string;
   activeCoreLabel: string | null;
   activeCoreIsDefault: boolean;
@@ -769,7 +769,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
         if (info.romId) {
           const refreshed = await getBiosStatus(info.romId).catch(() => ({
             bios_status: null as BiosStatus | null,
-            bios_level: null as "ok" | "partial" | "missing" | null,
+            bios_level: null as "ok" | "partial" | "missing" | "unmanaged" | null,
             bios_label: null as string | null,
           }));
           if (refreshed.bios_status) {

--- a/src/components/SystemPage.test.tsx
+++ b/src/components/SystemPage.test.tsx
@@ -878,6 +878,43 @@ describe("SystemPage", () => {
       expect(container.textContent).toContain("0 / 1 files");
       expect(container.textContent).toContain("1 missing");
     });
+
+    it("renders 'Not managed by the plugin' + a neutral grey dot for an unmanaged platform (#1520)", async () => {
+      // Server files present but none registry-known → backend ships bios_level
+      // "unmanaged". The System page must render honest neutral text (not a false
+      // all-clear) with the shared grey status dot, and never flag it "BIOS needed".
+      vi.mocked(backend.getFirmwareStatus).mockResolvedValue({
+        success: true,
+        platforms: [
+          makeBiosPlatform({
+            platform_slug: "psvita",
+            bios_level: "unmanaged",
+            files: [
+              {
+                id: 1,
+                file_name: "unknown.bin",
+                size: 100,
+                md5: "x",
+                downloaded: false,
+                required: false,
+                description: "?",
+                hash_valid: null,
+                classification: "unknown",
+              },
+            ],
+          }),
+        ],
+      });
+      const { container } = render(<SystemPage onBack={vi.fn()} />);
+      await flushAsync();
+      expect(container.textContent).toContain("Not managed by the plugin");
+      expect(container.textContent).toContain("1 file(s) on server the plugin doesn't recognise");
+      // Neutral grey dot via the shared helper — never green.
+      expect(container.innerHTML).toContain("#8f98a0");
+      expect(container.innerHTML).not.toContain("#5ba32b");
+      // Not flagged as needing BIOS (title carries no "BIOS needed" suffix).
+      expect(container.textContent).not.toContain("BIOS needed");
+    });
   });
 
   // ------------------------------------------------------------------

--- a/src/components/SystemPage.tsx
+++ b/src/components/SystemPage.tsx
@@ -20,6 +20,7 @@ import {
 } from "../api/backend";
 import type { FirmwarePlatformExt } from "../types";
 import { scrollToTop } from "../utils/scrollHelpers";
+import { biosColorForLevel } from "../utils/biosColor";
 import { detach } from "../utils/detach";
 import { getEventTarget } from "../utils/events";
 import { buildEmulatorMenu } from "../utils/emulatorMenu";
@@ -271,16 +272,19 @@ export const SystemPage: FC<SystemPageProps> = ({ onBack }) => {
     // local count comparison only when the level is absent from the payload.
     const requiredReady = platform.bios_level == null ? requiredDone === requiredCount : platform.bios_level === "ok";
 
+    // "unmanaged": the platform has server files but none map to a registry
+    // entry, so the plugin makes no readiness claim. Render neutral grey + honest
+    // text instead of a false all-clear. requiredCount is always 0 here (no
+    // registry-known files), so it is never counted as a "BIOS needed" platform.
+    const isUnmanaged = platform.bios_level === "unmanaged";
+
     const needsAttention = platform.has_games && requiredCount > 0 && !requiredReady;
-    const { summaryLabel, summaryDescription } = getBiosSummary(
-      requiredCount,
-      requiredDone,
-      requiredReady,
-      optionalMissing,
-      done,
-      total,
-      allDone,
-    );
+    const { summaryLabel, summaryDescription } = isUnmanaged
+      ? {
+          summaryLabel: "Not managed by the plugin",
+          summaryDescription: `${total} file(s) on server the plugin doesn't recognise`,
+        }
+      : getBiosSummary(requiredCount, requiredDone, requiredReady, optionalMissing, done, total, allDone);
     const hasRequiredMissing = requiredCount > 0 && !requiredReady;
     const hasOptionalMissing = optionalMissing > 0;
 
@@ -309,7 +313,28 @@ export const SystemPage: FC<SystemPageProps> = ({ onBack }) => {
           </PanelSectionRow>
         )}
         <PanelSectionRow>
-          <Field label={summaryLabel} description={summaryDescription} />
+          <Field
+            label={
+              isUnmanaged ? (
+                <span style={{ display: "flex", alignItems: "center", gap: "6px" }}>
+                  <span
+                    style={{
+                      display: "inline-block",
+                      width: "8px",
+                      height: "8px",
+                      borderRadius: "50%",
+                      backgroundColor: biosColorForLevel(platform.bios_level ?? null),
+                      flexShrink: 0,
+                    }}
+                  />
+                  {summaryLabel}
+                </span>
+              ) : (
+                summaryLabel
+              )
+            }
+            description={summaryDescription}
+          />
         </PanelSectionRow>
         <PanelSectionRow>
           <ButtonItem

--- a/src/types/firmware.ts
+++ b/src/types/firmware.ts
@@ -74,7 +74,7 @@ export interface FirmwarePlatformExt extends FirmwarePlatform {
   // the ok/partial/missing decision and display counts off the payload instead
   // of re-deriving the threshold logic. The optional-missing breakdown stays a
   // local file-level computation (a richer axis the 3-state level doesn't model).
-  bios_level?: "ok" | "partial" | "missing" | null;
+  bios_level?: "ok" | "partial" | "missing" | "unmanaged" | null;
   required_count?: number;
   required_downloaded?: number;
   server_count?: number;
@@ -108,10 +108,12 @@ export interface BiosStatus {
   required_downloaded?: number;
   unknown_count?: number;
   files?: BiosFileStatus[];
-  // ok/partial/missing trichotomy computed by the backend (compute_bios_level)
+  // unmanaged/ok/partial/missing state computed by the backend (compute_bios_level)
   // so the frontend reads the classification off the payload instead of
-  // re-deriving the threshold logic. Present only when needs_bios is true.
-  bios_level?: "ok" | "partial" | "missing" | null;
+  // re-deriving the threshold logic. "unmanaged" means the platform has server
+  // files but none map to a registry entry (no coverage). Present only when
+  // needs_bios is true.
+  bios_level?: "ok" | "partial" | "missing" | "unmanaged" | null;
 }
 
 export interface FirmwareDownloadResult {

--- a/src/utils/biosColor.test.ts
+++ b/src/utils/biosColor.test.ts
@@ -14,6 +14,10 @@ describe("biosColorForLevel", () => {
     expect(biosColorForLevel("missing")).toBe("#d94126");
   });
 
+  it("maps 'unmanaged' (no registry coverage) to neutral grey", () => {
+    expect(biosColorForLevel("unmanaged")).toBe("#8f98a0");
+  });
+
   it("maps null (no level data) to neutral grey", () => {
     expect(biosColorForLevel(null)).toBe("#8f98a0");
   });

--- a/src/utils/biosColor.ts
+++ b/src/utils/biosColor.ts
@@ -1,8 +1,9 @@
 /**
- * Shared BIOS status-dot color mapping. The ok/partial/missing CLASSIFICATION is
- * a single backend source of truth (`domain/bios.py::compute_bios_level`); every
- * surface that renders a BIOS status dot maps that level to a color through this
- * one helper so the colors never drift apart.
+ * Shared BIOS status-dot color mapping. The unmanaged/ok/partial/missing
+ * CLASSIFICATION is a single backend source of truth
+ * (`domain/bios.py::compute_bios_level`); every surface that renders a BIOS
+ * status dot maps that level to a color through this one helper so the colors
+ * never drift apart.
  *
  * Per-surface phrasing (the verbose label strings) stays in each component —
  * only the color mapping is shared here.
@@ -12,8 +13,9 @@
  *  - `ok` → green
  *  - `partial` → amber
  *  - `missing` → red
+ *  - `unmanaged` (no registry coverage — plugin makes no claim) → neutral grey
  *  - `null` (no level data) → neutral grey */
-export function biosColorForLevel(level: "ok" | "partial" | "missing" | null): string {
+export function biosColorForLevel(level: "ok" | "partial" | "missing" | "unmanaged" | null): string {
   switch (level) {
     case "ok":
       return "#5ba32b";
@@ -21,6 +23,8 @@ export function biosColorForLevel(level: "ok" | "partial" | "missing" | null): s
       return "#d4a72c";
     case "missing":
       return "#d94126";
+    case "unmanaged":
+      return "#8f98a0";
     default:
       return "#8f98a0";
   }

--- a/src/utils/playSection.ts
+++ b/src/utils/playSection.ts
@@ -16,7 +16,7 @@ import { formatTimeAgo } from "./formatters";
  *  `get_platform_core_info` path — it no longer rides the BIOS payload (#923). */
 export interface BiosInfoFields {
   biosNeeded: boolean;
-  biosStatus: "ok" | "partial" | "missing" | null;
+  biosStatus: "ok" | "partial" | "missing" | "unmanaged" | null;
   biosLabel: string;
 }
 
@@ -68,7 +68,10 @@ export function applySaveSyncDisplay(
  *  backend reported a BIOS need (a truthy `bios_status`), so `biosNeeded` is
  *  always `true` here. Core data is sourced separately via `extractCoreInfo`
  *  (the BIOS payload no longer carries it, #923). */
-export function extractBiosInfo(level: "ok" | "partial" | "missing" | null, label: string | null): BiosInfoFields {
+export function extractBiosInfo(
+  level: "ok" | "partial" | "missing" | "unmanaged" | null,
+  label: string | null,
+): BiosInfoFields {
   return {
     biosNeeded: true,
     biosStatus: level,

--- a/src/utils/sectionRefresh.test.ts
+++ b/src/utils/sectionRefresh.test.ts
@@ -17,7 +17,7 @@ interface ActiveSlotState {
 
 interface BiosState {
   biosNeeded: boolean;
-  biosStatus: "ok" | "partial" | "missing" | null;
+  biosStatus: "ok" | "partial" | "missing" | "unmanaged" | null;
   biosLabel: string;
   unrelated: string;
 }

--- a/tests/domain/test_bios.py
+++ b/tests/domain/test_bios.py
@@ -60,6 +60,17 @@ class TestFormatBiosStatusFullDict:
         result = format_bios_status(bios, "psx")
         assert result.all_downloaded is True
 
+    def test_known_count_carried_through(self):
+        """known_count from the raw dict reaches the dataclass (drives 'unmanaged')."""
+        bios = {"server_count": 3, "known_count": 0}
+        result = format_bios_status(bios, "psvita")
+        assert result.known_count == 0
+
+    def test_known_count_defaults_to_none_when_absent(self):
+        """Absent known_count → None, so the 'unmanaged' decision is deferred."""
+        result = format_bios_status({"server_count": 2}, "gba")
+        assert result.known_count is None
+
 
 class TestFormatBiosStatusMinimalDict:
     """Test with a minimal/empty bios dict — verify defaults."""
@@ -405,6 +416,24 @@ class TestComputeBiosLevel:
     def test_no_required_none_downloaded(self):
         assert compute_bios_level(_make_bios(local_count=0, all_downloaded=False)) == "missing"
 
+    def test_unmanaged_when_server_files_but_none_known(self):
+        """Server files present, zero registry-known → 'unmanaged' (no coverage)."""
+        level = compute_bios_level(_make_bios(server_count=2, known_count=0, required_count=0, required_downloaded=0))
+        assert level == "unmanaged"
+
+    def test_ok_when_no_server_files_even_with_known_count_zero(self):
+        """NES-like: no server files at all → not 'unmanaged' (guard needs server_count > 0)."""
+        assert compute_bios_level(_make_bios(server_count=0, known_count=0, all_downloaded=True)) == "ok"
+
+    def test_not_unmanaged_when_some_files_known(self):
+        """A registered platform (known_count > 0) never resolves to 'unmanaged'."""
+        level = compute_bios_level(_make_bios(server_count=3, known_count=2, required_count=2, required_downloaded=2))
+        assert level == "ok"
+
+    def test_known_count_none_defers_to_required_logic(self):
+        """Absent known_count (None) → 'unmanaged' never fires; existing logic decides."""
+        assert compute_bios_level(_make_bios(server_count=2, known_count=None, all_downloaded=True)) == "ok"
+
 
 class TestComputeBiosLabel:
     def test_required_all_downloaded(self):
@@ -424,6 +453,14 @@ class TestComputeBiosLabel:
 
     def test_no_required_none_downloaded(self):
         assert compute_bios_label(_make_bios(local_count=0, all_downloaded=False)) == "Missing"
+
+    def test_unmanaged_returns_not_managed(self):
+        """Server files present, none registry-known → compact 'Not managed' token."""
+        assert compute_bios_label(_make_bios(server_count=1, known_count=0, required_count=0)) == "Not managed"
+
+    def test_known_count_none_defers_to_required_logic(self):
+        """Absent known_count → 'Not managed' never fires; existing label logic decides."""
+        assert compute_bios_label(_make_bios(server_count=1, known_count=None, all_downloaded=True)) == "OK"
 
 
 class TestAvailableCore:

--- a/tests/services/test_firmware.py
+++ b/tests/services/test_firmware.py
@@ -567,6 +567,39 @@ class TestGetFirmwareStatusBiosAggregates:
         assert plat["bios_level"] == "ok"
 
     @pytest.mark.asyncio
+    async def test_uncovered_platform_projects_unmanaged_level(self, fw, tmp_path):
+        """System-page projection: server files but no registry coverage → 'unmanaged'.
+
+        A platform whose server firmware has no ``bios_registry.json`` entry
+        classifies every file ``unknown`` (known_count 0), so the aggregate stamps
+        ``bios_level == "unmanaged"`` instead of the false ``"ok"`` (#1520). It is
+        never flagged as a BIOS-needed platform (required_count is 0).
+        """
+        from unittest.mock import AsyncMock, MagicMock
+
+        # Registry with no entry for this platform → every server file is unknown.
+        fw._bios_registry = {"platforms": {}}
+        fw._bios_files_index = {}
+        firmware_list = [
+            {
+                "id": 1,
+                "file_name": "vita.bin",
+                "file_path": "bios/psvita/vita.bin",
+                "file_size_bytes": 100,
+                "md5_hash": "",
+            },
+        ]
+        fw._loop = MagicMock()
+        fw._loop.run_in_executor = AsyncMock(side_effect=[firmware_list, set()])
+
+        result = await fw.get_firmware_status()
+
+        plat = next(p for p in result["platforms"] if p["platform_slug"] == "psvita")
+        assert plat["bios_level"] == "unmanaged"
+        assert plat["required_count"] == 0
+        assert plat["server_count"] == 1
+
+    @pytest.mark.asyncio
     async def test_server_offline_fallback_ships_aggregates(self, plugin, fw, tmp_path):
         """Offline registry fallback still stamps bios_level + counts per platform."""
         fw._bios_registry = _BIOS_AGG_REGISTRY
@@ -646,6 +679,62 @@ class TestGetFirmwareStatusBiosAggregates:
         real_bios = os.path.realpath(str(bios_dir))
         for path in checked:
             assert os.path.realpath(path).startswith(real_bios + os.sep)
+
+
+class TestCheckPlatformBiosUnmanaged:
+    """``check_platform_bios`` surfaces the 'unmanaged' state for uncovered platforms.
+
+    A platform whose server firmware has no ``bios_registry.json`` entry has every
+    file classified ``unknown`` (known_count 0), so the per-game BIOS payload ships
+    ``bios_level == "unmanaged"`` instead of a false ``"ok"`` all-clear (#1520).
+    """
+
+    @pytest.mark.asyncio
+    async def test_uncovered_platform_is_unmanaged(self, fw, tmp_path):
+        from unittest.mock import AsyncMock, MagicMock
+
+        # Registry with no entry for this platform → every server file is unknown.
+        fw._bios_registry = {"platforms": {}}
+        fw._bios_files_index = {}
+        firmware_list = [
+            {
+                "id": 1,
+                "file_name": "vita.bin",
+                "file_path": "bios/psvita/vita.bin",
+                "file_size_bytes": 100,
+                "md5_hash": "",
+            },
+        ]
+        fw._loop = MagicMock()
+        fw._loop.run_in_executor = AsyncMock(return_value=firmware_list)
+
+        result = await fw.check_platform_bios("psvita")
+
+        assert result["needs_bios"] is True
+        assert result["server_count"] == 1
+        assert result["known_count"] == 0
+        assert result["unknown_count"] == 1
+        assert result["required_count"] == 0
+        assert result["bios_level"] == "unmanaged"
+
+    @pytest.mark.asyncio
+    async def test_covered_platform_threads_known_count_and_is_not_unmanaged(self, fw, tmp_path):
+        """A registered platform ships known_count > 0 and keeps its ok/partial/missing level."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        fw._bios_registry = _BIOS_AGG_REGISTRY
+        fw._bios_files_index = dict(_BIOS_AGG_INDEX)
+        firmware_list = [
+            {"id": 1, "file_name": "req1.bin", "file_path": "bios/dc/req1.bin", "file_size_bytes": 100, "md5_hash": ""},
+            {"id": 2, "file_name": "opt1.bin", "file_path": "bios/dc/opt1.bin", "file_size_bytes": 100, "md5_hash": ""},
+        ]
+        fw._loop = MagicMock()
+        fw._loop.run_in_executor = AsyncMock(return_value=firmware_list)
+
+        result = await fw.check_platform_bios("dc")
+
+        assert result["known_count"] == 2
+        assert result["bios_level"] != "unmanaged"
 
 
 class TestDownloadFirmware:


### PR DESCRIPTION
## What

The BIOS status model collapsed two distinct states into `required_count == 0`:

- **needs no firmware** (e.g. NES) — correctly shown as a green all-clear.
- **platform not in the plugin's firmware registry** (e.g. standalone-only systems like PS Vita) — the RomM server has firmware files, but none map to a `bios_registry.json` entry, so every file classified as `unknown`, `required_count` was `0`, and the status computed as a green "all ready" over an empty file list.

The second case claimed everything was fine for a platform the plugin has no coverage data for. A secondary bug hid the "N other files on server" note whenever *every* file was unknown, so the game-detail panel rendered a green header with nothing beneath it.

## Change

Adds a fourth BIOS status level, `unmanaged` — "the plugin has no registry coverage for this platform's firmware, so it makes no claim." It renders as a neutral grey dot with "Not managed by the plugin".

- Trigger: `server_count > 0 AND known_count == 0`, checked before the required-count thresholds. Because `known_count == 0` implies `required_count == 0`, it can only ever replace the false green — never mask a genuine "missing".
- `known_count` is threaded through every backend path that computes a BIOS level (game-detail, cached game-detail, System-page projection).
- The game-detail file list no longer swallows the "files on server the plugin doesn't recognise" note when all files are unknown.
- The play section stays quiet for `unmanaged` platforms — that state is non-actionable there and lives in the BIOS tab.

## Not included

Registry coverage for specific standalone platforms (e.g. a PS Vita entry) is tracked separately in #916. This PR only fixes the honesty of the status when coverage is absent.

## Docs

`docs/user-guide/bios-management.md` updated with the new "Not managed by the plugin" state.

Closes #1520
