### PR TITLE
fix(ui): draw System-page BIOS dividers only between platforms

### DIFF
--- a/src/components/SystemPage.test.tsx
+++ b/src/components/SystemPage.test.tsx
@@ -1696,24 +1696,27 @@ describe("SystemPage", () => {
   });
 
   // ------------------------------------------------------------------
-  // N4. Platform separators (#1534) — one divider between platform blocks,
-  // none between the rows of a single platform. The intra-row
-  // `bottomSeparator="none"` props are invisible through the @decky/ui mock
-  // (it ignores the prop), so only the between-platform rule is asserted here;
-  // the "no lines within a platform" look is confirmed on-device.
+  // N4. Platform separators (#1534) — a divider precedes every platform block:
+  // between the System intro and the first platform, and between each adjacent
+  // pair; none trails the last platform. So N platforms → N dividers. No divider
+  // sits between the rows of a single platform. The intra-row
+  // `bottomSeparator="none"` props are invisible through the @decky/ui mock (it
+  // ignores the prop), so only the between-block rule is asserted here; the "no
+  // lines within a platform" look is confirmed on-device.
   // ------------------------------------------------------------------
   describe("platform separators", () => {
-    it("renders no separator when only one platform is synced", async () => {
+    it("renders one separator between the System block and the single platform", async () => {
       vi.mocked(backend.getFirmwareStatus).mockResolvedValue({
         success: true,
         platforms: [makeBiosPlatform({ platform_slug: "snes" })],
       });
       const { container } = render(<SystemPage onBack={vi.fn()} />);
       await flushAsync();
-      expect(container.querySelectorAll('[data-testid="platform-separator"]')).toHaveLength(0);
+      // One platform → one divider (System → platform); none trails it.
+      expect(container.querySelectorAll('[data-testid="platform-separator"]')).toHaveLength(1);
     });
 
-    it("renders exactly one separator between each adjacent pair of synced platforms (N-1)", async () => {
+    it("renders one separator before each platform block (System→first plus each adjacent pair, N total)", async () => {
       vi.mocked(backend.getFirmwareStatus).mockResolvedValue({
         success: true,
         platforms: [
@@ -1724,8 +1727,8 @@ describe("SystemPage", () => {
       });
       const { container } = render(<SystemPage onBack={vi.fn()} />);
       await flushAsync();
-      // Three platforms → two dividers; none trails the last platform.
-      expect(container.querySelectorAll('[data-testid="platform-separator"]')).toHaveLength(2);
+      // Three platforms → three dividers (System→snes, snes→ps1, ps1→n64); none trails the last.
+      expect(container.querySelectorAll('[data-testid="platform-separator"]')).toHaveLength(3);
     });
   });
 

--- a/src/components/SystemPage.test.tsx
+++ b/src/components/SystemPage.test.tsx
@@ -1696,6 +1696,40 @@ describe("SystemPage", () => {
   });
 
   // ------------------------------------------------------------------
+  // N4. Platform separators (#1534) — one divider between platform blocks,
+  // none between the rows of a single platform. The intra-row
+  // `bottomSeparator="none"` props are invisible through the @decky/ui mock
+  // (it ignores the prop), so only the between-platform rule is asserted here;
+  // the "no lines within a platform" look is confirmed on-device.
+  // ------------------------------------------------------------------
+  describe("platform separators", () => {
+    it("renders no separator when only one platform is synced", async () => {
+      vi.mocked(backend.getFirmwareStatus).mockResolvedValue({
+        success: true,
+        platforms: [makeBiosPlatform({ platform_slug: "snes" })],
+      });
+      const { container } = render(<SystemPage onBack={vi.fn()} />);
+      await flushAsync();
+      expect(container.querySelectorAll('[data-testid="platform-separator"]')).toHaveLength(0);
+    });
+
+    it("renders exactly one separator between each adjacent pair of synced platforms (N-1)", async () => {
+      vi.mocked(backend.getFirmwareStatus).mockResolvedValue({
+        success: true,
+        platforms: [
+          makeBiosPlatform({ platform_slug: "snes" }),
+          makeBiosPlatform({ platform_slug: "ps1" }),
+          makeBiosPlatform({ platform_slug: "n64" }),
+        ],
+      });
+      const { container } = render(<SystemPage onBack={vi.fn()} />);
+      await flushAsync();
+      // Three platforms → two dividers; none trails the last platform.
+      expect(container.querySelectorAll('[data-testid="platform-separator"]')).toHaveLength(2);
+    });
+  });
+
+  // ------------------------------------------------------------------
   // O. Back button
   // ------------------------------------------------------------------
   describe("back button", () => {

--- a/src/components/SystemPage.tsx
+++ b/src/components/SystemPage.tsx
@@ -75,7 +75,13 @@ function hashIndicator(hv: boolean | null): string {
  */
 const PlatformSeparator: FC = () => (
   <PanelSectionRow>
-    <div data-testid="platform-separator" style={{ height: "1px", backgroundColor: "rgba(255, 255, 255, 0.12)" }} />
+    {/* marginTop offsets the built-in top lead of the following PanelSection
+        title (the block below the rule) so the line sits centred in the gap
+        rather than hugging the block above it. */}
+    <div
+      data-testid="platform-separator"
+      style={{ height: "1px", marginTop: "14px", backgroundColor: "rgba(255, 255, 255, 0.12)" }}
+    />
   </PanelSectionRow>
 );
 

--- a/src/components/SystemPage.tsx
+++ b/src/components/SystemPage.tsx
@@ -522,6 +522,10 @@ export const SystemPage: FC<SystemPageProps> = ({ onBack }) => {
             <Field label={biosStatus} />
           </PanelSectionRow>
         )}
+        {/* Close the System intro block off from the first platform with the same
+            divider that sits between platforms — so a line precedes every platform
+            block, none trails the last. Only when platforms actually follow. */}
+        {syncedPlatforms.length > 0 && <PlatformSeparator />}
       </PanelSection>
 
       {syncedPlatforms.map(renderBiosPlatform)}

--- a/src/components/SystemPage.tsx
+++ b/src/components/SystemPage.tsx
@@ -68,6 +68,17 @@ function hashIndicator(hv: boolean | null): string {
   return " —";
 }
 
+/**
+ * Thin horizontal rule dividing adjacent platform blocks. Rows within one
+ * platform carry `bottomSeparator="none"`, so this is the only divider — one
+ * line between neighbouring platforms, none between the rows of a platform.
+ */
+const PlatformSeparator: FC = () => (
+  <PanelSectionRow>
+    <div data-testid="platform-separator" style={{ height: "1px", backgroundColor: "rgba(255, 255, 255, 0.12)" }} />
+  </PanelSectionRow>
+);
+
 interface SystemPageProps {
   onBack: () => void;
 }
@@ -250,7 +261,8 @@ export const SystemPage: FC<SystemPageProps> = ({ onBack }) => {
   // when it has at least one ROM bound to a Steam shortcut (has_games).
   const syncedPlatforms = biosPlatforms.filter((p) => p.has_games);
 
-  const renderBiosPlatform = (platform: FirmwarePlatformExt) => {
+  const renderBiosPlatform = (platform: FirmwarePlatformExt, index: number) => {
+    const isLastPlatform = index === syncedPlatforms.length - 1;
     const unknownFiles = platform.files.filter((f) => f.classification === "unknown");
     // Display counts come from the backend aggregates (computed from the same
     // core-aware files); fall back to local derivation only if a payload omits
@@ -302,14 +314,14 @@ export const SystemPage: FC<SystemPageProps> = ({ onBack }) => {
             game-detail menu (#1210). */}
         {hasMultipleCores && (
           <PanelSectionRow>
-            <ButtonItem layout="below" onClick={(e: Event) => showSystemCoreMenu(platform, e)}>
+            <ButtonItem layout="below" bottomSeparator="none" onClick={(e: Event) => showSystemCoreMenu(platform, e)}>
               {`Emulator Core: ${platform.active_core_label ?? "Default"}`}
             </ButtonItem>
           </PanelSectionRow>
         )}
         {platform.active_core_label && !hasMultipleCores && (
           <PanelSectionRow>
-            <Field label="Emulator Core" description={platform.active_core_label} />
+            <Field label="Emulator Core" description={platform.active_core_label} bottomSeparator="none" />
           </PanelSectionRow>
         )}
         <PanelSectionRow>
@@ -334,11 +346,13 @@ export const SystemPage: FC<SystemPageProps> = ({ onBack }) => {
               )
             }
             description={summaryDescription}
+            bottomSeparator="none"
           />
         </PanelSectionRow>
         <PanelSectionRow>
           <ButtonItem
             layout="below"
+            bottomSeparator="none"
             onClick={() =>
               setExpanded((prev) => ({
                 ...prev,
@@ -385,6 +399,7 @@ export const SystemPage: FC<SystemPageProps> = ({ onBack }) => {
                         ? `${file.file_name}${hashIndicator(file.hash_valid)}`
                         : `${file.file_name} — Missing`
                     }
+                    bottomSeparator="none"
                   />
                 </PanelSectionRow>
               );
@@ -394,6 +409,7 @@ export const SystemPage: FC<SystemPageProps> = ({ onBack }) => {
                 <Field
                   label={`${unknownFiles.length} file(s) not recognized`}
                   description="Report at github.com/danielcopper/decky-romm-sync/issues if needed."
+                  bottomSeparator="none"
                 />
               </PanelSectionRow>
             )}
@@ -403,6 +419,7 @@ export const SystemPage: FC<SystemPageProps> = ({ onBack }) => {
           <PanelSectionRow>
             <ButtonItem
               layout="below"
+              bottomSeparator="none"
               onClick={() => {
                 detach(handleDownloadRequired(platform.platform_slug));
               }}
@@ -416,6 +433,7 @@ export const SystemPage: FC<SystemPageProps> = ({ onBack }) => {
           <PanelSectionRow>
             <ButtonItem
               layout="below"
+              bottomSeparator="none"
               onClick={() => {
                 detach(handleDownloadAll(platform.platform_slug));
               }}
@@ -431,6 +449,7 @@ export const SystemPage: FC<SystemPageProps> = ({ onBack }) => {
           <PanelSectionRow>
             <ButtonItem
               layout="below"
+              bottomSeparator="none"
               onClick={() => confirmDeleteBios(platform.platform_slug)}
               disabled={isDownloading}
             >
@@ -438,6 +457,7 @@ export const SystemPage: FC<SystemPageProps> = ({ onBack }) => {
             </ButtonItem>
           </PanelSectionRow>
         )}
+        {!isLastPlatform && <PlatformSeparator />}
       </PanelSection>
     );
   };


### PR DESCRIPTION
## What

On the System page, each platform's BIOS block drew a horizontal divider between every row (emulator-core, file count, Show Files, per-file rows, Download, Delete BIOS). Dividers now separate platform blocks only.

## Change

- `bottomSeparator="none"` on every row within a platform's block, so no line is drawn between the rows of one platform.
- A single thin divider precedes every platform block — between the System intro and the first platform, and between each adjacent pair — with none trailing the last (N platforms → N dividers).
- The divider carries a small top offset so it sits centred in the gap rather than hugging the block above it (the following section title's built-in top lead would otherwise pull it upward).

Presentation only — no counts, button gating, labels, colors, or BIOS status logic changed.

docs: N/A — cosmetic System-page layout, no user-facing behavior or flow change.

Closes #1534
