### PR TITLE
feat(saves): default new save slots to "autosave" to match Argosy and Grout

### DIFF
--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -278,7 +278,7 @@ backup.
   mode — `UPDATE rom_save_states SET slot_confirmed=0 WHERE active_slot IS NULL AND slot_confirmed=1` (the pre-rename
   table name migration `005` targets; migration `018` later renames it to `rom_save_sync_states`). No save data is
   touched; the wizard simply reappears for that ROM and the user re-picks a named slot (optionally migrating the legacy
-  saves in). `resolve_default_slot` never returns `None` — a blank/unset default coerces to `"default"`.
+  saves in). `resolve_default_slot` never returns `None` — a blank/unset default coerces to `"autosave"`.
 - **Why the bucket is not coming back as an opt-in write target** —
   [ADR-0026](../adr/0026-legacy-bucket-stays-read-only.md) records the decision and what was measured against a live
   RomM 5.0.0 server to reach it (the web player can continue a **named**-slot save, so interop does not require
@@ -1625,7 +1625,8 @@ The save-sync feature toggles (`save_sync_enabled`, `sync_before_launch`, `sync_
 forwards) surfaces a conflict the user has no UI to resolve — the SAVES tab where one would resolve it is hidden while
 disabled. A stale server-side conflict (e.g. another device moved the save) therefore can't render a game unplayable.
 `sync_before_launch` / `sync_after_exit` gate the automatic pre-launch / post-exit syncs; `default_slot` is the slot new
-games adopt (`"default"`); `autocleanup_limit` caps retained save versions per slot on the server (10).
+games adopt (`"autosave"`, matching the official RomM clients Argosy and Grout); `autocleanup_limit` caps retained save
+versions per slot on the server (10).
 
 Conflicts are no longer persisted. They are returned ephemerally from `do_sync_rom_saves` and `_get_save_status_io` and
 surfaced via the modal at the moment of the sync. If the user dismisses the modal (Cancel), the conflict re-fires on the

--- a/py_modules/adapters/persistence.py
+++ b/py_modules/adapters/persistence.py
@@ -16,7 +16,7 @@ from typing import Any, Protocol
 
 from adapters.system_clock import SystemClock
 
-_SETTINGS_VERSION = 11
+_SETTINGS_VERSION = 12
 _LOCK_EXT = ".lock"
 
 
@@ -62,7 +62,7 @@ DEFAULT_SETTINGS: dict[str, Any] = {
     "save_sync_enabled": False,
     "sync_before_launch": True,
     "sync_after_exit": True,
-    "default_slot": "default",
+    "default_slot": "autosave",
     "autocleanup_limit": 10,
     "device_name": None,
     "platform_cores": {},

--- a/py_modules/domain/state_migrations.py
+++ b/py_modules/domain/state_migrations.py
@@ -37,6 +37,8 @@ def migrate_settings(data: dict[str, Any]) -> dict[str, Any]:
         new_data = _migrate_v9_to_v10(new_data)
     if version < 11:
         new_data = _migrate_v10_to_v11(new_data)
+    if version < 12:
+        new_data = _migrate_v11_to_v12(new_data)
     return new_data
 
 
@@ -284,4 +286,22 @@ def _migrate_v10_to_v11(data: dict[str, Any]) -> dict[str, Any]:
         rebuilt["virtual"] = merged
         data["enabled_collections"] = rebuilt
     data["version"] = 11
+    return data
+
+
+def _migrate_v11_to_v12(data: dict[str, Any]) -> dict[str, Any]:
+    """v<12 → v12: align the default save slot with the ecosystem's ``autosave``.
+
+    ``default_slot`` — the slot a brand-new, never-configured ROM adopts on its
+    first sync — moves from ``"default"`` to ``"autosave"``, the slot name the
+    official RomM clients (Argosy, Grout) use, so a save synced from one client
+    lands in the slot the others read. Only a stored value of exactly
+    ``"default"`` is rewritten; a user-chosen slot name is left untouched, and an
+    absent key is left absent (``DEFAULT_SETTINGS`` seeds the new default on
+    load). Existing tracked ROMs are unaffected — each syncs to its persisted
+    ``active_slot``, never to this setting.
+    """
+    if data.get("default_slot") == "default":
+        data["default_slot"] = "autosave"
+    data["version"] = 12
     return data

--- a/py_modules/services/saves/_settings.py
+++ b/py_modules/services/saves/_settings.py
@@ -28,17 +28,18 @@ def sync_after_exit(settings: dict[str, Any]) -> bool:
 
 
 def resolve_default_slot(settings: dict[str, Any]) -> str:
-    """The configured default slot, coercing blank/None/whitespace to ``"default"``.
+    """The configured default slot, coercing blank/None/whitespace to ``"autosave"``.
 
     Never returns ``None``: the legacy no-slot mode is retired (#1276), so a
     missing, empty, or whitespace-only ``default_slot`` collapses to the
-    canonical ``"default"`` slot rather than legacy mode.
+    canonical ``"autosave"`` slot (the name the official RomM clients use)
+    rather than legacy mode.
     """
-    raw_slot = settings.get("default_slot", "default")
+    raw_slot = settings.get("default_slot", "autosave")
     if raw_slot is None:
-        return "default"
+        return "autosave"
     slot_str = str(raw_slot).strip()
-    return slot_str if slot_str else "default"
+    return slot_str if slot_str else "autosave"
 
 
 def autocleanup_limit(settings: dict[str, Any]) -> int:
@@ -61,16 +62,16 @@ def sanitize_setting(key: str, value: object) -> tuple[object, bool]:
     """Validate and coerce a single save-sync settings key/value pair.
 
     Returns ``(coerced_value, skip)`` where ``skip=True`` means the value should
-    be discarded. Empty/whitespace/None slot names collapse to ``"default"``
+    be discarded. Empty/whitespace/None slot names collapse to ``"autosave"``
     (the legacy no-slot mode is retired, #1276 — mirroring the
     ``autocleanup_limit`` clamp philosophy), ``autocleanup_limit`` is clamped to
     a positive int, and the three booleans pass through ``bool(...)``.
     """
     if key == "default_slot":
         if value is None:
-            return "default", False  # blank/None -> canonical "default" slot
+            return "autosave", False  # blank/None -> canonical "autosave" slot
         coerced = str(value).strip()
-        return (coerced if coerced else "default"), False  # empty -> "default"
+        return (coerced if coerced else "autosave"), False  # empty -> "autosave"
     if key == "autocleanup_limit":
         return max(1, int(value)), False  # type: ignore[arg-type]
     if key in ("save_sync_enabled", "sync_before_launch", "sync_after_exit"):

--- a/py_modules/services/saves/slots/listing.py
+++ b/py_modules/services/saves/slots/listing.py
@@ -74,7 +74,7 @@ class SlotListing:
             }
 
         rom_state, device_id = await self._loop.run_in_executor(None, self._read_inputs, rom_id)
-        default_slot = resolve_default_slot(self._settings) or "autosave"
+        default_slot = resolve_default_slot(self._settings)
         # ROM not tracked → fall back to the global default slot. ROM
         # tracked with ``active_slot=None`` → preserve legacy mode (None
         # means "no slots"; the persisted slots dict will contain ``""``).

--- a/py_modules/services/saves/slots/listing.py
+++ b/py_modules/services/saves/slots/listing.py
@@ -70,11 +70,11 @@ class SlotListing:
                 "reason": "sync_disabled",
                 "message": SAVE_SYNC_DISABLED,
                 "slots": [],
-                "active_slot": "default",
+                "active_slot": "autosave",
             }
 
         rom_state, device_id = await self._loop.run_in_executor(None, self._read_inputs, rom_id)
-        default_slot = resolve_default_slot(self._settings) or "default"
+        default_slot = resolve_default_slot(self._settings) or "autosave"
         # ROM not tracked → fall back to the global default slot. ROM
         # tracked with ``active_slot=None`` → preserve legacy mode (None
         # means "no slots"; the persisted slots dict will contain ``""``).

--- a/py_modules/services/saves/slots/setup.py
+++ b/py_modules/services/saves/slots/setup.py
@@ -118,7 +118,7 @@ class SetupWizard:
         # saves the user already had. Surface a distinct recommendation so
         # the frontend can hold the wizard and offer a retry instead.
         game_state, device_id = await self._loop.run_in_executor(None, self._read_setup_inputs, rom_id)
-        default_slot = resolve_default_slot(self._settings) or "autosave"
+        default_slot = resolve_default_slot(self._settings)
         try:
             server_saves: list[dict[str, Any]] = await self._loop.run_in_executor(
                 None,

--- a/py_modules/services/saves/slots/setup.py
+++ b/py_modules/services/saves/slots/setup.py
@@ -118,7 +118,7 @@ class SetupWizard:
         # saves the user already had. Surface a distinct recommendation so
         # the frontend can hold the wizard and offer a retry instead.
         game_state, device_id = await self._loop.run_in_executor(None, self._read_setup_inputs, rom_id)
-        default_slot = resolve_default_slot(self._settings) or "default"
+        default_slot = resolve_default_slot(self._settings) or "autosave"
         try:
             server_saves: list[dict[str, Any]] = await self._loop.run_in_executor(
                 None,

--- a/py_modules/services/saves/sync_engine/engine.py
+++ b/py_modules/services/saves/sync_engine/engine.py
@@ -231,6 +231,7 @@ class SyncEngine:
             logger=config.logger,
             log_debug=config.log_debug,
             resolve_core=self.resolve_core,
+            settings=config.settings,
         )
         # Device-level single-owner serialization gate: only one save-sync run
         # in flight at a time per device. A second trigger queues behind the

--- a/py_modules/services/saves/sync_engine/matrix.py
+++ b/py_modules/services/saves/sync_engine/matrix.py
@@ -235,7 +235,7 @@ class MatrixExecutor:
         if not save_state.system and system:
             save_state.adopt_system(system)
         if save_state.active_slot is None and not save_state.slots:
-            save_state.switch_active_slot(default_slot or "default")
+            save_state.switch_active_slot(default_slot or "autosave")
         save_state.record_synced_core(core_so, emulator_tag or save_state.emulator or "retroarch")
 
         now = self._clock.now().isoformat()
@@ -369,7 +369,7 @@ class MatrixExecutor:
             return save_state.active_slot
         if save_state.slots:
             return None
-        return default_slot or "default"
+        return default_slot or "autosave"
 
     def _confirm_upload_sync(self, response: dict[str, Any], device_id: str | None) -> None:
         """Ack the uploaded save on the server's DeviceSaveSync row, unless redundant.

--- a/py_modules/services/saves/sync_engine/rollback.py
+++ b/py_modules/services/saves/sync_engine/rollback.py
@@ -28,6 +28,7 @@ from lib.errors import DeviceNotRegisteredError, classify_error
 from lib.list_result import ErrorCode
 from services.saves._helpers import local_save_target
 from services.saves._messages import DEVICE_NOT_REGISTERED, DEVICE_NOT_REGISTERED_REASON
+from services.saves._settings import resolve_default_slot
 
 if TYPE_CHECKING:
     import asyncio
@@ -73,6 +74,7 @@ class RollbackOrchestrator:
         logger: logging.Logger,
         log_debug: DebugLogger,
         resolve_core: Callable[[int], str | None],
+        settings: dict[str, Any],
     ) -> None:
         self._uow_factory = uow_factory
         self._rom_info = rom_info
@@ -85,6 +87,7 @@ class RollbackOrchestrator:
         self._logger = logger
         self._log_debug = log_debug
         self._resolve_core = resolve_core
+        self._settings = settings
 
     def _read_inputs(self, rom_id: int) -> tuple[RomSaveSyncState, str | None]:
         """Short read UoW: load the ROM's save state + device id."""
@@ -265,7 +268,8 @@ class RollbackOrchestrator:
         lands at. Mutates *save_state* in memory; ``resolve`` owns the write UoW.
         """
         target = local_save_target(server, rom_name)
-        self._matrix.do_download_save(server, saves_dir, target, save_state, device_id, system)
+        default_slot = resolve_default_slot(self._settings)
+        self._matrix.do_download_save(server, saves_dir, target, save_state, device_id, system, default_slot)
 
     def _resolve_conflict_keep_local(
         self,
@@ -336,6 +340,7 @@ class RollbackOrchestrator:
         # write-time currency (409) gate rather than 409-backstop into a conflict
         # loop (ADR-0017). The freshness of the server head was already validated
         # by the STALE_CONFLICT check in ``resolve`` before we got here.
+        default_slot = resolve_default_slot(self._settings)
         self._matrix.do_upload_save(
-            rom_id, local_path, target, save_state, device_id, system, core_so, None, overwrite=True
+            rom_id, local_path, target, save_state, device_id, system, core_so, None, default_slot, overwrite=True
         )

--- a/tests/adapters/test_persistence.py
+++ b/tests/adapters/test_persistence.py
@@ -84,8 +84,13 @@ class TestLocking:
 class TestSettingsSchema:
     """Schema-level expectations for the settings defaults + version stamp."""
 
-    def test_settings_version_is_11(self):
-        assert _SETTINGS_VERSION == 11
+    def test_settings_version_is_12(self):
+        assert _SETTINGS_VERSION == 12
+
+    def test_default_settings_default_slot_is_autosave(self):
+        # New ROMs adopt "autosave" (the slot name the official RomM clients use),
+        # aligning first-sync placement with Argosy and Grout (#1529).
+        assert DEFAULT_SETTINGS["default_slot"] == "autosave"
 
     def test_default_settings_omit_retired_credential_keys(self):
         """The retired legacy-credential keys must not be re-seeded on load."""
@@ -142,7 +147,7 @@ class TestVersionStampingOnSave:
         with open(settings_path) as f:
             loaded = json.load(f)
         assert loaded["version"] == _SETTINGS_VERSION
-        assert loaded["version"] == 11
+        assert loaded["version"] == 12
 
 
 # ── Loading edge cases ─────────────────────────────────────────────────────────

--- a/tests/contract/test_saves_read.py
+++ b/tests/contract/test_saves_read.py
@@ -130,7 +130,7 @@ async def test_get_save_slots_sync_disabled_failure_shape(harness):
     assert isinstance(result["message"], str)
     assert result["message"]
     assert result["slots"] == []
-    assert result["active_slot"] == "default"
+    assert result["active_slot"] == "autosave"
 
 
 async def test_get_save_slots_server_failure_shape(harness):

--- a/tests/domain/test_state_migrations.py
+++ b/tests/domain/test_state_migrations.py
@@ -10,6 +10,7 @@ from domain.state_migrations import (
     _migrate_v8_to_v9,
     _migrate_v9_to_v10,
     _migrate_v10_to_v11,
+    _migrate_v11_to_v12,
     fold_legacy_save_sync_settings,
     migrate_settings,
 )
@@ -21,28 +22,28 @@ class TestMigrateSettings:
         result = migrate_settings(data)
         assert result["steam_input_mode"] == "force_off"
         assert "disable_steam_input" not in result
-        assert result["version"] == 11
+        assert result["version"] == 12
 
     def test_migrate_settings_v0_disable_steam_input_false(self):
         data = {"version": 0, "disable_steam_input": False}
         result = migrate_settings(data)
         assert "disable_steam_input" not in result
         assert "steam_input_mode" not in result  # False → no override set
-        assert result["version"] == 11
+        assert result["version"] == 12
 
     def test_migrate_settings_v0_debug_logging_true(self):
         data = {"version": 0, "debug_logging": True}
         result = migrate_settings(data)
         assert result["log_level"] == "debug"
         assert "debug_logging" not in result
-        assert result["version"] == 11
+        assert result["version"] == 12
 
     def test_migrate_settings_v0_debug_logging_false(self):
         data = {"version": 0, "debug_logging": False}
         result = migrate_settings(data)
         assert "debug_logging" not in result
         assert "log_level" not in result  # False → no log_level override set
-        assert result["version"] == 11
+        assert result["version"] == 12
 
     def test_migrate_settings_v0_both_deprecated(self):
         data = {"version": 0, "disable_steam_input": True, "debug_logging": True}
@@ -51,13 +52,13 @@ class TestMigrateSettings:
         assert result["log_level"] == "debug"
         assert "disable_steam_input" not in result
         assert "debug_logging" not in result
-        assert result["version"] == 11
+        assert result["version"] == 12
 
     def test_migrate_settings_v0_no_deprecated_keys(self):
         data = {"version": 0, "romm_url": "http://example.com"}
         result = migrate_settings(data)
         assert result["romm_url"] == "http://example.com"
-        assert result["version"] == 11
+        assert result["version"] == 12
 
     def test_migrate_settings_v3_advances_through_token_seeding(self):
         """v3 → v10: version stamp advances and the token slots are seeded.
@@ -73,7 +74,7 @@ class TestMigrateSettings:
         data = {"version": 3, "romm_url": "http://example.com", "log_level": "warn"}
         result = migrate_settings(data)
         assert result == {
-            "version": 11,
+            "version": 12,
             "romm_url": "http://example.com",
             "log_level": "warn",
             "romm_api_token": None,
@@ -87,7 +88,7 @@ class TestMigrateSettings:
         data = {"version": 4, "romm_url": "http://example.com", "log_level": "warn"}
         result = migrate_settings(data)
         assert result == {
-            "version": 11,
+            "version": 12,
             "romm_url": "http://example.com",
             "log_level": "warn",
             "romm_api_token": None,
@@ -108,7 +109,7 @@ class TestMigrateSettings:
         }
         result = migrate_settings(data)
         assert result == {
-            "version": 11,
+            "version": 12,
             "romm_url": "http://example.com",
             "log_level": "warn",
             "romm_api_token": "rmm_existing",
@@ -129,7 +130,7 @@ class TestMigrateSettings:
         }
         result = migrate_settings(data)
         assert result == {
-            "version": 11,
+            "version": 12,
             "romm_url": "http://example.com",
             "log_level": "warn",
             "romm_api_token": "rmm_existing",
@@ -151,7 +152,7 @@ class TestMigrateSettings:
         }
         result = migrate_settings(data)
         assert result == {
-            "version": 11,
+            "version": 12,
             "romm_url": "http://example.com",
             "log_level": "warn",
             "romm_api_token": "rmm_existing",
@@ -161,9 +162,9 @@ class TestMigrateSettings:
             "romm_api_token_source": "minted",
         }
 
-    def test_migrate_settings_v11_no_change(self):
+    def test_migrate_settings_v12_no_change(self):
         data = {
-            "version": 11,
+            "version": 12,
             "romm_url": "http://example.com",
             "log_level": "warn",
             "romm_api_token": "rmm_existing",
@@ -181,7 +182,7 @@ class TestMigrateSettings:
         result = migrate_settings(data)
         assert result["romm_api_token"] == "rmm_keep"
         assert result["romm_api_token_id"] == 3
-        assert result["version"] == 11
+        assert result["version"] == 12
 
     def test_migrate_settings_v0_to_v5_seeds_token_slots(self):
         """A pre-versioning file runs the whole chain and ends with token slots."""
@@ -189,12 +190,12 @@ class TestMigrateSettings:
         result = migrate_settings(data)
         assert result["romm_api_token"] is None
         assert result["romm_api_token_id"] is None
-        assert result["version"] == 11
+        assert result["version"] == 12
 
     def test_migrate_settings_fresh_empty(self):
         data = {}
         result = migrate_settings(data)
-        assert result["version"] == 11
+        assert result["version"] == 12
         assert "disable_steam_input" not in result
         assert "debug_logging" not in result
 
@@ -202,7 +203,7 @@ class TestMigrateSettings:
         data = {"romm_url": "http://example.com", "disable_steam_input": True}
         result = migrate_settings(data)
         assert result["steam_input_mode"] == "force_off"
-        assert result["version"] == 11
+        assert result["version"] == 12
 
     def test_migrate_settings_debug_logging_true_overrides_log_level(self):
         """When debug_logging=True is being migrated, log_level is set to 'debug' unconditionally.
@@ -214,7 +215,7 @@ class TestMigrateSettings:
         result = migrate_settings(data)
         assert result["log_level"] == "debug"
         assert "debug_logging" not in result
-        assert result["version"] == 11
+        assert result["version"] == 12
 
     def test_migrate_settings_idempotent(self):
         data = {"version": 0, "disable_steam_input": True, "debug_logging": True}
@@ -237,7 +238,7 @@ class TestMigrateSettingsV5Token:
         result = migrate_settings(data)
         assert result["romm_api_token"] is None
         assert result["romm_api_token_id"] is None
-        assert result["version"] == 11
+        assert result["version"] == 12
 
     def test_idempotent_across_two_runs(self):
         data = {"version": 4, "romm_url": "x"}
@@ -312,7 +313,7 @@ class TestMigrateSettingsV6LegacyCredentials:
         """
         data = {"version": 4, "romm_url": "http://example.com", "romm_user": "alice", "romm_pass": "secret"}
         result = migrate_settings(data)
-        assert result["version"] == 11
+        assert result["version"] == 12
         assert result["romm_api_token"] is None
         assert result["romm_user"] == "alice"
         assert result["romm_pass"] == "secret"
@@ -390,7 +391,7 @@ class TestMigrateSettingsV8TokenOrigin:
         data = {"version": 0, "romm_url": "http://example.com"}
         result = migrate_settings(data)
         assert result["romm_api_token_origin"] is None
-        assert result["version"] == 11
+        assert result["version"] == 12
 
     def test_idempotent_via_full_chain(self):
         data = {"version": 7, "romm_api_token_origin": "https://romm.local"}
@@ -469,7 +470,7 @@ class TestMigrateSettingsV9PurgeCredentials:
         result = migrate_settings(data)
         assert "romm_user" not in result
         assert "romm_pass" not in result
-        assert result["version"] == 11
+        assert result["version"] == 12
 
     def test_full_chain_tokenless_real_password_survives(self):
         """A token-less legacy install keeps its real creds for the startup mint."""
@@ -477,7 +478,7 @@ class TestMigrateSettingsV9PurgeCredentials:
         result = migrate_settings(data)
         assert result["romm_user"] == "alice"
         assert result["romm_pass"] == "secret"
-        assert result["version"] == 11
+        assert result["version"] == 12
 
 
 class TestMigrateSettingsV10TokenSource:
@@ -528,13 +529,13 @@ class TestMigrateSettingsV10TokenSource:
         }
         result = migrate_settings(data)
         assert result["romm_api_token_source"] == "minted"
-        assert result["version"] == 11
+        assert result["version"] == 12
 
     def test_full_chain_tokenless_stamps_none(self):
         data = {"version": 0, "romm_url": "http://example.com"}
         result = migrate_settings(data)
         assert result["romm_api_token_source"] is None
-        assert result["version"] == 11
+        assert result["version"] == 12
 
     def test_idempotent_via_full_chain(self):
         data = {"version": 9, "romm_api_token": "rmm_x", "romm_api_token_source": "minted"}
@@ -562,7 +563,7 @@ class TestMigrateSettingsV3Collections:
             "smart": {},
             "virtual": {},
         }
-        assert result["version"] == 11
+        assert result["version"] == 12
 
     def test_base64_keys_move_to_virtual_bucket(self):
         b64 = "eyJuYW1lIjogIlN5bnRoZXRpYyBTZXJpZXMifQ=="
@@ -584,7 +585,7 @@ class TestMigrateSettingsV3Collections:
             "smart": {},
             "virtual": {b64: True},
         }
-        assert result["version"] == 11
+        assert result["version"] == 12
 
     def test_smart_bucket_always_starts_empty(self):
         """Pre-v3 users had no smart collections — bucket must start empty."""
@@ -602,7 +603,7 @@ class TestMigrateSettingsV3Collections:
         data = {"version": 1, "romm_url": "x"}
         result = migrate_settings(data)
         assert "enabled_collections" not in result
-        assert result["version"] == 11
+        assert result["version"] == 12
 
     def test_already_nested_value_is_not_resplit_only_renamed(self):
         """Defensive: a half-stamped v3-shaped value must not be re-split.
@@ -623,7 +624,7 @@ class TestMigrateSettingsV3Collections:
             "smart": {"5": True},
             "virtual": {"abc": False},
         }
-        assert result["version"] == 11
+        assert result["version"] == 12
 
     def test_partial_nested_value_normalized_with_missing_buckets(self):
         """A partial-nested value (only one bucket present) is normalized to all three buckets."""
@@ -634,7 +635,7 @@ class TestMigrateSettingsV3Collections:
             "smart": {},
             "virtual": {},
         }
-        assert result["version"] == 11
+        assert result["version"] == 12
 
     def test_partial_nested_two_buckets_fills_missing_third(self):
         """Partial-nested with two bucket keys — missing bucket is filled empty.
@@ -652,7 +653,7 @@ class TestMigrateSettingsV3Collections:
             "smart": {},
             "virtual": {"abc": True},
         }
-        assert result["version"] == 11
+        assert result["version"] == 12
 
     def test_v0_to_v3_runs_both_steps(self):
         """A v0 file with both deprecated keys AND old enabled_collections gets both migrations."""
@@ -669,7 +670,7 @@ class TestMigrateSettingsV3Collections:
             "smart": {},
             "virtual": {},
         }
-        assert result["version"] == 11
+        assert result["version"] == 12
 
     def test_negative_numeric_string_keys_go_to_user(self):
         """``key.lstrip('-').isdigit()`` accepts ``-1`` as a numeric id."""
@@ -689,7 +690,7 @@ class TestMigrateSettingsV3Collections:
         }
         result = migrate_settings(data)
         assert result["enabled_collections"] == {"user": {"1": True}, "smart": {}, "virtual": {}}
-        assert result["version"] == 11
+        assert result["version"] == 12
 
     def test_v3_migration_does_not_mutate_caller_dict(self):
         data = {"version": 1, "enabled_collections": {"1": True, "abc": True}}
@@ -710,7 +711,7 @@ class TestFoldLegacySaveSyncSettings:
             "save_sync_enabled": False,
             "sync_before_launch": True,
             "sync_after_exit": True,
-            "default_slot": "default",
+            "default_slot": "autosave",
             "autocleanup_limit": 10,
             "device_name": None,
         }
@@ -766,7 +767,7 @@ class TestFoldLegacySaveSyncSettings:
         assert result["device_name"] == "deck"
         # Knobs keep the DEFAULT_SETTINGS placeholders.
         assert result["save_sync_enabled"] is False
-        assert result["default_slot"] == "default"
+        assert result["default_slot"] == "autosave"
 
     def test_missing_device_name_keeps_placeholder(self):
         settings = self._base_settings()
@@ -833,12 +834,12 @@ class TestMigrateSettingsV11Virtual:
             "virtual": {b64: True},
         }
         assert "franchise" not in result["enabled_collections"]
-        assert result["version"] == 11
+        assert result["version"] == 12
 
     def test_v10_without_enabled_collections_only_stamps_version(self):
         data = {"version": 10, "romm_url": "http://example.com"}
         result = migrate_settings(data)
-        assert result["version"] == 11
+        assert result["version"] == 12
         assert "enabled_collections" not in result
 
     def test_full_chain_v2_flat_lands_in_virtual_bucket(self):
@@ -851,9 +852,14 @@ class TestMigrateSettingsV11Virtual:
             "smart": {},
             "virtual": {b64: True},
         }
-        assert result["version"] == 11
+        assert result["version"] == 12
 
-    def test_v11_file_left_untouched(self):
+    def test_v11_virtual_bucket_survives_forward_migration(self):
+        """A v11 file advances to v12 (the default-slot step) with its virtual bucket intact.
+
+        The v10→v11 rename must not re-run — an already-``virtual`` bucket rides
+        through untouched while the chain stamps the version forward.
+        """
         data = {
             "version": 11,
             "enabled_collections": {"user": {"1": True}, "smart": {}, "virtual": {"vc-1": True}},
@@ -864,7 +870,7 @@ class TestMigrateSettingsV11Virtual:
             "smart": {},
             "virtual": {"vc-1": True},
         }
-        assert result["version"] == 11
+        assert result["version"] == 12
 
     def test_merges_into_existing_virtual_bucket_franchise_ids_win(self):
         """If a ``virtual`` bucket somehow already exists, franchise ids union in."""
@@ -891,5 +897,51 @@ class TestMigrateSettingsV11Virtual:
             "version": 10,
             "enabled_collections": {"user": {"1": True}, "smart": {}, "franchise": {"fr": True}},
         }
+        migrate_settings(data)
+        assert data == original
+
+
+class TestMigrateSettingsV12DefaultSlot:
+    """v11 → v12 migration: rewrite the stored default slot from ``default`` to ``autosave``."""
+
+    def test_default_value_rewritten_to_autosave(self):
+        """A stored default of exactly ``"default"`` becomes ``"autosave"`` (#1529)."""
+        result = _migrate_v11_to_v12({"version": 11, "default_slot": "default"})
+        assert result["default_slot"] == "autosave"
+        assert result["version"] == 12
+
+    def test_user_chosen_slot_left_untouched(self):
+        """A user-picked slot name is never rewritten — only exactly ``"default"`` is."""
+        result = _migrate_v11_to_v12({"version": 11, "default_slot": "main"})
+        assert result["default_slot"] == "main"
+        assert result["version"] == 12
+
+    def test_absent_key_left_absent(self):
+        """An absent ``default_slot`` stays absent — the load-time default seeds it."""
+        result = _migrate_v11_to_v12({"version": 11, "romm_url": "http://example.com"})
+        assert "default_slot" not in result
+        assert result["version"] == 12
+
+    def test_full_chain_from_v0_yields_autosave(self):
+        """A pre-versioning file with the legacy default lands on ``autosave`` at v12."""
+        result = migrate_settings({"version": 0, "default_slot": "default"})
+        assert result["default_slot"] == "autosave"
+        assert result["version"] == 12
+
+    def test_full_chain_preserves_user_chosen_slot(self):
+        """A user-chosen slot survives the whole chain unchanged."""
+        result = migrate_settings({"version": 0, "default_slot": "desktop"})
+        assert result["default_slot"] == "desktop"
+        assert result["version"] == 12
+
+    def test_idempotent_via_full_chain(self):
+        once = migrate_settings({"version": 11, "default_slot": "default"})
+        twice = migrate_settings(dict(once))
+        assert once == twice
+        assert once["default_slot"] == "autosave"
+
+    def test_does_not_mutate_caller_dict(self):
+        data = {"version": 11, "default_slot": "default"}
+        original = dict(data)
         migrate_settings(data)
         assert data == original

--- a/tests/services/saves/sync_engine/test_matrix.py
+++ b/tests/services/saves/sync_engine/test_matrix.py
@@ -289,7 +289,9 @@ class TestV47SyncFlow:
         upload_calls = [c for c in fake.call_log if c[0] == "upload_save"]
         assert len(upload_calls) == 1
         assert upload_calls[0][2]["device_id"] == "server-dev-123"
-        assert upload_calls[0][2]["slot"] == "default"
+        # Brand-new ROM (no active_slot, no slots) → first upload lands in the
+        # configured default slot, now "autosave" (#1529).
+        assert upload_calls[0][2]["slot"] == "autosave"
 
     def test_legacy_slot_uploads_as_null_not_default(self, tmp_path):
         """#1061: a sync on the explicit legacy slot uploads slot=None (slot:null), not 'default'.

--- a/tests/services/saves/sync_engine/test_matrix.py
+++ b/tests/services/saves/sync_engine/test_matrix.py
@@ -115,7 +115,8 @@ class TestUpdateFileSyncState:
 
         assert state.emulator == "retroarch-mgba"
         assert state.last_synced_core == "mgba_libretro"
-        assert state.active_slot == "default"
+        # No default_slot passed → brand-new state seeds the canonical default ("autosave").
+        assert state.active_slot == "autosave"
 
         file_state = state.files["pokemon.srm"]
         assert file_state.tracked_save_id == 200

--- a/tests/services/saves/sync_engine/test_rollback.py
+++ b/tests/services/saves/sync_engine/test_rollback.py
@@ -685,3 +685,124 @@ class TestResolveSyncConflictContentDirGate:
 
         assert result["success"] is True
         assert "reason" not in result
+
+
+class TestResolveSyncConflictSeedsConfiguredDefaultSlot:
+    """#1529: conflict resolution on a brand-new ROM must thread the *configured*
+    default slot, never a hard-coded fallback. A ROM already tracking its own slot
+    keeps that slot — the setting never overrides it.
+
+    The brand-new cases configure a distinctive ``default_slot`` ("main") rather
+    than relying on the "autosave" default: the matrix fallback literal is also
+    "autosave", so asserting "autosave" alone could not distinguish a threaded
+    setting from the fallback. Asserting a non-default configured value is what
+    makes these non-vacuous — they fail if ``default_slot`` is not threaded
+    through ``do_download_save`` / ``do_upload_save``. A separate case pins the
+    unconfigured end-to-end default at "autosave".
+    """
+
+    @pytest.mark.asyncio
+    async def test_use_server_new_rom_seeds_configured_default_slot(self, tmp_path):
+        """use_server on a never-configured ROM seeds active_slot from the configured default."""
+        svc, fake = make_service(tmp_path)
+        _enable_sync_with_device(svc)
+        svc._config.settings["default_slot"] = "main"
+        _install_rom(svc, tmp_path)
+        save_path = _create_save(tmp_path, content=b"local-stale")
+        # No save_state seeded → brand-new ROM (active_slot=None, empty slots),
+        # resolving against a legacy (slot:null) server save.
+
+        server_content = tmp_path / "server-content.bin"
+        server_content.write_bytes(b"server-truth")
+        ss = _server_save_with_syncs(device_syncs=[{"device_id": "device-1", "is_current": False}])
+        fake.saves[100] = ss
+        fake.uploaded_files[100] = str(server_content)
+
+        result = await svc.resolve_sync_conflict(
+            rom_id=42, filename="pokemon.srm", server_save_id=100, action="use_server"
+        )
+
+        assert result["success"] is True
+        assert save_path.read_bytes() == b"server-truth"
+        # Regression: without threading, do_download_save seeded the fallback slot
+        # instead of the configured "main".
+        assert _require_save_state(svc, 42).active_slot == "main"
+
+    @pytest.mark.asyncio
+    async def test_keep_local_new_rom_uploads_to_configured_default_slot(self, tmp_path):
+        """keep_local on a never-configured ROM POSTs to the configured default slot."""
+        svc, fake = make_service(tmp_path)
+        _enable_sync_with_device(svc)
+        svc._config.settings["default_slot"] = "main"
+        _install_rom(svc, tmp_path)
+        _create_save(tmp_path, content=b"local-edited")
+        # No save_state seeded → brand-new ROM resolving a legacy conflict.
+
+        ss = _server_save_with_syncs(device_syncs=[{"device_id": "device-1", "is_current": False}])
+        other = tmp_path / "other.bin"
+        other.write_bytes(b"server-flavor")  # differs from local → POST path
+        fake.saves[100] = ss
+        fake.uploaded_files[100] = str(other)
+
+        result = await svc.resolve_sync_conflict(
+            rom_id=42, filename="pokemon.srm", server_save_id=100, action="keep_local"
+        )
+
+        assert result["success"] is True
+        upload_calls = [c for c in fake.call_log if c[0] == "upload_save"]
+        assert len(upload_calls) == 1
+        # Regression: without threading, _resolve_upload_slot fell back to the
+        # hard-coded literal instead of the configured "main".
+        assert upload_calls[0][2]["slot"] == "main"
+        assert _require_save_state(svc, 42).active_slot == "main"
+
+    @pytest.mark.asyncio
+    async def test_new_rom_conflict_defaults_to_autosave_when_unconfigured(self, tmp_path):
+        """#1529 end-to-end: an unconfigured brand-new ROM resolves into "autosave", not "default"."""
+        svc, fake = make_service(tmp_path)
+        _enable_sync_with_device(svc)
+        # default_slot left unset → resolve_default_slot returns "autosave".
+        _install_rom(svc, tmp_path)
+        save_path = _create_save(tmp_path, content=b"local-stale")
+
+        server_content = tmp_path / "server-content.bin"
+        server_content.write_bytes(b"server-truth")
+        ss = _server_save_with_syncs(device_syncs=[{"device_id": "device-1", "is_current": False}])
+        fake.saves[100] = ss
+        fake.uploaded_files[100] = str(server_content)
+
+        result = await svc.resolve_sync_conflict(
+            rom_id=42, filename="pokemon.srm", server_save_id=100, action="use_server"
+        )
+
+        assert result["success"] is True
+        assert save_path.read_bytes() == b"server-truth"
+        assert _require_save_state(svc, 42).active_slot == "autosave"
+
+    @pytest.mark.asyncio
+    async def test_keep_local_tracked_rom_keeps_its_own_slot(self, tmp_path):
+        """A ROM already tracking a named slot resolves into THAT slot, not the default setting."""
+        svc, fake = make_service(tmp_path)
+        _enable_sync_with_device(svc)
+        # A distinctive configured default that must NOT win over the tracked slot.
+        svc._config.settings["default_slot"] = "main"
+        _install_rom(svc, tmp_path)
+        _create_save(tmp_path, content=b"local-edited")
+        _seed_save_state(svc, 42, RomSaveSyncState(system="gba", active_slot="desktop", slot_confirmed=True))
+
+        ss = _server_save_with_syncs(slot="desktop", device_syncs=[{"device_id": "device-1", "is_current": False}])
+        other = tmp_path / "other.bin"
+        other.write_bytes(b"server-flavor")  # differs → POST path
+        fake.saves[100] = ss
+        fake.uploaded_files[100] = str(other)
+
+        result = await svc.resolve_sync_conflict(
+            rom_id=42, filename="pokemon.srm", server_save_id=100, action="keep_local"
+        )
+
+        assert result["success"] is True
+        upload_calls = [c for c in fake.call_log if c[0] == "upload_save"]
+        assert len(upload_calls) == 1
+        # The tracked slot wins — the configured default is irrelevant here.
+        assert upload_calls[0][2]["slot"] == "desktop"
+        assert _require_save_state(svc, 42).active_slot == "desktop"

--- a/tests/services/saves/test_service.py
+++ b/tests/services/saves/test_service.py
@@ -779,28 +779,28 @@ class TestSaveSyncSettingsSlotAndCleanup:
         assert result["success"] is True
         assert result["settings"]["default_slot"] == "desktop"
 
-    def test_update_default_slot_empty_string_becomes_default(self, tmp_path):
+    def test_update_default_slot_empty_string_becomes_autosave(self, tmp_path):
         # Legacy no-slot mode is retired (#1276): a blank slot coerces to the
-        # canonical "default" slot rather than None/legacy.
+        # canonical "autosave" slot rather than None/legacy.
         svc, _ = make_service(tmp_path)
         svc._config.settings["save_sync_enabled"] = True
         svc._config.settings["default_slot"] = "desktop"
         result = svc.update_save_sync_settings({"default_slot": ""})
-        assert result["settings"]["default_slot"] == "default"
+        assert result["settings"]["default_slot"] == "autosave"
 
-    def test_empty_string_becomes_default(self, tmp_path):
+    def test_empty_string_becomes_autosave(self, tmp_path):
         val, skip = sanitize_setting("default_slot", "")
-        assert val == "default"
+        assert val == "autosave"
         assert skip is False
 
-    def test_none_value_becomes_default(self, tmp_path):
+    def test_none_value_becomes_autosave(self, tmp_path):
         val, skip = sanitize_setting("default_slot", None)
-        assert val == "default"
+        assert val == "autosave"
         assert skip is False
 
-    def test_whitespace_only_becomes_default(self, tmp_path):
+    def test_whitespace_only_becomes_autosave(self, tmp_path):
         val, skip = sanitize_setting("default_slot", "   ")
-        assert val == "default"
+        assert val == "autosave"
         assert skip is False
 
     def test_nonempty_string_trimmed(self, tmp_path):
@@ -808,12 +808,13 @@ class TestSaveSyncSettingsSlotAndCleanup:
         assert val == "desktop"
         assert skip is False
 
-    def test_resolve_default_slot_blank_none_whitespace_all_become_default(self, tmp_path):
-        # resolve_default_slot never returns None — legacy no-slot mode retired (#1276).
-        assert resolve_default_slot({}) == "default"
-        assert resolve_default_slot({"default_slot": None}) == "default"
-        assert resolve_default_slot({"default_slot": ""}) == "default"
-        assert resolve_default_slot({"default_slot": "   "}) == "default"
+    def test_resolve_default_slot_blank_none_whitespace_all_become_autosave(self, tmp_path):
+        # resolve_default_slot never returns None — legacy no-slot mode retired (#1276);
+        # the canonical fallback is "autosave" to match the official RomM clients (#1529).
+        assert resolve_default_slot({}) == "autosave"
+        assert resolve_default_slot({"default_slot": None}) == "autosave"
+        assert resolve_default_slot({"default_slot": ""}) == "autosave"
+        assert resolve_default_slot({"default_slot": "   "}) == "autosave"
 
     def test_resolve_default_slot_named_slot_trimmed(self, tmp_path):
         assert resolve_default_slot({"default_slot": "desktop"}) == "desktop"
@@ -842,7 +843,7 @@ class TestSaveSyncSettingsSlotAndCleanup:
     def test_get_settings_includes_new_defaults(self, tmp_path):
         svc, _ = make_service(tmp_path)
         result = svc.get_save_sync_settings()
-        assert result["default_slot"] == "default"
+        assert result["default_slot"] == "autosave"
         assert result["autocleanup_limit"] == 10
 
 

--- a/tests/services/saves/test_slots.py
+++ b/tests/services/saves/test_slots.py
@@ -53,7 +53,8 @@ class TestSaveSlots:
         result = await svc.get_save_slots(123)
         assert result["success"] is True
         assert len(result["slots"]) == 2
-        assert result["active_slot"] == "default"
+        # ROM is untracked → active_slot falls back to the configured default slot.
+        assert result["active_slot"] == "autosave"
 
     @pytest.mark.asyncio
     async def test_get_save_slots_latest_updated_at_from_server(self, tmp_path):
@@ -338,7 +339,7 @@ class TestGetSaveSetupInfo:
         assert result["has_local_saves"] is True
         assert len(result["server_slots"]) == 1
         assert result["server_slots"][0]["slot"] == "desktop"
-        assert result["default_slot"] == "default"
+        assert result["default_slot"] == "autosave"
 
     @pytest.mark.asyncio
     async def test_scenario_e_local_and_server_same_default_slot(self, tmp_path):
@@ -348,13 +349,13 @@ class TestGetSaveSetupInfo:
         _set_device_id(svc, "dev-1")
         _install_rom(svc, tmp_path)
         _create_save(tmp_path)
-        fake.saves[1] = _server_save(save_id=1, slot="default")
+        fake.saves[1] = _server_save(save_id=1, slot="autosave")
 
         result = await svc.get_save_setup_info(42)
         assert result["has_local_saves"] is True
         assert len(result["server_slots"]) == 1
-        assert result["server_slots"][0]["slot"] == "default"
-        assert result["default_slot"] == "default"
+        assert result["server_slots"][0]["slot"] == "autosave"
+        assert result["default_slot"] == "autosave"
 
     @pytest.mark.asyncio
     async def test_already_confirmed(self, tmp_path):
@@ -472,7 +473,7 @@ class TestGetSaveSetupInfo:
         assert result["has_local_saves"] is True
         assert len(result["local_files"]) == 1
         assert result["local_files"][0]["filename"] == "pokemon.srm"
-        assert result["default_slot"] == "default"
+        assert result["default_slot"] == "autosave"
         assert result["slot_confirmed"] is False
 
     @pytest.mark.asyncio

--- a/tests/services/saves/test_slots.py
+++ b/tests/services/saves/test_slots.py
@@ -97,7 +97,7 @@ class TestSaveSlots:
         assert result["reason"] == "sync_disabled"
         assert "disabled" in result["message"].lower()
         assert result["slots"] == []
-        assert result["active_slot"] == "default"
+        assert result["active_slot"] == "autosave"
 
     @pytest.mark.asyncio
     async def test_get_save_slots_preserves_map_on_api_failure(self, tmp_path):


### PR DESCRIPTION
The default slot a brand-new, never-configured ROM adopts on its first sync is now "autosave" — the slot name the official RomM clients (Argosy, Grout) use — instead of "default", so automatic saves land where those clients read them.

Existing tracked ROMs are unaffected: each syncs to its persisted active_slot, never to this setting. A settings migration (v11 → v12) rewrites a stored default_slot of "default" to "autosave", leaving user-chosen slot names untouched.

Conflict resolution now threads the configured default into both the use-server and keep-local paths, so a brand-new ROM resolving a conflict lands in the configured slot instead of falling back to "default"; the unreachable "default" fallbacks in the slot listing/setup paths are dropped too.

Closes #1529
