### PR TITLE
feat(ui): add Own/All collection owner-scope filter with lazy identity

### DIFF
--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -510,9 +510,25 @@ identity — the same identity the #742 completion stamp uses — with the displ
 reporter (`_resolve_collection_memberships`) then groups the accumulator's entries by name and **unions** their resolved
 appId sets (order-preserving, de-duplicated across collections; each collection's own resolution already dedups within),
 emitting the unchanged by-name `romm_collection_app_ids: {name → [appId]}` contract — a single-collection name unions a
-set of one and is byte-for-byte the pre-#1503 output. The plugin **unions rather than owner-filters** here: RomM
-deliberately exposes public collections across accounts, so syncing them unfiltered is the established behaviour (an
-own/all QAM toggle is a separate concern).
+set of one and is byte-for-byte the pre-#1503 output. The union runs **after** the owner-scope filter (below): once a
+foreign collection is dropped from the work queue it never reaches the accumulator, so "Own" narrows what is unioned
+rather than changing how the union works.
+
+**Collection owner-scope filter — "Own" is a sync scope, not just a display filter (#1532).** RomM's collection list
+endpoints return the signed-in user's own collections plus every other user's _public_ collection. The QAM
+`Show
+collections` control writes `collection_owner_scope` (`"own"` / `"all"`, default `"all"`); `get_collections` also
+tags each row with `is_own` so the frontend can hide foreign ones under "Own". Ownership is a pure predicate
+(`domain/collection_owner.is_own_collection`): a collection is own when it is a **franchise/virtual** collection (RomM's
+`VirtualCollection` model carries no `user_id` column — these are global/derived and belong to no one, so they always
+survive), when the plugin's own identity is unknown (the **degrade-to-"All" fallback**), or when the collection's
+`user_id` equals the stored `romm_user_id`; only user and smart collections carry a `user_id` to compare.
+`build_work_queue` applies the same predicate: under `"own"` **with a known identity** it drops foreign user/smart units
+from the queue — so a foreign collection enabled earlier is never synced — while franchise units and every unit under
+`"all"` pass through unchanged. The scope filters **over** the per-kind enable state without mutating it, so switching
+back to `"all"` restores the prior enables. Because an **unknown identity never filters**, the feature is non-breaking:
+it silently no-ops until `romm_user_id` is stamped (see the ConnectionService lazy-identity note), then activates — no
+re-login required.
 
 **Incremental skip — the per-platform completion stamp is the sole authority.** A platform unit skips only when its
 `PlatformSyncState` stamp exists
@@ -991,6 +1007,21 @@ path** — a failed local clear never turns a good sign-in into a failure, and a
 restored) keeps the still-current server's id. `ensure_device_registered` never deletes the id on any failure, so a
 permission-degraded (403/timeout) session leaves the identity intact. This is Phase 0a of the RomM Device Sync negotiate
 adoption ([ADR-0016](../adr/0016-save-sync-hands-detection-to-romm-negotiate.md)).
+
+**The signed-in user's own id (`romm_user_id`) is bound to the token — stamped at sign-in, backfilled lazily, cleared on
+sign-out.** It drives the collection owner-scope filter (`build_work_queue` + `get_collections`, described in the
+LibraryService section above). Every sign-in path re-derives it from the freshly authenticated token so it can never
+linger for a different user or a different server: the mint path (`establish_token`) probes `GET /api/users/me` after
+host-binding the minted token (the mint response carries only the token id, not the user id); the pasted/paired paths
+reuse the id from the `/api/users/me` validation probe they already run (no second call). In every case the id is set
+**in memory before** the token-persist save, so it rides the same single atomic `save_settings()` — the sign-in write
+shape is unchanged. It is part of the snapshot/restore auth-state set, so a failed sign-in restores the previous id, and
+it is cleared in each path's in-memory auth clear so a probe failure or a malformed payload leaves it `None` rather than
+stale — degrading the "Own" filter to "All" until the next backfill. Existing installs (a valid token minted before this
+setting existed) carry no id; `test_connection` **lazily backfills** it — when a token is present and the id is missing,
+the successful connection check probes `/api/users/me` and persists the id (its own save), so the filter activates
+without a re-login. A known id needs no network on later checks. Every identity read is best-effort: a failure never
+fails the sign-in or the connection check.
 
 The no-sign-in URL change path (`SettingsService.save_server_url`) deliberately does not touch the token, so pointing
 the URL at a different origin leaves the stored token's origin mismatched and the auth-header guard makes subsequent

--- a/docs/user-guide/syncing-your-library.md
+++ b/docs/user-guide/syncing-your-library.md
@@ -229,6 +229,22 @@ collections, or use the paired **Enable All** / **Disable All** buttons to bulk-
 **Show collection games in platform groups** toggle controls whether games pulled in via a collection also get added to
 their platform's Steam group.
 
+#### Own / All
+
+On a **shared RomM server** the collection list includes every other user's _public_ collections alongside your own. The
+**Show collections** control at the top of the Collections page lets you narrow that down:
+
+- **All** (default) — every collection the server lists, including other users' public ones. This is the original
+  behaviour.
+- **Own** — only the collections you own. Foreign collections are hidden from the sub-tabs and are excluded from the
+  sync, even if one was enabled earlier — switching back to **All** brings your earlier choices back, since the scope
+  filters over your enable state rather than changing it.
+
+**Franchise collections always sync** under either setting: they are auto-generated groupings that belong to no one, so
+"Own" never hides them. The filter only becomes active once the plugin knows your account identity, which it learns the
+first time you sign in (existing sign-ins pick it up on the next connection check). Until then, **Own** behaves exactly
+like **All** — it never hides a collection it can't yet attribute.
+
 If two enabled collections share the same name — for example a personal collection and a smart or franchise collection
 called the same thing, or (on a shared server) another account's public collection — they **merge into a single Steam
 collection** carrying the combined set of games. RomM allows collections to share a name, but Steam identifies a

--- a/main.py
+++ b/main.py
@@ -339,6 +339,9 @@ class Plugin:
     async def save_collection_platform_groups(self, enabled):
         return self._settings_service.save_collection_platform_groups(enabled)
 
+    async def set_collection_owner_scope(self, scope):
+        return self._settings_service.set_collection_owner_scope(scope)
+
     @migration_blocked
     async def start_sync(self):
         return self._sync_service.start_sync()

--- a/py_modules/adapters/persistence.py
+++ b/py_modules/adapters/persistence.py
@@ -41,9 +41,19 @@ DEFAULT_SETTINGS: dict[str, Any] = {
     "romm_api_token_id": None,
     "romm_api_token_origin": None,
     "romm_api_token_source": None,
+    # The signed-in RomM user's own id (``/api/users/me`` ``id``), or ``None``
+    # when identity is not yet known. Bound to the token like the device id —
+    # stamped at sign-in, backfilled lazily on a connection check, cleared on
+    # sign-out. Drives the collection owner-scope filter; ``None`` makes "Own"
+    # behave like "All" (the non-breaking fallback).
+    "romm_user_id": None,
     "enabled_platforms": {},
     "enabled_collections": {"user": {}, "smart": {}, "franchise": {}},
     "collection_create_platform_groups": False,
+    # QAM collection owner-scope: ``"all"`` (default — every collection the
+    # server lists) or ``"own"`` (only the signed-in user's own collections;
+    # franchise/virtual collections have no owner and always survive).
+    "collection_owner_scope": "all",
     "preferred_region": "auto",
     "steam_input_mode": "default",
     "steamgriddb_api_key": "",

--- a/py_modules/domain/collection_owner.py
+++ b/py_modules/domain/collection_owner.py
@@ -1,0 +1,49 @@
+"""Owner-scope classification for RomM collections.
+
+The pure predicate behind the QAM "Own / All" collection filter. RomM's
+collection listings return the signed-in user's own collections plus every
+other user's PUBLIC collection; "Own" hides the foreign ones. This module owns
+the single rule that decides whether a collection counts as the user's own —
+used both to tag the frontend list (``is_own``) and to drop foreign units from
+the sync work queue. No I/O, no state: identity and the collection's owner id
+come in as arguments.
+
+Two invariants make the filter safe and non-breaking:
+
+* **Franchise/virtual collections have no owner.** They are global/derived —
+  RomM's ``VirtualCollection`` model carries no ``user_id`` column and returns
+  them identically to every user — so they are always own and always survive
+  an "Own" filter.
+* **Unknown identity degrades to "All".** When the plugin does not yet know its
+  own user id (never fetched / offline), every collection is treated as own, so
+  "Own" filters nothing rather than filtering against the wrong identity.
+"""
+
+from __future__ import annotations
+
+
+def is_own_collection(collection_user_id: object, own_user_id: int | None, *, kind: str) -> bool:
+    """Whether a collection is the signed-in user's own (survives an "Own" filter).
+
+    Parameters
+    ----------
+    collection_user_id:
+        The collection's owner id (``user_id``) from the RomM listing dict, or
+        ``None``/absent. Compared by value against *own_user_id*. Only user and
+        smart collections carry it; franchise/virtual collections never do.
+    own_user_id:
+        The signed-in user's own id (``settings["romm_user_id"]``), or ``None``
+        when identity is not yet known.
+    kind:
+        ``"user"``, ``"smart"`` or ``"franchise"``.
+
+    Returns ``True`` (own) when the collection is a franchise/virtual collection
+    (no owner), when our own identity is unknown (the non-breaking fallback), or
+    when the collection's owner id equals ours. ``False`` (foreign) only when a
+    user/smart collection is owned by a different known id.
+    """
+    if kind == "franchise":
+        return True
+    if own_user_id is None:
+        return True
+    return collection_user_id == own_user_id

--- a/py_modules/services/connection.py
+++ b/py_modules/services/connection.py
@@ -173,6 +173,7 @@ class ConnectionService:
         if version_error is not None:
             return version_error
 
+        await self._backfill_user_id_best_effort()
         return self._success_result(version)
 
     async def probe_reachability(self) -> dict[str, Any]:
@@ -240,6 +241,10 @@ class ConnectionService:
         self._settings["romm_api_token"] = None
         self._settings["romm_api_token_id"] = None
         self._settings["romm_api_token_origin"] = None
+        # A new sign-in invalidates the stored identity — re-derived below from
+        # the freshly minted token, so it can never linger for a different user
+        # or a different server.
+        self._settings["romm_user_id"] = None
 
         try:
             version = await self._loop.run_in_executor(None, self._probe_version)
@@ -288,6 +293,14 @@ class ConnectionService:
                 "reason": ErrorCode.SERVER_UNREACHABLE.value,
                 "message": "RomM did not return a usable token",
             }
+
+        # Host-bind the minted token in memory so the identity probe
+        # authenticates, then stamp the user id — both ride the single atomic
+        # token-persist save below (the mint response carries only the token id,
+        # not the user id, so /api/users/me is the only source here).
+        self._settings["romm_api_token"] = raw_token
+        self._settings["romm_api_token_origin"] = normalize_origin(trimmed)
+        await self._resolve_user_id_in_memory()
 
         try:
             self._persist_token(raw_token, token_id, origin=normalize_origin(trimmed), source="minted")
@@ -344,6 +357,9 @@ class ConnectionService:
         self._settings["romm_api_token_id"] = None
         self._settings["romm_api_token_origin"] = normalize_origin(trimmed)
         self._settings["romm_api_token_source"] = "user"
+        # A new sign-in invalidates the stored identity — re-derived from the
+        # pasted token's /api/users/me validation probe below.
+        self._settings["romm_user_id"] = None
 
         try:
             version = await self._loop.run_in_executor(None, self._probe_version)
@@ -403,6 +419,9 @@ class ConnectionService:
         self._settings["romm_api_token"] = None
         self._settings["romm_api_token_id"] = None
         self._settings["romm_api_token_origin"] = None
+        # A new sign-in invalidates the stored identity — re-derived from the
+        # exchanged token's /api/users/me validation probe below.
+        self._settings["romm_user_id"] = None
 
         try:
             version = await self._loop.run_in_executor(None, self._probe_version)
@@ -475,7 +494,7 @@ class ConnectionService:
         token value is never logged.
         """
         try:
-            await self._loop.run_in_executor(None, self._romm_api.get_current_user)
+            user_data = await self._loop.run_in_executor(None, self._romm_api.get_current_user)
         except RommAuthError:
             self._restore_auth_state(snapshot)
             return {"success": False, "reason": ErrorCode.AUTH_FAILED.value, "message": _USER_TOKEN_INVALID_MESSAGE}
@@ -485,6 +504,11 @@ class ConnectionService:
         except Exception as e:
             self._restore_auth_state(snapshot)
             return error_response(e)
+
+        # Stamp the user identity in memory so it rides the single atomic
+        # token-persist save (the validation probe already returned it — no
+        # second /api/users/me call).
+        self._set_user_id_in_memory(user_data)
 
         try:
             self._persist_token(raw_token, None, origin=normalize_origin(trimmed), source="user")
@@ -535,6 +559,72 @@ class ConnectionService:
             await self._loop.run_in_executor(None, self._forget_device)
         except Exception as e:
             self._logger.warning(f"Could not clear device id after origin change: {e}")
+
+    @staticmethod
+    def _extract_user_id(user_data: object) -> int | None:
+        """Read the RomM user id off a ``/api/users/me`` dict, or ``None``.
+
+        Tolerant of an untrusted server shape: a non-dict payload, a missing
+        ``id``, a non-int, or a bool (``isinstance(True, int)`` is ``True`` in
+        Python) all yield ``None`` so a malformed identity never becomes a wrong
+        owner-scope filter.
+        """
+        user_id = user_data.get("id") if isinstance(user_data, dict) else None
+        if isinstance(user_id, bool) or not isinstance(user_id, int):
+            return None
+        return user_id
+
+    def _set_user_id_in_memory(self, user_data: object) -> None:
+        """Stamp ``settings['romm_user_id']`` from a ``/api/users/me`` dict, no save.
+
+        The value rides the sign-in's single atomic token-persist save, so
+        identity lands on disk together with the token (never a second write). A
+        malformed payload yields ``None`` — "Own" then degrades to "All" until
+        the lazy backfill re-derives it.
+        """
+        self._settings["romm_user_id"] = self._extract_user_id(user_data)
+
+    async def _resolve_user_id_in_memory(self) -> None:
+        """Fetch the minted token's user identity into memory (best-effort, no save).
+
+        The mint response carries only the token id, not the user id, so the
+        freshly host-bound token is probed against ``/api/users/me``.
+        Best-effort: a failure leaves ``romm_user_id`` cleared (``None``) so the
+        single token-persist save records ``None`` and the lazy backfill
+        re-derives it on the next connection check. Never fails the sign-in.
+        """
+        try:
+            user_data = await self._loop.run_in_executor(None, self._romm_api.get_current_user)
+        except Exception as e:
+            self._logger.warning(f"Could not read RomM user identity at sign-in: {e}")
+            return
+        self._set_user_id_in_memory(user_data)
+
+    async def _backfill_user_id_best_effort(self) -> None:
+        """Lazily stamp ``romm_user_id`` from the current token when it is unknown.
+
+        Existing installs carry a valid token but no stored identity (the setting
+        postdates them). This backfills it on the next connection check so the
+        collection owner-scope filter can activate without a re-login. Fires only
+        when the id is missing (a known id needs no network) and a token exists;
+        persists in its own save (no token write is in flight here). Best-effort
+        — a failure or malformed payload leaves the id unknown, so "Own" keeps
+        behaving like "All".
+        """
+        if self._settings.get("romm_user_id") is not None:
+            return
+        if not self._settings.get("romm_api_token"):
+            return
+        try:
+            user_data = await self._loop.run_in_executor(None, self._romm_api.get_current_user)
+        except Exception as e:
+            self._logger.warning(f"Could not backfill RomM user identity: {e}")
+            return
+        user_id = self._extract_user_id(user_data)
+        if user_id is None:
+            return
+        self._settings["romm_user_id"] = user_id
+        self._settings_persister.save_settings()
 
     async def migrate_legacy_credentials(self) -> None:
         """Upgrade a stored-password install to a Client API Token on startup.
@@ -601,6 +691,9 @@ class ConnectionService:
         self._settings["romm_api_token_id"] = None
         self._settings["romm_api_token_origin"] = None
         self._settings["romm_api_token_source"] = None
+        # Identity is forgotten alongside the token — "Own" collection scope has
+        # no basis without a signed-in user, and the next sign-in re-derives it.
+        self._settings["romm_user_id"] = None
         try:
             self._settings_persister.save_settings()
         except Exception as e:
@@ -618,6 +711,9 @@ class ConnectionService:
         "romm_api_token_id",
         "romm_api_token_origin",
         "romm_api_token_source",
+        # Identity is bound to the token: a failed sign-in restores the previous
+        # user id, never leaving a half-changed identity behind.
+        "romm_user_id",
     )
 
     def _snapshot_auth_state(self) -> dict[str, Any]:

--- a/py_modules/services/library/fetcher.py
+++ b/py_modules/services/library/fetcher.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Any, NamedTuple
 
+from domain.collection_owner import is_own_collection
 from domain.fetch_generation import count_rows_for_skip
 from domain.platform_prefs import materialize_enabled_platforms, resolve_sync_enabled
 from domain.skip_prediction import collapsed_shortcut_count, new_shortcut_count, predict_unit_skip
@@ -81,12 +82,28 @@ class _SkipBaseline(NamedTuple):
 _FETCH_PROGRESS_PAGE_INTERVAL = 1
 
 
-def _collection_units(collections: list[dict[str, Any]], enabled_ids: set[str], kind: CollectionKind) -> list[WorkUnit]:
-    """Build WorkUnits for collections whose id is in *enabled_ids*, tagged with *kind*."""
+def _collection_units(
+    collections: list[dict[str, Any]],
+    enabled_ids: set[str],
+    kind: CollectionKind,
+    *,
+    own_user_id: int | None = None,
+    filter_to_own: bool = False,
+) -> list[WorkUnit]:
+    """Build WorkUnits for collections whose id is in *enabled_ids*, tagged with *kind*.
+
+    When *filter_to_own* is set (the "Own" owner-scope), a foreign collection —
+    one owned by a known user id other than *own_user_id* — is dropped from the
+    queue even if it is enabled, so a scope selected over an earlier enable never
+    syncs someone else's collection. Franchise collections have no owner and
+    always survive (:func:`is_own_collection`).
+    """
     units: list[WorkUnit] = []
     for c in collections:
         cid = str(c.get("id", ""))
         if cid not in enabled_ids:
+            continue
+        if filter_to_own and not is_own_collection(c.get("user_id"), own_user_id, kind=kind):
             continue
         units.append(
             WorkUnit(
@@ -255,6 +272,11 @@ class LibraryFetcher:
             franchise_collections = []
 
         enabled = self._get_enabled_collections_buckets()
+        # Own identity for the owner-scope tag. ``None`` (never fetched / offline)
+        # tags every collection ``is_own=True`` so the frontend "Own" filter
+        # degrades to "All" rather than filtering wrongly (the non-breaking
+        # fallback).
+        own_user_id = self._settings.get("romm_user_id")
         result = []
         for c in user_collections:
             cid = str(c["id"])
@@ -266,6 +288,7 @@ class LibraryFetcher:
                     "sync_enabled": enabled["user"].get(cid, False),
                     "kind": "user",
                     "is_favorite": bool(c.get("is_favorite", False)),
+                    "is_own": is_own_collection(c.get("user_id"), own_user_id, kind="user"),
                 }
             )
         for c in smart_collections:
@@ -278,6 +301,7 @@ class LibraryFetcher:
                     "sync_enabled": enabled["smart"].get(cid, False),
                     "kind": "smart",
                     "is_favorite": False,
+                    "is_own": is_own_collection(c.get("user_id"), own_user_id, kind="smart"),
                 }
             )
         for c in franchise_collections:
@@ -290,6 +314,8 @@ class LibraryFetcher:
                     "sync_enabled": enabled["franchise"].get(cid, False),
                     "kind": "franchise",
                     "is_favorite": False,
+                    # Franchise/virtual collections have no owner — always own.
+                    "is_own": True,
                 }
             )
 
@@ -462,9 +488,26 @@ class LibraryFetcher:
         if not (enabled_user_ids or enabled_smart_ids or enabled_franchise_ids):
             return units
 
+        # Owner-scope filter (#1532): when "Own" is selected AND our identity is
+        # known, foreign user/smart collections are dropped from the queue — a
+        # sync scope that filters OVER the enabled ids without mutating them.
+        # Unknown identity (own_user_id is None) never filters, so "Own" is a
+        # no-op until identity is available (non-breaking). Franchise collections
+        # have no owner and are never filtered.
+        own_user_id = self._settings.get("romm_user_id")
+        filter_to_own = self._settings.get("collection_owner_scope") == "own" and own_user_id is not None
+
         collection_units: list[WorkUnit] = []
-        collection_units.extend(await self._build_user_collection_units(enabled_user_ids))
-        collection_units.extend(await self._build_smart_collection_units(enabled_smart_ids))
+        collection_units.extend(
+            await self._build_user_collection_units(
+                enabled_user_ids, own_user_id=own_user_id, filter_to_own=filter_to_own
+            )
+        )
+        collection_units.extend(
+            await self._build_smart_collection_units(
+                enabled_smart_ids, own_user_id=own_user_id, filter_to_own=filter_to_own
+            )
+        )
         collection_units.extend(await self._build_franchise_collection_units(enabled_franchise_ids))
         # One short read UoW for every collection at once — after the listing
         # fetches, never across them.
@@ -472,8 +515,14 @@ class LibraryFetcher:
 
         return units
 
-    async def _build_user_collection_units(self, enabled_ids: set[str]) -> list[WorkUnit]:
-        """Fetch user collections and emit work units for those whose id is in *enabled_ids*."""
+    async def _build_user_collection_units(
+        self, enabled_ids: set[str], *, own_user_id: int | None = None, filter_to_own: bool = False
+    ) -> list[WorkUnit]:
+        """Fetch user collections and emit work units for those whose id is in *enabled_ids*.
+
+        Under the "Own" owner-scope (*filter_to_own*), foreign collections are
+        dropped even when enabled (see :func:`_collection_units`).
+        """
         if not enabled_ids:
             return []
         try:
@@ -481,10 +530,16 @@ class LibraryFetcher:
         except Exception as e:
             self._logger.warning(f"Failed to fetch user collections for work queue: {e}")
             collections = []
-        return _collection_units(collections, enabled_ids, "user")
+        return _collection_units(collections, enabled_ids, "user", own_user_id=own_user_id, filter_to_own=filter_to_own)
 
-    async def _build_smart_collection_units(self, enabled_ids: set[str]) -> list[WorkUnit]:
-        """Fetch smart collections and emit work units for those whose id is in *enabled_ids*."""
+    async def _build_smart_collection_units(
+        self, enabled_ids: set[str], *, own_user_id: int | None = None, filter_to_own: bool = False
+    ) -> list[WorkUnit]:
+        """Fetch smart collections and emit work units for those whose id is in *enabled_ids*.
+
+        Under the "Own" owner-scope (*filter_to_own*), foreign collections are
+        dropped even when enabled (see :func:`_collection_units`).
+        """
         if not enabled_ids:
             return []
         try:
@@ -492,7 +547,9 @@ class LibraryFetcher:
         except Exception as e:
             self._logger.warning(f"Failed to fetch smart collections for work queue: {e}")
             collections = []
-        return _collection_units(collections, enabled_ids, "smart")
+        return _collection_units(
+            collections, enabled_ids, "smart", own_user_id=own_user_id, filter_to_own=filter_to_own
+        )
 
     async def _build_franchise_collection_units(self, enabled_ids: set[str]) -> list[WorkUnit]:
         """Fetch franchise collections and emit work units for those whose id is in *enabled_ids*."""

--- a/py_modules/services/library/fetcher.py
+++ b/py_modules/services/library/fetcher.py
@@ -308,7 +308,7 @@ class LibraryFetcher:
 
     async def set_all_collections_sync(self, enabled, scope=None):
         enabled = bool(enabled)
-        if scope not in (None, "my", "smart", "franchise"):
+        if scope not in (None, "user", "smart", "franchise"):
             return {"success": False, "reason": "invalid_scope", "message": f"Invalid scope: {scope}"}
 
         buckets = self._get_enabled_collections_buckets()
@@ -326,7 +326,7 @@ class LibraryFetcher:
         self, *, buckets: dict[str, dict[str, bool]], enabled: bool, scope: str | None
     ) -> dict[str, Any] | None:
         """Fetch user collections and stamp the ``user`` bucket. Returns failure dict or None."""
-        if scope not in (None, "my"):
+        if scope not in (None, "user"):
             return None
         try:
             user_collections = await self._loop.run_in_executor(None, self._romm_api.list_collections)
@@ -335,7 +335,7 @@ class LibraryFetcher:
             _reason, _msg = classify_error(e)
             return {"success": False, "reason": _reason, "message": _msg}
         for c in user_collections:
-            if scope == "my" and bool(c.get("is_favorite", False)):
+            if scope == "user" and bool(c.get("is_favorite", False)):
                 continue
             buckets["user"][str(c["id"])] = enabled
         return None

--- a/py_modules/services/settings.py
+++ b/py_modules/services/settings.py
@@ -106,6 +106,7 @@ class SettingsService:
             "log_level": self._settings.get("log_level", "warn"),
             "romm_allow_insecure_ssl": self._settings.get("romm_allow_insecure_ssl", False),
             "collection_create_platform_groups": self._settings.get("collection_create_platform_groups", False),
+            "collection_owner_scope": self._settings.get("collection_owner_scope", "all"),
             "preferred_region": self._settings.get("preferred_region", AUTO_REGION),
         }
 
@@ -239,6 +240,21 @@ class SettingsService:
     def save_collection_platform_groups(self, enabled: bool) -> dict[str, Any]:
         """Persist the collection platform-group toggle."""
         self._settings["collection_create_platform_groups"] = bool(enabled)
+        self._settings_persister.save_settings()
+        return {"success": True}
+
+    def set_collection_owner_scope(self, scope: object) -> dict[str, Any]:
+        """Validate and persist the QAM collection owner-scope (``"own"`` / ``"all"``).
+
+        ``"all"`` (the default) syncs every collection the server lists;
+        ``"own"`` restricts the sync + display to the signed-in user's own
+        collections (franchise/virtual collections have no owner and always
+        sync). An unrecognised value from the untrusted frontend wire is rejected
+        with the canonical failure shape so a bad call cannot corrupt the setting.
+        """
+        if scope not in ("own", "all"):
+            return {"success": False, "reason": "invalid_scope", "message": f"Invalid owner scope: {scope}"}
+        self._settings["collection_owner_scope"] = scope
         self._settings_persister.save_settings()
         return {"success": True}
 

--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -9,6 +9,7 @@ import type {
   PlatformSyncSetting,
   CollectionSyncSetting,
   CollectionKind,
+  CollectionOwnerScope,
   RegistryPlatform,
   FirmwareStatus,
   FirmwareDownloadResult,
@@ -167,6 +168,12 @@ export const setAllCollectionsSync = callable<
 export const saveCollectionPlatformGroups = callable<[boolean], { success: boolean }>(
   "save_collection_platform_groups",
 );
+// Owner-scope for the Collections tab (#1532). "all" (default) or "own" (only
+// the signed-in user's own collections). Read via getSettings().collection_owner_scope.
+export const setCollectionOwnerScope = callable<
+  [CollectionOwnerScope],
+  { success: boolean; reason?: string; message?: string }
+>("set_collection_owner_scope");
 export const getRegistryPlatforms = callable<[], { platforms: RegistryPlatform[] }>("get_registry_platforms");
 export const removePlatformShortcuts = callable<
   [string],

--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -161,7 +161,7 @@ export const saveCollectionSync = callable<[string, CollectionKind, boolean], { 
   "save_collection_sync",
 );
 export const setAllCollectionsSync = callable<
-  [boolean, "my" | "smart" | "franchise" | null],
+  [boolean, "user" | "smart" | "franchise" | null],
   { success: boolean; message?: string }
 >("set_all_collections_sync");
 export const saveCollectionPlatformGroups = callable<[boolean], { success: boolean }>(

--- a/src/components/LibraryPage.test.tsx
+++ b/src/components/LibraryPage.test.tsx
@@ -504,7 +504,7 @@ describe("LibraryPage", () => {
         await Promise.resolve();
         await Promise.resolve();
       });
-      // Find the collection toggle by label (default sub-tab "my" → user collection visible).
+      // Find the collection toggle by label (default sub-tab "user" → user collection visible).
       const collectionToggle = container.querySelector<HTMLInputElement>('[data-label="MyColl"] input')!;
       expect(collectionToggle.checked).toBe(false);
       await act(async () => {
@@ -575,7 +575,7 @@ describe("LibraryPage", () => {
   // G. Collections tab — Enable/Disable All + platform-groups toggle
   // ------------------------------------------------------------------
   describe("collections tab — set-all + platform groups", () => {
-    it("calls setAllCollectionsSync(true, 'my') on Enable All in default My sub-tab", async () => {
+    it("calls setAllCollectionsSync(true, 'user') on Enable All in default My sub-tab", async () => {
       vi.mocked(backend.getCollections).mockResolvedValue({
         success: true,
         collections: [makeCollection({ id: "c1", kind: "user", is_favorite: false, sync_enabled: false })],
@@ -591,7 +591,7 @@ describe("LibraryPage", () => {
         fireEvent.click(getByText("Enable All"));
         await Promise.resolve();
       });
-      expect(vi.mocked(backend.setAllCollectionsSync)).toHaveBeenCalledWith(true, "my");
+      expect(vi.mocked(backend.setAllCollectionsSync)).toHaveBeenCalledWith(true, "user");
     });
 
     it("calls setAllCollectionsSync(true, 'smart') when Smart sub-tab is active", async () => {

--- a/src/components/LibraryPage.test.tsx
+++ b/src/components/LibraryPage.test.tsx
@@ -155,6 +155,7 @@ describe("LibraryPage", () => {
     vi.mocked(backend.saveCollectionPlatformGroups).mockResolvedValue({
       success: true,
     });
+    vi.mocked(backend.setCollectionOwnerScope).mockResolvedValue({ success: true });
     vi.mocked(backend.getSettings).mockResolvedValue(defaultSettings());
   });
 
@@ -1036,6 +1037,86 @@ describe("LibraryPage", () => {
       } finally {
         warn.mockRestore();
       }
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // N. Collections tab — owner scope (Own / All) — #1532
+  // ------------------------------------------------------------------
+  describe("collections tab — owner scope (Own / All)", () => {
+    const ownAndForeign = (): CollectionSyncSetting[] => [
+      makeCollection({ id: "u1", name: "MineColl", kind: "user", is_favorite: false, is_own: true }),
+      makeCollection({ id: "u2", name: "TheirColl", kind: "user", is_favorite: false, is_own: false }),
+    ];
+
+    const openCollections = async (getByText: (t: string) => HTMLElement) => {
+      await flushAsync();
+      await act(async () => {
+        fireEvent.click(getByText("Collections"));
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+    };
+
+    it("renders the Own / All control on the Collections tab", async () => {
+      vi.mocked(backend.getCollections).mockResolvedValue({ success: true, collections: ownAndForeign() });
+      const { getByText } = render(<LibraryPage onBack={vi.fn()} />);
+      await openCollections(getByText);
+      expect(getByText("Own")).not.toBeNull();
+      expect(getByText("All")).not.toBeNull();
+    });
+
+    it("clicking Own calls setCollectionOwnerScope('own')", async () => {
+      vi.mocked(backend.getCollections).mockResolvedValue({ success: true, collections: ownAndForeign() });
+      const { getByText } = render(<LibraryPage onBack={vi.fn()} />);
+      await openCollections(getByText);
+      await act(async () => {
+        fireEvent.click(getByText("Own"));
+        await Promise.resolve();
+      });
+      expect(vi.mocked(backend.setCollectionOwnerScope)).toHaveBeenCalledWith("own");
+    });
+
+    it("Own hides foreign (is_own=false) collections from the list", async () => {
+      vi.mocked(backend.getCollections).mockResolvedValue({ success: true, collections: ownAndForeign() });
+      const { getByText, container } = render(<LibraryPage onBack={vi.fn()} />);
+      await openCollections(getByText);
+      // Default "All" → both visible.
+      expect(container.querySelector('[data-label="MineColl"]')).not.toBeNull();
+      expect(container.querySelector('[data-label="TheirColl"]')).not.toBeNull();
+      // Switch to Own → the foreign collection is hidden.
+      await act(async () => {
+        fireEvent.click(getByText("Own"));
+        await Promise.resolve();
+      });
+      expect(container.querySelector('[data-label="MineColl"]')).not.toBeNull();
+      expect(container.querySelector('[data-label="TheirColl"]')).toBeNull();
+    });
+
+    it("initializes the scope from getSettings().collection_owner_scope", async () => {
+      vi.mocked(backend.getSettings).mockResolvedValue({ ...defaultSettings(), collection_owner_scope: "own" });
+      vi.mocked(backend.getCollections).mockResolvedValue({ success: true, collections: ownAndForeign() });
+      const { getByText, container } = render(<LibraryPage onBack={vi.fn()} />);
+      await openCollections(getByText);
+      // Loaded as Own → the foreign collection is hidden from the start.
+      expect(container.querySelector('[data-label="MineColl"]')).not.toBeNull();
+      expect(container.querySelector('[data-label="TheirColl"]')).toBeNull();
+    });
+
+    it("rolls the scope back (foreign reappears) when setCollectionOwnerScope rejects", async () => {
+      vi.mocked(backend.getCollections).mockResolvedValue({ success: true, collections: ownAndForeign() });
+      vi.mocked(backend.setCollectionOwnerScope).mockRejectedValue(new Error("net"));
+      const { getByText, container } = render(<LibraryPage onBack={vi.fn()} />);
+      await openCollections(getByText);
+      await act(async () => {
+        fireEvent.click(getByText("Own"));
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      // The rejected write proves the click fired; the catch rolls ownerScope
+      // back to "all", so the foreign collection is visible again.
+      expect(vi.mocked(backend.setCollectionOwnerScope)).toHaveBeenCalledWith("own");
+      expect(container.querySelector('[data-label="TheirColl"]')).not.toBeNull();
     });
   });
 

--- a/src/components/LibraryPage.tsx
+++ b/src/components/LibraryPage.tsx
@@ -8,9 +8,16 @@ import {
   saveCollectionSync,
   setAllCollectionsSync,
   saveCollectionPlatformGroups,
+  setCollectionOwnerScope,
   getSettings,
 } from "../api/backend";
-import type { PlatformSyncSetting, CollectionSyncSetting, CollectionKind, CollectionScope } from "../types";
+import type {
+  PlatformSyncSetting,
+  CollectionSyncSetting,
+  CollectionKind,
+  CollectionScope,
+  CollectionOwnerScope,
+} from "../types";
 import { scrollToTop } from "../utils/scrollHelpers";
 import { detach } from "../utils/detach";
 import { LoadingRow } from "./LoadingRow";
@@ -51,6 +58,19 @@ function filterCollectionsBySubTab(
   }
 }
 
+// Owner-scope filter (#1532): under "Own", hide collections owned by another
+// user so foreign ones can't be toggled on while the scope excludes them from
+// the sync. An absent `is_own` (older backend, or unknown own identity) is
+// treated as own, so "Own" never hides a collection it can't classify —
+// matching the backend's degrade-to-"All" fallback.
+function filterCollectionsByOwnerScope(
+  collections: CollectionSyncSetting[],
+  ownerScope: CollectionOwnerScope,
+): CollectionSyncSetting[] {
+  if (ownerScope === "all") return collections;
+  return collections.filter((c) => c.is_own !== false);
+}
+
 function favoritesDescription(romCount: number): string {
   if (romCount === 1) return "Includes 1 favorited ROM";
   return `Includes ${romCount} favorited ROMs`;
@@ -74,6 +94,7 @@ export const LibraryPage: FC<LibraryPageProps> = ({ onBack }) => {
   const [collectionsError, setCollectionsError] = useState(false);
   const collectionsLoaded = useRef(false);
   const [platformGroups, setPlatformGroups] = useState(false);
+  const [ownerScope, setOwnerScope] = useState<CollectionOwnerScope>("all");
   const [activeSubTab, setActiveSubTab] = useState<CollectionSubTab>("user");
 
   // The favorites collection (a user collection with is_favorite=true) is
@@ -121,6 +142,7 @@ export const LibraryPage: FC<LibraryPageProps> = ({ onBack }) => {
             setCollectionsError(true);
           }
           setPlatformGroups(!!settingsResult.collection_create_platform_groups);
+          setOwnerScope(settingsResult.collection_owner_scope === "own" ? "own" : "all");
         })
         .catch(() => setCollectionsError(true))
         .finally(() => setCollectionsLoading(false));
@@ -176,6 +198,17 @@ export const LibraryPage: FC<LibraryPageProps> = ({ onBack }) => {
       await setAllCollectionsSync(enabled, scope);
     } catch {
       setCollections(previous);
+    }
+  };
+
+  const handleOwnerScopeChange = async (scope: CollectionOwnerScope) => {
+    if (scope === ownerScope) return;
+    const previous = ownerScope;
+    setOwnerScope(scope);
+    try {
+      await setCollectionOwnerScope(scope);
+    } catch {
+      setOwnerScope(previous);
     }
   };
 
@@ -265,7 +298,10 @@ export const LibraryPage: FC<LibraryPageProps> = ({ onBack }) => {
     // When the favorites toggle isn't rendered (zero or multi-favorites case),
     // include any favorites in the "My" sub-tab so they stay reachable.
     const includeFavoritesInMy = favoritesCollection === null;
-    const visible = filterCollectionsBySubTab(collections, activeSubTab, includeFavoritesInMy);
+    const kindFiltered = filterCollectionsBySubTab(collections, activeSubTab, includeFavoritesInMy);
+    // Owner-scope filter runs OVER the kind sub-tab filter — under "Own" a
+    // foreign collection is hidden from every kind tab (#1532).
+    const visible = filterCollectionsByOwnerScope(kindFiltered, ownerScope);
     const activeLabel = SUB_TAB_LABELS[activeSubTab];
     const sectionTitle = `${SUB_TAB_HEADERS[activeSubTab]} (${visible.length})`;
 
@@ -303,6 +339,39 @@ export const LibraryPage: FC<LibraryPageProps> = ({ onBack }) => {
               />
             </PanelSectionRow>
           )}
+        </PanelSection>
+        <PanelSection>
+          <PanelSectionRow>
+            <Field
+              label="Show collections"
+              description={
+                ownerScope === "own"
+                  ? "Only your own collections (franchise collections always sync)."
+                  : "Every collection on the server, including other users' public ones."
+              }
+            />
+          </PanelSectionRow>
+          <PanelSectionRow>
+            <Focusable flow-children="horizontal" style={{ display: "flex", gap: "8px" }}>
+              {(["all", "own"] as CollectionOwnerScope[]).map((scope) => (
+                <DialogButton
+                  key={scope}
+                  style={{
+                    flex: 1,
+                    minWidth: 0,
+                    padding: "8px 0",
+                    opacity: ownerScope === scope ? 1 : 0.5,
+                    borderBottom: ownerScope === scope ? "2px solid #1a9fff" : "2px solid transparent",
+                  }}
+                  onClick={() => {
+                    detach(handleOwnerScopeChange(scope));
+                  }}
+                >
+                  {scope === "own" ? "Own" : "All"}
+                </DialogButton>
+              ))}
+            </Focusable>
+          </PanelSectionRow>
         </PanelSection>
         <Focusable flow-children="horizontal" style={{ display: "flex", gap: "4px", padding: "0 16px 12px" }}>
           {SUB_TAB_ORDER.map((sub) => (

--- a/src/components/LibraryPage.tsx
+++ b/src/components/LibraryPage.tsx
@@ -15,18 +15,18 @@ import { scrollToTop } from "../utils/scrollHelpers";
 import { detach } from "../utils/detach";
 import { LoadingRow } from "./LoadingRow";
 
-type CollectionSubTab = "my" | "smart" | "franchise";
+type CollectionSubTab = "user" | "smart" | "franchise";
 
-const SUB_TAB_ORDER: readonly CollectionSubTab[] = ["my", "smart", "franchise"];
+const SUB_TAB_ORDER: readonly CollectionSubTab[] = ["user", "smart", "franchise"];
 
 const SUB_TAB_LABELS: Record<CollectionSubTab, string> = {
-  my: "My",
+  user: "My",
   smart: "Smart",
   franchise: "Franchise",
 };
 
 const SUB_TAB_HEADERS: Record<CollectionSubTab, string> = {
-  my: "MY COLLECTIONS",
+  user: "MY COLLECTIONS",
   smart: "SMART COLLECTIONS",
   franchise: "FRANCHISE",
 };
@@ -42,7 +42,7 @@ function filterCollectionsBySubTab(
   includeFavoritesInMy = false,
 ): CollectionSyncSetting[] {
   switch (subTab) {
-    case "my":
+    case "user":
       return collections.filter((c) => c.kind === "user" && (includeFavoritesInMy || !c.is_favorite));
     case "smart":
       return collections.filter((c) => c.kind === "smart");
@@ -74,7 +74,7 @@ export const LibraryPage: FC<LibraryPageProps> = ({ onBack }) => {
   const [collectionsError, setCollectionsError] = useState(false);
   const collectionsLoaded = useRef(false);
   const [platformGroups, setPlatformGroups] = useState(false);
-  const [activeSubTab, setActiveSubTab] = useState<CollectionSubTab>("my");
+  const [activeSubTab, setActiveSubTab] = useState<CollectionSubTab>("user");
 
   // The favorites collection (a user collection with is_favorite=true) is
   // promoted to a top-level toggle. RomM's schema theoretically allows more
@@ -108,7 +108,7 @@ export const LibraryPage: FC<LibraryPageProps> = ({ onBack }) => {
   }, []);
 
   // Load collections data lazily on first switch to collections tab.
-  // Sub-tab is reset to "my" in the tab-click handler (not here);
+  // Sub-tab is reset to "user" in the tab-click handler (not here);
   // that's an event-driven concern, not state synchronisation.
   useEffect(() => {
     if (activeTab === "collections" && !collectionsLoaded.current) {
@@ -130,7 +130,7 @@ export const LibraryPage: FC<LibraryPageProps> = ({ onBack }) => {
   // Reset the collections sub-tab on every entry into the Collections tab
   // so the user lands on a predictable view (no persistence).
   const handleCollectionsTabClick = () => {
-    setActiveSubTab("my");
+    setActiveSubTab("user");
     setActiveTab("collections");
   };
 

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -63,6 +63,10 @@ export interface PluginSettings {
   romm_allow_insecure_ssl: boolean;
   retroarch_input_check?: RetroArchInputCheck;
   collection_create_platform_groups?: boolean;
+  // QAM collection owner-scope (#1532): "all" (default) or "own" (only the
+  // signed-in user's own collections). Optional: older payloads may omit it,
+  // treated as "all". Mirrors the CollectionOwnerScope type in sync.ts.
+  collection_owner_scope?: "own" | "all";
   // Preferred sibling-group region (ADR-0021 §3). "auto" = the fixed build-time
   // default order (World > USA > Europe > Japan); any other value heads the
   // ranking with that region on the next sync. Optional: the backend always

--- a/src/types/sync.ts
+++ b/src/types/sync.ts
@@ -23,6 +23,13 @@ export type CollectionKind = "user" | "smart" | "franchise";
 
 export type CollectionScope = "user" | "smart" | "franchise";
 
+/**
+ * QAM collection owner-scope. `"all"` (default) syncs every collection the
+ * server lists; `"own"` restricts sync + display to the signed-in user's own
+ * collections. Independent of the kind sub-tab — it filters by owner, not kind.
+ */
+export type CollectionOwnerScope = "own" | "all";
+
 export interface CollectionSyncSetting {
   id: string;
   name: string;
@@ -30,6 +37,13 @@ export interface CollectionSyncSetting {
   sync_enabled: boolean;
   kind: CollectionKind;
   is_favorite: boolean;
+  /**
+   * Whether this collection is the signed-in user's own (#1532). Franchise
+   * collections have no owner and are always `true`; when the plugin does not
+   * yet know its own identity every collection is `true` (so the "Own" filter
+   * degrades to "All"). Absent on older backends — treat absent as `true`.
+   */
+  is_own?: boolean;
 }
 
 export type SyncStage = "discovering" | "fetching" | "applying" | "finalizing" | "done" | "cancelled" | "error";

--- a/src/types/sync.ts
+++ b/src/types/sync.ts
@@ -21,7 +21,7 @@ export interface PlatformSyncSetting {
 
 export type CollectionKind = "user" | "smart" | "franchise";
 
-export type CollectionScope = "my" | "smart" | "franchise";
+export type CollectionScope = "user" | "smart" | "franchise";
 
 export interface CollectionSyncSetting {
   id: string;

--- a/tests/adapters/test_persistence.py
+++ b/tests/adapters/test_persistence.py
@@ -101,6 +101,12 @@ class TestSettingsSchema:
     def test_default_settings_carry_empty_platform_cores(self):
         assert DEFAULT_SETTINGS["platform_cores"] == {}
 
+    def test_default_settings_carry_owner_scope_defaults(self):
+        # Identity unknown and scope "all" by default → the "Own" filter is inert
+        # on a fresh install, matching today's behaviour (#1532).
+        assert DEFAULT_SETTINGS["romm_user_id"] is None
+        assert DEFAULT_SETTINGS["collection_owner_scope"] == "all"
+
     def test_mutable_default_is_not_aliased_to_template(self, adapter):
         """A missing key is backfilled with a COPY of its mutable default.
 

--- a/tests/contract/test_sync_read.py
+++ b/tests/contract/test_sync_read.py
@@ -203,6 +203,31 @@ async def test_get_collections_happy_shape(harness):
     assert c["name"] == "Favorites"
     assert c["kind"] == "user"
     assert isinstance(c["sync_enabled"], bool)
+    # Owner-scope tag (#1532): no stored identity → treated as own (degrade to "All").
+    assert c["is_own"] is True
+
+
+async def test_set_collection_owner_scope_persists(harness):
+    """set_collection_owner_scope stores the value and get_settings reports it back."""
+    result = await harness.plugin.set_collection_owner_scope("own")
+    assert result == {"success": True}
+    assert harness.plugin.settings["collection_owner_scope"] == "own"
+    assert (await harness.plugin.get_settings())["collection_owner_scope"] == "own"
+
+    result = await harness.plugin.set_collection_owner_scope("all")
+    assert result == {"success": True}
+    assert harness.plugin.settings["collection_owner_scope"] == "all"
+
+
+async def test_set_collection_owner_scope_rejects_invalid(harness):
+    """An unrecognised scope returns the canonical failure shape and stores nothing."""
+    result = await harness.plugin.set_collection_owner_scope("everyone")
+    assert result["success"] is False
+    assert isinstance(result["reason"], str)
+    assert isinstance(result["message"], str) and result["message"]
+    assert "error" not in result
+    assert "error_code" not in result
+    assert harness.plugin.settings.get("collection_owner_scope", "all") == "all"
 
 
 async def test_get_collections_server_failure_shape(harness):

--- a/tests/domain/test_collection_owner.py
+++ b/tests/domain/test_collection_owner.py
@@ -1,0 +1,49 @@
+"""Tests for domain.collection_owner.is_own_collection."""
+
+from __future__ import annotations
+
+import pytest
+
+from domain.collection_owner import is_own_collection
+
+
+class TestFranchiseAlwaysOwn:
+    """Franchise/virtual collections have no owner and always survive an "Own" filter."""
+
+    def test_franchise_is_own_even_with_foreign_id(self):
+        # A franchise collection carries no user_id; even a mismatched value is ignored.
+        assert is_own_collection(999, own_user_id=1, kind="franchise") is True
+
+    def test_franchise_is_own_when_identity_unknown(self):
+        assert is_own_collection(None, own_user_id=None, kind="franchise") is True
+
+    def test_franchise_is_own_with_no_owner_field(self):
+        assert is_own_collection(None, own_user_id=1, kind="franchise") is True
+
+
+class TestUnknownIdentityDegradesToAll:
+    """Unknown own identity → every collection is own (the non-breaking fallback)."""
+
+    @pytest.mark.parametrize("kind", ["user", "smart"])
+    def test_own_when_identity_unknown(self, kind):
+        assert is_own_collection(42, own_user_id=None, kind=kind) is True
+
+    def test_own_when_identity_unknown_and_owner_missing(self):
+        assert is_own_collection(None, own_user_id=None, kind="user") is True
+
+
+class TestKnownIdentityOwnership:
+    """With a known own id, user/smart collections split on the owner id."""
+
+    @pytest.mark.parametrize("kind", ["user", "smart"])
+    def test_own_when_ids_match(self, kind):
+        assert is_own_collection(7, own_user_id=7, kind=kind) is True
+
+    @pytest.mark.parametrize("kind", ["user", "smart"])
+    def test_foreign_when_ids_differ(self, kind):
+        assert is_own_collection(8, own_user_id=7, kind=kind) is False
+
+    def test_foreign_when_owner_id_missing_but_identity_known(self):
+        # A user/smart collection with no user_id and a known own id can't be
+        # confirmed as ours — treated as foreign (RomM always sends user_id here).
+        assert is_own_collection(None, own_user_id=7, kind="user") is False

--- a/tests/services/library/test_fetcher.py
+++ b/tests/services/library/test_fetcher.py
@@ -288,6 +288,86 @@ class TestBuildWorkQueueErrorPaths:
         assert kinds == ["user", "smart", "franchise"]
 
 
+class TestBuildWorkQueueOwnerScope:
+    """build_work_queue applies the collection owner-scope filter (#1532)."""
+
+    @staticmethod
+    def _seed(fake_romm_api):
+        """Two user, two smart (one own / one foreign each), one franchise — all enabled."""
+        fake_romm_api.collections = [
+            {"id": "1", "name": "Mine", "slug": "mine", "rom_count": 1, "user_id": 7},
+            {"id": "2", "name": "Theirs", "slug": "theirs", "rom_count": 1, "user_id": 8},
+        ]
+        fake_romm_api.smart_collections = [
+            {"id": "5", "name": "MySmart", "slug": "ms", "rom_count": 1, "user_id": 7},
+            {"id": "6", "name": "TheirSmart", "slug": "ts", "rom_count": 1, "user_id": 8},
+        ]
+        fake_romm_api.virtual_collections = {
+            "franchise": [{"id": "100", "name": "Mario", "slug": "mario", "rom_count": 1}],
+        }
+
+    @staticmethod
+    def _enable_all(plugin):
+        plugin.settings["enabled_platforms"] = {}
+        plugin.settings["enabled_collections"] = {
+            "user": {"1": True, "2": True},
+            "smart": {"5": True, "6": True},
+            "franchise": {"100": True},
+        }
+
+    @pytest.mark.asyncio
+    async def test_own_scope_drops_foreign_keeps_own_and_franchise(self, plugin, fake_romm_api):
+        """AC2: a foreign user + foreign smart collection are excluded; own + ALL franchise survive."""
+        _wire_fake(plugin, fake_romm_api)
+        self._enable_all(plugin)
+        self._seed(fake_romm_api)
+        plugin.settings["romm_user_id"] = 7
+        plugin.settings["collection_owner_scope"] = "own"
+
+        units = await plugin._sync_service._fetcher.build_work_queue()
+
+        assert [u.name for u in units] == ["Mine", "MySmart", "Mario"]
+
+    @pytest.mark.asyncio
+    async def test_all_scope_keeps_every_collection(self, plugin, fake_romm_api):
+        """AC3: the default "all" scope syncs every collection — today's behaviour, byte-for-byte."""
+        _wire_fake(plugin, fake_romm_api)
+        self._enable_all(plugin)
+        self._seed(fake_romm_api)
+        plugin.settings["romm_user_id"] = 7
+        plugin.settings["collection_owner_scope"] = "all"
+
+        units = await plugin._sync_service._fetcher.build_work_queue()
+
+        assert [u.name for u in units] == ["Mine", "Theirs", "MySmart", "TheirSmart", "Mario"]
+
+    @pytest.mark.asyncio
+    async def test_own_scope_unknown_identity_keeps_every_collection(self, plugin, fake_romm_api):
+        """AC4 (load-bearing): "own" with no known identity must NOT filter — degrade to "All"."""
+        _wire_fake(plugin, fake_romm_api)
+        self._enable_all(plugin)
+        self._seed(fake_romm_api)
+        plugin.settings.pop("romm_user_id", None)
+        plugin.settings["collection_owner_scope"] = "own"
+
+        units = await plugin._sync_service._fetcher.build_work_queue()
+
+        assert [u.name for u in units] == ["Mine", "Theirs", "MySmart", "TheirSmart", "Mario"]
+
+    @pytest.mark.asyncio
+    async def test_own_scope_is_default_all_when_setting_absent(self, plugin, fake_romm_api):
+        """No collection_owner_scope setting → treated as "all" (no filtering)."""
+        _wire_fake(plugin, fake_romm_api)
+        self._enable_all(plugin)
+        self._seed(fake_romm_api)
+        plugin.settings["romm_user_id"] = 7
+        plugin.settings.pop("collection_owner_scope", None)
+
+        units = await plugin._sync_service._fetcher.build_work_queue()
+
+        assert [u.name for u in units] == ["Mine", "Theirs", "MySmart", "TheirSmart", "Mario"]
+
+
 class TestTryUnitIncrementalSkip:
     """Tests for _try_unit_incremental_skip() exception fallback."""
 

--- a/tests/services/library/test_service.py
+++ b/tests/services/library/test_service.py
@@ -440,6 +440,63 @@ class TestGetCollections:
         assert result["collections"][0]["id"] == "42"
 
 
+class TestGetCollectionsOwnerScope:
+    """get_collections tags each collection with is_own for the owner-scope filter (#1532)."""
+
+    @pytest.mark.asyncio
+    async def test_own_and_foreign_user_collections_tagged(self, plugin):
+        """With a known identity, user collections split on user_id."""
+        user = [
+            {"id": 1, "name": "Mine", "rom_count": 1, "is_favorite": False, "user_id": 7},
+            {"id": 2, "name": "Theirs", "rom_count": 1, "is_favorite": False, "user_id": 8},
+        ]
+        rebind_loop(plugin._sync_service, _make_loop_with_executor(user, [], []))
+        plugin._sync_service._settings["romm_user_id"] = 7
+
+        result = await plugin._sync_service.get_collections()
+
+        by_name = {c["name"]: c for c in result["collections"]}
+        assert by_name["Mine"]["is_own"] is True
+        assert by_name["Theirs"]["is_own"] is False
+
+    @pytest.mark.asyncio
+    async def test_smart_collections_tagged_by_owner(self, plugin):
+        smart = [
+            {"id": 5, "name": "MySmart", "rom_count": 1, "user_id": 7},
+            {"id": 6, "name": "TheirSmart", "rom_count": 1, "user_id": 8},
+        ]
+        rebind_loop(plugin._sync_service, _make_loop_with_executor([], smart, []))
+        plugin._sync_service._settings["romm_user_id"] = 7
+
+        result = await plugin._sync_service.get_collections()
+
+        by_name = {c["name"]: c for c in result["collections"]}
+        assert by_name["MySmart"]["is_own"] is True
+        assert by_name["TheirSmart"]["is_own"] is False
+
+    @pytest.mark.asyncio
+    async def test_franchise_always_own_even_with_known_identity(self, plugin):
+        """Franchise collections have no owner — always is_own=True."""
+        franchise = [{"id": 101, "name": "Mario", "rom_count": 1}]
+        rebind_loop(plugin._sync_service, _make_loop_with_executor([], [], franchise))
+        plugin._sync_service._settings["romm_user_id"] = 7
+
+        result = await plugin._sync_service.get_collections()
+
+        assert result["collections"][0]["is_own"] is True
+
+    @pytest.mark.asyncio
+    async def test_unknown_identity_tags_every_collection_own(self, plugin):
+        """No stored romm_user_id → all collections is_own=True (degrade to "All")."""
+        user = [{"id": 2, "name": "Theirs", "rom_count": 1, "is_favorite": False, "user_id": 8}]
+        rebind_loop(plugin._sync_service, _make_loop_with_executor(user, [], []))
+        plugin._sync_service._settings.pop("romm_user_id", None)
+
+        result = await plugin._sync_service.get_collections()
+
+        assert result["collections"][0]["is_own"] is True
+
+
 # ---------------------------------------------------------------------------
 # TestSaveCollectionSync
 # ---------------------------------------------------------------------------

--- a/tests/services/library/test_service.py
+++ b/tests/services/library/test_service.py
@@ -609,15 +609,15 @@ class TestSetAllCollectionsSync:
         assert ec["franchise"] == {}
 
     @pytest.mark.asyncio
-    async def test_filter_by_my_scope(self, plugin):
-        """Passing scope='my' only touches non-favorite user collections."""
+    async def test_filter_by_user_scope(self, plugin):
+        """Passing scope='user' only touches non-favorite user collections."""
         user = [
             {"id": 1, "name": "RPGs", "is_favorite": False},
             {"id": 2, "name": "Faves", "is_favorite": True},
         ]
         rebind_loop(plugin._sync_service, _make_loop_with_executor(user))
 
-        result = await plugin._sync_service.set_all_collections_sync(True, scope="my")
+        result = await plugin._sync_service.set_all_collections_sync(True, scope="user")
 
         assert result["success"] is True
         ec = plugin._sync_service._settings["enabled_collections"]

--- a/tests/services/test_connection.py
+++ b/tests/services/test_connection.py
@@ -1608,3 +1608,249 @@ class TestSignOut:
         assert settings["romm_api_token_source"] == "minted"
         # The version cache is cleared only after a successful save.
         romm_api.set_version.assert_not_called()
+
+
+class TestUserIdentityStamping:
+    """romm_user_id lifecycle: stamped at sign-in, backfilled lazily, cleared on sign-out.
+
+    The signed-in user's own id drives the collection owner-scope filter (#1532).
+    It is bound to the token — re-derived on every sign-in, restored on a failed
+    one, and forgotten on sign-out — so "Own" is never computed against a stale
+    server's or a different user's identity, and degrades to "All" when unknown.
+    """
+
+    # ── Fresh sign-in stamps identity (AC1) ──────────────────────────────────
+
+    def test_mint_sign_in_stamps_user_id(self, event_loop, romm_api, logger, settings_persister):
+        romm_api.get_current_user.return_value = {"id": 3, "username": "alice"}
+        settings: dict[str, Any] = {}
+        service = _make_service(
+            settings=settings,
+            romm_api=romm_api,
+            loop=event_loop,
+            logger=logger,
+            settings_persister=settings_persister,
+        )
+
+        result = event_loop.run_until_complete(service.establish_token("http://romm.local", "alice", "secret"))
+
+        assert result["success"] is True
+        assert settings["romm_user_id"] == 3
+        # The identity rides the SINGLE atomic token-persist save (#1015 shape held).
+        assert settings_persister.save_settings.call_count == 1
+
+    def test_mint_sign_in_identity_probe_failure_leaves_id_none_but_succeeds(
+        self, event_loop, romm_api, logger, settings_persister
+    ):
+        """A failed /api/users/me probe never fails the sign-in — id stays None (→ "Own" acts as "All")."""
+        romm_api.get_current_user.side_effect = RommConnectionError("offline")
+        settings: dict[str, Any] = {}
+        service = _make_service(
+            settings=settings,
+            romm_api=romm_api,
+            loop=event_loop,
+            logger=logger,
+            settings_persister=settings_persister,
+        )
+
+        result = event_loop.run_until_complete(service.establish_token("http://romm.local", "alice", "secret"))
+
+        assert result["success"] is True
+        assert settings["romm_user_id"] is None
+        assert settings_persister.save_settings.call_count == 1
+
+    def test_user_token_sign_in_stamps_user_id_from_validation_probe(
+        self, event_loop, romm_api, logger, settings_persister
+    ):
+        romm_api.get_current_user.return_value = {"id": 9, "username": "bob"}
+        settings: dict[str, Any] = {}
+        service = _make_service(
+            settings=settings,
+            romm_api=romm_api,
+            loop=event_loop,
+            logger=logger,
+            settings_persister=settings_persister,
+        )
+
+        result = event_loop.run_until_complete(service.establish_user_token("http://romm.local", "rmm_pasted"))
+
+        assert result["success"] is True
+        assert settings["romm_user_id"] == 9
+        # No SECOND /api/users/me call — the validation probe's result is reused.
+        romm_api.get_current_user.assert_called_once_with()
+        assert settings_persister.save_settings.call_count == 1
+
+    def test_paired_token_sign_in_stamps_user_id(self, event_loop, romm_api, logger, settings_persister):
+        romm_api.get_current_user.return_value = {"id": 11, "username": "carol"}
+        settings: dict[str, Any] = {}
+        service = _make_service(
+            settings=settings,
+            romm_api=romm_api,
+            loop=event_loop,
+            logger=logger,
+            settings_persister=settings_persister,
+        )
+
+        result = event_loop.run_until_complete(service.establish_paired_token("http://romm.local", "ABCD2345"))
+
+        assert result["success"] is True
+        assert settings["romm_user_id"] == 11
+        assert settings_persister.save_settings.call_count == 1
+
+    def test_malformed_identity_payload_leaves_id_none(self, event_loop, romm_api, logger):
+        """A payload with no int id (or a bool) never becomes a wrong owner id."""
+        romm_api.get_current_user.return_value = {"username": "no-id"}
+        settings: dict[str, Any] = {}
+        service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
+
+        event_loop.run_until_complete(service.establish_token("http://romm.local", "u", "p"))
+
+        assert settings["romm_user_id"] is None
+
+    # ── Origin change re-derives / clears identity (AC5) ─────────────────────
+
+    def test_origin_change_refetches_user_id_from_new_server(self, event_loop, romm_api, logger):
+        """Signing into a different server re-derives identity from THAT server."""
+        romm_api.get_current_user.return_value = {"id": 2, "username": "new-server-user"}
+        settings = _working_settings()
+        settings["romm_user_id"] = 1  # the old server's identity
+        service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
+
+        result = event_loop.run_until_complete(service.establish_token("https://new.server", "u", "p"))
+
+        assert result["success"] is True
+        assert settings["romm_user_id"] == 2
+
+    def test_origin_change_with_probe_failure_clears_stale_id(self, event_loop, romm_api, logger):
+        """On a server switch whose identity probe fails, the old id is cleared — never stale."""
+        romm_api.get_current_user.side_effect = RommConnectionError("offline")
+        settings = _working_settings()
+        settings["romm_user_id"] = 1
+        service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
+
+        result = event_loop.run_until_complete(service.establish_token("https://new.server", "u", "p"))
+
+        assert result["success"] is True
+        assert settings["romm_user_id"] is None
+
+    def test_same_origin_different_user_rederives_identity(self, event_loop, romm_api, logger):
+        """A DIFFERENT user signing in on the SAME server re-derives identity to THEM.
+
+        The shared-server scenario the token-binding design exists for: user A
+        signs out, user B signs in against the same origin. Here
+        ``is_origin_change`` is False (the ``forget_device`` seam never fires,
+        asserted below), so identity is bound to the TOKEN, not the origin — it
+        re-derives on every sign-in. An origin-GATED re-derivation
+        (``if is_origin_change(...)``) would leave A's id in place and pass every
+        other identity test; this asserts B's id after the same-origin re-sign-in,
+        so it fails the moment the re-derivation is wrongly origin-gated.
+        """
+        forget_device = MagicMock()
+        romm_api.get_current_user.side_effect = [
+            {"id": 101, "username": "user-a"},
+            {"id": 202, "username": "user-b"},
+        ]
+        settings: dict[str, Any] = {}
+        service = _make_service(
+            settings=settings, romm_api=romm_api, loop=event_loop, logger=logger, forget_device=forget_device
+        )
+
+        # User A signs in on server X.
+        result_a = event_loop.run_until_complete(service.establish_token("http://server.x", "user-a", "pw"))
+        assert result_a["success"] is True
+        assert settings["romm_user_id"] == 101
+
+        # User B signs in on the SAME server X — same origin, no server switch.
+        result_b = event_loop.run_until_complete(service.establish_token("http://server.x", "user-b", "pw"))
+        assert result_b["success"] is True
+        # Identity re-derived to B — NOT left at A's 101 — even though the origin
+        # never changed (proven by the untouched device-forget seam).
+        assert settings["romm_user_id"] == 202
+        forget_device.assert_not_called()
+
+    def test_failed_sign_in_restores_previous_user_id(self, event_loop, romm_api, logger):
+        """A failed sign-in must not wipe the still-valid current identity."""
+        romm_api.mint_client_token.side_effect = RommConnectionError("offline")
+        settings = _working_settings()
+        settings["romm_user_id"] = 5
+        service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
+
+        result = event_loop.run_until_complete(service.establish_token("https://new.server", "u", "p"))
+
+        assert result["success"] is False
+        assert settings["romm_user_id"] == 5
+
+    # ── Sign-out forgets identity ────────────────────────────────────────────
+
+    def test_sign_out_clears_user_id(self, event_loop, romm_api, logger, settings_persister):
+        settings = _working_settings()
+        settings["romm_user_id"] = 5
+        service = _make_service(
+            settings=settings,
+            romm_api=romm_api,
+            loop=event_loop,
+            logger=logger,
+            settings_persister=settings_persister,
+        )
+
+        service.sign_out()
+
+        assert settings["romm_user_id"] is None
+        # Still exactly one atomic save — identity clears alongside the token quad.
+        settings_persister.save_settings.assert_called_once_with()
+
+    # ── Lazy backfill on a connection check (AC1) ────────────────────────────
+
+    def test_test_connection_backfills_missing_user_id(self, event_loop, romm_api, logger, settings_persister):
+        """An existing session with a token but no stored id backfills it — no re-login."""
+        romm_api.get_current_user.return_value = {"id": 4, "username": "existing"}
+        settings = {"romm_url": "http://romm.local", "romm_api_token": "rmm_token"}
+        service = _make_service(
+            settings=settings,
+            romm_api=romm_api,
+            loop=event_loop,
+            logger=logger,
+            settings_persister=settings_persister,
+        )
+
+        result = event_loop.run_until_complete(service.test_connection())
+
+        assert result["success"] is True
+        assert settings["romm_user_id"] == 4
+        settings_persister.save_settings.assert_called_once_with()
+
+    def test_test_connection_skips_backfill_when_user_id_known(self, event_loop, romm_api, logger, settings_persister):
+        """A known id needs no network and no save on every connection check."""
+        settings = {"romm_url": "http://romm.local", "romm_api_token": "rmm_token", "romm_user_id": 4}
+        service = _make_service(
+            settings=settings,
+            romm_api=romm_api,
+            loop=event_loop,
+            logger=logger,
+            settings_persister=settings_persister,
+        )
+
+        result = event_loop.run_until_complete(service.test_connection())
+
+        assert result["success"] is True
+        assert settings["romm_user_id"] == 4
+        romm_api.get_current_user.assert_not_called()
+        settings_persister.save_settings.assert_not_called()
+
+    def test_test_connection_backfill_failure_is_best_effort(self, event_loop, romm_api, logger, settings_persister):
+        """A backfill probe failure leaves the id unknown and never fails the connection check."""
+        romm_api.get_current_user.side_effect = RommConnectionError("offline")
+        settings = {"romm_url": "http://romm.local", "romm_api_token": "rmm_token"}
+        service = _make_service(
+            settings=settings,
+            romm_api=romm_api,
+            loop=event_loop,
+            logger=logger,
+            settings_persister=settings_persister,
+        )
+
+        result = event_loop.run_until_complete(service.test_connection())
+
+        assert result["success"] is True
+        assert settings.get("romm_user_id") is None
+        settings_persister.save_settings.assert_not_called()

--- a/tests/services/test_settings.py
+++ b/tests/services/test_settings.py
@@ -140,6 +140,7 @@ class TestGetSettings:
                 "log_level": "info",
                 "romm_allow_insecure_ssl": True,
                 "collection_create_platform_groups": True,
+                "collection_owner_scope": "own",
                 "preferred_region": "USA",
             }
         )
@@ -152,6 +153,7 @@ class TestGetSettings:
         assert result["log_level"] == "info"
         assert result["romm_allow_insecure_ssl"] is True
         assert result["collection_create_platform_groups"] is True
+        assert result["collection_owner_scope"] == "own"
         assert result["preferred_region"] == "USA"
         assert result["retroarch_input_check"] == {"warning": False}
 
@@ -200,6 +202,7 @@ class TestGetSettings:
         assert result["log_level"] == "warn"
         assert result["romm_allow_insecure_ssl"] is False
         assert result["collection_create_platform_groups"] is False
+        assert result["collection_owner_scope"] == "all"
         assert result["preferred_region"] == "auto"
 
     def test_includes_retroarch_input_check_payload(self, service, steam_config):
@@ -520,6 +523,29 @@ class TestSaveCollectionPlatformGroups:
     def test_coerces_falsy(self, service, settings):
         service.save_collection_platform_groups(0)  # type: ignore[arg-type]
         assert settings["collection_create_platform_groups"] is False
+
+
+class TestSetCollectionOwnerScope:
+    @pytest.mark.parametrize("scope", ["own", "all"])
+    def test_valid_scopes_persist(self, service, settings, settings_persister, scope):
+        result = service.set_collection_owner_scope(scope)
+        assert result == {"success": True}
+        assert settings["collection_owner_scope"] == scope
+        settings_persister.save_settings.assert_called_once_with()
+
+    def test_invalid_scope_rejected_with_canonical_failure(self, service, settings, settings_persister):
+        result = service.set_collection_owner_scope("everyone")
+        assert result["success"] is False
+        assert result["reason"] == "invalid_scope"
+        assert "Invalid owner scope" in result["message"]
+        assert "collection_owner_scope" not in settings
+        settings_persister.save_settings.assert_not_called()
+
+    def test_non_string_rejected(self, service, settings, settings_persister):
+        result = service.set_collection_owner_scope(None)  # type: ignore[arg-type]
+        assert result["success"] is False
+        assert "collection_owner_scope" not in settings
+        settings_persister.save_settings.assert_not_called()
 
 
 class TestDismissSettingsResetNotice:

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -727,6 +727,9 @@ _MIGRATION_BLOCKED_WHITELIST: set[str] = {
     "get_whitelist_settings",
     "update_whitelist_settings",
     "save_collection_platform_groups",
+    # Collection owner-scope (#1532) — a settings.json-only write, never touches
+    # RetroDECK state; takes effect on the next sync's work-queue build.
+    "set_collection_owner_scope",
     # Preferred sibling-group region — a settings.json-only write (ADR-0021 §3),
     # never touches RetroDECK state; takes effect on the next sync. Its companion
     # read (distinct regions in the local library) is a pure local DB read.

--- a/tests/test_plugin_callable_delegation.py
+++ b/tests/test_plugin_callable_delegation.py
@@ -331,8 +331,8 @@ class TestLibrarySyncCallableDelegation:
     @pytest.mark.asyncio
     async def test_set_all_collections_sync_delegates(self, plugin):
         plugin._sync_service.set_all_collections_sync = AsyncMock(return_value={"ok": True})
-        result = await plugin.set_all_collections_sync(True, "my")
-        plugin._sync_service.set_all_collections_sync.assert_awaited_once_with(True, "my")
+        result = await plugin.set_all_collections_sync(True, "user")
+        plugin._sync_service.set_all_collections_sync.assert_awaited_once_with(True, "user")
         assert result == {"ok": True}
 
     @pytest.mark.asyncio

--- a/tests/test_plugin_callable_delegation.py
+++ b/tests/test_plugin_callable_delegation.py
@@ -136,6 +136,13 @@ class TestSettingsCallableDelegation:
         assert result == {"ok": True}
 
     @pytest.mark.asyncio
+    async def test_set_collection_owner_scope_delegates(self, plugin):
+        plugin._settings_service.set_collection_owner_scope.return_value = {"success": True}
+        result = await plugin.set_collection_owner_scope("own")
+        plugin._settings_service.set_collection_owner_scope.assert_called_once_with("own")
+        assert result == {"success": True}
+
+    @pytest.mark.asyncio
     async def test_debug_log_routes_through_frontend_log(self, plugin):
         await plugin.debug_log("hello")
         plugin._settings_service.frontend_log.assert_called_once_with("debug", "hello")


### PR DESCRIPTION
RomM's collection list endpoints return the signed-in user's own collections plus every other user's *public* one, and the plugin synced all of them unfiltered. On a shared server a user may want only their own. This adds an optional QAM **Own / All** toggle in the collection settings.

**Default is `All`** — today's behaviour, unchanged byte-for-byte. `Own` filters other users' collections out of the sync entirely (a sync scope, not just a display filter — it never mutates your enabled toggles, so switching back to `All` restores them).

**Franchise/virtual collections always sync**, in both modes. Verified against the RomM 5.0.0 source: franchise/virtual collections have no owner at all (no `user_id`, global to every user) — they belong to nobody, so the filter, which hides *other people's* collections, correctly leaves them in.

**Not a breaking change — no re-login needed.** To know which collections are "yours", the plugin needs its own RomM user id, which it didn't track before. It's now read from `/api/users/me` and stored:
- stamped at sign-in (reusing the existing identity probe — no extra call),
- lazily backfilled for existing installs on the next connection check (so nobody has to sign in again),
- bound to the token: re-derived on every sign-in, so switching users on the same shared server updates it, and a failed sign-in restores the prior value,
- and when it's unknown (e.g. offline, never fetched), `Own` simply behaves like `All` — the feature no-ops safely rather than filtering wrongly.

Also renames the internal collection kind-scope `"my"` → `"user"` (first commit, behaviour-preserving, not persisted) so it doesn't collide with the new owner-scope `"own"`; the visible "My" label is unchanged.

Closes #1532
