### PR TITLE
feat(ui): make the collections QAM navigable and declutter its panel

### DIFF
--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -531,6 +531,15 @@ key while preserving every enabled id, so a previously-enabled franchise collect
 required. (The historical v2 → v3 split still produces the `franchise` bucket; the v10 → v11 step renames it afterwards,
 so that frozen step is untouched.)
 
+**Batch collection enable — `save_collections_sync` for a filtered subset (#1539).** The Collections tab adds a name
+search and (on Virtual) a per-type filter, and its **Enable All / Disable All** act on the current filter. When the view
+is a bounded subset (a search or per-type filter is active) the frontend calls `save_collections_sync` with the matched
+ids, the kind, and the enabled flag — a single settings write that stamps every id into the `kind` bucket, so the whole
+kind is never touched. An unknown kind or a non-list id argument is rejected with the canonical failure shape; an empty
+id list is a success no-op. The **unfiltered** whole-kind case still uses `set_all_collections_sync` (which re-fetches
+the kind from the server) so a large id list never crosses the WebSocket bridge; the frontend gates that whole-kind call
+behind a confirm. Both live on `LibraryFetcher`.
+
 **Collection owner-scope filter — "Own" is a sync scope, not just a display filter (#1532).** RomM's collection list
 endpoints return the signed-in user's own collections plus every other user's _public_ collection. The QAM
 `Show

--- a/docs/user-guide/syncing-your-library.md
+++ b/docs/user-guide/syncing-your-library.md
@@ -225,10 +225,19 @@ The **Collections** page splits collections into three sub-tabs plus a dedicated
 - **Virtual** sub-tab — auto-generated groupings RomM derives from IGDB metadata: both IGDB **franchise** groupings and
   IGDB **collection** (series) groupings. Each row is labelled with its type (Franchise / IGDB Collection).
 
-Each sub-tab shows its visible count in the section header (e.g. `MY COLLECTIONS (4)`) and lets you toggle individual
-collections, or use the paired **Enable All** / **Disable All** buttons to bulk-toggle just that sub-tab. The global
-**Show collection games in platform groups** toggle controls whether games pulled in via a collection also get added to
-their platform's Steam group.
+Each sub-tab shows its match count in the section header (e.g. `MY COLLECTIONS (4)`) and lets you toggle individual
+collections. A **search box** above the list filters the current sub-tab by name — most useful on **Virtual**, which can
+run to hundreds of entries. On the **Virtual** sub-tab a segmented **All / Franchise / IGDB Collection** control narrows
+the list to one virtual type. The list itself is capped for performance: when more collections match than fit, the first
+rows render and a `… more — refine your search` hint appears — type in the search box to bring the rest into view.
+
+The paired **Enable All** / **Disable All** buttons act on the **current filter**: with a search or the Virtual per-type
+filter active, they toggle exactly the matching collections; with no filter they toggle the whole sub-tab and ask for
+confirmation first, since that can be a large number.
+
+The **Show collection games in platform groups** setting — whether games pulled in via a collection also get added to
+their platform's Steam group — now lives on the **Settings** page under **Library**, alongside the preferred-region
+preference. It applies to every sync, so it sits with the other set-and-forget preferences rather than on this tab.
 
 #### Own / All
 
@@ -241,7 +250,7 @@ On a **shared RomM server** the collection list includes every other user's _pub
   sync, even if one was enabled earlier — switching back to **All** brings your earlier choices back, since the scope
   filters over your enable state rather than changing it.
 
-**Virtual collections always sync** under either setting: they are auto-generated groupings that belong to no one, so
+**Virtual collections always appear** under either setting: they are auto-generated groupings that have no owner, so
 "Own" never hides them. The filter only becomes active once the plugin knows your account identity, which it learns the
 first time you sign in (existing sign-ins pick it up on the next connection check). Until then, **Own** behaves exactly
 like **All** — it never hides a collection it can't yet attribute.

--- a/main.py
+++ b/main.py
@@ -333,6 +333,10 @@ class Plugin:
         return self._sync_service.save_collection_sync(collection_id, kind, enabled)
 
     @migration_blocked
+    async def save_collections_sync(self, collection_ids, kind, enabled):
+        return self._sync_service.save_collections_sync(collection_ids, kind, enabled)
+
+    @migration_blocked
     async def set_all_collections_sync(self, enabled, scope=None):
         return await self._sync_service.set_all_collections_sync(enabled, scope)
 

--- a/py_modules/services/library/fetcher.py
+++ b/py_modules/services/library/fetcher.py
@@ -348,6 +348,31 @@ class LibraryFetcher:
         self._settings_persister.save_settings()
         return {"success": True}
 
+    def save_collections_sync(self, collection_ids, kind, enabled):
+        """Batch-stamp a bounded set of collection ids into one kind's bucket.
+
+        The frontend uses this for the filtered-subset Enable/Disable All (a
+        search or per-type filter is active) so the whole-kind
+        ``set_all_collections_sync`` — which re-fetches every collection from the
+        server — stays reserved for the unfiltered case. One settings write
+        stamps every id in ``collection_ids`` to ``enabled`` in the ``kind``
+        bucket. An unknown kind or a non-list id argument is rejected with the
+        canonical failure shape; an empty id list is a success no-op (nothing to
+        stamp, no write).
+        """
+        if kind not in ("user", "smart", "virtual"):
+            return {"success": False, "reason": "invalid_kind", "message": f"Invalid collection kind: {kind}"}
+        if not isinstance(collection_ids, list):
+            return {"success": False, "reason": "invalid_ids", "message": "collection_ids must be a list"}
+        if not collection_ids:
+            return {"success": True}
+        buckets = self._get_enabled_collections_buckets()
+        for cid in collection_ids:
+            buckets[kind][str(cid)] = bool(enabled)
+        self._settings["enabled_collections"] = buckets
+        self._settings_persister.save_settings()
+        return {"success": True}
+
     async def set_all_collections_sync(self, enabled, scope=None):
         enabled = bool(enabled)
         if scope not in (None, "user", "smart", "virtual"):

--- a/py_modules/services/library/service.py
+++ b/py_modules/services/library/service.py
@@ -290,6 +290,9 @@ class LibraryService:
     def save_collection_sync(self, collection_id, kind, enabled):
         return self._fetcher.save_collection_sync(collection_id, kind, enabled)
 
+    def save_collections_sync(self, collection_ids, kind, enabled):
+        return self._fetcher.save_collections_sync(collection_ids, kind, enabled)
+
     async def set_all_collections_sync(self, enabled, scope=None):
         return await self._fetcher.set_all_collections_sync(enabled, scope)
 

--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -161,6 +161,13 @@ export const getCollections = callable<
 export const saveCollectionSync = callable<[string, CollectionKind, boolean], { success: boolean; message?: string }>(
   "save_collection_sync",
 );
+// Batch stamp for a bounded, filtered subset of collections (search / per-type
+// filter active). The whole-kind Enable/Disable All keeps setAllCollectionsSync
+// so a huge id list never crosses the wire.
+export const saveCollectionsSync = callable<
+  [string[], CollectionKind, boolean],
+  { success: boolean; reason?: string; message?: string }
+>("save_collections_sync");
 export const setAllCollectionsSync = callable<
   [boolean, "user" | "smart" | "virtual" | null],
   { success: boolean; message?: string }

--- a/src/components/DangerZone.tsx
+++ b/src/components/DangerZone.tsx
@@ -36,6 +36,7 @@ import { clearPlatformCollection, clearAllRomMCollections } from "../utils/colle
 import { formatUninstallStatus } from "../utils/formatters";
 import type { RegistryPlatform } from "../types";
 import { detach } from "../utils/detach";
+import { fuzzyMatch } from "../utils/fuzzyMatch";
 
 const DEFAULT_WHITELIST_PATTERNS: string[] = [
   "retrodeck",
@@ -54,17 +55,6 @@ const DEFAULT_WHITELIST_PATTERNS: string[] = [
   "return to gaming mode",
   "nonsteamlaunchers",
 ];
-
-// Fuzzy match: each character of the query must appear in order in the target (like fzf)
-const fuzzyMatch = (query: string, target: string): boolean => {
-  const q = query.toLowerCase();
-  const t = target.toLowerCase();
-  let qi = 0;
-  for (let ti = 0; ti < t.length && qi < q.length; ti++) {
-    if (t[ti] === q[qi]) qi++;
-  }
-  return qi === q.length;
-};
 
 interface NonSteamApp {
   appId: number;

--- a/src/components/LibraryPage.test.tsx
+++ b/src/components/LibraryPage.test.tsx
@@ -27,11 +27,13 @@
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { render, fireEvent, act } from "@testing-library/react";
+import type { ReactElement } from "react";
 import { LibraryPage } from "./LibraryPage";
 import * as backend from "../api/backend";
+import { showModal } from "@decky/ui";
 import type { PlatformSyncSetting, CollectionSyncSetting, PluginSettings } from "../types";
 
-// scrollToTop is a no-op in happy-dom; mock for cleanliness.
+// scroll helpers are no-ops in happy-dom; mock for cleanliness.
 vi.mock("../utils/scrollHelpers", () => ({ scrollToTop: vi.fn() }));
 
 // Re-mock @decky/ui locally so the component tree renders with inspectable
@@ -61,6 +63,25 @@ vi.mock("@decky/ui", async () => {
     Focusable: passthrough("div"),
     DialogButton: ({ children, onClick }: AnyProps & { onClick?: () => void }) =>
       ce("button", { onClick }, children as never),
+    TextField: (
+      p: AnyProps & {
+        value?: string;
+        onChange?: (e: unknown) => void;
+        onFocus?: (e: unknown) => void;
+        onKeyDown?: (e: unknown) => void;
+      },
+    ) =>
+      ce("input", {
+        "data-testid": "text-field",
+        value: p.value ?? "",
+        onChange: (e: unknown) => p.onChange?.(e),
+        onFocus: (e: unknown) => p.onFocus?.(e),
+        onKeyDown: (e: unknown) => p.onKeyDown?.(e),
+      }),
+    // A no-render stub — showModal captures the element, so the modal body is
+    // inspected off the showModal mock, not the DOM.
+    ConfirmModal: () => null,
+    showModal: vi.fn(),
     ToggleField: (
       p: AnyProps & {
         checked?: boolean;
@@ -87,6 +108,15 @@ vi.mock("@decky/ui", async () => {
     Spinner: () => ce("div", { "data-testid": "spinner" }),
   };
 });
+
+// Inspect the last ConfirmModal shown via showModal (the whole-kind Enable/
+// Disable All confirm), and drive its onOK.
+function lastConfirmModalProps<T = Record<string, unknown>>(): T | null {
+  const calls = vi.mocked(showModal).mock.calls;
+  if (calls.length === 0) return null;
+  const el = calls[calls.length - 1]?.[0] as ReactElement<T> | undefined;
+  return el?.props ?? null;
+}
 
 // Flush mount-time + chained promise resolutions.
 const flushAsync = () =>
@@ -151,12 +181,14 @@ describe("LibraryPage", () => {
       collections: [],
     });
     vi.mocked(backend.saveCollectionSync).mockResolvedValue({ success: true });
+    vi.mocked(backend.saveCollectionsSync).mockResolvedValue({ success: true });
     vi.mocked(backend.setAllCollectionsSync).mockResolvedValue({ success: true });
-    vi.mocked(backend.saveCollectionPlatformGroups).mockResolvedValue({
-      success: true,
-    });
     vi.mocked(backend.setCollectionOwnerScope).mockResolvedValue({ success: true });
     vi.mocked(backend.getSettings).mockResolvedValue(defaultSettings());
+    vi.mocked(showModal).mockReset();
+    // happy-dom doesn't implement scrollIntoView; the search field calls it on
+    // the first keystroke / focus. Stub it so those paths are safe + spyable.
+    HTMLElement.prototype.scrollIntoView = vi.fn();
   });
 
   // ------------------------------------------------------------------
@@ -398,14 +430,10 @@ describe("LibraryPage", () => {
   // E. Collections tab — mount (lazy load)
   // ------------------------------------------------------------------
   describe("collections tab — mount", () => {
-    it("populates collections + platformGroups from Promise.all on success", async () => {
+    it("populates collections from Promise.all on success", async () => {
       vi.mocked(backend.getCollections).mockResolvedValue({
         success: true,
         collections: [makeCollection({ id: "u1", name: "MyColl", kind: "user", is_favorite: false })],
-      });
-      vi.mocked(backend.getSettings).mockResolvedValue({
-        ...defaultSettings(),
-        collection_create_platform_groups: true,
       });
       const { getByText, container } = render(<LibraryPage onBack={vi.fn()} />);
       await flushAsync();
@@ -415,33 +443,6 @@ describe("LibraryPage", () => {
         await Promise.resolve();
       });
       expect(container.textContent).toContain("MyColl");
-      // platformGroups true → the renamed toggle is checked.
-      const platformGroupsToggle = container.querySelector<HTMLInputElement>(
-        '[data-label="Show collection games in platform groups"] input',
-      );
-      expect(platformGroupsToggle?.checked).toBe(true);
-    });
-
-    it("falsy collection_create_platform_groups maps to checked=false", async () => {
-      vi.mocked(backend.getCollections).mockResolvedValue({
-        success: true,
-        collections: [makeCollection({ id: "c1" })],
-      });
-      vi.mocked(backend.getSettings).mockResolvedValue({
-        ...defaultSettings(),
-        collection_create_platform_groups: false,
-      });
-      const { getByText, container } = render(<LibraryPage onBack={vi.fn()} />);
-      await flushAsync();
-      await act(async () => {
-        fireEvent.click(getByText("Collections"));
-        await Promise.resolve();
-        await Promise.resolve();
-      });
-      const platformGroupsToggle = container.querySelector<HTMLInputElement>(
-        '[data-label="Show collection games in platform groups"] input',
-      );
-      expect(platformGroupsToggle?.checked).toBe(false);
     });
 
     it("surfaces an error when getCollections returns success=false", async () => {
@@ -573,10 +574,10 @@ describe("LibraryPage", () => {
   });
 
   // ------------------------------------------------------------------
-  // G. Collections tab — Enable/Disable All + platform-groups toggle
+  // G. Collections tab — Enable/Disable All (whole-kind confirm path)
   // ------------------------------------------------------------------
-  describe("collections tab — set-all + platform groups", () => {
-    it("calls setAllCollectionsSync(true, 'user') on Enable All in default My sub-tab", async () => {
+  describe("collections tab — whole-kind Enable/Disable All", () => {
+    it("Enable All with no filter opens a confirm and only calls setAllCollectionsSync on OK", async () => {
       vi.mocked(backend.getCollections).mockResolvedValue({
         success: true,
         collections: [makeCollection({ id: "c1", kind: "user", is_favorite: false, sync_enabled: false })],
@@ -592,13 +593,24 @@ describe("LibraryPage", () => {
         fireEvent.click(getByText("Enable All"));
         await Promise.resolve();
       });
+      // The confirm is shown; nothing persisted yet.
+      expect(vi.mocked(showModal)).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(backend.setAllCollectionsSync)).not.toHaveBeenCalled();
+      // Drive the modal's onOK.
+      const props = lastConfirmModalProps<{ onOK?: () => void }>();
+      await act(async () => {
+        props?.onOK?.();
+        await Promise.resolve();
+      });
       expect(vi.mocked(backend.setAllCollectionsSync)).toHaveBeenCalledWith(true, "user");
+      // The batch callable is never used on the whole-kind path.
+      expect(vi.mocked(backend.saveCollectionsSync)).not.toHaveBeenCalled();
     });
 
-    it("calls setAllCollectionsSync(true, 'smart') when Smart sub-tab is active", async () => {
+    it("Disable All with no filter confirms then calls setAllCollectionsSync(false, scope) on the active sub-tab", async () => {
       vi.mocked(backend.getCollections).mockResolvedValue({
         success: true,
-        collections: [makeCollection({ id: "s1", name: "S1", sync_enabled: false, kind: "smart", is_favorite: false })],
+        collections: [makeCollection({ id: "s1", name: "S1", sync_enabled: true, kind: "smart", is_favorite: false })],
       });
       const { getByText } = render(<LibraryPage onBack={vi.fn()} />);
       await flushAsync();
@@ -612,10 +624,15 @@ describe("LibraryPage", () => {
         await Promise.resolve();
       });
       await act(async () => {
-        fireEvent.click(getByText("Enable All"));
+        fireEvent.click(getByText("Disable All"));
         await Promise.resolve();
       });
-      expect(vi.mocked(backend.setAllCollectionsSync)).toHaveBeenCalledWith(true, "smart");
+      const props = lastConfirmModalProps<{ onOK?: () => void }>();
+      await act(async () => {
+        props?.onOK?.();
+        await Promise.resolve();
+      });
+      expect(vi.mocked(backend.setAllCollectionsSync)).toHaveBeenCalledWith(false, "smart");
     });
 
     it("restores the previous collections snapshot on setAllCollectionsSync rejection", async () => {
@@ -637,6 +654,11 @@ describe("LibraryPage", () => {
       await act(async () => {
         fireEvent.click(getByText("Disable All"));
         await Promise.resolve();
+      });
+      const props = lastConfirmModalProps<{ onOK?: () => void }>();
+      await act(async () => {
+        props?.onOK?.();
+        await Promise.resolve();
         await Promise.resolve();
         await Promise.resolve();
       });
@@ -647,10 +669,10 @@ describe("LibraryPage", () => {
       expect(b?.checked).toBe(false);
     });
 
-    it("toggling 'Show collection games in platform groups' calls saveCollectionPlatformGroups", async () => {
+    it("does not render the platform-groups toggle on the Collections tab (moved to Settings)", async () => {
       vi.mocked(backend.getCollections).mockResolvedValue({
         success: true,
-        collections: [makeCollection({ id: "c1" })],
+        collections: [makeCollection({ id: "c1", kind: "user", is_favorite: false })],
       });
       const { container, getByText } = render(<LibraryPage onBack={vi.fn()} />);
       await flushAsync();
@@ -659,43 +681,7 @@ describe("LibraryPage", () => {
         await Promise.resolve();
         await Promise.resolve();
       });
-      const toggle = container.querySelector<HTMLInputElement>(
-        '[data-label="Show collection games in platform groups"] input',
-      )!;
-      await act(async () => {
-        fireEvent.click(toggle);
-        await Promise.resolve();
-      });
-      expect(vi.mocked(backend.saveCollectionPlatformGroups)).toHaveBeenCalledWith(true);
-    });
-
-    it("reverts platformGroups state when saveCollectionPlatformGroups rejects", async () => {
-      vi.mocked(backend.getCollections).mockResolvedValue({
-        success: true,
-        collections: [makeCollection({ id: "c1" })],
-      });
-      vi.mocked(backend.saveCollectionPlatformGroups).mockRejectedValue(new Error("x"));
-      const { container, getByText } = render(<LibraryPage onBack={vi.fn()} />);
-      await flushAsync();
-      await act(async () => {
-        fireEvent.click(getByText("Collections"));
-        await Promise.resolve();
-        await Promise.resolve();
-      });
-      const toggle = container.querySelector<HTMLInputElement>(
-        '[data-label="Show collection games in platform groups"] input',
-      )!;
-      await act(async () => {
-        fireEvent.click(toggle);
-        await Promise.resolve();
-        await Promise.resolve();
-        await Promise.resolve();
-      });
-      // CATCH-REJECTION assert: rolled back to false
-      const after = container.querySelector<HTMLInputElement>(
-        '[data-label="Show collection games in platform groups"] input',
-      )!;
-      expect(after.checked).toBe(false);
+      expect(container.querySelector('[data-label="Show collection games in platform groups"]')).toBeNull();
     });
   });
 
@@ -1182,6 +1168,340 @@ describe("LibraryPage", () => {
       // back to "all", so the foreign collection is visible again.
       expect(vi.mocked(backend.setCollectionOwnerScope)).toHaveBeenCalledWith("own");
       expect(container.querySelector('[data-label="TheirColl"]')).not.toBeNull();
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // N2. Collections tab — search + render-cap + per-type filter + batch set-all
+  // ------------------------------------------------------------------
+  describe("collections tab — search, render-cap, per-type filter, batch set-all", () => {
+    const openCollections = async (getByText: (t: string) => HTMLElement) => {
+      await flushAsync();
+      await act(async () => {
+        fireEvent.click(getByText("Collections"));
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+    };
+
+    const typeSearch = async (getByTestId: (t: string) => HTMLElement, value: string) => {
+      await act(async () => {
+        fireEvent.change(getByTestId("text-field"), { target: { value } });
+        await Promise.resolve();
+      });
+    };
+
+    it("filters the visible list by fuzzy name match and restores it when cleared", async () => {
+      vi.mocked(backend.getCollections).mockResolvedValue({
+        success: true,
+        collections: [
+          makeCollection({ id: "u1", name: "Action Heroes", kind: "user", is_favorite: false }),
+          makeCollection({ id: "u2", name: "Puzzle Box", kind: "user", is_favorite: false }),
+        ],
+      });
+      const { getByText, getByTestId, container } = render(<LibraryPage onBack={vi.fn()} />);
+      await openCollections(getByText);
+      // "actn" is an in-order subsequence of "Action Heroes" but not "Puzzle Box".
+      await typeSearch(getByTestId, "actn");
+      expect(container.querySelector('[data-label="Action Heroes"]')).not.toBeNull();
+      expect(container.querySelector('[data-label="Puzzle Box"]')).toBeNull();
+      // Clearing restores both.
+      await typeSearch(getByTestId, "");
+      expect(container.querySelector('[data-label="Action Heroes"]')).not.toBeNull();
+      expect(container.querySelector('[data-label="Puzzle Box"]')).not.toBeNull();
+    });
+
+    it("Enter on the search field blurs it (dismisses the on-screen keyboard)", async () => {
+      vi.mocked(backend.getCollections).mockResolvedValue({
+        success: true,
+        collections: [makeCollection({ id: "u1", name: "Action Heroes", kind: "user", is_favorite: false })],
+      });
+      const { getByText, getByTestId } = render(<LibraryPage onBack={vi.fn()} />);
+      await openCollections(getByText);
+      const field = getByTestId("text-field") as HTMLInputElement;
+      field.focus();
+      expect(document.activeElement).toBe(field);
+      await act(async () => {
+        fireEvent.keyDown(field, { key: "Enter" });
+        await Promise.resolve();
+      });
+      // The handler blurs the active element, which is what dismisses the OSK.
+      expect(document.activeElement).not.toBe(field);
+    });
+
+    it("scrolls the search field into view on the FIRST keystroke only (not on later keystrokes)", async () => {
+      vi.mocked(backend.getCollections).mockResolvedValue({
+        success: true,
+        collections: [makeCollection({ id: "u1", name: "Action Heroes", kind: "user", is_favorite: false })],
+      });
+      const scrollIntoView = vi.mocked(HTMLElement.prototype.scrollIntoView);
+      const { getByText, getByTestId } = render(<LibraryPage onBack={vi.fn()} />);
+      await openCollections(getByText);
+      scrollIntoView.mockClear();
+      // First keystroke: empty → non-empty → scroll the field into view.
+      await typeSearch(getByTestId, "a");
+      expect(scrollIntoView).toHaveBeenCalledTimes(1);
+      expect(scrollIntoView).toHaveBeenCalledWith({ behavior: "smooth", block: "start" });
+      // Later keystrokes (still non-empty) must NOT re-scroll.
+      await typeSearch(getByTestId, "ac");
+      expect(scrollIntoView).toHaveBeenCalledTimes(1);
+    });
+
+    it("scrolls the search field into view when it gains focus", async () => {
+      vi.mocked(backend.getCollections).mockResolvedValue({
+        success: true,
+        collections: [makeCollection({ id: "u1", name: "Action Heroes", kind: "user", is_favorite: false })],
+      });
+      const scrollIntoView = vi.mocked(HTMLElement.prototype.scrollIntoView);
+      const { getByText, getByTestId } = render(<LibraryPage onBack={vi.fn()} />);
+      await openCollections(getByText);
+      scrollIntoView.mockClear();
+      await act(async () => {
+        fireEvent.focus(getByTestId("text-field"));
+        await Promise.resolve();
+      });
+      expect(scrollIntoView).toHaveBeenCalledWith({ behavior: "smooth", block: "start" });
+    });
+
+    it("caps the rendered rows and shows a '<n> more' hint past the cap", async () => {
+      const many: CollectionSyncSetting[] = Array.from({ length: 60 }, (_, i) =>
+        makeCollection({
+          id: `u${i}`,
+          name: `Coll ${String(i).padStart(3, "0")}`,
+          kind: "user",
+          is_favorite: false,
+        }),
+      );
+      vi.mocked(backend.getCollections).mockResolvedValue({ success: true, collections: many });
+      const { getByText, container } = render(<LibraryPage onBack={vi.fn()} />);
+      await openCollections(getByText);
+      // Never paints more than the cap (50): exactly 50 toggle rows, not 60.
+      const toggles = container.querySelectorAll('[data-testid="toggle-input"]');
+      expect(toggles).toHaveLength(50);
+      // The overflow (60 - 50 = 10) is surfaced as a single hint row.
+      expect(container.textContent).toContain("10 more — refine your search");
+      // The section header still reflects the full match count.
+      expect(container.textContent).toContain("MY COLLECTIONS (60)");
+    });
+
+    it("search narrows a huge list below the cap and drops the hint", async () => {
+      const many: CollectionSyncSetting[] = Array.from({ length: 60 }, (_, i) =>
+        makeCollection({
+          id: `u${i}`,
+          name: `Coll ${String(i).padStart(3, "0")}`,
+          kind: "user",
+          is_favorite: false,
+        }),
+      );
+      vi.mocked(backend.getCollections).mockResolvedValue({ success: true, collections: many });
+      const { getByText, getByTestId, container } = render(<LibraryPage onBack={vi.fn()} />);
+      await openCollections(getByText);
+      // "coll 001" matches exactly one collection.
+      await typeSearch(getByTestId, "coll 001");
+      const toggles = container.querySelectorAll('[data-testid="toggle-input"]');
+      expect(toggles).toHaveLength(1);
+      expect(container.textContent).not.toContain("more — refine your search");
+    });
+
+    it("shows the per-type filter only on the Virtual sub-tab", async () => {
+      vi.mocked(backend.getCollections).mockResolvedValue({
+        success: true,
+        collections: [
+          makeCollection({ id: "u1", name: "UserOne", kind: "user", is_favorite: false }),
+          makeCollection({ id: "fr1", name: "Fr1", kind: "virtual", virtual_type: "franchise", is_favorite: false }),
+        ],
+      });
+      const { getByText, queryByText } = render(<LibraryPage onBack={vi.fn()} />);
+      await openCollections(getByText);
+      // On the default My sub-tab the per-type labels are absent.
+      expect(queryByText("Franchise")).toBeNull();
+      expect(queryByText("IGDB Collection")).toBeNull();
+      // On the Virtual sub-tab they appear.
+      await act(async () => {
+        fireEvent.click(getByText("Virtual"));
+        await Promise.resolve();
+      });
+      expect(getByText("Franchise")).not.toBeNull();
+      expect(getByText("IGDB Collection")).not.toBeNull();
+    });
+
+    it("the per-type filter narrows the Virtual list by virtual_type", async () => {
+      vi.mocked(backend.getCollections).mockResolvedValue({
+        success: true,
+        collections: [
+          makeCollection({
+            id: "fr1",
+            name: "FranchiseOne",
+            kind: "virtual",
+            virtual_type: "franchise",
+            is_favorite: false,
+          }),
+          makeCollection({
+            id: "vc1",
+            name: "SeriesOne",
+            kind: "virtual",
+            virtual_type: "collection",
+            is_favorite: false,
+          }),
+        ],
+      });
+      const { getByText, container } = render(<LibraryPage onBack={vi.fn()} />);
+      await openCollections(getByText);
+      await act(async () => {
+        fireEvent.click(getByText("Virtual"));
+        await Promise.resolve();
+      });
+      // Both visible under "All".
+      expect(container.querySelector('[data-label="FranchiseOne"]')).not.toBeNull();
+      expect(container.querySelector('[data-label="SeriesOne"]')).not.toBeNull();
+      // Narrow to Franchise → only the franchise-typed row remains.
+      await act(async () => {
+        fireEvent.click(getByText("Franchise"));
+        await Promise.resolve();
+      });
+      expect(container.querySelector('[data-label="FranchiseOne"]')).not.toBeNull();
+      expect(container.querySelector('[data-label="SeriesOne"]')).toBeNull();
+    });
+
+    it("Enable All with an active search uses the batch callable with only the matched ids", async () => {
+      vi.mocked(backend.getCollections).mockResolvedValue({
+        success: true,
+        collections: [
+          makeCollection({ id: "u1", name: "Action Heroes", kind: "user", is_favorite: false, sync_enabled: false }),
+          makeCollection({ id: "u2", name: "Action Squad", kind: "user", is_favorite: false, sync_enabled: false }),
+          makeCollection({ id: "u3", name: "Puzzle Box", kind: "user", is_favorite: false, sync_enabled: false }),
+        ],
+      });
+      const { getByText, getByTestId } = render(<LibraryPage onBack={vi.fn()} />);
+      await openCollections(getByText);
+      await typeSearch(getByTestId, "action");
+      await act(async () => {
+        fireEvent.click(getByText("Enable All"));
+        await Promise.resolve();
+      });
+      // No confirm (bounded subset), no whole-kind call, batch with only matches.
+      expect(vi.mocked(showModal)).not.toHaveBeenCalled();
+      expect(vi.mocked(backend.setAllCollectionsSync)).not.toHaveBeenCalled();
+      expect(vi.mocked(backend.saveCollectionsSync)).toHaveBeenCalledWith(["u1", "u2"], "user", true);
+    });
+
+    it("Enable All under 'Own' scope (empty search) batches the own ids and never takes the whole-kind path", async () => {
+      // Own scope makes the visible set a bounded subset (one user's own
+      // collections), so Enable-All must NOT stamp the whole kind — no confirm,
+      // no set_all_collections_sync, and the foreign id is excluded.
+      vi.mocked(backend.getSettings).mockResolvedValue({ ...defaultSettings(), collection_owner_scope: "own" });
+      vi.mocked(backend.getCollections).mockResolvedValue({
+        success: true,
+        collections: [
+          makeCollection({
+            id: "u1",
+            name: "MineOne",
+            kind: "user",
+            is_favorite: false,
+            is_own: true,
+            sync_enabled: false,
+          }),
+          makeCollection({
+            id: "u2",
+            name: "MineTwo",
+            kind: "user",
+            is_favorite: false,
+            is_own: true,
+            sync_enabled: false,
+          }),
+          makeCollection({
+            id: "u3",
+            name: "TheirOne",
+            kind: "user",
+            is_favorite: false,
+            is_own: false,
+            sync_enabled: false,
+          }),
+        ],
+      });
+      const { getByText } = render(<LibraryPage onBack={vi.fn()} />);
+      await openCollections(getByText);
+      await act(async () => {
+        fireEvent.click(getByText("Enable All"));
+        await Promise.resolve();
+      });
+      expect(vi.mocked(showModal)).not.toHaveBeenCalled();
+      expect(vi.mocked(backend.setAllCollectionsSync)).not.toHaveBeenCalled();
+      expect(vi.mocked(backend.saveCollectionsSync)).toHaveBeenCalledWith(["u1", "u2"], "user", true);
+    });
+
+    it("Disable All under an active per-type filter batches only that type's ids", async () => {
+      vi.mocked(backend.getCollections).mockResolvedValue({
+        success: true,
+        collections: [
+          makeCollection({
+            id: "fr1",
+            name: "FranchiseOne",
+            kind: "virtual",
+            virtual_type: "franchise",
+            is_favorite: false,
+            sync_enabled: true,
+          }),
+          makeCollection({
+            id: "fr2",
+            name: "FranchiseTwo",
+            kind: "virtual",
+            virtual_type: "franchise",
+            is_favorite: false,
+            sync_enabled: true,
+          }),
+          makeCollection({
+            id: "vc1",
+            name: "SeriesOne",
+            kind: "virtual",
+            virtual_type: "collection",
+            is_favorite: false,
+            sync_enabled: true,
+          }),
+        ],
+      });
+      const { getByText } = render(<LibraryPage onBack={vi.fn()} />);
+      await openCollections(getByText);
+      await act(async () => {
+        fireEvent.click(getByText("Virtual"));
+        await Promise.resolve();
+      });
+      await act(async () => {
+        fireEvent.click(getByText("Franchise"));
+        await Promise.resolve();
+      });
+      await act(async () => {
+        fireEvent.click(getByText("Disable All"));
+        await Promise.resolve();
+      });
+      expect(vi.mocked(showModal)).not.toHaveBeenCalled();
+      expect(vi.mocked(backend.setAllCollectionsSync)).not.toHaveBeenCalled();
+      expect(vi.mocked(backend.saveCollectionsSync)).toHaveBeenCalledWith(["fr1", "fr2"], "virtual", false);
+    });
+
+    it("rolls back the optimistic batch flip when saveCollectionsSync rejects", async () => {
+      vi.mocked(backend.getCollections).mockResolvedValue({
+        success: true,
+        collections: [
+          makeCollection({ id: "u1", name: "Action Heroes", kind: "user", is_favorite: false, sync_enabled: false }),
+          makeCollection({ id: "u2", name: "Puzzle Box", kind: "user", is_favorite: false, sync_enabled: false }),
+        ],
+      });
+      vi.mocked(backend.saveCollectionsSync).mockRejectedValue(new Error("boom"));
+      const { getByText, getByTestId, container } = render(<LibraryPage onBack={vi.fn()} />);
+      await openCollections(getByText);
+      await typeSearch(getByTestId, "action");
+      await act(async () => {
+        fireEvent.click(getByText("Enable All"));
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      // Clear the search to bring both rows back into view and assert the flip
+      // rolled back (Action Heroes is unchecked again).
+      await typeSearch(getByTestId, "");
+      const a = container.querySelector<HTMLInputElement>('[data-label="Action Heroes"] input');
+      expect(a?.checked).toBe(false);
     });
   });
 

--- a/src/components/LibraryPage.tsx
+++ b/src/components/LibraryPage.tsx
@@ -1,13 +1,24 @@
-import { useState, useEffect, useMemo, useRef, FC } from "react";
-import { PanelSection, PanelSectionRow, ButtonItem, ToggleField, DialogButton, Field, Focusable } from "@decky/ui";
+import { useState, useEffect, useMemo, useRef, FC, KeyboardEvent } from "react";
+import {
+  PanelSection,
+  PanelSectionRow,
+  ButtonItem,
+  ToggleField,
+  DialogButton,
+  Field,
+  Focusable,
+  TextField,
+  ConfirmModal,
+  showModal,
+} from "@decky/ui";
 import {
   getPlatforms,
   savePlatformSync,
   setAllPlatformsSync,
   getCollections,
   saveCollectionSync,
+  saveCollectionsSync,
   setAllCollectionsSync,
-  saveCollectionPlatformGroups,
   setCollectionOwnerScope,
   getSettings,
 } from "../api/backend";
@@ -21,7 +32,18 @@ import type {
 } from "../types";
 import { scrollToTop } from "../utils/scrollHelpers";
 import { detach } from "../utils/detach";
+import { fuzzyMatch } from "../utils/fuzzyMatch";
 import { LoadingRow } from "./LoadingRow";
+
+// Best-effort on-screen-keyboard dismissal: Enter (R2 on the OSK) blurs the
+// focused field. Whether R2/Enter reliably closes the Steam OSK is Steam-
+// controlled and UNVERIFIED — this is a harmless best effort to revisit in
+// PR 2 (#1539); it must not be relied upon to work.
+function dismissKeyboardOnEnter(e: KeyboardEvent<HTMLInputElement>): void {
+  if (e.key === "Enter") {
+    (document.activeElement as HTMLElement | null)?.blur();
+  }
+}
 
 type CollectionSubTab = "user" | "smart" | "virtual";
 
@@ -39,11 +61,32 @@ const SUB_TAB_HEADERS: Record<CollectionSubTab, string> = {
   virtual: "VIRTUAL",
 };
 
+// Hard ceiling on how many collection rows are ever painted at once. A large
+// library's Virtual list runs to many hundreds of entries; rendering them all
+// strains the CEF renderer, so the list is capped and the overflow is surfaced
+// as a single "refine your search" hint instead. Search + the per-type filter
+// narrow BELOW this cap.
+const COLLECTION_RENDER_CAP = 50;
+
+// The Virtual sub-tab's per-type segmented filter. "all" shows both virtual
+// types; the others narrow to one `virtual_type`.
+type VirtualTypeFilter = "all" | VirtualCollectionType;
+
+const VIRTUAL_TYPE_FILTER_ORDER: readonly VirtualTypeFilter[] = ["all", "franchise", "collection"];
+
 // Row-description label per virtual type. "IGDB Collection" (not "Collection")
 // disambiguates from the Collections page it lives inside — RomM's own label.
 const VIRTUAL_TYPE_LABELS: Record<VirtualCollectionType, string> = {
   franchise: "Franchise",
   collection: "IGDB Collection",
+};
+
+// Segmented-control labels for the per-type filter. "All" reuses the plain word;
+// the two types reuse the row labels so the control and the rows read alike.
+const VIRTUAL_TYPE_FILTER_LABELS: Record<VirtualTypeFilter, string> = {
+  all: "All",
+  franchise: VIRTUAL_TYPE_LABELS.franchise,
+  collection: VIRTUAL_TYPE_LABELS.collection,
 };
 
 // A virtual row shows its type ("Franchise" / "IGDB Collection") before the ROM
@@ -111,9 +154,20 @@ export const LibraryPage: FC<LibraryPageProps> = ({ onBack }) => {
   const [collectionsLoading, setCollectionsLoading] = useState(true);
   const [collectionsError, setCollectionsError] = useState(false);
   const collectionsLoaded = useRef(false);
-  const [platformGroups, setPlatformGroups] = useState(false);
   const [ownerScope, setOwnerScope] = useState<CollectionOwnerScope>("all");
   const [activeSubTab, setActiveSubTab] = useState<CollectionSubTab>("user");
+  // Search + per-type filter narrow the active sub-tab's list. Both reset when
+  // the sub-tab changes so each sub-tab is entered unfiltered.
+  const [search, setSearch] = useState("");
+  const [virtualTypeFilter, setVirtualTypeFilter] = useState<VirtualTypeFilter>("all");
+  // Wraps the search field's label + input so it can be scrolled into view when
+  // the on-screen keyboard opens over the lower half of the screen (#1539).
+  const searchFieldRef = useRef<HTMLDivElement>(null);
+  const scrollSearchIntoView = () => {
+    // scrollIntoView finds the scroll parent itself and only scrolls when the
+    // element isn't already visible, so it can never push the field off-screen.
+    searchFieldRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+  };
 
   // The favorites collection (a user collection with is_favorite=true) is
   // promoted to a top-level toggle. RomM's schema theoretically allows more
@@ -159,7 +213,6 @@ export const LibraryPage: FC<LibraryPageProps> = ({ onBack }) => {
           } else {
             setCollectionsError(true);
           }
-          setPlatformGroups(!!settingsResult.collection_create_platform_groups);
           setOwnerScope(settingsResult.collection_owner_scope === "own" ? "own" : "all");
         })
         .catch(() => setCollectionsError(true))
@@ -167,11 +220,22 @@ export const LibraryPage: FC<LibraryPageProps> = ({ onBack }) => {
     }
   }, [activeTab]);
 
-  // Reset the collections sub-tab on every entry into the Collections tab
-  // so the user lands on a predictable view (no persistence).
+  // Reset the collections sub-tab (and its search + per-type filter) on every
+  // entry into the Collections tab so the user lands on a predictable view (no
+  // persistence).
   const handleCollectionsTabClick = () => {
     setActiveSubTab("user");
+    setSearch("");
+    setVirtualTypeFilter("all");
     setActiveTab("collections");
+  };
+
+  // Switch sub-tabs and reset the per-sub-tab filters so a query typed in one
+  // sub-tab never silently hides another sub-tab's list.
+  const handleSubTabChange = (sub: CollectionSubTab) => {
+    setActiveSubTab(sub);
+    setSearch("");
+    setVirtualTypeFilter("all");
   };
 
   // --- Platforms tab handlers ---
@@ -206,6 +270,9 @@ export const LibraryPage: FC<LibraryPageProps> = ({ onBack }) => {
     }
   };
 
+  // Whole-kind Enable/Disable All: flip every collection in the sub-tab and
+  // persist via the whole-kind callable (the server re-fetches the kind), so a
+  // huge id list never crosses the wire. Gated behind a confirm at the callsite.
   const handleSetAllCollections = async (enabled: boolean, scope: CollectionScope) => {
     const previous = collections.map((c) => ({ ...c }));
     // Optimistically flip only the entries in the active sub-tab.
@@ -217,6 +284,51 @@ export const LibraryPage: FC<LibraryPageProps> = ({ onBack }) => {
     } catch {
       setCollections(previous);
     }
+  };
+
+  // Filtered-subset Enable/Disable All (a search or per-type filter is active):
+  // flip exactly the matched ids and persist them in one batch write, so the
+  // whole kind is never touched.
+  const handleBatchCollectionsSync = async (enabled: boolean, kind: CollectionKind, ids: string[]) => {
+    if (ids.length === 0) return;
+    const idSet = new Set(ids);
+    const previous = collections.map((c) => ({ ...c }));
+    setCollections((prev) =>
+      prev.map((c) => (c.kind === kind && idSet.has(c.id) ? { ...c, sync_enabled: enabled } : c)),
+    );
+    try {
+      await saveCollectionsSync(ids, kind, enabled);
+    } catch {
+      setCollections(previous);
+    }
+  };
+
+  // Enable/Disable All entry point. When the current view is the whole kind
+  // (no search, and for Virtual no per-type filter) the whole-kind callable is
+  // used behind a ConfirmModal — it can flip a very large number. Otherwise the
+  // bounded matched set goes through the batch callable directly.
+  const handleCollectionsSetAll = (enabled: boolean, isWholeKind: boolean, matchedIds: string[]) => {
+    const kind = activeSubTab as CollectionKind;
+    if (isWholeKind) {
+      const label = SUB_TAB_LABELS[activeSubTab];
+      showModal(
+        <ConfirmModal
+          strTitle={enabled ? `Enable all ${label} collections?` : `Disable all ${label} collections?`}
+          strDescription={
+            enabled
+              ? `This turns on syncing for every collection in the ${label} tab, including any not currently shown. On a large library this can be a lot of collections.`
+              : `This turns off syncing for every collection in the ${label} tab, including any not currently shown.`
+          }
+          strOKButtonText={enabled ? "Enable All" : "Disable All"}
+          strCancelButtonText="Cancel"
+          onOK={() => {
+            detach(handleSetAllCollections(enabled, activeSubTab));
+          }}
+        />,
+      );
+      return;
+    }
+    detach(handleBatchCollectionsSync(enabled, kind, matchedIds));
   };
 
   const handleOwnerScopeChange = async (scope: CollectionOwnerScope) => {
@@ -319,33 +431,34 @@ export const LibraryPage: FC<LibraryPageProps> = ({ onBack }) => {
     const kindFiltered = filterCollectionsBySubTab(collections, activeSubTab, includeFavoritesInMy);
     // Owner-scope filter runs OVER the kind sub-tab filter — under "Own" a
     // foreign collection is hidden from every kind tab (#1532).
-    const visible = filterCollectionsByOwnerScope(kindFiltered, ownerScope);
+    const scopeFiltered = filterCollectionsByOwnerScope(kindFiltered, ownerScope);
+    // Per-type filter (Virtual sub-tab only) narrows by virtual_type.
+    const showTypeFilter = activeSubTab === "virtual";
+    const typeFiltered =
+      showTypeFilter && virtualTypeFilter !== "all"
+        ? scopeFiltered.filter((c) => c.virtual_type === virtualTypeFilter)
+        : scopeFiltered;
+    // Search filter (fuzzy name match) is last, over the type-narrowed set.
+    const matched = search ? typeFiltered.filter((c) => fuzzyMatch(search, c.name)) : typeFiltered;
+    // The list is capped so the renderer never paints an unbounded set; the
+    // overflow is surfaced as a single hint row.
+    const rendered = matched.slice(0, COLLECTION_RENDER_CAP);
+    const overflow = matched.length - rendered.length;
+    // Whole-kind = nothing filtered (no search, "All" owner-scope, and for
+    // Virtual no per-type filter). Only then does Enable/Disable All use the
+    // whole-kind callable — under "Own" the owner-scoped `matched` set is a
+    // bounded subset, so it goes through the batch path instead of letting
+    // set_all_collections_sync stamp foreign collections.
+    const isWholeKind = search === "" && ownerScope === "all" && !(showTypeFilter && virtualTypeFilter !== "all");
+    const matchedIds = matched.map((c) => c.id);
+
     const activeLabel = SUB_TAB_LABELS[activeSubTab];
-    const sectionTitle = `${SUB_TAB_HEADERS[activeSubTab]} (${visible.length})`;
+    const sectionTitle = `${SUB_TAB_HEADERS[activeSubTab]} (${matched.length})`;
 
     return (
       <>
-        <PanelSection>
-          <PanelSectionRow>
-            <ToggleField
-              label="Show collection games in platform groups"
-              description="When syncing a collection, also add its games to their platform-specific Steam group."
-              checked={platformGroups}
-              onChange={(value: boolean) => {
-                setPlatformGroups(value);
-                detach(
-                  (async () => {
-                    try {
-                      await saveCollectionPlatformGroups(value);
-                    } catch {
-                      setPlatformGroups(!value);
-                    }
-                  })(),
-                );
-              }}
-            />
-          </PanelSectionRow>
-          {favoritesCollection && (
+        {favoritesCollection && (
+          <PanelSection>
             <PanelSectionRow>
               <ToggleField
                 label="Sync RomM favorites"
@@ -356,15 +469,15 @@ export const LibraryPage: FC<LibraryPageProps> = ({ onBack }) => {
                 }}
               />
             </PanelSectionRow>
-          )}
-        </PanelSection>
+          </PanelSection>
+        )}
         <PanelSection>
           <PanelSectionRow>
             <Field
               label="Show collections"
               description={
                 ownerScope === "own"
-                  ? "Only your own collections (virtual collections always sync)."
+                  ? "Only your own collections (virtual collections have no owner, so they always appear)."
                   : "Every collection on the server, including other users' public ones."
               }
             />
@@ -402,7 +515,7 @@ export const LibraryPage: FC<LibraryPageProps> = ({ onBack }) => {
                 opacity: activeSubTab === sub ? 1 : 0.5,
                 borderBottom: activeSubTab === sub ? "2px solid #1a9fff" : "2px solid transparent",
               }}
-              onClick={() => setActiveSubTab(sub)}
+              onClick={() => handleSubTabChange(sub)}
             >
               {SUB_TAB_LABELS[sub]}
             </DialogButton>
@@ -410,42 +523,114 @@ export const LibraryPage: FC<LibraryPageProps> = ({ onBack }) => {
         </Focusable>
         <PanelSection title={sectionTitle}>
           <PanelSectionRow>
+            <div ref={searchFieldRef}>
+              <TextField
+                label="Search collections"
+                value={search}
+                onChange={(e) => {
+                  const value = e.target.value;
+                  // Bring the field into view on the first keystroke (empty →
+                  // non-empty), when the on-screen keyboard is actually in use
+                  // and would otherwise cover the field (#1539).
+                  if (search === "" && value !== "") {
+                    scrollSearchIntoView();
+                  }
+                  setSearch(value);
+                }}
+                // onFocus covers the "press A to edit" case; scrollIntoView is
+                // idempotent (no-op when already visible), so this is harmless.
+                onFocus={scrollSearchIntoView}
+                // Best-effort OSK dismissal: Enter (R2 on the keyboard) blurs the
+                // field. Whether R2/Enter reliably closes the OSK is Steam-
+                // controlled and UNVERIFIED — revisit in PR 2 (#1539). Harmless if
+                // it no-ops; do not claim it works.
+                onKeyDown={dismissKeyboardOnEnter}
+              />
+            </div>
+          </PanelSectionRow>
+          {showTypeFilter && (
+            <PanelSectionRow>
+              <Focusable
+                flow-children="horizontal"
+                // alignItems:stretch makes every button as tall as the tallest,
+                // so the wrapped "IGDB Collection" label reads as intentional
+                // rather than leaving the single-line buttons short. marginBottom
+                // separates this row from the Enable/Disable All row below (#1539).
+                style={{ display: "flex", gap: "8px", alignItems: "stretch", marginBottom: "12px" }}
+              >
+                {VIRTUAL_TYPE_FILTER_ORDER.map((type) => (
+                  <DialogButton
+                    key={type}
+                    style={{
+                      flex: 1,
+                      minWidth: 0,
+                      padding: "8px 4px",
+                      // Center the label in the stretched button so a wrapped
+                      // two-line label sits centered like the single-line ones.
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      textAlign: "center",
+                      opacity: virtualTypeFilter === type ? 1 : 0.5,
+                      borderBottom: virtualTypeFilter === type ? "2px solid #1a9fff" : "2px solid transparent",
+                    }}
+                    onClick={() => setVirtualTypeFilter(type)}
+                  >
+                    {VIRTUAL_TYPE_FILTER_LABELS[type]}
+                  </DialogButton>
+                ))}
+              </Focusable>
+            </PanelSectionRow>
+          )}
+          <PanelSectionRow>
             <Focusable flow-children="horizontal" style={{ display: "flex", gap: "8px" }}>
               <DialogButton
                 style={{ flex: 1, minWidth: 0 }}
-                onClick={() => {
-                  detach(handleSetAllCollections(true, activeSubTab));
-                }}
+                onClick={() => handleCollectionsSetAll(true, isWholeKind, matchedIds)}
               >
                 Enable All
               </DialogButton>
               <DialogButton
                 style={{ flex: 1, minWidth: 0 }}
-                onClick={() => {
-                  detach(handleSetAllCollections(false, activeSubTab));
-                }}
+                onClick={() => handleCollectionsSetAll(false, isWholeKind, matchedIds)}
               >
                 Disable All
               </DialogButton>
             </Focusable>
           </PanelSectionRow>
-          {visible.length === 0 ? (
+          {matched.length === 0 ? (
             <PanelSectionRow>
-              <Field label={`No ${activeLabel.toLowerCase()} collections`} />
+              <Field
+                label={
+                  search
+                    ? `No ${activeLabel.toLowerCase()} collections match your search`
+                    : `No ${activeLabel.toLowerCase()} collections`
+                }
+              />
             </PanelSectionRow>
           ) : (
-            visible.map((collection) => (
-              <PanelSectionRow key={`${collection.kind}:${collection.id}`}>
-                <ToggleField
-                  label={collection.name}
-                  description={collectionRowDescription(collection)}
-                  checked={collection.sync_enabled}
-                  onChange={(value: boolean) => {
-                    detach(handleCollectionToggle(collection.id, collection.kind, value));
-                  }}
-                />
-              </PanelSectionRow>
-            ))
+            <>
+              {rendered.map((collection) => (
+                <PanelSectionRow key={`${collection.kind}:${collection.id}`}>
+                  <ToggleField
+                    label={collection.name}
+                    description={collectionRowDescription(collection)}
+                    checked={collection.sync_enabled}
+                    onChange={(value: boolean) => {
+                      detach(handleCollectionToggle(collection.id, collection.kind, value));
+                    }}
+                  />
+                </PanelSectionRow>
+              ))}
+              {overflow > 0 && (
+                <PanelSectionRow>
+                  <Field
+                    label={`${overflow} more — refine your search`}
+                    description="Type in the search box above to narrow the list."
+                  />
+                </PanelSectionRow>
+              )}
+            </>
           )}
         </PanelSection>
       </>

--- a/src/components/SettingsPage.test.tsx
+++ b/src/components/SettingsPage.test.tsx
@@ -1542,6 +1542,48 @@ describe("SettingsPage", () => {
       expect(vi.mocked(showPreferredRegionModal)).not.toHaveBeenCalled();
       expect(vi.mocked(backend.savePreferredRegion)).not.toHaveBeenCalled();
     });
+
+    it("hydrates platformGroups from getSettings", async () => {
+      vi.mocked(backend.getSettings).mockResolvedValue({
+        ...defaultSettings(),
+        collection_create_platform_groups: true,
+      });
+      render(<SettingsPage onBack={vi.fn()} />);
+      await flushAsync();
+      expect(capturedLibrary[capturedLibrary.length - 1]?.platformGroups).toBe(true);
+    });
+
+    it("defaults platformGroups to false when getSettings omits it", async () => {
+      render(<SettingsPage onBack={vi.fn()} />);
+      await flushAsync();
+      expect(capturedLibrary[capturedLibrary.length - 1]?.platformGroups).toBe(false);
+    });
+
+    it("onPlatformGroupsChange persists via saveCollectionPlatformGroups and flips the value", async () => {
+      vi.mocked(backend.saveCollectionPlatformGroups).mockResolvedValue({ success: true });
+      render(<SettingsPage onBack={vi.fn()} />);
+      await flushAsync();
+      await act(async () => {
+        capturedLibrary[capturedLibrary.length - 1]?.onPlatformGroupsChange(true);
+        await Promise.resolve();
+      });
+      expect(vi.mocked(backend.saveCollectionPlatformGroups)).toHaveBeenCalledWith(true);
+      expect(capturedLibrary[capturedLibrary.length - 1]?.platformGroups).toBe(true);
+    });
+
+    it("reverts platformGroups when saveCollectionPlatformGroups rejects", async () => {
+      vi.mocked(backend.saveCollectionPlatformGroups).mockRejectedValue(new Error("boom"));
+      render(<SettingsPage onBack={vi.fn()} />);
+      await flushAsync();
+      await act(async () => {
+        capturedLibrary[capturedLibrary.length - 1]?.onPlatformGroupsChange(true);
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      // CATCH-REJECTION assert: rolled back to false.
+      expect(capturedLibrary[capturedLibrary.length - 1]?.platformGroups).toBe(false);
+    });
   });
 
   describe("save-sort migration handlers", () => {

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -18,6 +18,7 @@ import {
   syncAllSaves,
   saveLogLevel,
   savePreferredRegion,
+  saveCollectionPlatformGroups,
   getKnownRegions,
   fixRetroarchInputDriver,
   ensureDeviceRegistered,
@@ -95,6 +96,8 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
   // Library state (preferred sibling-group region, ADR-0021)
   const [preferredRegion, setPreferredRegion] = useState(AUTO_REGION);
   const [libraryRegions, setLibraryRegions] = useState<string[]>([]);
+  // Collection platform-groups toggle (relocated from the Collections tab, #1539).
+  const [platformGroups, setPlatformGroups] = useState(false);
 
   useEffect(() => {
     getSettings()
@@ -107,6 +110,7 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
         setSteamInputMode(s.steam_input_mode);
         setLogLevel(s.log_level);
         setPreferredRegion(s.preferred_region ?? AUTO_REGION);
+        setPlatformGroups(!!s.collection_create_platform_groups);
         if (s.retroarch_input_check) {
           setRetroarchWarning(s.retroarch_input_check);
         }
@@ -452,6 +456,20 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
     );
   };
 
+  // --- Collection platform-groups handler ---
+  const handlePlatformGroupsChange = (value: boolean) => {
+    setPlatformGroups(value);
+    detach(
+      (async () => {
+        try {
+          await saveCollectionPlatformGroups(value);
+        } catch {
+          setPlatformGroups(!value);
+        }
+      })(),
+    );
+  };
+
   // --- Save sort migration handlers ---
   const handleMigrateSaveSort = async () => {
     setSaveSortMigrating(true);
@@ -585,6 +603,8 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
         preferredRegion={preferredRegion}
         libraryRegions={libraryRegions}
         onPreferredRegionChange={handlePreferredRegionChange}
+        platformGroups={platformGroups}
+        onPlatformGroupsChange={handlePlatformGroupsChange}
       />
 
       <AdvancedSection logLevel={logLevel} onLogLevelChange={handleLogLevelChange} />

--- a/src/components/settings/LibrarySection.test.tsx
+++ b/src/components/settings/LibrarySection.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { render } from "@testing-library/react";
+import { render, fireEvent } from "@testing-library/react";
 import { createElement } from "react";
 import { LibrarySection, buildRegionOptions, DEFAULT_REGION_LABEL, AUTO_REGION } from "./LibrarySection";
 
@@ -28,6 +28,20 @@ vi.mock("@decky/ui", () => {
       captured.items.push(p);
       return createElement("div", { "data-testid": "dropdown" }, p.label as never);
     },
+    ToggleField: (p: AnyProps & { checked?: boolean; onChange?: (v: boolean) => void; label?: unknown }) =>
+      createElement(
+        "div",
+        {
+          "data-testid": "toggle",
+          "data-label": typeof p.label === "string" ? p.label : undefined,
+        },
+        createElement("input", {
+          type: "checkbox",
+          "data-testid": "toggle-input",
+          checked: p.checked ?? false,
+          onChange: (e: { target: { checked: boolean } }) => p.onChange?.(e.target.checked),
+        }),
+      ),
   };
 });
 
@@ -73,7 +87,13 @@ describe("LibrarySection", () => {
 
   it("renders the preferred-region dropdown with anchors + library regions", () => {
     render(
-      <LibrarySection preferredRegion={AUTO_REGION} libraryRegions={["Korea"]} onPreferredRegionChange={vi.fn()} />,
+      <LibrarySection
+        preferredRegion={AUTO_REGION}
+        libraryRegions={["Korea"]}
+        onPreferredRegionChange={vi.fn()}
+        platformGroups={false}
+        onPlatformGroupsChange={vi.fn()}
+      />,
     );
     expect(captured.items).toHaveLength(1);
     const item = captured.items[0];
@@ -82,13 +102,29 @@ describe("LibrarySection", () => {
   });
 
   it("forwards the current preferredRegion as selectedOption", () => {
-    render(<LibrarySection preferredRegion="Japan" libraryRegions={[]} onPreferredRegionChange={vi.fn()} />);
+    render(
+      <LibrarySection
+        preferredRegion="Japan"
+        libraryRegions={[]}
+        onPreferredRegionChange={vi.fn()}
+        platformGroups={false}
+        onPlatformGroupsChange={vi.fn()}
+      />,
+    );
     expect(captured.items[0]?.selectedOption).toBe("Japan");
   });
 
   it("dispatches onPreferredRegionChange with option.data when the dropdown fires", () => {
     const onChange = vi.fn();
-    render(<LibrarySection preferredRegion={AUTO_REGION} libraryRegions={[]} onPreferredRegionChange={onChange} />);
+    render(
+      <LibrarySection
+        preferredRegion={AUTO_REGION}
+        libraryRegions={[]}
+        onPreferredRegionChange={onChange}
+        platformGroups={false}
+        onPlatformGroupsChange={vi.fn()}
+      />,
+    );
     captured.items[0]?.onChange?.({ data: "Japan", label: "Japan" });
     expect(onChange).toHaveBeenCalledTimes(1);
     expect(onChange).toHaveBeenCalledWith("Japan");
@@ -96,8 +132,52 @@ describe("LibrarySection", () => {
 
   it("passes the auto sentinel straight through", () => {
     const onChange = vi.fn();
-    render(<LibrarySection preferredRegion="Europe" libraryRegions={[]} onPreferredRegionChange={onChange} />);
+    render(
+      <LibrarySection
+        preferredRegion="Europe"
+        libraryRegions={[]}
+        onPreferredRegionChange={onChange}
+        platformGroups={false}
+        onPlatformGroupsChange={vi.fn()}
+      />,
+    );
     captured.items[0]?.onChange?.({ data: AUTO_REGION, label: DEFAULT_REGION_LABEL });
     expect(onChange).toHaveBeenCalledWith(AUTO_REGION);
+  });
+
+  it("renders the platform-groups toggle reflecting the current value", () => {
+    const { container } = render(
+      <LibrarySection
+        preferredRegion={AUTO_REGION}
+        libraryRegions={[]}
+        onPreferredRegionChange={vi.fn()}
+        platformGroups={true}
+        onPlatformGroupsChange={vi.fn()}
+      />,
+    );
+    const toggle = container.querySelector<HTMLInputElement>(
+      '[data-label="Show collection games in platform groups"] input',
+    );
+    expect(toggle).not.toBeNull();
+    expect(toggle?.checked).toBe(true);
+  });
+
+  it("dispatches onPlatformGroupsChange when the platform-groups toggle fires", () => {
+    const onChange = vi.fn();
+    const { container } = render(
+      <LibrarySection
+        preferredRegion={AUTO_REGION}
+        libraryRegions={[]}
+        onPreferredRegionChange={vi.fn()}
+        platformGroups={false}
+        onPlatformGroupsChange={onChange}
+      />,
+    );
+    const toggle = container.querySelector<HTMLInputElement>(
+      '[data-label="Show collection games in platform groups"] input',
+    )!;
+    fireEvent.click(toggle);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(true);
   });
 });

--- a/src/components/settings/LibrarySection.tsx
+++ b/src/components/settings/LibrarySection.tsx
@@ -1,13 +1,13 @@
 /**
- * Library-wide sync preferences. Currently houses the preferred-region
- * dropdown (ADR-0021 §3): which region wins when a game has several dumps
- * (versions) and the plugin must pick one to bind and to name the Steam
- * shortcut after. Pure renderer: parent owns the current value, the list of
- * regions discovered in the local library, and the save/confirm flow.
+ * Library-wide sync preferences. Houses set-and-forget library toggles: the
+ * preferred-region dropdown (ADR-0021 §3, which region wins when a game has
+ * several dumps and the plugin must pick one to bind + name the shortcut after)
+ * and the collection platform-groups toggle. Pure renderer: parent owns every
+ * value and the save/confirm flow.
  */
 
 import { FC } from "react";
-import { PanelSection, PanelSectionRow, DropdownItem } from "@decky/ui";
+import { PanelSection, PanelSectionRow, DropdownItem, ToggleField } from "@decky/ui";
 
 interface LibrarySectionProps {
   preferredRegion: string;
@@ -15,6 +15,11 @@ interface LibrarySectionProps {
   // backend get_known_regions read). Appended after the fixed anchors.
   libraryRegions: string[];
   onPreferredRegionChange: (region: string) => void;
+  // Whether a synced collection's games are also added to their platform's
+  // Steam group. A set-and-forget library preference, so it lives here rather
+  // than on the per-sync Collections tab.
+  platformGroups: boolean;
+  onPlatformGroupsChange: (enabled: boolean) => void;
 }
 
 // The internal sentinel for "no preference — use the fixed build-time order".
@@ -58,6 +63,8 @@ export const LibrarySection: FC<LibrarySectionProps> = ({
   preferredRegion,
   libraryRegions,
   onPreferredRegionChange,
+  platformGroups,
+  onPlatformGroupsChange,
 }) => {
   return (
     <PanelSection title="Library">
@@ -68,6 +75,14 @@ export const LibrarySection: FC<LibrarySectionProps> = ({
           rgOptions={buildRegionOptions(libraryRegions, preferredRegion)}
           selectedOption={preferredRegion}
           onChange={(option) => onPreferredRegionChange(option.data)}
+        />
+      </PanelSectionRow>
+      <PanelSectionRow>
+        <ToggleField
+          label="Show collection games in platform groups"
+          description="When syncing a collection, also add its games to their platform-specific Steam group."
+          checked={platformGroups}
+          onChange={onPlatformGroupsChange}
         />
       </PanelSectionRow>
     </PanelSection>

--- a/src/utils/fuzzyMatch.test.ts
+++ b/src/utils/fuzzyMatch.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { fuzzyMatch } from "./fuzzyMatch";
+
+describe("fuzzyMatch", () => {
+  it("matches an in-order subsequence", () => {
+    expect(fuzzyMatch("abc", "aXbXc")).toBe(true);
+    expect(fuzzyMatch("rpg", "Retro Playable Games")).toBe(true);
+  });
+
+  it("matches a contiguous substring", () => {
+    expect(fuzzyMatch("game", "My Game List")).toBe(true);
+  });
+
+  it("does not match when characters are out of order", () => {
+    expect(fuzzyMatch("cba", "abc")).toBe(false);
+  });
+
+  it("does not match when a query character is absent", () => {
+    expect(fuzzyMatch("xyz", "abc")).toBe(false);
+    expect(fuzzyMatch("abcd", "abc")).toBe(false);
+  });
+
+  it("is case-insensitive in both directions", () => {
+    expect(fuzzyMatch("ABC", "aXbXc")).toBe(true);
+    expect(fuzzyMatch("abc", "AXBXC")).toBe(true);
+  });
+
+  it("matches everything on an empty query", () => {
+    expect(fuzzyMatch("", "anything")).toBe(true);
+    expect(fuzzyMatch("", "")).toBe(true);
+  });
+
+  it("never matches a non-empty query against an empty target", () => {
+    expect(fuzzyMatch("a", "")).toBe(false);
+  });
+});

--- a/src/utils/fuzzyMatch.ts
+++ b/src/utils/fuzzyMatch.ts
@@ -1,0 +1,16 @@
+/**
+ * Subsequence fuzzy match (fzf-style): every character of `query` must appear in
+ * `target` in order, case-insensitively. Used to filter long name lists (the
+ * Danger Zone whitelist, the Collections list) from a single search box.
+ *
+ * An empty query matches everything, so an empty search box never hides rows.
+ */
+export function fuzzyMatch(query: string, target: string): boolean {
+  const q = query.toLowerCase();
+  const t = target.toLowerCase();
+  let qi = 0;
+  for (let ti = 0; ti < t.length && qi < q.length; ti++) {
+    if (t[ti] === q[qi]) qi++;
+  }
+  return qi === q.length;
+}

--- a/tests/contract/test_sync_read.py
+++ b/tests/contract/test_sync_read.py
@@ -247,6 +247,45 @@ async def test_virtual_collection_enable_round_trips(harness):
     assert "error_code" not in rejected
 
 
+async def test_save_collections_sync_batch_round_trips(harness):
+    """The batch callable stamps every id in one write and reads back enabled."""
+    harness.romm.collections = [
+        {"id": 1, "name": "Alpha", "rom_count": 1},
+        {"id": 2, "name": "Beta", "rom_count": 1},
+        {"id": 3, "name": "Gamma", "rom_count": 1},
+    ]
+    result = await harness.plugin.save_collections_sync(["1", "3"], "user", True)
+    assert result == {"success": True}
+    bucket = harness.plugin.settings["enabled_collections"]["user"]
+    assert bucket["1"] is True
+    assert bucket["3"] is True
+    assert "2" not in bucket
+
+    listing = await harness.plugin.get_collections()
+    by_id = {c["id"]: c for c in listing["collections"]}
+    assert by_id["1"]["sync_enabled"] is True
+    assert by_id["2"]["sync_enabled"] is False
+    assert by_id["3"]["sync_enabled"] is True
+
+
+async def test_save_collections_sync_rejects_invalid_kind(harness):
+    """An unknown kind returns the canonical failure shape and stamps nothing."""
+    result = await harness.plugin.save_collections_sync(["1"], "franchise", True)
+    assert result["success"] is False
+    assert isinstance(result["reason"], str)
+    assert isinstance(result["message"], str) and result["message"]
+    assert "error" not in result
+    assert "error_code" not in result
+    assert harness.plugin.settings["enabled_collections"]["user"] == {}
+
+
+async def test_save_collections_sync_empty_ids_is_no_op(harness):
+    """An empty id list is a success no-op — nothing stamped."""
+    result = await harness.plugin.save_collections_sync([], "user", True)
+    assert result == {"success": True}
+    assert harness.plugin.settings["enabled_collections"]["user"] == {}
+
+
 async def test_set_collection_owner_scope_persists(harness):
     """set_collection_owner_scope stores the value and get_settings reports it back."""
     result = await harness.plugin.set_collection_owner_scope("own")

--- a/tests/services/library/test_fetcher.py
+++ b/tests/services/library/test_fetcher.py
@@ -339,6 +339,92 @@ class TestGetCollectionsVirtualFailOpen:
         assert not [c for c in result["collections"] if c.get("virtual_type") == "franchise"]
 
 
+class TestSaveCollectionsSync:
+    """save_collections_sync — batch-stamp a filtered subset into one kind bucket (#1539)."""
+
+    def test_stamps_multiple_ids_in_one_write(self, plugin):
+        """Every id in the list lands enabled in the kind bucket, one persist."""
+        plugin.settings["enabled_collections"] = {"user": {}, "smart": {}, "virtual": {}}
+        recorder = plugin._settings_persister
+
+        result = plugin._sync_service._fetcher.save_collections_sync(["10", "20", "30"], "user", True)
+
+        assert result == {"success": True}
+        bucket = plugin.settings["enabled_collections"]["user"]
+        assert bucket == {"10": True, "20": True, "30": True}
+        # A single settings write for the whole batch.
+        assert recorder.save_count == 1
+
+    def test_disable_stamps_false_without_touching_other_buckets(self, plugin):
+        """Disabling a subset writes False for those ids and leaves siblings intact."""
+        plugin.settings["enabled_collections"] = {
+            "user": {},
+            "smart": {"5": True, "6": True},
+            "virtual": {},
+        }
+
+        result = plugin._sync_service._fetcher.save_collections_sync(["5"], "smart", False)
+
+        assert result == {"success": True}
+        assert plugin.settings["enabled_collections"]["smart"] == {"5": False, "6": True}
+
+    def test_coerces_non_string_ids_to_string_keys(self, plugin):
+        """Integer ids are coerced to string keys (parity with save_collection_sync)."""
+        plugin.settings["enabled_collections"] = {"user": {}, "smart": {}, "virtual": {}}
+
+        plugin._sync_service._fetcher.save_collections_sync([7, 8], "user", True)
+
+        bucket = plugin.settings["enabled_collections"]["user"]
+        assert bucket == {"7": True, "8": True}
+
+    def test_rejects_invalid_kind_with_failure_shape(self, plugin):
+        """An unknown kind is rejected with the canonical failure shape, no write."""
+        recorder = plugin._settings_persister
+
+        result = plugin._sync_service._fetcher.save_collections_sync(["1"], "bogus", True)
+
+        assert result["success"] is False
+        assert result["reason"] == "invalid_kind"
+        assert "Invalid collection kind" in result["message"]
+        assert "error" not in result
+        assert "error_code" not in result
+        assert recorder.save_count == 0
+
+    def test_rejects_non_list_ids_with_failure_shape(self, plugin):
+        """A non-list ids argument from the wire is rejected, no write."""
+        recorder = plugin._settings_persister
+
+        result = plugin._sync_service._fetcher.save_collections_sync("not-a-list", "user", True)
+
+        assert result["success"] is False
+        assert result["reason"] == "invalid_ids"
+        assert isinstance(result["message"], str) and result["message"]
+        assert recorder.save_count == 0
+
+    def test_empty_ids_is_a_success_no_op(self, plugin):
+        """An empty id list stamps nothing and does not write settings."""
+        plugin.settings["enabled_collections"] = {"user": {"1": True}, "smart": {}, "virtual": {}}
+        recorder = plugin._settings_persister
+
+        result = plugin._sync_service._fetcher.save_collections_sync([], "user", True)
+
+        assert result == {"success": True}
+        # Unchanged bucket, no persist.
+        assert plugin.settings["enabled_collections"]["user"] == {"1": True}
+        assert recorder.save_count == 0
+
+    def test_materializes_missing_buckets_before_stamping(self, plugin):
+        """A settings dict seeded without enabled_collections gets all buckets."""
+        plugin.settings.pop("enabled_collections", None)
+
+        plugin._sync_service._fetcher.save_collections_sync(["100"], "virtual", True)
+
+        ec = plugin.settings["enabled_collections"]
+        assert ec["virtual"]["100"] is True
+        assert ec["user"] == {}
+        assert ec["smart"] == {}
+
+
 class TestBuildWorkQueueOwnerScope:
     """build_work_queue applies the collection owner-scope filter (#1532)."""
 

--- a/tests/test_plugin_callable_delegation.py
+++ b/tests/test_plugin_callable_delegation.py
@@ -336,6 +336,13 @@ class TestLibrarySyncCallableDelegation:
         assert result == {"ok": True}
 
     @pytest.mark.asyncio
+    async def test_save_collections_sync_delegates(self, plugin):
+        plugin._sync_service.save_collections_sync.return_value = {"success": True}
+        result = await plugin.save_collections_sync(["1", "2"], "user", True)
+        plugin._sync_service.save_collections_sync.assert_called_once_with(["1", "2"], "user", True)
+        assert result == {"success": True}
+
+    @pytest.mark.asyncio
     async def test_set_all_collections_sync_delegates(self, plugin):
         plugin._sync_service.set_all_collections_sync = AsyncMock(return_value={"ok": True})
         result = await plugin.set_all_collections_sync(True, "user")


### PR DESCRIPTION
First of two PRs for #1539. Restructures the collections QAM so it stays usable as the virtual-collection list grows.

- **Search** — a fuzzy name filter over the collection list (a shared `fuzzyMatch` util).
- **Render cap** — the list paints at most 50 rows plus a "N more — refine your search" hint, so a large virtual list never strains the renderer.
- **Per-type filter** — on the Virtual sub-tab, an All / Franchise / IGDB Collection control narrows by type.
- **Enable All / Disable All act on the current filter** — a new `save_collections_sync` batch callable toggles exactly the matched collections; enabling a whole kind (no filter) asks for confirmation first.
- **Declutter** — the "Show collection games in platform groups" toggle moves to Settings → Library, leaving the Collections panel for browsing and selection.

The collection naming/provenance toggle (`collection_naming_mode`) is the second PR.

Part of #1539.
