### PR TITLE
fix(ui): render collections controls before the slow list fetch resolves

### DIFF
--- a/docs/user-guide/syncing-your-library.md
+++ b/docs/user-guide/syncing-your-library.md
@@ -218,7 +218,8 @@ Collections appear in Steam's library sidebar and can be used to browse games by
 The **Collections** page splits collections into three sub-tabs plus a dedicated top-level toggle for RomM favorites:
 
 - **Sync RomM favorites** (top-level toggle) — the user collection RomM auto-manages as your favorites. Always exactly
-  one per account, so it sits above the sub-tabs as a single switch.
+  one per account, so it sits above the sub-tabs as a single switch. It stays visible but grayed out when your account
+  has no favorites collection.
 - **My** sub-tab — your other user-created collections
 - **Smart** sub-tab — filter-based collections that resolve membership at query time, so syncing always picks up the
   current matches
@@ -226,10 +227,16 @@ The **Collections** page splits collections into three sub-tabs plus a dedicated
   IGDB **collection** (series) groupings. Each row is labelled with its type (Franchise / IGDB Collection).
 
 Each sub-tab shows its match count in the section header (e.g. `MY COLLECTIONS (4)`) and lets you toggle individual
-collections. A **search box** above the list filters the current sub-tab by name — most useful on **Virtual**, which can
-run to hundreds of entries. On the **Virtual** sub-tab a segmented **All / Franchise / IGDB Collection** control narrows
-the list to one virtual type. The list itself is capped for performance: when more collections match than fit, the first
-rows render and a `… more — refine your search` hint appears — type in the search box to bring the rest into view.
+collections. A **search box** above the list filters the current sub-tab by a **fuzzy** name match (its heading is
+labelled _Search collections (fuzzy)_), so a loose or partial query still finds a name — most useful on **Virtual**,
+which can run to hundreds of entries. On the **Virtual** sub-tab a segmented **All / Franchise / IGDB Collection**
+control narrows the list to one virtual type. The list itself is capped for performance: when more collections match
+than fit, the first rows render and a `… more — refine your search` hint appears — type in the search box to bring the
+rest into view.
+
+The owner-scope, sub-tab, and search controls appear as soon as you open the page — the collection list loads in behind
+them, so you can pick a sub-tab or start typing a search straight away. **Enable All** / **Disable All** stay disabled
+until the list has finished loading.
 
 The paired **Enable All** / **Disable All** buttons act on the **current filter**: with a search or the Virtual per-type
 filter active, they toggle exactly the matching collections; with no filter they toggle the whole sub-tab and ask for

--- a/src/components/LibraryPage.test.tsx
+++ b/src/components/LibraryPage.test.tsx
@@ -11,7 +11,9 @@
 //   - handleCollectionToggle catch → rollback setCollections
 //   - handleSetAllCollections catch → restore previous collections snapshot
 //   - platform-groups inline catch → setPlatformGroups(!value) rollback
-//   - getCollections/getSettings .catch → setCollectionsError(true)
+//   - getCollections .catch → setCollectionsError(true) (the list-driving fetch)
+//   - getSettings .catch → owner-scope stays at its "all" default; the two
+//     fetches are decoupled so a settings-read failure never blanks the list.
 //
 // The System view (per-platform core + BIOS state) lives in SystemPage, a
 // top-level QAM page — its tests are in SystemPage.test.tsx, not here.
@@ -30,11 +32,13 @@ import { render, fireEvent, act } from "@testing-library/react";
 import type { ReactElement } from "react";
 import { LibraryPage } from "./LibraryPage";
 import * as backend from "../api/backend";
+import { scrollElementToTop } from "../utils/scrollHelpers";
 import { showModal } from "@decky/ui";
 import type { PlatformSyncSetting, CollectionSyncSetting, PluginSettings } from "../types";
 
-// scroll helpers are no-ops in happy-dom; mock for cleanliness.
-vi.mock("../utils/scrollHelpers", () => ({ scrollToTop: vi.fn() }));
+// scroll helpers are no-ops in happy-dom; mock so the search-field scroll and
+// the Back-button scroll can be asserted without a real layout engine.
+vi.mock("../utils/scrollHelpers", () => ({ scrollToTop: vi.fn(), scrollElementToTop: vi.fn() }));
 
 // Re-mock @decky/ui locally so the component tree renders with inspectable
 // stubs (ToggleField checked-prop, Field label/description, DialogButton click).
@@ -61,22 +65,24 @@ vi.mock("@decky/ui", async () => {
         ce("span", { "data-testid": "field-desc" }, p.description as never),
       ),
     Focusable: passthrough("div"),
-    DialogButton: ({ children, onClick }: AnyProps & { onClick?: () => void }) =>
-      ce("button", { onClick }, children as never),
+    DialogButton: ({ children, onClick, disabled }: AnyProps & { onClick?: () => void; disabled?: boolean }) =>
+      ce("button", { onClick, disabled }, children as never),
     TextField: (
       p: AnyProps & {
         value?: string;
+        label?: unknown;
         onChange?: (e: unknown) => void;
         onFocus?: (e: unknown) => void;
-        onKeyDown?: (e: unknown) => void;
       },
     ) =>
       ce("input", {
         "data-testid": "text-field",
+        // Real TextField renders `label` as a heading above the input; expose it
+        // as aria-label so tests can assert the heading text (e.g. the fuzzy hint).
+        "aria-label": typeof p.label === "string" ? p.label : undefined,
         value: p.value ?? "",
         onChange: (e: unknown) => p.onChange?.(e),
         onFocus: (e: unknown) => p.onFocus?.(e),
-        onKeyDown: (e: unknown) => p.onKeyDown?.(e),
       }),
     // A no-render stub — showModal captures the element, so the modal body is
     // inspected off the showModal mock, not the DOM.
@@ -85,6 +91,7 @@ vi.mock("@decky/ui", async () => {
     ToggleField: (
       p: AnyProps & {
         checked?: boolean;
+        disabled?: boolean;
         onChange?: (v: boolean) => void;
         label?: unknown;
         description?: unknown;
@@ -101,6 +108,7 @@ vi.mock("@decky/ui", async () => {
           type: "checkbox",
           "data-testid": "toggle-input",
           checked: p.checked ?? false,
+          disabled: p.disabled ?? false,
           onChange: (e: { target: { checked: boolean } }) => p.onChange?.(e.target.checked),
         }),
         typeof p.label === "string" ? p.label : null,
@@ -186,9 +194,6 @@ describe("LibraryPage", () => {
     vi.mocked(backend.setCollectionOwnerScope).mockResolvedValue({ success: true });
     vi.mocked(backend.getSettings).mockResolvedValue(defaultSettings());
     vi.mocked(showModal).mockReset();
-    // happy-dom doesn't implement scrollIntoView; the search field calls it on
-    // the first keystroke / focus. Stub it so those paths are safe + spyable.
-    HTMLElement.prototype.scrollIntoView = vi.fn();
   });
 
   // ------------------------------------------------------------------
@@ -485,6 +490,150 @@ describe("LibraryPage", () => {
         await Promise.resolve();
       });
       expect(container.textContent).toContain("No collections found");
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // E2. Collections tab — loading UX (controls render before the list) — #1539
+  // ------------------------------------------------------------------
+  describe("collections tab — loading UX (#1539)", () => {
+    type CollectionsResult = { success: boolean; collections: CollectionSyncSetting[] };
+
+    // A getCollections promise the test resolves by hand, so the list stays in
+    // its pending state while the controls are asserted.
+    const deferredCollections = () => {
+      let resolve!: (value: CollectionsResult) => void;
+      const promise = new Promise<CollectionsResult>((r) => {
+        resolve = r;
+      });
+      return { promise, resolve };
+    };
+
+    const openCollections = async (getByText: (t: string) => HTMLElement) => {
+      await flushAsync();
+      await act(async () => {
+        fireEvent.click(getByText("Collections"));
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+    };
+
+    it("renders the owner-scope, sub-tabs, and search controls while getCollections is still pending", async () => {
+      const { promise } = deferredCollections();
+      vi.mocked(backend.getCollections).mockReturnValue(promise);
+      const { getByText, getByTestId, queryByTestId } = render(<LibraryPage onBack={vi.fn()} />);
+      await openCollections(getByText);
+      // Controls are already visible before the (still-pending) list resolves.
+      expect(getByText("Own")).not.toBeNull();
+      expect(getByText("All")).not.toBeNull();
+      expect(getByText("My")).not.toBeNull();
+      expect(getByText("Smart")).not.toBeNull();
+      expect(getByText("Virtual")).not.toBeNull();
+      expect(getByTestId("text-field")).not.toBeNull();
+      // The list area shows a spinner in the meantime.
+      expect(queryByTestId("spinner")).not.toBeNull();
+    });
+
+    it("populates the owner-scope from getSettings without waiting on the slow getCollections", async () => {
+      // getSettings resolves; getCollections never does. The owner-scope must
+      // still initialize to "own" (the foreign collection would be hidden) even
+      // though the list is still loading — proof the fetches are decoupled.
+      vi.mocked(backend.getSettings).mockResolvedValue({ ...defaultSettings(), collection_owner_scope: "own" });
+      const { promise } = deferredCollections();
+      vi.mocked(backend.getCollections).mockReturnValue(promise);
+      const { getByText, container } = render(<LibraryPage onBack={vi.fn()} />);
+      await openCollections(getByText);
+      // "Show collections" description reflects the resolved "own" scope while
+      // the list itself is still pending (spinner shown).
+      expect(container.textContent).toContain("Only your own collections");
+    });
+
+    it("swallows a getSettings failure — owner-scope stays 'All' and the list still loads", async () => {
+      // The decoupling property (#1539): getSettings() and getCollections() are
+      // independent, so a settings-read failure only degrades owner-scope to its
+      // "all" default — it must NOT blank or error the collection list.
+      vi.mocked(backend.getSettings).mockRejectedValue(new Error("boom"));
+      vi.mocked(backend.getCollections).mockResolvedValue({
+        success: true,
+        collections: [
+          makeCollection({ id: "u1", name: "MineColl", kind: "user", is_favorite: false, is_own: true }),
+          makeCollection({ id: "u2", name: "TheirColl", kind: "user", is_favorite: false, is_own: false }),
+        ],
+      });
+      const { getByText, getByTestId, container } = render(<LibraryPage onBack={vi.fn()} />);
+      await openCollections(getByText);
+      // Scope stayed at the "All" default: a foreign (is_own=false) collection is
+      // visible — under "Own" it would be hidden.
+      expect(container.querySelector('[data-label="MineColl"]')).not.toBeNull();
+      expect(container.querySelector('[data-label="TheirColl"]')).not.toBeNull();
+      // The list loaded normally — no error surfaced from the settings failure.
+      expect(container.textContent).not.toContain("Failed to load collections");
+      // Controls remain present.
+      expect(getByText("Own")).not.toBeNull();
+      expect(getByText("All")).not.toBeNull();
+      expect(getByTestId("text-field")).not.toBeNull();
+    });
+
+    it("keeps Enable/Disable All disabled while loading, then enables them once the list loads", async () => {
+      const { promise, resolve } = deferredCollections();
+      vi.mocked(backend.getCollections).mockReturnValue(promise);
+      const { getByText, queryByTestId } = render(<LibraryPage onBack={vi.fn()} />);
+      await openCollections(getByText);
+      // While pending: buttons rendered but disabled, spinner shown.
+      expect((getByText("Enable All") as HTMLButtonElement).disabled).toBe(true);
+      expect((getByText("Disable All") as HTMLButtonElement).disabled).toBe(true);
+      expect(queryByTestId("spinner")).not.toBeNull();
+      // Resolve the list → buttons enabled, spinner gone.
+      await act(async () => {
+        resolve({
+          success: true,
+          collections: [makeCollection({ id: "u1", name: "UserOne", kind: "user", is_favorite: false })],
+        });
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect((getByText("Enable All") as HTMLButtonElement).disabled).toBe(false);
+      expect((getByText("Disable All") as HTMLButtonElement).disabled).toBe(false);
+      expect(queryByTestId("spinner")).toBeNull();
+    });
+
+    it("renders the favorites toggle present but disabled while the list is loading", async () => {
+      const { promise } = deferredCollections();
+      vi.mocked(backend.getCollections).mockReturnValue(promise);
+      const { getByText, container, queryByTestId } = render(<LibraryPage onBack={vi.fn()} />);
+      await openCollections(getByText);
+      // The favorites row is rendered up front (no late pop-in) but grayed until
+      // the list resolves and reveals whether a single favorites collection exists.
+      const favInput = container.querySelector<HTMLInputElement>('[data-label="Sync RomM favorites"] input');
+      expect(favInput).not.toBeNull();
+      expect(favInput?.disabled).toBe(true);
+      expect(queryByTestId("spinner")).not.toBeNull();
+    });
+
+    it("renders the error state in the list area with the controls still present", async () => {
+      vi.mocked(backend.getCollections).mockResolvedValue({ success: false, collections: [] });
+      const { getByText, getByTestId, container } = render(<LibraryPage onBack={vi.fn()} />);
+      await openCollections(getByText);
+      // Error surfaces in the list area, not as a full-panel replacement — the
+      // controls remain rendered alongside it.
+      expect(container.textContent).toContain("Failed to load collections");
+      expect(getByText("Own")).not.toBeNull();
+      expect(getByText("Virtual")).not.toBeNull();
+      expect(getByTestId("text-field")).not.toBeNull();
+      // Enable/Disable All stay disabled on the error path (nothing to act on).
+      expect((getByText("Enable All") as HTMLButtonElement).disabled).toBe(true);
+    });
+
+    it("renders the empty state in the list area with the controls still present", async () => {
+      vi.mocked(backend.getCollections).mockResolvedValue({ success: true, collections: [] });
+      const { getByText, getByTestId, container } = render(<LibraryPage onBack={vi.fn()} />);
+      await openCollections(getByText);
+      expect(container.textContent).toContain("No collections found");
+      expect(getByText("Own")).not.toBeNull();
+      expect(getByText("Virtual")).not.toBeNull();
+      expect(getByTestId("text-field")).not.toBeNull();
+      // Empty library → nothing to enable, buttons disabled.
+      expect((getByText("Enable All") as HTMLButtonElement).disabled).toBe(true);
     });
   });
 
@@ -924,6 +1073,23 @@ describe("LibraryPage", () => {
   // H2. Collections tab — favorites top-level toggle
   // ------------------------------------------------------------------
   describe("collections tab — favorites toggle", () => {
+    it("renders the favorites toggle ENABLED when exactly one favorites collection exists", async () => {
+      vi.mocked(backend.getCollections).mockResolvedValue({
+        success: true,
+        collections: [makeCollection({ id: "f1", name: "Faves", kind: "user", is_favorite: true, rom_count: 3 })],
+      });
+      const { getByText, container } = render(<LibraryPage onBack={vi.fn()} />);
+      await flushAsync();
+      await act(async () => {
+        fireEvent.click(getByText("Collections"));
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      const favInput = container.querySelector<HTMLInputElement>('[data-label="Sync RomM favorites"] input');
+      expect(favInput).not.toBeNull();
+      expect(favInput?.disabled).toBe(false);
+    });
+
     it("renders the Sync RomM favorites toggle with the singular description for 1 game", async () => {
       vi.mocked(backend.getCollections).mockResolvedValue({
         success: true,
@@ -1045,7 +1211,7 @@ describe("LibraryPage", () => {
       expect(reverted.checked).toBe(false);
     });
 
-    it("omits the favorites toggle when no favorites collection exists", async () => {
+    it("renders the favorites toggle disabled (grayed, not hidden) when no favorites collection exists", async () => {
       vi.mocked(backend.getCollections).mockResolvedValue({
         success: true,
         collections: [makeCollection({ id: "u1", name: "U1", kind: "user", is_favorite: false })],
@@ -1057,7 +1223,10 @@ describe("LibraryPage", () => {
         await Promise.resolve();
         await Promise.resolve();
       });
-      expect(container.querySelector('[data-label="Sync RomM favorites"]')).toBeNull();
+      // Present (never hidden / no pop-in), but disabled — nothing to sync.
+      const favInput = container.querySelector<HTMLInputElement>('[data-label="Sync RomM favorites"] input');
+      expect(favInput).not.toBeNull();
+      expect(favInput?.disabled).toBe(true);
     });
 
     it("falls back to listing favorites in the My sub-tab when more than one exists (with console warning)", async () => {
@@ -1078,8 +1247,11 @@ describe("LibraryPage", () => {
           await Promise.resolve();
           await Promise.resolve();
         });
-        // Toggle hidden — single-toggle UI can't represent multiple favorites.
-        expect(container.querySelector('[data-label="Sync RomM favorites"]')).toBeNull();
+        // Top toggle stays present but disabled — a single toggle can't
+        // represent multiple favorites, so it grays out rather than hiding.
+        const favInput = container.querySelector<HTMLInputElement>('[data-label="Sync RomM favorites"] input');
+        expect(favInput).not.toBeNull();
+        expect(favInput?.disabled).toBe(true);
         // Both favorites surface in My (alongside the regular user collection).
         expect(container.querySelector('[data-label="FavA"]')).not.toBeNull();
         expect(container.querySelector('[data-label="FavB"]')).not.toBeNull();
@@ -1211,56 +1383,54 @@ describe("LibraryPage", () => {
       expect(container.querySelector('[data-label="Puzzle Box"]')).not.toBeNull();
     });
 
-    it("Enter on the search field blurs it (dismisses the on-screen keyboard)", async () => {
+    it("hints the fuzzy match in the search field heading", async () => {
       vi.mocked(backend.getCollections).mockResolvedValue({
         success: true,
         collections: [makeCollection({ id: "u1", name: "Action Heroes", kind: "user", is_favorite: false })],
       });
       const { getByText, getByTestId } = render(<LibraryPage onBack={vi.fn()} />);
       await openCollections(getByText);
-      const field = getByTestId("text-field") as HTMLInputElement;
-      field.focus();
-      expect(document.activeElement).toBe(field);
-      await act(async () => {
-        fireEvent.keyDown(field, { key: "Enter" });
-        await Promise.resolve();
-      });
-      // The handler blurs the active element, which is what dismisses the OSK.
-      expect(document.activeElement).not.toBe(field);
+      expect(getByTestId("text-field").getAttribute("aria-label")).toBe("Search collections (fuzzy)");
     });
 
-    it("scrolls the search field into view on the FIRST keystroke only (not on later keystrokes)", async () => {
+    it("lifts the search field to the top of the view on the FIRST keystroke only (not on later keystrokes)", async () => {
+      // Element-to-top scroll (#1539): the wrapper ref is handed to
+      // scrollElementToTop so its "SEARCH COLLECTIONS" heading lands at the top
+      // of the outermost scroller, clear of the on-screen keyboard. The scroll
+      // math itself is unit-tested in scrollHelpers.test.ts; here we assert the
+      // component wires the trigger correctly (first keystroke only).
       vi.mocked(backend.getCollections).mockResolvedValue({
         success: true,
         collections: [makeCollection({ id: "u1", name: "Action Heroes", kind: "user", is_favorite: false })],
       });
-      const scrollIntoView = vi.mocked(HTMLElement.prototype.scrollIntoView);
+      const scrollToField = vi.mocked(scrollElementToTop);
       const { getByText, getByTestId } = render(<LibraryPage onBack={vi.fn()} />);
       await openCollections(getByText);
-      scrollIntoView.mockClear();
-      // First keystroke: empty → non-empty → scroll the field into view.
+      scrollToField.mockClear();
+      // First keystroke: empty → non-empty → lift the field to the top.
       await typeSearch(getByTestId, "a");
-      expect(scrollIntoView).toHaveBeenCalledTimes(1);
-      expect(scrollIntoView).toHaveBeenCalledWith({ behavior: "smooth", block: "start" });
+      expect(scrollToField).toHaveBeenCalledTimes(1);
+      expect(scrollToField.mock.calls[0]?.[0]).toBeInstanceOf(HTMLElement);
       // Later keystrokes (still non-empty) must NOT re-scroll.
       await typeSearch(getByTestId, "ac");
-      expect(scrollIntoView).toHaveBeenCalledTimes(1);
+      expect(scrollToField).toHaveBeenCalledTimes(1);
     });
 
-    it("scrolls the search field into view when it gains focus", async () => {
+    it("lifts the search field to the top of the view when it gains focus", async () => {
       vi.mocked(backend.getCollections).mockResolvedValue({
         success: true,
         collections: [makeCollection({ id: "u1", name: "Action Heroes", kind: "user", is_favorite: false })],
       });
-      const scrollIntoView = vi.mocked(HTMLElement.prototype.scrollIntoView);
+      const scrollToField = vi.mocked(scrollElementToTop);
       const { getByText, getByTestId } = render(<LibraryPage onBack={vi.fn()} />);
       await openCollections(getByText);
-      scrollIntoView.mockClear();
+      scrollToField.mockClear();
       await act(async () => {
         fireEvent.focus(getByTestId("text-field"));
         await Promise.resolve();
       });
-      expect(scrollIntoView).toHaveBeenCalledWith({ behavior: "smooth", block: "start" });
+      expect(scrollToField).toHaveBeenCalledTimes(1);
+      expect(scrollToField.mock.calls[0]?.[0]).toBeInstanceOf(HTMLElement);
     });
 
     it("caps the rendered rows and shows a '<n> more' hint past the cap", async () => {
@@ -1275,8 +1445,10 @@ describe("LibraryPage", () => {
       vi.mocked(backend.getCollections).mockResolvedValue({ success: true, collections: many });
       const { getByText, container } = render(<LibraryPage onBack={vi.fn()} />);
       await openCollections(getByText);
-      // Never paints more than the cap (50): exactly 50 toggle rows, not 60.
-      const toggles = container.querySelectorAll('[data-testid="toggle-input"]');
+      // Never paints more than the cap (50): exactly 50 collection rows, not 60.
+      // Count the list rows by their "Coll " label so the always-present
+      // (here disabled) favorites toggle isn't counted.
+      const toggles = container.querySelectorAll('[data-label^="Coll "]');
       expect(toggles).toHaveLength(50);
       // The overflow (60 - 50 = 10) is surfaced as a single hint row.
       expect(container.textContent).toContain("10 more — refine your search");
@@ -1298,7 +1470,8 @@ describe("LibraryPage", () => {
       await openCollections(getByText);
       // "coll 001" matches exactly one collection.
       await typeSearch(getByTestId, "coll 001");
-      const toggles = container.querySelectorAll('[data-testid="toggle-input"]');
+      // Count list rows by their "Coll " label (excludes the favorites toggle).
+      const toggles = container.querySelectorAll('[data-label^="Coll "]');
       expect(toggles).toHaveLength(1);
       expect(container.textContent).not.toContain("more — refine your search");
     });

--- a/src/components/LibraryPage.tsx
+++ b/src/components/LibraryPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useRef, FC, KeyboardEvent } from "react";
+import { useState, useEffect, useMemo, useRef, FC } from "react";
 import {
   PanelSection,
   PanelSectionRow,
@@ -30,20 +30,10 @@ import type {
   CollectionOwnerScope,
   VirtualCollectionType,
 } from "../types";
-import { scrollToTop } from "../utils/scrollHelpers";
+import { scrollToTop, scrollElementToTop } from "../utils/scrollHelpers";
 import { detach } from "../utils/detach";
 import { fuzzyMatch } from "../utils/fuzzyMatch";
 import { LoadingRow } from "./LoadingRow";
-
-// Best-effort on-screen-keyboard dismissal: Enter (R2 on the OSK) blurs the
-// focused field. Whether R2/Enter reliably closes the Steam OSK is Steam-
-// controlled and UNVERIFIED — this is a harmless best effort to revisit in
-// PR 2 (#1539); it must not be relied upon to work.
-function dismissKeyboardOnEnter(e: KeyboardEvent<HTMLInputElement>): void {
-  if (e.key === "Enter") {
-    (document.activeElement as HTMLElement | null)?.blur();
-  }
-}
 
 type CollectionSubTab = "user" | "smart" | "virtual";
 
@@ -160,13 +150,17 @@ export const LibraryPage: FC<LibraryPageProps> = ({ onBack }) => {
   // the sub-tab changes so each sub-tab is entered unfiltered.
   const [search, setSearch] = useState("");
   const [virtualTypeFilter, setVirtualTypeFilter] = useState<VirtualTypeFilter>("all");
-  // Wraps the search field's label + input so it can be scrolled into view when
-  // the on-screen keyboard opens over the lower half of the screen (#1539).
+  // Wraps the search field's label + input so it can be lifted to the top of
+  // the scroll view when the on-screen keyboard opens over the lower half of
+  // the screen (#1539).
   const searchFieldRef = useRef<HTMLDivElement>(null);
-  const scrollSearchIntoView = () => {
-    // scrollIntoView finds the scroll parent itself and only scrolls when the
-    // element isn't already visible, so it can never push the field off-screen.
-    searchFieldRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+  const scrollSearchToTop = () => {
+    // Element-to-top rather than scrollIntoView (which centers the field
+    // on-device) or a plain panel scrollToTop (the field sits below the
+    // owner-scope + sub-tab controls, so a panel-top scroll can leave it under
+    // the keyboard). Lift the field itself to just below the QAM header at the
+    // top of the outermost scroller (the clearance scales with the viewport).
+    scrollElementToTop(searchFieldRef.current);
   };
 
   // The favorites collection (a user collection with is_favorite=true) is
@@ -203,17 +197,31 @@ export const LibraryPage: FC<LibraryPageProps> = ({ onBack }) => {
   // Load collections data lazily on first switch to collections tab.
   // Sub-tab is reset to "user" in the tab-click handler (not here);
   // that's an event-driven concern, not state synchronisation.
+  //
+  // The two fetches are DECOUPLED so the slow one never blocks the fast one:
+  // getSettings() is quick and only supplies the owner-scope, so it populates
+  // that control right away; getCollections() is slow (a large virtual list)
+  // and drives the list area's own loading/error/empty states. The controls
+  // render immediately regardless of the list fetch (#1539). A settings-read
+  // failure leaves the owner-scope at its "all" default rather than blanking
+  // the list — only a collections-read failure is a list error.
   useEffect(() => {
     if (activeTab === "collections" && !collectionsLoaded.current) {
       collectionsLoaded.current = true;
-      Promise.all([getCollections(), getSettings()])
-        .then(([collResult, settingsResult]) => {
+      getSettings()
+        .then((settingsResult) => {
+          setOwnerScope(settingsResult.collection_owner_scope === "own" ? "own" : "all");
+        })
+        .catch(() => {
+          // Owner-scope stays at its "all" default; the list is unaffected.
+        });
+      getCollections()
+        .then((collResult) => {
           if (collResult.success) {
             setCollections(collResult.collections);
           } else {
             setCollectionsError(true);
           }
-          setOwnerScope(settingsResult.collection_owner_scope === "own" ? "own" : "all");
         })
         .catch(() => setCollectionsError(true))
         .finally(() => setCollectionsLoading(false));
@@ -399,31 +407,13 @@ export const LibraryPage: FC<LibraryPageProps> = ({ onBack }) => {
 
   // --- Collections tab content ---
   const renderCollectionsContent = () => {
-    if (collectionsLoading) {
-      return (
-        <PanelSection title="Collections">
-          <LoadingRow />
-        </PanelSection>
-      );
-    }
-    if (collectionsError) {
-      return (
-        <PanelSection title="Collections">
-          <PanelSectionRow>
-            <Field label="Failed to load collections" description="Check your connection and try again" />
-          </PanelSectionRow>
-        </PanelSection>
-      );
-    }
-    if (collections.length === 0) {
-      return (
-        <PanelSection title="Collections">
-          <PanelSectionRow>
-            <Field label="No collections found" description="Create collections in RomM to sync them here" />
-          </PanelSectionRow>
-        </PanelSection>
-      );
-    }
+    // The control shell (owner-scope, sub-tabs, search, per-type filter,
+    // Enable/Disable All) renders IMMEDIATELY — the slow getCollections fetch
+    // only gates the list AREA, not the controls (#1539). `hasCollections`
+    // gates everything that needs the loaded set: the favorites toggle, the
+    // header count, and the Enable/Disable All buttons (which must not act on
+    // an unloaded/empty set).
+    const hasCollections = collections.length > 0;
 
     // When the favorites toggle isn't rendered (zero or multi-favorites case),
     // include any favorites in the "My" sub-tab so they stay reachable.
@@ -453,24 +443,33 @@ export const LibraryPage: FC<LibraryPageProps> = ({ onBack }) => {
     const matchedIds = matched.map((c) => c.id);
 
     const activeLabel = SUB_TAB_LABELS[activeSubTab];
-    const sectionTitle = `${SUB_TAB_HEADERS[activeSubTab]} (${matched.length})`;
+    // The header count only appears once the list has loaded, so it doesn't
+    // flash "(0)" while getCollections is still pending.
+    const sectionTitle = hasCollections
+      ? `${SUB_TAB_HEADERS[activeSubTab]} (${matched.length})`
+      : SUB_TAB_HEADERS[activeSubTab];
 
     return (
       <>
-        {favoritesCollection && (
-          <PanelSection>
-            <PanelSectionRow>
-              <ToggleField
-                label="Sync RomM favorites"
-                description={favoritesDescription(favoritesCollection.rom_count)}
-                checked={favoritesCollection.sync_enabled}
-                onChange={(value: boolean) => {
-                  detach(handleCollectionToggle(favoritesCollection.id, favoritesCollection.kind, value));
-                }}
-              />
-            </PanelSectionRow>
-          </PanelSection>
-        )}
+        {/* The favorites toggle ALWAYS renders so it never pops in late. It's
+            interactive only when exactly one favorites collection exists;
+            otherwise (still loading, zero favorites, or the multi-favorites
+            fallback that lists them in the "My" sub-tab) it sits disabled and
+            grayed rather than disappearing. */}
+        <PanelSection>
+          <PanelSectionRow>
+            <ToggleField
+              label="Sync RomM favorites"
+              description={favoritesCollection ? favoritesDescription(favoritesCollection.rom_count) : undefined}
+              checked={favoritesCollection ? favoritesCollection.sync_enabled : false}
+              disabled={favoritesCollection === null}
+              onChange={(value: boolean) => {
+                if (!favoritesCollection) return;
+                detach(handleCollectionToggle(favoritesCollection.id, favoritesCollection.kind, value));
+              }}
+            />
+          </PanelSectionRow>
+        </PanelSection>
         <PanelSection>
           <PanelSectionRow>
             <Field
@@ -525,26 +524,24 @@ export const LibraryPage: FC<LibraryPageProps> = ({ onBack }) => {
           <PanelSectionRow>
             <div ref={searchFieldRef}>
               <TextField
-                label="Search collections"
+                // "(fuzzy)" in the heading signals the match is a subsequence,
+                // so a partial/loose query hitting more than the exact name
+                // reads as intended.
+                label="Search collections (fuzzy)"
                 value={search}
                 onChange={(e) => {
                   const value = e.target.value;
-                  // Bring the field into view on the first keystroke (empty →
-                  // non-empty), when the on-screen keyboard is actually in use
-                  // and would otherwise cover the field (#1539).
+                  // Lift the field to the top of the view on the first keystroke
+                  // (empty → non-empty), when the on-screen keyboard is actually
+                  // in use and would otherwise cover the field (#1539).
                   if (search === "" && value !== "") {
-                    scrollSearchIntoView();
+                    scrollSearchToTop();
                   }
                   setSearch(value);
                 }}
-                // onFocus covers the "press A to edit" case; scrollIntoView is
-                // idempotent (no-op when already visible), so this is harmless.
-                onFocus={scrollSearchIntoView}
-                // Best-effort OSK dismissal: Enter (R2 on the keyboard) blurs the
-                // field. Whether R2/Enter reliably closes the OSK is Steam-
-                // controlled and UNVERIFIED — revisit in PR 2 (#1539). Harmless if
-                // it no-ops; do not claim it works.
-                onKeyDown={dismissKeyboardOnEnter}
+                // onFocus covers the "press A to edit" case; the scroll is a
+                // no-op when the field is already at the top, so this is harmless.
+                onFocus={scrollSearchToTop}
               />
             </div>
           </PanelSectionRow>
@@ -584,55 +581,91 @@ export const LibraryPage: FC<LibraryPageProps> = ({ onBack }) => {
           )}
           <PanelSectionRow>
             <Focusable flow-children="horizontal" style={{ display: "flex", gap: "8px" }}>
+              {/* Disabled until the list has loaded — acting on an unloaded set
+                  would stamp the whole kind server-side sight-unseen (#1539). */}
               <DialogButton
                 style={{ flex: 1, minWidth: 0 }}
+                disabled={!hasCollections}
                 onClick={() => handleCollectionsSetAll(true, isWholeKind, matchedIds)}
               >
                 Enable All
               </DialogButton>
               <DialogButton
                 style={{ flex: 1, minWidth: 0 }}
+                disabled={!hasCollections}
                 onClick={() => handleCollectionsSetAll(false, isWholeKind, matchedIds)}
               >
                 Disable All
               </DialogButton>
             </Focusable>
           </PanelSectionRow>
-          {matched.length === 0 ? (
-            <PanelSectionRow>
-              <Field
-                label={
-                  search
-                    ? `No ${activeLabel.toLowerCase()} collections match your search`
-                    : `No ${activeLabel.toLowerCase()} collections`
-                }
-              />
-            </PanelSectionRow>
-          ) : (
-            <>
-              {rendered.map((collection) => (
-                <PanelSectionRow key={`${collection.kind}:${collection.id}`}>
-                  <ToggleField
-                    label={collection.name}
-                    description={collectionRowDescription(collection)}
-                    checked={collection.sync_enabled}
-                    onChange={(value: boolean) => {
-                      detach(handleCollectionToggle(collection.id, collection.kind, value));
-                    }}
-                  />
-                </PanelSectionRow>
-              ))}
-              {overflow > 0 && (
-                <PanelSectionRow>
-                  <Field
-                    label={`${overflow} more — refine your search`}
-                    description="Type in the search box above to narrow the list."
-                  />
-                </PanelSectionRow>
-              )}
-            </>
-          )}
+          {renderCollectionListBody(matched, rendered, overflow, activeLabel)}
         </PanelSection>
+      </>
+    );
+  };
+
+  // The list AREA only: a spinner while getCollections is pending, then the
+  // error / empty-library / empty-sub-tab / rows states. The controls above it
+  // stay visible in every one of these states (#1539).
+  const renderCollectionListBody = (
+    matched: CollectionSyncSetting[],
+    rendered: CollectionSyncSetting[],
+    overflow: number,
+    activeLabel: string,
+  ) => {
+    if (collectionsLoading) {
+      return <LoadingRow />;
+    }
+    if (collectionsError) {
+      return (
+        <PanelSectionRow>
+          <Field label="Failed to load collections" description="Check your connection and try again" />
+        </PanelSectionRow>
+      );
+    }
+    if (collections.length === 0) {
+      return (
+        <PanelSectionRow>
+          <Field label="No collections found" description="Create collections in RomM to sync them here" />
+        </PanelSectionRow>
+      );
+    }
+    if (matched.length === 0) {
+      return (
+        <PanelSectionRow>
+          <Field
+            label={
+              search
+                ? `No ${activeLabel.toLowerCase()} collections match your search`
+                : `No ${activeLabel.toLowerCase()} collections`
+            }
+          />
+        </PanelSectionRow>
+      );
+    }
+    return (
+      <>
+        {rendered.map((collection) => (
+          <PanelSectionRow key={`${collection.kind}:${collection.id}`}>
+            <ToggleField
+              label={collection.name}
+              description={collectionRowDescription(collection)}
+              checked={collection.sync_enabled}
+              onChange={(value: boolean) => {
+                detach(handleCollectionToggle(collection.id, collection.kind, value));
+              }}
+            />
+          </PanelSectionRow>
+        ))}
+        {overflow > 0 && (
+          <PanelSectionRow>
+            <Field
+              label={`${overflow} more — refine your search`}
+              description="Type in the search box above to narrow the list."
+            />
+          </PanelSectionRow>
+        )}
       </>
     );
   };

--- a/src/utils/scrollHelpers.test.ts
+++ b/src/utils/scrollHelpers.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { findScrollParent, findOutermostScrollParent, scrollToTop, scrollFocusedToCenter } from "./scrollHelpers";
+import {
+  findScrollParent,
+  findOutermostScrollParent,
+  scrollToTop,
+  scrollFocusedToCenter,
+  scrollElementToTop,
+} from "./scrollHelpers";
 
 /**
  * happy-dom does not compute layout. Set `scrollHeight` / `clientHeight` and
@@ -201,5 +207,106 @@ describe("scrollFocusedToCenter", () => {
     vi.runAllTimers();
 
     expect(scrollTo).not.toHaveBeenCalled();
+  });
+});
+
+describe("scrollElementToTop", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("derives the top clearance from the OUTERMOST scroll parent's clientHeight (fraction path) after the 50ms timer", () => {
+    // Outermost container: clientHeight 600, at viewport top 0, already scrolled
+    // 100px. element at viewport top 400, 40px tall.
+    // margin = min(120 cap, 600 * 0.10) = min(120, 60) = 60
+    // expected targetScroll = 100 + (400 - 0) - 60 = 440
+    const outer = makeElement({
+      overflowY: "auto",
+      scrollHeight: 2000,
+      clientHeight: 600,
+      rect: { top: 0, height: 600 },
+    });
+    outer.scrollTop = 100;
+    const inner = makeElement({
+      overflowY: "auto",
+      scrollHeight: 1000,
+      clientHeight: 400,
+      rect: { top: 0, height: 400 },
+    });
+    const leaf = makeElement({ rect: { top: 400, height: 40 } });
+    chain(outer, inner, leaf);
+    const scrollTo = vi.fn();
+    outer.scrollTo = scrollTo as unknown as typeof outer.scrollTo;
+
+    scrollElementToTop(leaf);
+    expect(scrollTo).not.toHaveBeenCalled();
+    vi.runAllTimers();
+
+    expect(scrollTo).toHaveBeenCalledOnce();
+    // Instant (behavior: "auto") — the smooth animation raced typing re-renders
+    // and jittered the field width, so the scroll settles in one frame.
+    expect(scrollTo).toHaveBeenCalledWith({ top: 440, behavior: "auto" });
+  });
+
+  it("caps the top clearance on a tall viewport (cap path)", () => {
+    // clientHeight 2000 → 2000 * 0.10 = 200, capped at 120.
+    // expected targetScroll = 0 + (500 - 0) - 120 = 380
+    const outer = makeElement({
+      overflowY: "auto",
+      scrollHeight: 5000,
+      clientHeight: 2000,
+      rect: { top: 0, height: 2000 },
+    });
+    outer.scrollTop = 0;
+    const leaf = makeElement({ rect: { top: 500, height: 40 } });
+    chain(outer, leaf);
+    const scrollTo = vi.fn();
+    outer.scrollTo = scrollTo as unknown as typeof outer.scrollTo;
+
+    scrollElementToTop(leaf);
+    vi.runAllTimers();
+
+    expect(scrollTo).toHaveBeenCalledWith({ top: 380, behavior: "auto" });
+  });
+
+  it("clamps the target to 0 when the element sits above the margin (never scrolls negative)", () => {
+    const outer = makeElement({
+      overflowY: "auto",
+      scrollHeight: 2000,
+      clientHeight: 600,
+      rect: { top: 0, height: 600 },
+    });
+    outer.scrollTop = 0;
+    // element only 5px below the container top; margin = min(120, 600*0.10) = 60
+    // → raw target 0 + 5 - 60 = -55 → clamp 0.
+    const leaf = makeElement({ rect: { top: 5, height: 40 } });
+    chain(outer, leaf);
+    const scrollTo = vi.fn();
+    outer.scrollTo = scrollTo as unknown as typeof outer.scrollTo;
+
+    scrollElementToTop(leaf);
+    vi.runAllTimers();
+
+    expect(scrollTo).toHaveBeenCalledWith({ top: 0, behavior: "auto" });
+  });
+
+  it("is a no-op when no scroll parent is found", () => {
+    const wrapper = makeElement({ overflowY: "visible", scrollHeight: 600, clientHeight: 600 });
+    const leaf = makeElement({ rect: { top: 0, height: 40 } });
+    chain(wrapper, leaf);
+    const scrollTo = vi.fn();
+    wrapper.scrollTo = scrollTo as unknown as typeof wrapper.scrollTo;
+
+    scrollElementToTop(leaf);
+    vi.runAllTimers();
+
+    expect(scrollTo).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when the element is null", () => {
+    // Guards the searchFieldRef.current === null case before first mount.
+    expect(() => {
+      scrollElementToTop(null);
+      vi.runAllTimers();
+    }).not.toThrow();
   });
 });

--- a/src/utils/scrollHelpers.ts
+++ b/src/utils/scrollHelpers.ts
@@ -74,3 +74,53 @@ export function scrollToTop(e: FocusLike): void {
     }
   }, 50);
 }
+
+// Resolution-relative top clearance for scrollElementToTop, derived from the
+// scroll parent's clientHeight so it scales with the viewport. The QAM's fixed
+// "RomM Sync" header sits over the scroll parent's top:0, and its height scales
+// with resolution / UI scale (Deck 1280x800 vs Big Picture 1080p/1440p/4K), so
+// a fixed px clears the header on only one display. `fraction * clientHeight`
+// lands ~64px on the Deck QAM (on-device-tuned so the heading sits just clear of
+// the header, not a tick too low) and scales up on larger displays; the cap
+// keeps it from over-scrolling the field back off the top on very tall
+// viewports. Tunable knobs.
+const SCROLL_TOP_MARGIN_FRACTION = 0.1;
+const SCROLL_TOP_MARGIN_CAP = 120;
+
+/**
+ * Scroll the outermost scroll parent so `el` sits near the TOP of the scroll
+ * view, clear of the QAM's fixed header, instead of Steam's default
+ * center-on-focus. Used to lift a field above the on-screen keyboard, which
+ * covers the lower half of the screen — plain `scrollToTop` only reaches the
+ * panel's top, which can leave a mid-panel field still under the keyboard.
+ *
+ * The top clearance is resolution-relative (see the constants above), derived
+ * from the scroll parent's clientHeight so it holds across display sizes rather
+ * than clearing the header at one resolution only.
+ *
+ * Takes the element directly (not a focus event) so a wrapper ref can be
+ * scrolled even when focus lands on a child input. The 50ms delay overrides
+ * Steam's own gamepad-focus scroll, matching the other helpers here.
+ */
+export function scrollElementToTop(el: HTMLElement | null): void {
+  setTimeout(() => {
+    if (!el) return;
+    const scrollParent = findOutermostScrollParent(el);
+    if (!scrollParent) return;
+    // Resolution-aware clearance below the scroll parent's top edge.
+    const topMargin = Math.min(SCROLL_TOP_MARGIN_CAP, scrollParent.clientHeight * SCROLL_TOP_MARGIN_FRACTION);
+    // Cumulative offset of `el` within the scroll content: its current distance
+    // from the scroll parent's top edge (getBoundingClientRect delta accounts
+    // for all nesting) plus how far the parent is already scrolled. Setting
+    // scrollTop to that (minus the clearance) lands the element's top just below
+    // the fixed header.
+    const elRect = el.getBoundingClientRect();
+    const spRect = scrollParent.getBoundingClientRect();
+    const targetScroll = scrollParent.scrollTop + (elRect.top - spRect.top) - topMargin;
+    // Instant, not smooth: a smooth animation runs for several frames and races
+    // the per-keystroke re-renders that follow the first-keystroke trigger, so
+    // the vertical scrollbar toggling mid-animation jitters the field's width.
+    // An instant jump settles the scroll in one frame, before typing continues.
+    scrollParent.scrollTo({ top: Math.max(0, targetScroll), behavior: "auto" });
+  }, 50);
+}


### PR DESCRIPTION
Second follow-on for #1539 (after PR #1550): UI polish for the collections QAM.

- **Loading** — the controls (owner scope, sub-tabs, search, per-type filter, Enable/Disable All) now render immediately; only the collection list waits on the slow fetch and shows a spinner in its own area. The fast settings read no longer blocks behind the slow collection fetch, and empty/error states render in the list area with the controls still visible. Enable/Disable All stay disabled until the list has loaded.
- **Search scroll** — focusing the search field scrolls its "SEARCH COLLECTIONS" heading to the top of the view (relative element-to-top), clear of the on-screen keyboard, instead of centering it.
- **On-screen keyboard** — removed a non-working best-effort R2/Enter dismiss handler: closing the OSK is Steam-controlled and not reachable from the plugin (use B or the keyboard's dismiss button).

Part of #1539.
