### PR TITLE
fix(sync): union same-named collections instead of overwriting in finalize

### DIFF
--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -500,6 +500,20 @@ sibling row holding `shortcut_app_id` is the group's **active version**.
   to its group's bound sibling's appId — so collecting or favouriting any version puts the game's single shortcut in the
   collection.
 
+**Same-named collections union into one Steam collection (#1503).** RomM enforces name uniqueness only per-table and
+per-`(name, user_id)`, so two enabled collections can share a display name — a user collection and a smart/franchise
+collection, or (multi-user) another account's public collection the list endpoints return. Steam's collection namespace
+is **by-name** (`RomM: [<name>] (host)`), so both must resolve to the one Steam collection. The finalize accumulator
+(`_state.py` `pending_collection_memberships`) is therefore keyed by a collision-free `(collection_kind, collection_id)`
+identity — the same identity the #742 completion stamp uses — with the display name carried in the
+`CollectionMembership` value; the real-sync and preview write paths share one key builder so they cannot drift. The
+reporter (`_resolve_collection_memberships`) then groups the accumulator's entries by name and **unions** their resolved
+appId sets (order-preserving, de-duplicated across collections; each collection's own resolution already dedups within),
+emitting the unchanged by-name `romm_collection_app_ids: {name → [appId]}` contract — a single-collection name unions a
+set of one and is byte-for-byte the pre-#1503 output. The plugin **unions rather than owner-filters** here: RomM
+deliberately exposes public collections across accounts, so syncing them unfiltered is the established behaviour (an
+own/all QAM toggle is a separate concern).
+
 **Incremental skip — the per-platform completion stamp is the sole authority.** A platform unit skips only when its
 `PlatformSyncState` stamp exists
 ([ADR-0023](https://github.com/danielcopper/decky-romm-sync/blob/main/docs/adr/0023-chunked-per-unit-apply.md)); the

--- a/docs/user-guide/syncing-your-library.md
+++ b/docs/user-guide/syncing-your-library.md
@@ -229,6 +229,11 @@ collections, or use the paired **Enable All** / **Disable All** buttons to bulk-
 **Show collection games in platform groups** toggle controls whether games pulled in via a collection also get added to
 their platform's Steam group.
 
+If two enabled collections share the same name — for example a personal collection and a smart or franchise collection
+called the same thing, or (on a shared server) another account's public collection — they **merge into a single Steam
+collection** carrying the combined set of games. RomM allows collections to share a name, but Steam identifies a
+collection by its name, so the plugin unions their members rather than dropping one.
+
 ## Artwork
 
 Each synced game gets up to five types of artwork:

--- a/py_modules/domain/sync_diff.py
+++ b/py_modules/domain/sync_diff.py
@@ -270,16 +270,21 @@ def select_stale_removals(
 
 
 def compute_collection_diff(
-    collection_memberships: dict[str, list[int]],
+    current_collection_names: set[str],
     last_synced_collections: list[str],
 ) -> dict[str, Any]:
     """Diff enabled collections (by name) against the last-synced set.
 
-    Returns ``{"has_changes": bool, "added": [...], "removed": [...]}``.
-    ``has_changes`` is True if there are any added/removed collections, or
-    if there are any current collections at all (covers first-sync case).
+    ``current_collection_names`` is the set of DISTINCT display names present in
+    this run's collection accumulator — a name counts as present iff at least one
+    collection carries it, so two same-named collections (RomM permits them across
+    kinds/users, #1503) collapse to one entry, matching the by-name Steam
+    collection they merge into. Returns
+    ``{"has_changes": bool, "added": [...], "removed": [...]}``; ``has_changes`` is
+    True if there are any added/removed collections, or if there are any current
+    collections at all (covers first-sync case).
     """
-    current = set(collection_memberships.keys())
+    current = current_collection_names
     previous = set(last_synced_collections)
     added = sorted(current - previous)
     removed = sorted(previous - current)

--- a/py_modules/services/library/_state.py
+++ b/py_modules/services/library/_state.py
@@ -43,6 +43,24 @@ def _default_progress() -> dict[str, Any]:
 
 
 @dataclass(frozen=True)
+class CollectionMembership:
+    """One enabled collection's full member rom_ids, tagged with its display name.
+
+    The value type of :attr:`LibrarySyncStateBox.pending_collection_memberships`,
+    whose key is a collision-free ``(collection_kind, collection_id)`` identity so
+    two collections that merely SHARE a display name never overwrite each other's
+    members in the finalize accumulator. The name rides here in the value because
+    Steam's collection namespace is by-name: the reporter groups same-named
+    memberships and UNIONs their resolved appIds into the one
+    ``RomM: [<name>] (host)`` Steam collection (RomM permits same-named collections
+    across kinds/users, so the plugin merges rather than owner-filters, #1503).
+    """
+
+    name: str
+    rom_ids: list[int]
+
+
+@dataclass(frozen=True)
 class AbandonedChunk:
     """A heartbeat-timed-out apply chunk, stashed for a late-ack commit.
 
@@ -98,7 +116,13 @@ class LibrarySyncStateBox:
     # abandon window so a late ack still stamps the confirmed values.
     pending_cover_sources: dict[int, str] = field(default_factory=dict)
     pending_delta: PreviewDelta | None = None
-    pending_collection_memberships: dict[str, list[int]] = field(default_factory=dict)
+    # Per-run collection-membership accumulator, keyed by a collision-free
+    # ``(collection_kind, collection_id)`` identity (never the display name), so
+    # two collections that share a name each keep their own members. The name
+    # travels in the :class:`CollectionMembership` value; the reporter unions
+    # same-named memberships when it builds the by-name Steam-collection map
+    # (#1503).
+    pending_collection_memberships: dict[tuple[str, str], CollectionMembership] = field(default_factory=dict)
     pending_platform_rom_ids: set[int] | None = None
     # Per-unit pipeline coordination. ``unit_complete_event`` is set by
     # :meth:`SyncReporter.report_unit_results` when the frontend acks the

--- a/py_modules/services/library/reporter.py
+++ b/py_modules/services/library/reporter.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
     from domain.collection_sync_state import CollectionSyncState
     from domain.platform_sync_state import PlatformSyncState
     from domain.sync_run import SyncRun
-    from services.library._state import LibrarySyncStateBox
+    from services.library._state import CollectionMembership, LibrarySyncStateBox
     from services.protocols import (
         ArtworkManager,
         Clock,
@@ -116,7 +116,7 @@ class SyncReporter:
         self,
         uow: UnitOfWork,
         pending_platform_rom_ids: set[int] | None,
-        pending_collection_memberships: dict[str, list[int]],
+        pending_collection_memberships: dict[tuple[str, str], CollectionMembership],
         platform_names: dict[str, str],
     ) -> tuple[dict[str, list[int]], dict[str, list[int]]]:
         """Build platform_app_ids and romm_collection_app_ids from ``uow.roms``.
@@ -127,14 +127,17 @@ class SyncReporter:
         resolved from *platform_names* (the work-queue), falling back to
         the slug when absent.
 
-        RomM collections keep the per-run membership accumulator and resolve
-        each member ``rom_id`` to a Steam appId with a **sibling-group
-        fallback** (ADR-0021): a bound member uses its own binding; an unbound
-        member maps to its group's bound sibling's appId, so favouriting /
-        collecting ANY version of a game puts the game's single shortcut into
-        the Steam collection. Per-collection appIds are de-duplicated — several
-        siblings of one group collapse onto the one shortcut. The platform loop
-        still excludes rows whose ``shortcut_app_id`` is ``None``.
+        RomM collections keep the per-run membership accumulator (keyed by a
+        collision-free ``(collection_kind, collection_id)`` identity, name in the
+        value) and resolve each member ``rom_id`` to a Steam appId with a
+        **sibling-group fallback** (ADR-0021): a bound member uses its own
+        binding; an unbound member maps to its group's bound sibling's appId, so
+        favouriting / collecting ANY version of a game puts the game's single
+        shortcut into the Steam collection. Per-collection appIds are
+        de-duplicated — several siblings of one group collapse onto the one
+        shortcut — and same-named collections UNION into the one by-name Steam
+        collection (#1503). The platform loop still excludes rows whose
+        ``shortcut_app_id`` is ``None``.
         """
         platform_app_ids, group_bound_app_id = self._scan_bound_rows(uow, pending_platform_rom_ids, platform_names)
         romm_collection_app_ids = self._resolve_collection_memberships(
@@ -178,27 +181,33 @@ class SyncReporter:
     def _resolve_collection_memberships(
         self,
         uow: UnitOfWork,
-        pending_collection_memberships: dict[str, list[int]],
+        pending_collection_memberships: dict[tuple[str, str], CollectionMembership],
         group_bound_app_id: dict[str, int],
     ) -> dict[str, list[int]]:
-        """Resolve each collection's member rom_ids to de-duplicated appIds.
+        """Resolve each collection's member rom_ids to de-duplicated appIds, UNION by name.
 
-        A bound member uses its own binding; an unbound member falls back to
-        its sibling group's bound appId (ADR-0021). Collections that resolve
-        to no appId are omitted.
+        A bound member uses its own binding; an unbound member falls back to its
+        sibling group's bound appId (ADR-0021). Steam's collection namespace is
+        by-name, so same-named RomM collections (permitted across kinds/users,
+        #1503) merge into one entry: their resolved appIds are UNIONed,
+        order-preserving and de-duplicated ACROSS collections (each collection's
+        own resolution already dedups within). The accumulator is keyed by a
+        collision-free identity, so a same-named pair never overwrote either
+        member set upstream. Names that resolve to no appId are omitted; the
+        common single-collection case unions a set of one and is byte-for-byte
+        identical to the pre-#1503 output.
         """
         romm_collection_app_ids: dict[str, list[int]] = {}
-        for coll_name, rom_ids in pending_collection_memberships.items():
-            seen: set[int] = set()
-            app_ids: list[int] = []
-            for rid in rom_ids:
+        seen_by_name: dict[str, set[int]] = {}
+        for membership in pending_collection_memberships.values():
+            app_ids = romm_collection_app_ids.setdefault(membership.name, [])
+            seen = seen_by_name.setdefault(membership.name, set())
+            for rid in membership.rom_ids:
                 app_id = self._member_app_id(uow, rid, group_bound_app_id)
                 if app_id is not None and app_id not in seen:
                     seen.add(app_id)
                     app_ids.append(app_id)
-            if app_ids:
-                romm_collection_app_ids[coll_name] = app_ids
-        return romm_collection_app_ids
+        return {name: app_ids for name, app_ids in romm_collection_app_ids.items() if app_ids}
 
     @staticmethod
     def _member_app_id(uow: UnitOfWork, rid: int, group_bound_app_id: dict[str, int]) -> int | None:
@@ -216,7 +225,7 @@ class SyncReporter:
 
     def _finalize_per_unit_run_io(
         self,
-        pending_collection_memberships: dict[str, list[int]],
+        pending_collection_memberships: dict[tuple[str, str], CollectionMembership],
         pending_platform_rom_ids: set[int] | None,
         platform_names: dict[str, str],
         stale_rom_ids: list[int] | None = None,
@@ -262,7 +271,7 @@ class SyncReporter:
 
     async def finalize_per_unit_run(
         self,
-        pending_collection_memberships: dict[str, list[int]],
+        pending_collection_memberships: dict[tuple[str, str], CollectionMembership],
         pending_platform_rom_ids: set[int] | None,
         platform_names: dict[str, str] | None = None,
         stale_rom_ids: list[int] | None = None,

--- a/py_modules/services/library/service.py
+++ b/py_modules/services/library/service.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from lib.late_binding import LateBinding
-from services.library._state import LibrarySyncStateBox
+from services.library._state import CollectionMembership, LibrarySyncStateBox
 from services.library.fetcher import LibraryFetcher, LibraryFetcherConfig
 from services.library.reporter import SyncReporter, SyncReporterConfig
 from services.library.sync_orchestrator import SyncOrchestrator, SyncOrchestratorConfig
@@ -228,11 +228,11 @@ class LibraryService:
         self._box.pending_delta = value
 
     @property
-    def _pending_collection_memberships(self) -> dict[str, list[int]]:
+    def _pending_collection_memberships(self) -> dict[tuple[str, str], CollectionMembership]:
         return self._box.pending_collection_memberships
 
     @_pending_collection_memberships.setter
-    def _pending_collection_memberships(self, value: dict[str, list[int]]) -> None:
+    def _pending_collection_memberships(self, value: dict[tuple[str, str], CollectionMembership]) -> None:
         self._box.pending_collection_memberships = value
 
     @property

--- a/py_modules/services/library/sync_orchestrator.py
+++ b/py_modules/services/library/sync_orchestrator.py
@@ -56,6 +56,7 @@ from domain.sync_stage import SyncStage
 from domain.sync_state import SyncCancelled
 from lib.errors import classify_error
 from lib.list_result import ErrorCode
+from services.library._state import CollectionMembership
 
 if TYPE_CHECKING:
     import logging
@@ -117,6 +118,18 @@ _APPLY_CHUNK_SIZE = 200
 # prices each planned CREATE at it; a CHANGED item stays at the lighter
 # ``UPDATE_TOUCH_KB`` (an update reuses its existing grid file, no cover applied).
 _CREATE_WITH_COVER_KB = WORST_CASE_CREATE_KB + COVER_TRANSIENT_KB
+
+
+def _collection_membership_key(unit: WorkUnit) -> tuple[str, str]:
+    """The collision-free accumulator key for a collection unit.
+
+    ``(collection_kind, collection_id)`` — the same per-collection identity the
+    #742 ``CollectionSyncState`` stamp keys off — so two collections that share a
+    display NAME never collide in the finalize accumulator. The single builder
+    keeps the real-sync and preview write paths (and the stamp read-back) on one
+    key so they cannot drift (#1503).
+    """
+    return (str(unit.collection_kind), str(unit.id))
 
 
 @dataclass(frozen=True)
@@ -270,7 +283,7 @@ class SyncOrchestrator:
 
             all_roms: list[dict[str, Any]] = []
             platform_rom_ids: set[int] = set()
-            collection_memberships: dict[str, list[int]] = {}
+            collection_memberships: dict[tuple[str, str], CollectionMembership] = {}
             synced_rom_ids: set[int] = set()
 
             total_units = len(work_queue)
@@ -414,7 +427,7 @@ class SyncOrchestrator:
                     "sync_platform_count": platforms_count,
                     "sync_collection_count": collections_count,
                     "collection_diff": compute_collection_diff(
-                        collection_memberships,
+                        {m.name for m in collection_memberships.values()},
                         last_synced_collections,
                     ),
                     "platform_collection_diff": compute_platform_collection_diff(
@@ -456,7 +469,7 @@ class SyncOrchestrator:
         all_roms: list[dict[str, Any]],
         platform_rom_ids: set[int],
         synced_rom_ids: set[int],
-        collection_memberships: dict[str, list[int]],
+        collection_memberships: dict[tuple[str, str], CollectionMembership],
         *,
         progress_step: int = 0,
         progress_total_steps: int = 0,
@@ -465,7 +478,9 @@ class SyncOrchestrator:
 
         Platform units add every ROM to ``platform_rom_ids`` and
         ``synced_rom_ids``; collection units record their full membership
-        list under the unit name. ``all_roms`` is extended in both cases.
+        under a collision-free ``(collection_kind, collection_id)`` key (with the
+        name in the value), so same-named collections never overwrite each other
+        (#1503). ``all_roms`` is extended in both cases.
         Mutates the passed-in accumulators in place. ``progress_step`` /
         ``progress_total_steps`` thread the unit's coarse position into the
         fetcher's per-page ``fetching`` frames (on top of the per-unit frame
@@ -484,7 +499,9 @@ class SyncOrchestrator:
                 unit, synced_rom_ids, progress_step=progress_step, progress_total_steps=progress_total_steps
             )
             if all_collection_rom_ids:
-                collection_memberships[unit.name] = all_collection_rom_ids
+                collection_memberships[_collection_membership_key(unit)] = CollectionMembership(
+                    name=unit.name, rom_ids=all_collection_rom_ids
+                )
             all_roms.extend(unit_roms)
 
     async def sync_apply_delta(self, preview_id):
@@ -665,7 +682,7 @@ class SyncOrchestrator:
         # applies alike — surfaced as ``total_games`` (the terminal frame's
         # "N of M games processed" numerator).
         synced_rom_ids: set[int] = set()
-        collection_memberships: dict[str, list[int]] = {}
+        collection_memberships: dict[tuple[str, str], CollectionMembership] = {}
         platform_rom_ids: set[int] = set()
         total_games_applied = 0
         cancelled = False
@@ -1060,7 +1077,7 @@ class SyncOrchestrator:
         unit_index: int,
         total_units: int,
         synced_rom_ids: set[int],
-        collection_memberships: dict[str, list[int]],
+        collection_memberships: dict[tuple[str, str], CollectionMembership],
         platform_rom_ids: set[int],
     ) -> int:
         """Process one work unit start-to-finish; return its processed-ROM count.
@@ -1256,6 +1273,17 @@ class SyncOrchestrator:
         box.pending_all_roms = {sd["rom_id"]: sd for sd in shortcuts_data}
         box.pending_cover_sources = confirmed_cover_sources
 
+        # A collection unit's final chunk stamps a CollectionSyncState over its
+        # full membership (the accumulator just populated by the fetch, #742); a
+        # platform unit passes None. The full set — not just the applied new_roms —
+        # is what a future skip replays to rebuild membership. Read back by the
+        # collision-free ``(collection_kind, collection_id)`` key, not the name, so
+        # a same-named sibling collection can't shadow this unit's members (#1503).
+        collection_member_ids = None
+        if unit.type == "collection":
+            membership = collection_memberships.get(_collection_membership_key(unit))
+            collection_member_ids = membership.rom_ids if membership is not None else None
+
         applied_count = await self._apply_unit_in_chunks(
             unit,
             unit_index=unit_index,
@@ -1265,11 +1293,7 @@ class SyncOrchestrator:
             unit_roms=unit_roms,
             new_ids=new_ids,
             cover_refreshes=cover_refreshes,
-            # A collection unit's final chunk stamps a CollectionSyncState over its
-            # full membership (the accumulator just populated by the fetch, #742);
-            # a platform unit passes None. The full set — not just the applied
-            # new_roms — is what a future skip replays to rebuild membership.
-            collection_member_ids=collection_memberships.get(unit.name) if unit.type == "collection" else None,
+            collection_member_ids=collection_member_ids,
         )
         return len(skip_ids) + applied_count
 
@@ -1727,7 +1751,7 @@ class SyncOrchestrator:
         unit: WorkUnit,
         *,
         synced_rom_ids: set[int],
-        collection_memberships: dict[str, list[int]],
+        collection_memberships: dict[tuple[str, str], CollectionMembership],
         progress_step: int = 0,
         progress_total_steps: int = 0,
     ) -> tuple[list[dict[str, Any]], bool]:
@@ -1744,7 +1768,9 @@ class SyncOrchestrator:
             unit, synced_rom_ids, progress_step=progress_step, progress_total_steps=progress_total_steps
         )
         if all_collection_rom_ids:
-            collection_memberships[unit.name] = all_collection_rom_ids
+            collection_memberships[_collection_membership_key(unit)] = CollectionMembership(
+                name=unit.name, rom_ids=all_collection_rom_ids
+            )
         return unit_roms, skipped
 
     async def _wait_for_unit_complete(self, unit: WorkUnit, event: asyncio.Event) -> dict[str, int] | None:
@@ -1781,7 +1807,7 @@ class SyncOrchestrator:
         self,
         *,
         synced_rom_ids: set[int],
-        collection_memberships: dict[str, list[int]],
+        collection_memberships: dict[tuple[str, str], CollectionMembership],
         platform_rom_ids: set[int],
         platform_names: dict[str, str],
         cancelled: bool,

--- a/tests/domain/test_sync_diff.py
+++ b/tests/domain/test_sync_diff.py
@@ -303,43 +303,54 @@ class TestComputeCollectionDiff:
     """compute_collection_diff() — diff enabled collections vs last-synced set."""
 
     def test_first_sync_with_collections_has_changes(self):
-        result = compute_collection_diff({"Favorites": [1, 2]}, [])
+        result = compute_collection_diff({"Alpha"}, [])
         assert result["has_changes"] is True
-        assert result["added"] == ["Favorites"]
+        assert result["added"] == ["Alpha"]
         assert result["removed"] == []
 
     def test_empty_current_and_previous_no_changes(self):
-        result = compute_collection_diff({}, [])
+        result = compute_collection_diff(set(), [])
         assert result["has_changes"] is False
         assert result["added"] == []
         assert result["removed"] == []
 
     def test_added_collection_detected(self):
-        result = compute_collection_diff({"Favorites": [1], "RPG": [2]}, ["Favorites"])
+        result = compute_collection_diff({"Alpha", "Beta"}, ["Alpha"])
         assert result["has_changes"] is True
-        assert result["added"] == ["RPG"]
+        assert result["added"] == ["Beta"]
         assert result["removed"] == []
 
     def test_removed_collection_detected(self):
-        result = compute_collection_diff({"Favorites": [1]}, ["Favorites", "RPG"])
+        result = compute_collection_diff({"Alpha"}, ["Alpha", "Beta"])
         assert result["has_changes"] is True
         assert result["added"] == []
-        assert result["removed"] == ["RPG"]
+        assert result["removed"] == ["Beta"]
 
     def test_unchanged_collections_still_has_changes_when_current_nonempty(self):
         """has_changes is True even with no add/remove if current is non-empty."""
-        result = compute_collection_diff({"Favorites": [1]}, ["Favorites"])
+        result = compute_collection_diff({"Alpha"}, ["Alpha"])
         assert result["has_changes"] is True
         assert result["added"] == []
         assert result["removed"] == []
 
     def test_added_and_removed_sorted(self):
         result = compute_collection_diff(
-            {"Zelda": [1], "Mario": [2], "Pokemon": [3]},
-            ["Sonic", "Kirby"],
+            {"Gamma", "Beta", "Delta"},
+            ["Sigma", "Kappa"],
         )
-        assert result["added"] == ["Mario", "Pokemon", "Zelda"]
-        assert result["removed"] == ["Kirby", "Sonic"]
+        assert result["added"] == ["Beta", "Delta", "Gamma"]
+        assert result["removed"] == ["Kappa", "Sigma"]
+
+    def test_same_named_collections_collapse_to_one_present_name(self):
+        """A name is present once no matter how many collections carry it (#1503).
+
+        The caller derives the name set from the accumulator, so two same-named
+        collections yield a single set member — matching the by-name Steam
+        collection they merge into. Diffing that set is unchanged for the run.
+        """
+        result = compute_collection_diff({"X"}, [])
+        assert result["added"] == ["X"]
+        assert result["removed"] == []
 
 
 class TestShouldIncludeInPlatformCollection:

--- a/tests/services/library/test_reporter.py
+++ b/tests/services/library/test_reporter.py
@@ -8,6 +8,7 @@ from fakes.fake_cover_art_file_store import FakeCoverArtFileStore
 
 from domain.rom import Rom
 from domain.sync_diff import BIND_ROM_ID_KEY
+from services.library._state import CollectionMembership
 
 # conftest.py patches decky before this import
 
@@ -1359,7 +1360,7 @@ class TestFinalizePerUnitRun:
         _seed_rom(uow, 2, app_id=None, platform_slug="snes", name="B (unbound)")
 
         await plugin._sync_service._reporter.finalize_per_unit_run(
-            pending_collection_memberships={"Faves": [1, 2]},
+            pending_collection_memberships={("user", "7"): CollectionMembership(name="Faves", rom_ids=[1, 2])},
             pending_platform_rom_ids={1},
             platform_names={"n64": "Nintendo 64"},
         )
@@ -1382,7 +1383,8 @@ class TestFinalizePerUnitRun:
         _seed_rom(uow, 2, app_id=None, platform_slug="n64", name="Game (JP)", group_key="g")
 
         await plugin._sync_service._reporter.finalize_per_unit_run(
-            pending_collection_memberships={"Faves": [2]},  # the UNBOUND sibling is collected
+            # the UNBOUND sibling is collected
+            pending_collection_memberships={("user", "7"): CollectionMembership(name="Faves", rom_ids=[2])},
             pending_platform_rom_ids={1},
             platform_names={"n64": "Nintendo 64"},
         )
@@ -1403,13 +1405,93 @@ class TestFinalizePerUnitRun:
         _seed_rom(uow, 2, app_id=None, platform_slug="n64", name="Game (JP)", group_key="g")
 
         await plugin._sync_service._reporter.finalize_per_unit_run(
-            pending_collection_memberships={"Faves": [1, 2]},  # BOTH siblings collected
+            # BOTH siblings collected
+            pending_collection_memberships={("user", "7"): CollectionMembership(name="Faves", rom_ids=[1, 2])},
             pending_platform_rom_ids={1},
             platform_names={"n64": "Nintendo 64"},
         )
 
         payload = next(c for c in decky.emit.call_args_list if c[0][0] == "sync_collections")[0][1]
         assert payload["romm_collection_app_ids"] == {"Faves": [1001]}
+
+    @pytest.mark.asyncio
+    async def test_same_named_collections_union_their_members(self, plugin):
+        """Two same-named DIFFERENT-kind collections UNION into one Steam collection (#1503).
+
+        RomM permits same-named collections across kinds/users. Steam's collection
+        namespace is by-name, so both must map to the single ``RomM: [X]`` tag with
+        the UNION of their members. Load-bearing: against the pre-#1503 name-keyed
+        overwrite, only the last-synced collection's member would survive.
+        """
+        import decky
+
+        decky.emit.reset_mock()
+        uow = plugin._uow
+        _seed_rom(uow, 1, app_id=1001, platform_slug="n64", name="A")
+        _seed_rom(uow, 2, app_id=1002, platform_slug="snes", name="B")
+
+        await plugin._sync_service._reporter.finalize_per_unit_run(
+            pending_collection_memberships={
+                ("user", "7"): CollectionMembership(name="X", rom_ids=[1]),
+                ("smart", "9"): CollectionMembership(name="X", rom_ids=[2]),
+            },
+            pending_platform_rom_ids={1, 2},
+            platform_names={"n64": "Nintendo 64", "snes": "Super Nintendo"},
+        )
+
+        payload = next(c for c in decky.emit.call_args_list if c[0][0] == "sync_collections")[0][1]
+        # UNION of both collections' resolved appIds, order-preserving, deduped.
+        assert payload["romm_collection_app_ids"] == {"X": [1001, 1002]}
+
+    @pytest.mark.asyncio
+    async def test_same_named_union_dedups_shared_member_across_collections(self, plugin):
+        """A member shared by two same-named collections contributes its appId once."""
+        import decky
+
+        decky.emit.reset_mock()
+        uow = plugin._uow
+        _seed_rom(uow, 1, app_id=1001, platform_slug="n64", name="A")
+        _seed_rom(uow, 2, app_id=1002, platform_slug="snes", name="B")
+
+        await plugin._sync_service._reporter.finalize_per_unit_run(
+            pending_collection_memberships={
+                ("user", "7"): CollectionMembership(name="X", rom_ids=[1, 2]),
+                ("smart", "9"): CollectionMembership(name="X", rom_ids=[1]),
+            },
+            pending_platform_rom_ids={1, 2},
+            platform_names={"n64": "Nintendo 64", "snes": "Super Nintendo"},
+        )
+
+        payload = next(c for c in decky.emit.call_args_list if c[0][0] == "sync_collections")[0][1]
+        # app 1001 is shared by both collections but appears once; 1002 follows it.
+        # (Also non-vacuous vs the old overwrite: last-write-wins would drop 1002.)
+        assert payload["romm_collection_app_ids"] == {"X": [1001, 1002]}
+
+    @pytest.mark.asyncio
+    async def test_distinct_named_collections_unchanged_common_case(self, plugin):
+        """The all-distinct-names common case is byte-for-byte the pre-#1503 output.
+
+        Each name unions a set of one, so distinct collections keep their own
+        member sets — no merge, no reordering.
+        """
+        import decky
+
+        decky.emit.reset_mock()
+        uow = plugin._uow
+        _seed_rom(uow, 1, app_id=1001, platform_slug="n64", name="A")
+        _seed_rom(uow, 2, app_id=1002, platform_slug="snes", name="B")
+
+        await plugin._sync_service._reporter.finalize_per_unit_run(
+            pending_collection_memberships={
+                ("user", "7"): CollectionMembership(name="Alpha", rom_ids=[1]),
+                ("smart", "9"): CollectionMembership(name="Beta", rom_ids=[2]),
+            },
+            pending_platform_rom_ids={1, 2},
+            platform_names={"n64": "Nintendo 64", "snes": "Super Nintendo"},
+        )
+
+        payload = next(c for c in decky.emit.call_args_list if c[0][0] == "sync_collections")[0][1]
+        assert payload["romm_collection_app_ids"] == {"Alpha": [1001], "Beta": [1002]}
 
     @pytest.mark.asyncio
     async def test_emit_sync_complete_terminal(self, plugin):

--- a/tests/services/library/test_service.py
+++ b/tests/services/library/test_service.py
@@ -8,6 +8,7 @@ from fakes.fake_settings_persister import FakeSettingsPersister
 
 from domain.rom import Rom
 from domain.sync_diff import classify_roms
+from services.library._state import CollectionMembership
 
 # conftest.py patches decky before this import
 from tests.services.library._helpers import (
@@ -1149,7 +1150,7 @@ class TestCollectionSyncEdgeCases:
 
         with plugin._uow as uow:
             platform_app_ids, _ = svc._reporter._build_collection_app_ids(
-                uow, platform_rom_ids, {"Favorites": [1, 2]}, names
+                uow, platform_rom_ids, {("user", "3"): CollectionMembership(name="Favorites", rom_ids=[1, 2])}, names
             )
 
         assert "Game Boy Advance" in platform_app_ids
@@ -1186,7 +1187,7 @@ class TestCollectionSyncEdgeCases:
         _seed_rom(plugin._uow, 1, app_id=1001, platform_slug="gba", name="ROM A")
         names = {"gba": "Game Boy Advance"}
         platform_rom_ids = {1}
-        collection_memberships = {"Favorites": [1]}
+        collection_memberships = {("user", "3"): CollectionMembership(name="Favorites", rom_ids=[1])}
 
         with plugin._uow as uow:
             platform_app_ids, romm_collection_app_ids = svc._reporter._build_collection_app_ids(
@@ -1250,7 +1251,7 @@ class TestCollectionSyncEdgeCases:
 
         with plugin._uow as uow:
             _platform_app_ids, romm_collection_app_ids = svc._reporter._build_collection_app_ids(
-                uow, {1}, {"Favorites": [1, 99]}, {"gba": "GBA"}
+                uow, {1}, {("user", "3"): CollectionMembership(name="Favorites", rom_ids=[1, 99])}, {"gba": "GBA"}
             )
 
         assert "Favorites" in romm_collection_app_ids


### PR DESCRIPTION
Two enabled collections that share a display name overwrote each other's member set during finalize: the finalize accumulator was keyed by name with a wholesale write, so the single Steam collection `RomM: [<name>] (host)` reflected only the last-synced collection's members, and stale-cleanup for that tag worked from the wrong set.

**This is reachable.** Verified against the RomM 5.0.0 source: RomM has no cross-table name constraint, so a user collection and a smart or franchise collection can share a name on a single-user server — no multi-user setup needed. On a shared server the list endpoints return your own collections plus every other user's *public* ones, widening it further.

**No owner filter — deliberate.** RomM's list endpoints intentionally expose public collections across accounts, and syncing them unfiltered is the established behaviour. We keep that convention. (A QAM own/all toggle is tracked separately as #1532.)

**Fix.** The finalize accumulator is re-keyed from the display name to a collision-free `(collection_kind, collection_id)` identity, carrying the name in the value. When the reporter builds the Steam-collection appId map it groups by name and *unions* same-named collections' resolved appIds (order-preserving, deduped across collections). Because Steam's collection namespace is by-name, two same-named RomM collections necessarily map to one Steam collection — the union is the correct merge, and no membership is lost.

The frontend contract (`romm_collection_app_ids`, keyed by name) is byte-for-byte unchanged — the union happens backend-side before the emit, so `collections.ts` and stale-cleanup need no change. A single-collection name (the common case) unions a set of one and is identical to today. A side benefit: the #742 completion stamp now records each collection's own membership rather than a same-named sibling's last write.

Closes #1503
