### PR TITLE
feat(saves): copy a save into another slot

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -3,6 +3,6 @@
     "name": "dist/index.js (raw)",
     "path": "dist/index.js",
     "brotli": false,
-    "limit": "800 KB"
+    "limit": "820 KB"
   }
 ]

--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -1233,6 +1233,50 @@ rollback API.
   devices still see the original newest save. Calling `rollback_to_version` again is safe and idempotent: step 1 is
   already done, step 2 retries the PUT.
 
+## Copy a save to another slot
+
+A per-save **"Copy to slot…"** action (`SaveCopyService`, `services/saves/copies.py`; callable `copy_save_to_slot`)
+takes one server save — from a named slot, an older version, or the read-only legacy no-slot bucket — and copies its
+content into a target slot. The action is offered on every save row that carries a server save id: the active slot's
+current save, its Previous-Versions rows, and the inactive/legacy slot panels.
+
+Two things define the semantics:
+
+- **It is a copy, never a move.** The source save is never deleted (the user removes it in the RomM web app if they want
+  to). A ROM has many slots; this does not "move the ROM onto one slot".
+- **The target slot becomes the ROM's active/confirmed slot,** with the copied save as its current save. This is
+  mechanically forced: `do_upload_save` resolves its upload slot purely from `save_state.active_slot`
+  (`_resolve_upload_slot`) — there is no per-call slot override — so `active_slot` is set to the target (`confirm_slot`)
+  _before_ the upload.
+
+The flow is a composition of the rollback orchestration shell and the wizard-migration's make-current step (it extends
+neither in place):
+
+1. Validate the target name (empty/whitespace → `invalid_slot_name`).
+2. Under `rom_lock`, refuse an unconfigured ROM (`active_slot` is `None` or the slot is unconfirmed) with
+   `not_configured` — the Copy action is only reachable on a configured ROM, and this is the defensive backstop, not a
+   UI-gate reliance (the #1529 lesson). `rom_not_installed` when there is no install record.
+3. Multi-file (#908) and content-dir (#239) layouts are refused with `unsupported` (the content-dir case carries the
+   `savefiles_in_content_dir` reason), exactly as rollback refuses them — copying one component of an N-file set would
+   produce an incoherent save, and a content-dir layout writes where RetroArch never reads.
+4. A **matrix pre-flight** (`do_sync_rom_saves`) runs unconditionally on the _current_ slot, protecting its dirty local
+   before the copy overwrites it: `conflict_blocked` / `preflight_failed` on a bad pre-flight (same shapes as rollback).
+5. `list_saves` with **no slot filter** (the chosen save may live in any slot) locates the save by id; a missing id is
+   `version_deleted`, a failed call is `server_unreachable`.
+6. `SaveCopyService._copy_save_to_slot_io` then: `confirm_slot(target)` (creates the slot if new, switches active +
+   confirms) → `do_download_save` (the chosen content onto the canonical local file, quarantining the current local file
+   first, #965) → `do_upload_save(server_save=None, overwrite=False)` — a POST into the now-active target slot. A
+   **409** is `target_slot_busy` (the target has newer changes from another device — sync it first, then retry); any
+   other upload error is `copy_failed`.
+
+The status union mirrors `RollbackStatus`:
+`ok | not_configured | invalid_slot_name | rom_not_installed | version_deleted | unsupported{reason?} |
+server_unreachable{message} | conflict_blocked{conflicts} | preflight_failed{errors} | target_slot_busy{message} |
+copy_failed{message}`.
+On `ok` the frontend dispatches `romm_data_changed` so the parent re-fetches — refreshing both the source and the target
+slot views. The source slot is excluded from the target picker (a same-slot copy is just a rollback) and the legacy `""`
+bucket is excluded as a target (it stays a read-only source).
+
 ## RomM Save Sync API Behaviour
 
 The plugin depends on several RomM v4.8.1 behaviours that are not obvious from the OpenAPI schema and were discovered
@@ -1802,11 +1846,13 @@ RetroArch save states (`<states_path>/{system}/`, where `<states_path>` comes fr
 `paths.states_path`) are not synced. Only SRAM saves (`.srm`) are handled. Save states are large,
 emulator-version-specific, and not portable between different RetroArch core versions.
 
-### Save slot migration between slots not yet implemented
+### Copying a save into another slot
 
-Moving saves between slots (copy from slot A to slot B) is not supported. Users can delete named slots (which removes
-all saves in the slot from the server) and create new ones, but there is no "move saves from slot X to slot Y"
-operation. The legacy (web-player) bucket is the one exception — it is read-only and cannot be deleted from the plugin
+Copying a single save from one slot into another is supported via the per-save **"Copy to slot…"** action (see
+[Copy a save to another slot](#copy-a-save-to-another-slot)) — the target slot becomes the ROM's active slot and the
+source save is preserved. What is _not_ supported is a bulk **move** of a whole slot's contents (delete-from-source
+semantics): users copy individual saves, then delete the source slot from the server if they want it gone. The legacy
+(web-player) bucket is a read-only copy _source_ — it cannot be a copy target, and cannot be deleted from the plugin
 (#1478).
 
 ### Cross-device save browsing limited

--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -1263,7 +1263,12 @@ neither in place):
    before the copy overwrites it: `conflict_blocked` / `preflight_failed` on a bad pre-flight (same shapes as rollback).
 5. `list_saves` with **no slot filter** (the chosen save may live in any slot) locates the save by id; a missing id is
    `version_deleted`, a failed call is `server_unreachable`.
-6. `SaveCopyService._copy_save_to_slot_io` then: `confirm_slot(target)` (creates the slot if new, switches active +
+6. **Dedup pre-check**: if the chosen save's `content_hash` already matches a save in the _target_ slot, the copy is a
+   no-op — `already_present{existing_id}` (the existing twin's id) is returned with **no** download / upload /
+   make-current, so nothing churns (the frontend toasts "already in slot … as `#<id>`" and does not refresh). It fires
+   only when `content_hash` is populated (RomM 5.0.0+); an absent hash falls through to the copy and RomM's own
+   server-side dedup. This is what stops a repeat-copy of already-present content from re-pointing the tracked save.
+7. `SaveCopyService._copy_save_to_slot_io` then: `confirm_slot(target)` (creates the slot if new, switches active +
    confirms) → `do_download_save` (the chosen content onto the canonical local file, quarantining the current local file
    first, #965) → `do_upload_save(server_save=None, overwrite=False)` — a POST into the now-active target slot. A
    **409** is `target_slot_busy` (the target has newer changes from another device — sync it first, then retry); any
@@ -1272,7 +1277,7 @@ neither in place):
 The status union mirrors `RollbackStatus`:
 `ok | not_configured | invalid_slot_name | rom_not_installed | version_deleted | unsupported{reason?} |
 server_unreachable{message} | conflict_blocked{conflicts} | preflight_failed{errors} | target_slot_busy{message} |
-copy_failed{message}`.
+already_present{existing_id} | copy_failed{message}`.
 On `ok` the frontend dispatches `romm_data_changed` so the parent re-fetches — refreshing both the source and the target
 slot views. The source slot is excluded from the target picker (a same-slot copy is just a rollback) and the legacy `""`
 bucket is excluded as a target (it stays a read-only source).

--- a/docs/user-guide/save-sync.md
+++ b/docs/user-guide/save-sync.md
@@ -115,6 +115,24 @@ The modal blocks the Play action until you choose. If a post-exit sync detects a
 opens the next time you tap Play, where it blocks launch until resolved. There is no longer a separate "pending
 conflicts" list on the settings page.
 
+## Copying a Save to Another Slot
+
+On the SAVES tab, most save rows carry a **Copy to slot…** button — the active slot's current save, its Previous
+Versions, and the saves listed under any other slot (including the read-only legacy web-player bucket). Tap it to copy
+that save into another slot:
+
+- Pick an existing slot, or type a name to create a new one.
+- The **copy is not a move** — the original save stays where it is. Delete it from the RomM web app later if you want it
+  gone.
+- The slot you copy into **becomes the game's active slot**, with the copied save as its current save.
+
+Common uses: promote an old web-player (legacy) save into a proper named slot, or bring a save from one slot onto
+another so you can continue it there.
+
+The button is unavailable while RomM is offline. If the game's current slot has an unresolved conflict, resolve it first
+(you'll be prompted). If the destination slot has newer changes from another device, sync that slot first, then copy
+again.
+
 ## Core Switch Warning
 
 When you switch the emulator core for a game (e.g., from mGBA to gpSP for GBA), the plugin detects the change and shows

--- a/docs/user-guide/save-sync.md
+++ b/docs/user-guide/save-sync.md
@@ -125,6 +125,8 @@ that save into another slot:
 - The **copy is not a move** — the original save stays where it is. Delete it from the RomM web app later if you want it
   gone.
 - The slot you copy into **becomes the game's active slot**, with the copied save as its current save.
+- If that save's content is **already in the destination slot**, nothing is copied — you're told it's already there
+  (shown as `#<id>`).
 
 Common uses: promote an old web-player (legacy) save into a proper named slot, or bring a save from one slot onto
 another so you can continue it there.

--- a/main.py
+++ b/main.py
@@ -566,6 +566,10 @@ class Plugin:
     async def saves_rollback_to_version(self, rom_id, slot, save_id):
         return await self._save_sync_service.rollback_to_version(rom_id, slot, save_id)
 
+    @migration_blocked
+    async def copy_save_to_slot(self, rom_id, save_id, target_slot):
+        return await self._save_sync_service.copy_save_to_slot(rom_id, save_id, target_slot)
+
     async def record_session_start(self, rom_id):
         result = self._playtime_service.record_session_start(rom_id)
         # Fire-and-forget: drain any offline play-session backlog into RomM's

--- a/py_modules/services/saves/copies.py
+++ b/py_modules/services/saves/copies.py
@@ -1,0 +1,331 @@
+"""Copy a specific server save into another slot.
+
+Owns the per-save "Copy to slot…" flow: it takes one server save (from a
+named slot or the read-only legacy no-slot bucket) and copies its content
+into a target slot, which becomes the ROM's active/confirmed slot with the
+copied save as its current save. The source save is never deleted — this is
+a copy, not a move. The actual file/server writes go through SyncEngine;
+this class owns only the orchestration (pre-flight sync, make-current,
+POST into the target). Persistence is the operation's own narrow Unit of
+Work (ADR-0006).
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from domain.rom_save_sync_state import RomSaveSyncState
+from domain.save_layout import SAVE_SYNC_CONTENT_DIR_REASON
+from domain.save_status import compute_multi_file_slot
+from lib.errors import RommConflictError
+from services.saves._helpers import local_save_target
+from services.saves._settings import resolve_default_slot
+
+if TYPE_CHECKING:
+    import asyncio
+    import logging
+    from collections.abc import Callable
+
+    from services.protocols import DebugLogger, RetryStrategy, RommSaveApi, UnitOfWorkFactory
+    from services.saves.rom_info import RomInfoService
+    from services.saves.sync_engine import SyncEngine
+    from services.saves.sync_engine.devices import DeviceRegistry
+
+
+@dataclass(frozen=True)
+class SaveCopyServiceConfig:
+    """Frozen wiring bundle handed to ``SaveCopyService.__init__``.
+
+    Mirrors :class:`VersionsServiceConfig` — the copy flow reuses the same
+    rollback-orchestration machinery (per-ROM lock, pre-flight sync, the
+    download/upload workers) — minus ``save_file_store``: every file write
+    routes through ``sync_engine``. Holds the live ``settings.json`` dict
+    (default-slot seeding), the Unit-of-Work factory (the transactional seam
+    over the SQLite repositories), the peer save sub-services consumed during
+    orchestration (sync_engine, rom_info, and the shared :class:`DeviceRegistry`
+    that owns the server device id), the core resolver used to stamp the upload
+    emulator tag, the Protocol-typed RomM adapter and retry strategy, the plugin
+    event loop, the standard-library logger, and the ``DebugLogger`` seam.
+    """
+
+    settings: dict[str, Any]
+    uow_factory: UnitOfWorkFactory
+    sync_engine: SyncEngine
+    device_registry: DeviceRegistry
+    rom_info: RomInfoService
+    resolve_core: Callable[[int], str | None]
+    romm_api: RommSaveApi
+    retry: RetryStrategy
+    loop: asyncio.AbstractEventLoop
+    logger: logging.Logger
+    log_debug: DebugLogger
+
+
+class SaveCopyService:
+    """Aggregate root for the copy-save-to-slot flow.
+
+    Per-ROM lock acquisition is delegated to the injected ``SyncEngine``;
+    save-state persistence is the operation's own narrow Unit of Work. This
+    class owns the copy orchestration on top of them.
+    """
+
+    def __init__(self, *, config: SaveCopyServiceConfig) -> None:
+        self._config = config
+        self._settings = config.settings
+        self._uow_factory = config.uow_factory
+        self._sync_engine = config.sync_engine
+        self._device_registry = config.device_registry
+        self._rom_info = config.rom_info
+        self._resolve_core = config.resolve_core
+        self._romm_api = config.romm_api
+        self._retry = config.retry
+        self._loop = config.loop
+        self._logger = config.logger
+        self._log_debug = config.log_debug
+
+    # ------------------------------------------------------------------
+    # Narrow-UoW read/write helpers (ADR-0006)
+    # ------------------------------------------------------------------
+
+    def _read_inputs(self, rom_id: int) -> tuple[RomSaveSyncState, str | None]:
+        with self._uow_factory() as uow:
+            state = uow.rom_save_sync_states.get(rom_id) or RomSaveSyncState()
+        return state, self._device_registry.get_device_id()
+
+    def _write_save_state(self, rom_id: int, save_state: RomSaveSyncState) -> None:
+        with self._uow_factory() as uow:
+            uow.rom_save_sync_states.save(rom_id, save_state)
+
+    def _local_component_filenames(self, rom_id: int) -> list[str]:
+        """Distinct local save filenames on disk for the ROM (one per extension).
+
+        More than one distinct filename means the current slot's save is an
+        N-file set (e.g. Saturn ``.bkr``/``.bcr``/``.smpc``), not a single file
+        — the interim #908 guard refuses a copy in that case. Reads only the
+        local saves directory, no network: a copy target is always an
+        *installed* ROM. Returns an empty list when the ROM is not installed.
+        """
+        return [lf["filename"] for lf in self._rom_info.find_save_files(rom_id)]
+
+    # ------------------------------------------------------------------
+    # Copy-to-slot API
+    # ------------------------------------------------------------------
+
+    def _copy_save_to_slot_io(
+        self,
+        rom_id: int,
+        save_state: RomSaveSyncState,
+        device_id: str | None,
+        core_so: str | None,
+        save_id: int,
+        target_slot: str,
+        info: dict[str, Any],
+        server_saves: list[dict[str, Any]],
+        default_slot: str,
+    ) -> dict[str, Any]:
+        """Blocking I/O portion of the copy flow — runs in executor.
+
+        By the time this runs the caller has already brought the *current* slot
+        in sync (the matrix pre-flight) so no dirty local is lost when the
+        download below overwrites the canonical local file. This function is the
+        copy proper:
+
+        1. Locate the chosen save in the (unfiltered) server list; a missing id
+           is ``version_deleted``.
+        2. Make the target the ROM's active/confirmed slot
+           (:meth:`RomSaveSyncState.confirm_slot`) — the upload resolves its slot
+           purely from ``active_slot`` (``_resolve_upload_slot``), so this must
+           precede the POST for the copy to land in the target.
+        3. Download the chosen save's content onto the canonical local file
+           (quarantines the current local file first, #965).
+        4. POST that content into the now-active target slot
+           (``server_save=None`` → a new save, ``overwrite=false`` → the 409
+           backstop guards a busy target). A 409 is ``target_slot_busy`` (the
+           target has newer changes from another device — resolve it first); any
+           other upload error is ``copy_failed``.
+
+        The source save is never touched. Mutates *save_state* in memory; the
+        caller owns the write UoW.
+        """
+        target_save = next((s for s in server_saves if s.get("id") == save_id), None)
+        if target_save is None:
+            return {"status": "version_deleted"}
+
+        saves_dir = info["saves_dir"]
+        system = info["system"]
+        rom_name = info["rom_name"]
+        canonical = local_save_target(target_save, rom_name)
+        local_path = os.path.join(saves_dir, canonical)
+
+        # Make the target current BEFORE the upload: do_upload_save resolves the
+        # upload slot from save_state.active_slot with no per-call override, so
+        # the POST only lands in the target once it is the confirmed active slot.
+        save_state.confirm_slot(target_slot)
+
+        # Bring the chosen save's content down onto the canonical local file. The
+        # existing local file (the current slot's save) is quarantined into
+        # ``.romm-backup`` first, so nothing that lives only on disk is lost.
+        self._sync_engine.do_download_save(
+            target_save, saves_dir, canonical, save_state, device_id, system, default_slot
+        )
+
+        try:
+            self._sync_engine.do_upload_save(
+                rom_id,
+                local_path,
+                canonical,
+                save_state,
+                device_id,
+                system,
+                core_so,
+                server_save=None,
+                default_slot=default_slot,
+                overwrite=False,
+            )
+        except RommConflictError as e:
+            # The target slot has a newer server version this device hasn't
+            # synced — an overwrite=false POST 409s rather than stack on it.
+            # Surface it so the user resolves/syncs the target first, then retries.
+            self._logger.warning(
+                "_copy_save_to_slot_io: target slot %r busy for rom=%s save=%s: %s",
+                target_slot,
+                rom_id,
+                save_id,
+                e,
+            )
+            return {"status": "target_slot_busy", "message": str(e)}
+        except Exception as e:
+            self._logger.error(
+                "_copy_save_to_slot_io: upload into slot %r failed for rom=%s save=%s: %s",
+                target_slot,
+                rom_id,
+                save_id,
+                e,
+            )
+            return {"status": "copy_failed", "message": str(e)}
+
+        return {"status": "ok"}
+
+    async def copy_save_to_slot(self, rom_id: int, save_id: int, target_slot: str) -> dict[str, Any]:
+        """Copy one server save into *target_slot*, making it the active slot.
+
+        The source save (``save_id``, from any slot including the legacy no-slot
+        bucket) is copied — never moved or deleted — into ``target_slot``, which
+        becomes the ROM's active/confirmed slot with the copied save as its
+        current save.
+
+        Flow:
+
+        1. Validate ``target_slot`` (strip; empty/whitespace/None →
+           ``invalid_slot_name``).
+        2. Acquire ``rom_lock`` — every ``RomSaveSyncState`` read-mutate-write
+           runs under it.
+        3. Refuse an unconfigured ROM (``active_slot`` None / slot not confirmed)
+           with ``not_configured``. The Copy action is only reachable on a
+           configured ROM; this is the defensive backstop, not a UI-gate reliance.
+        4. ``rom_not_installed`` when the ROM has no install record.
+        5. Multi-file (#908) and content-dir (#239) layouts are ``unsupported``.
+        6. Pre-flight ``do_sync_rom_saves`` on the current (confirmed) slot,
+           unconditionally, to protect its dirty local before the copy overwrites
+           it — ``conflict_blocked`` / ``preflight_failed`` on a bad pre-flight.
+        7. ``list_saves`` with no slot filter (the source may be in any slot);
+           failure is ``server_unreachable``.
+        8. The copy proper runs in :meth:`_copy_save_to_slot_io`.
+
+        Returns a discriminated-status dict (mirrors ``RollbackStatus``):
+        ``ok | not_configured | invalid_slot_name | rom_not_installed |
+        version_deleted | unsupported{reason?} | server_unreachable{message} |
+        conflict_blocked{conflicts} | preflight_failed{errors} |
+        target_slot_busy{message} | copy_failed{message}``.
+        """
+        rom_id = int(rom_id)
+        save_id = int(save_id)
+
+        target_slot = str(target_slot).strip()
+        if not target_slot:
+            return {"status": "invalid_slot_name"}
+
+        async with self._sync_engine.rom_lock(rom_id):
+            save_state, device_id = await self._loop.run_in_executor(None, self._read_inputs, rom_id)
+
+            # Configured ROMs only: the current slot must be a confirmed named
+            # slot. An unconfirmed slot, ``active_slot`` None, or the legacy
+            # no-slot mode ("") is refused — the copy would otherwise land its
+            # pre-flight/upload without a real source-slot context (#1529 lesson).
+            if not (save_state.slot_confirmed and save_state.active_slot):
+                self._log_debug(f"copy_save_to_slot: rom {rom_id} not configured; refusing")
+                return {"status": "not_configured"}
+
+            info = self._rom_info.get_rom_save_info(rom_id)
+            if not info:
+                return {"status": "rom_not_installed"}
+
+            # Interim #908 guard: a multi-file slot (e.g. Saturn .bkr/.bcr/.smpc)
+            # is one game state across N files — copying a single save into a slot
+            # would produce an incoherent set. Local-only (no network): a copy
+            # source is always installed, so its component files are on disk.
+            component_files = await self._loop.run_in_executor(None, self._local_component_filenames, rom_id)
+            if compute_multi_file_slot(component_files).is_multi_file:
+                self._log_debug(f"copy_save_to_slot: multi-file slot for rom {rom_id} ({component_files}); refusing")
+                return {"status": "unsupported"}
+
+            # #239: RetroArch writes saves to the content dir — the copy's
+            # download/POST target is ``saves_dir``, which RetroArch ignores in
+            # that layout, so the copy could never take effect. Refuse before any
+            # preflight or destructive I/O.
+            if await self._sync_engine.content_dir_blocked("copy_save_to_slot"):
+                self._log_debug(f"copy_save_to_slot: content-dir layout for rom {rom_id}; refusing")
+                return {"status": "unsupported", "reason": SAVE_SYNC_CONTENT_DIR_REASON}
+
+            core_so = await self._loop.run_in_executor(None, self._resolve_core, rom_id)
+            default_slot = resolve_default_slot(self._settings)
+
+            # Matrix pre-flight on the CURRENT slot: get its tracked save in sync
+            # first (or surface a conflict), so the download below never overwrites
+            # a dirty local that lives nowhere else.
+            _uploaded, _downloaded, errors, conflicts = await self._loop.run_in_executor(
+                None, self._sync_engine.do_sync_rom_saves, rom_id, save_state, device_id, core_so, default_slot
+            )
+            if conflicts:
+                await self._loop.run_in_executor(None, self._write_save_state, rom_id, save_state)
+                return {"status": "conflict_blocked", "conflicts": list(conflicts)}
+            if errors:
+                await self._loop.run_in_executor(None, self._write_save_state, rom_id, save_state)
+                return {"status": "preflight_failed", "errors": errors}
+
+            # No slot filter: the chosen save may live in ANY slot (a named slot or
+            # the legacy no-slot bucket), so list everything and find it by id.
+            try:
+                server_saves: list[dict[str, Any]] = await self._loop.run_in_executor(
+                    None,
+                    lambda: self._retry.with_retry(lambda: self._romm_api.list_saves(rom_id, device_id=device_id)),
+                )
+            except Exception as e:
+                self._log_debug(f"copy_save_to_slot: failed to list saves: {e}")
+                # Persist whatever the pre-flight mutated before bailing.
+                await self._loop.run_in_executor(None, self._write_save_state, rom_id, save_state)
+                return {"status": "server_unreachable", "message": str(e)}
+
+            try:
+                result = await self._loop.run_in_executor(
+                    None,
+                    self._copy_save_to_slot_io,
+                    rom_id,
+                    save_state,
+                    device_id,
+                    core_so,
+                    save_id,
+                    target_slot,
+                    info,
+                    server_saves,
+                    default_slot,
+                )
+            finally:
+                # The pre-flight (and the copy's own download/upload) mutate the
+                # in-memory aggregate; persist regardless of how the copy ends or
+                # the next sync mis-classifies (#1012).
+                await self._loop.run_in_executor(None, self._write_save_state, rom_id, save_state)
+
+            return result

--- a/py_modules/services/saves/copies.py
+++ b/py_modules/services/saves/copies.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any
 
 from domain.rom_save_sync_state import RomSaveSyncState
 from domain.save_layout import SAVE_SYNC_CONTENT_DIR_REASON
+from domain.save_slot import save_in_slot
 from domain.save_status import compute_multi_file_slot
 from lib.errors import RommConflictError
 from services.saves._helpers import local_save_target
@@ -108,6 +109,30 @@ class SaveCopyService:
         *installed* ROM. Returns an empty list when the ROM is not installed.
         """
         return [lf["filename"] for lf in self._rom_info.find_save_files(rom_id)]
+
+    @staticmethod
+    def _find_already_present(server_saves: list[dict[str, Any]], save_id: int, target_slot: str) -> int | None:
+        """The id of a save in *target_slot* whose content matches *save_id*, or None.
+
+        Compares the chosen save's ``content_hash`` (RomM's own digest of the
+        bytes) against every save already in the target slot. Returns the first
+        match's id — meaning the copy would be a content-identical no-op that
+        RomM would dedup server-side. Returns None when the chosen save is absent
+        (a later ``version_deleted``), carries no ``content_hash`` (older servers;
+        the copy falls through to RomM's own dedup), or has no content twin in the
+        slot.
+        """
+        source = next((s for s in server_saves if s.get("id") == save_id), None)
+        if source is None:
+            return None
+        source_hash = source.get("content_hash")
+        if not source_hash:
+            return None
+        match = next(
+            (s for s in server_saves if save_in_slot(s, target_slot) and s.get("content_hash") == source_hash),
+            None,
+        )
+        return match.get("id") if match is not None else None
 
     # ------------------------------------------------------------------
     # Copy-to-slot API
@@ -234,11 +259,16 @@ class SaveCopyService:
            failure is ``server_unreachable``.
         8. The copy proper runs in :meth:`_copy_save_to_slot_io`.
 
+        A dedup pre-check between the ``list_saves`` and the copy short-circuits
+        with ``already_present{existing_id}`` when the chosen save's content is
+        already in the target slot — copying it would only churn the tracked save
+        (RomM dedups server-side).
+
         Returns a discriminated-status dict (mirrors ``RollbackStatus``):
-        ``ok | not_configured | invalid_slot_name | rom_not_installed |
-        version_deleted | unsupported{reason?} | server_unreachable{message} |
-        conflict_blocked{conflicts} | preflight_failed{errors} |
-        target_slot_busy{message} | copy_failed{message}``.
+        ``ok | already_present{existing_id} | not_configured | invalid_slot_name |
+        rom_not_installed | version_deleted | unsupported{reason?} |
+        server_unreachable{message} | conflict_blocked{conflicts} |
+        preflight_failed{errors} | target_slot_busy{message} | copy_failed{message}``.
         """
         rom_id = int(rom_id)
         save_id = int(save_id)
@@ -307,6 +337,26 @@ class SaveCopyService:
                 # Persist whatever the pre-flight mutated before bailing.
                 await self._loop.run_in_executor(None, self._write_save_state, rom_id, save_state)
                 return {"status": "server_unreachable", "message": str(e)}
+
+            # Dedup pre-check: if the chosen save's content is already present in
+            # the target slot, a copy would make RomM dedup server-side and
+            # do_upload_save would adopt the pre-existing save as current —
+            # churning the tracked save for no gain (which surfaced the current
+            # save in its own version history). Detect it up front via the
+            # content_hash RomM populates on each save and refuse without touching
+            # any copy state. A missing source content_hash skips the check; the
+            # copy then falls through and RomM's own server-side dedup applies.
+            existing_id = self._find_already_present(server_saves, save_id, target_slot)
+            if existing_id is not None:
+                self._log_debug(
+                    f"copy_save_to_slot: rom {rom_id} save {save_id} already present in slot "
+                    f"{target_slot!r} as {existing_id}; skipping copy"
+                )
+                # The pre-flight may have performed real uploads/downloads on the
+                # current slot; persist those baselines even though the copy is a
+                # no-op (#1012). No copy state was mutated.
+                await self._loop.run_in_executor(None, self._write_save_state, rom_id, save_state)
+                return {"status": "already_present", "existing_id": existing_id}
 
             try:
                 result = await self._loop.run_in_executor(

--- a/py_modules/services/saves/service.py
+++ b/py_modules/services/saves/service.py
@@ -24,6 +24,7 @@ from services.saves._settings import (
     save_sync_enabled,
     save_sync_settings_view,
 )
+from services.saves.copies import SaveCopyService, SaveCopyServiceConfig
 from services.saves.rom_info import RomInfoService, RomInfoServiceConfig
 from services.saves.slots import SlotsService, SlotsServiceConfig
 from services.saves.status import StatusService, StatusServiceConfig
@@ -137,6 +138,22 @@ class SaveService:
 
         self._versions = VersionsService(
             config=VersionsServiceConfig(
+                settings=config.settings,
+                uow_factory=config.uow_factory,
+                sync_engine=self._sync_engine,
+                device_registry=self._device_registry,
+                rom_info=self._rom_info,
+                resolve_core=self._sync_engine.resolve_core,
+                romm_api=config.romm_api,
+                retry=config.retry,
+                loop=config.loop,
+                logger=config.logger,
+                log_debug=config.log_debug,
+            ),
+        )
+
+        self._copies = SaveCopyService(
+            config=SaveCopyServiceConfig(
                 settings=config.settings,
                 uow_factory=config.uow_factory,
                 sync_engine=self._sync_engine,
@@ -334,6 +351,14 @@ class SaveService:
     async def rollback_to_version(self, rom_id: int, slot: str, save_id: int) -> dict[str, Any]:
         """Switch the local + tracked save to a chosen older server version."""
         return await self._versions.rollback_to_version(rom_id, slot, save_id)
+
+    # ------------------------------------------------------------------
+    # Copy-to-slot (delegated to SaveCopyService)
+    # ------------------------------------------------------------------
+
+    async def copy_save_to_slot(self, rom_id: int, save_id: int, target_slot: str) -> dict[str, Any]:
+        """Copy a specific server save into another slot (which becomes active)."""
+        return await self._copies.copy_save_to_slot(rom_id, save_id, target_slot)
 
     # ------------------------------------------------------------------
     # Settings (settings.json — read/written directly)

--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -41,6 +41,7 @@ import type {
   SaveSortMigrationStatus,
   RollbackStatus,
   ListFileVersionsResult,
+  CopySaveToSlotStatus,
   ListDevicesResponse,
 } from "../types";
 
@@ -743,6 +744,7 @@ export const savesListFileVersions = callable<[number, string, string], ListFile
   "saves_list_file_versions",
 );
 export const savesRollbackToVersion = callable<[number, string, number], RollbackStatus>("saves_rollback_to_version");
+export const copySaveToSlot = callable<[number, number, string], CopySaveToSlotStatus>("copy_save_to_slot");
 
 // Achievements callables
 export const getAchievements = callable<[number], AchievementList>("get_achievements");

--- a/src/components/SavesTab.tsx
+++ b/src/components/SavesTab.tsx
@@ -21,6 +21,7 @@ import { NewSlotModal } from "./saves/NewSlotModal";
 import { SlotPanel } from "./saves/SlotPanel";
 import { ConnectingIndicator } from "./saves/ConnectingIndicator";
 import { renderSaveFileRow } from "./saves/SaveFileRow";
+import { useCopyToSlot } from "./saves/useCopyToSlot";
 import { detach } from "../utils/detach";
 
 interface SavesTabProps {
@@ -125,6 +126,12 @@ export const SavesTab: FC<SavesTabProps> = ({
       cancelled = true;
     };
   }, [appId, romId]);
+
+  // Copy-to-slot opener, shared by every save row across the slot panels. The
+  // picker's target list is derived from availableSlots (minus the source slot
+  // and the legacy "" bucket); on success it dispatches romm_data_changed so the
+  // parent re-fetches and both the source and target views refresh.
+  const openCopyModal = useCopyToSlot(romId, availableSlots);
 
   // --- Offline banner ---
   const offlineBanner = isOffline
@@ -316,6 +323,7 @@ export const SavesTab: FC<SavesTabProps> = ({
           onSlotSwitched,
           onVersionRestored: handleVersionRestored,
           onSlotDeleted: handleSlotDeleted,
+          onCopy: openCopyModal,
         });
       }),
 

--- a/src/components/saves/CopyToSlotButton.test.tsx
+++ b/src/components/saves/CopyToSlotButton.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import { renderCopyToSlotButton, type CopyToSlotRowProps } from "./CopyToSlotButton";
+
+function renderButton(overrides: Partial<CopyToSlotRowProps> = {}) {
+  const onCopy = vi.fn();
+  const copy: CopyToSlotRowProps = { onCopy, sourceSlot: "backup", isOffline: false, ...overrides };
+  const utils = render(renderCopyToSlotButton("copy-7", 7, copy));
+  return { ...utils, onCopy };
+}
+
+describe("renderCopyToSlotButton", () => {
+  it("renders the 'Copy to slot…' label", () => {
+    const { getByText } = renderButton();
+    expect(getByText("Copy to slot…")).toBeInTheDocument();
+  });
+
+  it("hands (saveId, sourceSlot) to onCopy on click", () => {
+    const { getByText, onCopy } = renderButton({ sourceSlot: "backup" });
+    fireEvent.click(getByText("Copy to slot…"));
+    // Non-vacuous: the exact save id and source slot flow through.
+    expect(onCopy).toHaveBeenCalledWith(7, "backup");
+  });
+
+  it("is disabled and inert while offline", () => {
+    const { getByText, onCopy } = renderButton({ isOffline: true });
+    const btn = getByText("Copy to slot…").closest("button");
+    expect(btn).toBeDisabled();
+    // A disabled button never fires onCopy.
+    fireEvent.click(getByText("Copy to slot…"));
+    expect(onCopy).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/saves/CopyToSlotButton.tsx
+++ b/src/components/saves/CopyToSlotButton.tsx
@@ -1,0 +1,48 @@
+/**
+ * Shared "Copy to slot…" button rendered on every save row that carries a
+ * non-null server save id — the legacy bucket + inactive slots (ServerSaveRow),
+ * the active tracked file (SaveFileRow), and version-history rows. Pure render
+ * helper: the click hands (saveId, sourceSlot) to the parent's `onCopy`, which
+ * owns the picker modal and the copy flow (`useCopyToSlot`). Disabled offline.
+ */
+
+import { createElement } from "react";
+import { DialogButton } from "@decky/ui";
+import { scrollFocusedToCenter } from "../../utils/scrollHelpers";
+
+/** Callback opening the copy-to-slot picker for one source save. */
+export type CopyToSlotHandler = (saveId: number, sourceSlot: string) => void;
+
+/** Bundle threaded down to each row that can offer the copy action. */
+export interface CopyToSlotRowProps {
+  onCopy: CopyToSlotHandler;
+  sourceSlot: string;
+  isOffline: boolean;
+}
+
+export function renderCopyToSlotButton(
+  key: string,
+  saveId: number,
+  copy: CopyToSlotRowProps,
+): ReturnType<typeof createElement> {
+  return createElement(
+    DialogButton,
+    {
+      key,
+      style: {
+        padding: "2px 8px",
+        minWidth: "auto",
+        fontSize: "11px",
+        width: "auto",
+        flexShrink: 0,
+      },
+      noFocusRing: false,
+      onFocus: scrollFocusedToCenter,
+      disabled: copy.isOffline,
+      onClick: () => {
+        copy.onCopy(saveId, copy.sourceSlot);
+      },
+    },
+    "Copy to slot…",
+  );
+}

--- a/src/components/saves/CopyToSlotModal.test.tsx
+++ b/src/components/saves/CopyToSlotModal.test.tsx
@@ -50,6 +50,22 @@ describe("CopyToSlotModal", () => {
     expect(closeModal).toHaveBeenCalled();
   });
 
+  it("submits the new-slot name on Enter (the on-screen keyboard's Eingabe key)", () => {
+    const { getByTestId, onSubmit, closeModal } = renderModal();
+    const field = getByTestId("text-field");
+    fireEvent.change(field, { target: { value: "  speedrun  " } });
+    fireEvent.keyDown(field, { key: "Enter" });
+    expect(onSubmit).toHaveBeenCalledWith("speedrun");
+    expect(closeModal).toHaveBeenCalled();
+  });
+
+  it("ignores Enter while the new-slot field is empty (no onSubmit)", () => {
+    const { getByTestId, onSubmit, closeModal } = renderModal();
+    fireEvent.keyDown(getByTestId("text-field"), { key: "Enter" });
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(closeModal).not.toHaveBeenCalled();
+  });
+
   it("disables Create while the new-slot field is empty or whitespace", () => {
     const { getByText, getByTestId } = renderModal();
     const createBtn = getByText("Create & copy here").closest("button");

--- a/src/components/saves/CopyToSlotModal.test.tsx
+++ b/src/components/saves/CopyToSlotModal.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import { CopyToSlotModal } from "./CopyToSlotModal";
+import type { SaveSlotSummary } from "../../types";
+
+function slot(name: string): SaveSlotSummary {
+  return { slot: name, source: "server", count: 1, latest_updated_at: null };
+}
+
+const SLOTS: SaveSlotSummary[] = [slot("autosave"), slot("backup"), slot(""), slot("promoted")];
+
+function renderModal(overrides: { sourceSlot?: string; availableSlots?: SaveSlotSummary[] } = {}) {
+  const onSubmit = vi.fn();
+  const closeModal = vi.fn();
+  const utils = render(
+    <CopyToSlotModal
+      availableSlots={overrides.availableSlots ?? SLOTS}
+      sourceSlot={overrides.sourceSlot ?? "backup"}
+      onSubmit={onSubmit}
+      closeModal={closeModal}
+    />,
+  );
+  return { ...utils, onSubmit, closeModal };
+}
+
+describe("CopyToSlotModal", () => {
+  it("lists existing named slots as targets, excluding the source and the legacy bucket", () => {
+    const { getByText, queryByText } = renderModal({ sourceSlot: "backup" });
+    // Named siblings are offered…
+    expect(getByText("autosave")).toBeInTheDocument();
+    expect(getByText("promoted")).toBeInTheDocument();
+    // …the source slot is not (same-slot copy == rollback)…
+    expect(queryByText("backup")).toBeNull();
+    // …and the legacy "" bucket (displayed as "Legacy") is a read-only source only.
+    expect(queryByText("Legacy")).toBeNull();
+  });
+
+  it("submits an existing target and closes on pick", () => {
+    const { getByText, onSubmit, closeModal } = renderModal({ sourceSlot: "backup" });
+    fireEvent.click(getByText("autosave"));
+    expect(onSubmit).toHaveBeenCalledWith("autosave");
+    expect(closeModal).toHaveBeenCalled();
+  });
+
+  it("creates and copies into a new slot with the trimmed name", () => {
+    const { getByTestId, getByText, onSubmit, closeModal } = renderModal();
+    fireEvent.change(getByTestId("text-field"), { target: { value: "  speedrun  " } });
+    fireEvent.click(getByText("Create & copy here"));
+    expect(onSubmit).toHaveBeenCalledWith("speedrun");
+    expect(closeModal).toHaveBeenCalled();
+  });
+
+  it("disables Create while the new-slot field is empty or whitespace", () => {
+    const { getByText, getByTestId } = renderModal();
+    const createBtn = getByText("Create & copy here").closest("button");
+    expect(createBtn).toBeDisabled();
+    fireEvent.change(getByTestId("text-field"), { target: { value: "   " } });
+    expect(createBtn).toBeDisabled();
+  });
+
+  it("rejects an empty new-slot submission (no onSubmit)", () => {
+    const { getByText, onSubmit } = renderModal();
+    // The button is disabled, so a click never reaches the empty-guarded pick().
+    fireEvent.click(getByText("Create & copy here"));
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("shows a hint when there are no other slots to copy into", () => {
+    const { getByText } = renderModal({ sourceSlot: "backup", availableSlots: [slot("backup"), slot("")] });
+    expect(getByText("No other slots yet — create one below.")).toBeInTheDocument();
+  });
+});

--- a/src/components/saves/CopyToSlotModal.tsx
+++ b/src/components/saves/CopyToSlotModal.tsx
@@ -1,0 +1,109 @@
+/**
+ * Picker for the "Copy to slot…" action. Lists the ROM's existing slots as copy
+ * targets — minus the source slot (a same-slot copy is just a rollback) and
+ * minus the read-only legacy no-slot bucket ("") — plus a "New slot…" text field
+ * for creating a fresh named slot. Owns only its text-field state; the chosen
+ * target is handed to `onSubmit` (trimmed, never empty) and the copy side effects
+ * belong to the parent (`useCopyToSlot`).
+ */
+
+import { useState, createElement, FC, ChangeEvent } from "react";
+import { ModalRoot, DialogButton, TextField } from "@decky/ui";
+import type { SaveSlotSummary } from "../../types";
+import { displaySlot } from "./helpers";
+
+export const CopyToSlotModal: FC<{
+  availableSlots: SaveSlotSummary[];
+  sourceSlot: string;
+  onSubmit: (target: string) => void;
+  closeModal?: () => void;
+}> = ({ availableSlots, sourceSlot, onSubmit, closeModal }) => {
+  const [newName, setNewName] = useState("");
+
+  // Existing named slots eligible as targets: never the source (same-slot copy
+  // == rollback) and never the legacy "" bucket (read-only source only). Dedupe
+  // defensively so a repeated slot can't render two identical rows.
+  const targetSlots = Array.from(
+    new Set(availableSlots.map((s) => s.slot).filter((name) => name !== "" && name !== sourceSlot)),
+  ).sort((a, b) => a.localeCompare(b));
+
+  const pick = (target: string) => {
+    const trimmed = target.trim();
+    if (!trimmed) return;
+    closeModal?.();
+    onSubmit(trimmed);
+  };
+
+  const existingRows =
+    targetSlots.length > 0
+      ? targetSlots.map((name) =>
+          createElement(
+            DialogButton,
+            {
+              key: `target-${name}`,
+              style: { padding: "6px 12px", width: "100%", textAlign: "left" as const },
+              onClick: () => {
+                pick(name);
+              },
+            },
+            displaySlot(name),
+          ),
+        )
+      : [
+          createElement(
+            "div",
+            {
+              key: "no-existing",
+              style: { fontSize: "12px", color: "rgba(255,255,255,0.5)", fontStyle: "italic" as const },
+            },
+            "No other slots yet — create one below.",
+          ),
+        ];
+
+  return createElement(
+    ModalRoot,
+    { ...(closeModal !== undefined ? { closeModal } : {}) },
+    createElement(
+      "div",
+      { style: { padding: "16px", minWidth: "320px" } },
+      createElement(
+        "div",
+        { style: { fontSize: "16px", fontWeight: "bold", marginBottom: "4px", color: "#fff" } },
+        "Copy save to slot",
+      ),
+      createElement(
+        "div",
+        { style: { fontSize: "13px", color: "rgba(255,255,255,0.6)", marginBottom: "16px", lineHeight: "1.4" } },
+        "Copies this save into the chosen slot, which becomes the active slot. The original save is kept.",
+      ),
+      // Existing-slot targets.
+      createElement(
+        "div",
+        { style: { display: "flex", flexDirection: "column" as const, gap: "8px" } },
+        ...existingRows,
+      ),
+      // New-slot creator.
+      createElement(
+        "div",
+        { style: { marginTop: "16px" } },
+        createElement(TextField, {
+          focusOnMount: false,
+          label: "New slot…",
+          value: newName,
+          onChange: (e: ChangeEvent<HTMLInputElement>) => setNewName(e.target.value),
+        }),
+        createElement(
+          DialogButton,
+          {
+            style: { marginTop: "8px", padding: "6px 12px", width: "100%" },
+            disabled: newName.trim() === "",
+            onClick: () => {
+              pick(newName);
+            },
+          },
+          "Create & copy here",
+        ),
+      ),
+    ),
+  );
+};

--- a/src/components/saves/CopyToSlotModal.tsx
+++ b/src/components/saves/CopyToSlotModal.tsx
@@ -7,7 +7,7 @@
  * belong to the parent (`useCopyToSlot`).
  */
 
-import { useState, createElement, FC, ChangeEvent } from "react";
+import { useState, createElement, FC, ChangeEvent, KeyboardEvent } from "react";
 import { ModalRoot, DialogButton, TextField } from "@decky/ui";
 import type { SaveSlotSummary } from "../../types";
 import { displaySlot } from "./helpers";
@@ -91,6 +91,12 @@ export const CopyToSlotModal: FC<{
           label: "New slot…",
           value: newName,
           onChange: (e: ChangeEvent<HTMLInputElement>) => setNewName(e.target.value),
+          // Enter (the on-screen keyboard's "Eingabe" key) submits the typed name,
+          // same as the "Create & copy here" button — pick() no-ops on an empty
+          // name, so a stray Enter in a blank field does nothing.
+          onKeyDown: (e: KeyboardEvent<HTMLInputElement>) => {
+            if (e.key === "Enter") pick(newName);
+          },
         }),
         createElement(
           DialogButton,

--- a/src/components/saves/InactiveSlotBody.test.tsx
+++ b/src/components/saves/InactiveSlotBody.test.tsx
@@ -45,6 +45,7 @@ function defaultProps(overrides: Partial<InactiveSlotBodyProps> = {}): InactiveS
     handleActivate: vi.fn(),
     handleDelete: vi.fn(),
     deleting: false,
+    copy: { onCopy: vi.fn(), sourceSlot: "backup", isOffline: false },
     ...overrides,
   };
 }

--- a/src/components/saves/InactiveSlotBody.tsx
+++ b/src/components/saves/InactiveSlotBody.tsx
@@ -10,6 +10,7 @@ import type { SlotSaveFile } from "../../types";
 import { scrollFocusedToCenter } from "../../utils/scrollHelpers";
 import { MUTED_COLOR } from "./helpers";
 import { renderServerSaveRow } from "./ServerSaveRow";
+import type { CopyToSlotRowProps } from "./CopyToSlotButton";
 
 export interface InactiveSlotBodyProps {
   loadingSlot: boolean;
@@ -26,6 +27,8 @@ export interface InactiveSlotBodyProps {
   handleActivate: () => void;
   handleDelete: () => void;
   deleting: boolean;
+  /** Copy-to-slot binding for each server save row (source = this slot). */
+  copy: CopyToSlotRowProps;
 }
 
 export const InactiveSlotBody: FC<InactiveSlotBodyProps> = ({
@@ -38,6 +41,7 @@ export const InactiveSlotBody: FC<InactiveSlotBodyProps> = ({
   handleActivate,
   handleDelete,
   deleting,
+  copy,
 }) => {
   const children: (ReturnType<typeof createElement> | null)[] = [];
 
@@ -47,7 +51,7 @@ export const InactiveSlotBody: FC<InactiveSlotBodyProps> = ({
     );
   } else if (slotFiles && slotFiles.length > 0) {
     for (const f of slotFiles) {
-      children.push(renderServerSaveRow(f));
+      children.push(renderServerSaveRow(f, copy));
     }
   } else if (slotFiles !== null) {
     children.push(

--- a/src/components/saves/ServerSaveRow.test.tsx
+++ b/src/components/saves/ServerSaveRow.test.tsx
@@ -22,12 +22,20 @@ describe("renderServerSaveRow", () => {
   });
   afterEach(() => vi.useRealTimers());
 
-  it("renders just the filename when size and updated_at are missing", () => {
-    const { container } = render(<div>{renderServerSaveRow(makeFile({ updated_at: "" }))}</div>);
+  it("renders the filename + the #id line when size and updated_at are missing", () => {
+    const { container } = render(<div>{renderServerSaveRow(makeFile({ id: 7, updated_at: "" }))}</div>);
     expect(container.textContent).toContain("save.srm");
-    // No second line (size · Updated) when both are absent
+    // The #id always shows (leads the details line); with nothing else there is
+    // no separator and no "Updated" segment.
+    expect(container.textContent).toContain("#7");
     expect(container.textContent).not.toContain("·");
     expect(container.textContent).not.toContain("Updated");
+  });
+
+  it("shows the server save id with a # prefix, leading the details line", () => {
+    const { container } = render(<div>{renderServerSaveRow(makeFile({ id: 122, size: 1024 }))}</div>);
+    // Consistent with the version-history header style (#122 · …).
+    expect(container.textContent).toContain("#122 · 1.0 KB");
   });
 
   it("renders filename + formatted size when size is present", () => {
@@ -52,9 +60,11 @@ describe("renderServerSaveRow", () => {
     expect(container.textContent).toContain("Updated 30m ago");
   });
 
-  it("renders only the filename when size is null", () => {
-    const { container } = render(<div>{renderServerSaveRow(makeFile({ size: null, updated_at: "" }))}</div>);
-    expect(container.textContent).toBe("save.srm");
+  it("renders the filename + #id (no size) when size is null", () => {
+    const { container } = render(<div>{renderServerSaveRow(makeFile({ id: 3, size: null, updated_at: "" }))}</div>);
+    expect(container.textContent).toContain("save.srm");
+    expect(container.textContent).toContain("#3");
+    expect(container.textContent).not.toContain("KB");
   });
 
   it("renders only filename + Updated when updated_at is set but size is null", () => {
@@ -73,13 +83,15 @@ describe("renderServerSaveRow", () => {
     expect(container.textContent).not.toContain("KB");
   });
 
-  it("returns null for the second line when both size and updated_at are missing (no separator)", () => {
-    const { container } = render(<div>{renderServerSaveRow(makeFile())}</div>);
-    // Only the filename div exists — no second line at all
+  it("always renders the details line (the #id) even when size and updated_at are missing", () => {
+    const { container } = render(<div>{renderServerSaveRow(makeFile({ id: 9 }))}</div>);
     const wrapper = container.firstChild as HTMLElement;
-    const rowDiv = wrapper.firstChild as HTMLElement;
-    // First child = filename div; nothing else inside the row
-    expect(rowDiv.children.length).toBe(1);
+    // The info column is the first child of the flex row (the copy button, when
+    // present, is the second — absent here).
+    const infoCol = wrapper.firstChild?.firstChild as HTMLElement;
+    // Two lines now: the filename div + the #id details div.
+    expect(infoCol.children.length).toBe(2);
+    expect(infoCol.textContent).toContain("#9");
   });
 
   it("uses a unique key per save id so list reconciliation stays stable", () => {

--- a/src/components/saves/ServerSaveRow.tsx
+++ b/src/components/saves/ServerSaveRow.tsx
@@ -1,6 +1,6 @@
 /**
  * Renderer for one server-side save entry inside an inactive slot panel —
- * a compact filename + (size · updated-relative) line. No state, no I/O.
+ * a compact filename + (#id · size · updated-relative) line. No state, no I/O.
  */
 
 import { createElement } from "react";
@@ -10,7 +10,9 @@ import { formatRelativeTime } from "./helpers";
 import { renderCopyToSlotButton, type CopyToSlotRowProps } from "./CopyToSlotButton";
 
 export function renderServerSaveRow(f: SlotSaveFile, copy?: CopyToSlotRowProps): ReturnType<typeof createElement> {
-  const details: string[] = [];
+  // Lead with the server save id (#<id> · …), matching the version-history
+  // header style, so a specific save can be identified across slots.
+  const details: string[] = [`#${f.id}`];
   if (f.size != null) details.push(formatBytes(f.size));
   if (f.updated_at) details.push(`Updated ${formatRelativeTime(f.updated_at)}`);
 

--- a/src/components/saves/ServerSaveRow.tsx
+++ b/src/components/saves/ServerSaveRow.tsx
@@ -7,8 +7,9 @@ import { createElement } from "react";
 import type { SlotSaveFile } from "../../types";
 import { formatBytes } from "../../utils/formatters";
 import { formatRelativeTime } from "./helpers";
+import { renderCopyToSlotButton, type CopyToSlotRowProps } from "./CopyToSlotButton";
 
-export function renderServerSaveRow(f: SlotSaveFile): ReturnType<typeof createElement> {
+export function renderServerSaveRow(f: SlotSaveFile, copy?: CopyToSlotRowProps): ReturnType<typeof createElement> {
   const details: string[] = [];
   if (f.size != null) details.push(formatBytes(f.size));
   if (f.updated_at) details.push(`Updated ${formatRelativeTime(f.updated_at)}`);
@@ -17,23 +18,34 @@ export function renderServerSaveRow(f: SlotSaveFile): ReturnType<typeof createEl
     "div",
     {
       key: `server-${f.id}`,
-      style: { padding: "4px 0", borderBottom: "1px solid rgba(255,255,255,0.04)" },
+      style: {
+        padding: "4px 0",
+        borderBottom: "1px solid rgba(255,255,255,0.04)",
+        display: "flex",
+        alignItems: "flex-start",
+        gap: "8px",
+      },
     },
     createElement(
       "div",
-      {
-        style: { fontSize: "12px", color: "#dcdedf", fontWeight: 500 },
-      },
-      f.filename,
+      { style: { flex: 1, minWidth: 0 } },
+      createElement(
+        "div",
+        {
+          style: { fontSize: "12px", color: "#dcdedf", fontWeight: 500 },
+        },
+        f.filename,
+      ),
+      details.length > 0
+        ? createElement(
+            "div",
+            {
+              style: { fontSize: "11px", color: "#8f98a0", marginTop: "2px" },
+            },
+            details.join(" · "),
+          )
+        : null,
     ),
-    details.length > 0
-      ? createElement(
-          "div",
-          {
-            style: { fontSize: "11px", color: "#8f98a0", marginTop: "2px" },
-          },
-          details.join(" · "),
-        )
-      : null,
+    copy ? renderCopyToSlotButton(`copy-${f.id}`, f.id, copy) : null,
   );
 }

--- a/src/components/saves/SlotPanel.test.tsx
+++ b/src/components/saves/SlotPanel.test.tsx
@@ -91,6 +91,7 @@ function defaultProps(overrides: Partial<React.ComponentProps<typeof SlotPanel>>
     onSlotSwitched: vi.fn(),
     onVersionRestored: vi.fn(),
     onSlotDeleted: vi.fn(),
+    onCopy: vi.fn(),
     ...overrides,
   };
 }

--- a/src/components/saves/SlotPanel.test.tsx
+++ b/src/components/saves/SlotPanel.test.tsx
@@ -223,6 +223,52 @@ describe("SlotPanel", () => {
       expect(queryByTestId("vhp-b.srm")).not.toBeNull();
     });
 
+    // The header count is the number of SAVES in the slot, from the (fresh)
+    // SaveSlotSummary — not the tracked-file count, which a copy that adds a
+    // version would never move off "1 save".
+    const oneFile: SaveStatus["files"][number] = {
+      filename: "a.srm",
+      local_path: "/data/a.srm",
+      local_hash: "h",
+      local_mtime: "2025-06-15T10:00:00Z",
+      local_size: 100,
+      server_save_id: 1,
+      server_file_name: null,
+      server_emulator: null,
+      server_updated_at: null,
+      server_size: null,
+      last_sync_at: null,
+      status: "synced",
+    };
+
+    it("shows the server-side slot count in the active header, not the tracked-file count", () => {
+      const { container } = render(
+        <SlotPanel
+          {...defaultProps({
+            isActive: true,
+            slot: makeSummary({ count: 3 }),
+            saveStatus: makeStatus({ files: [oneFile] }),
+          })}
+        />,
+      );
+      // One tracked file, but the slot holds 3 saves → "3 saves", not "1 save".
+      expect(container.textContent).toContain("3 saves");
+      expect(container.textContent).not.toContain("1 save");
+    });
+
+    it("falls back to the tracked-file count when the summary count is 0 (placeholder active slot)", () => {
+      const { container } = render(
+        <SlotPanel
+          {...defaultProps({
+            isActive: true,
+            slot: makeSummary({ count: 0 }),
+            saveStatus: makeStatus({ files: [oneFile] }),
+          })}
+        />,
+      );
+      expect(container.textContent).toContain("1 save");
+    });
+
     it("multi-file slot: shows component list + #908 note and NO VersionHistoryPanel", () => {
       const status = makeStatus({
         files: [

--- a/src/components/saves/SlotPanel.tsx
+++ b/src/components/saves/SlotPanel.tsx
@@ -108,7 +108,10 @@ function renderActiveSlotBody(
         f.server_save_id != null
           ? createElement(
               "div",
-              { key: `copy-active-${f.filename}`, style: { marginTop: "4px", marginLeft: "8px" } },
+              {
+                key: `copy-active-${f.filename}`,
+                style: { display: "flex", justifyContent: "flex-end" as const, marginTop: "4px" },
+              },
               renderCopyToSlotButton(`copy-active-${f.filename}`, f.server_save_id, {
                 onCopy,
                 sourceSlot: slot,

--- a/src/components/saves/SlotPanel.tsx
+++ b/src/components/saves/SlotPanel.tsx
@@ -22,6 +22,7 @@ import { MUTED_COLOR, computeSyncSummary, displaySlot, slotDeleteFailureToast } 
 import { renderSaveFileRow } from "./SaveFileRow";
 import { InactiveSlotBody } from "./InactiveSlotBody";
 import { VersionHistoryPanel } from "./VersionHistoryPanel";
+import { renderCopyToSlotButton, type CopyToSlotHandler } from "./CopyToSlotButton";
 import { detach } from "../../utils/detach";
 
 /**
@@ -73,11 +74,13 @@ function renderActiveSlotBody(
   slot: string,
   isOffline: boolean,
   onVersionRestored: () => void,
+  onCopy: CopyToSlotHandler,
 ): (ReturnType<typeof createElement> | null)[] {
   if (saveStatus && saveStatus.files.length > 0) {
     // Multi-file save (#908 guard): the slot's current save is one game state
     // spread across N files. The siblings are components, not prior versions,
-    // so suppress the per-file VersionHistoryPanel/rollback and show the
+    // so suppress the per-file VersionHistoryPanel/rollback AND the copy action
+    // (copying one component would produce an incoherent set) and show the
     // component list + a calm note instead.
     if (saveStatus.multi_file) {
       const componentFiles = saveStatus.component_files ?? [];
@@ -99,6 +102,20 @@ function renderActiveSlotBody(
         "div",
         { key: f.filename },
         renderSaveFileRow(f, conflict, saveStatus.last_sync_check_at),
+        // Copy-to-slot on the active slot's current save (source = this slot).
+        // Rendered as a sibling of the save-file row (never nested in its
+        // DialogButton) so Deck focus stays flat. Only when it has a server save.
+        f.server_save_id != null
+          ? createElement(
+              "div",
+              { key: `copy-active-${f.filename}`, style: { marginTop: "4px", marginLeft: "8px" } },
+              renderCopyToSlotButton(`copy-active-${f.filename}`, f.server_save_id, {
+                onCopy,
+                sourceSlot: slot,
+                isOffline,
+              }),
+            )
+          : null,
         createElement(VersionHistoryPanel, {
           key: `vhp-${f.filename}`,
           romId,
@@ -106,6 +123,7 @@ function renderActiveSlotBody(
           filename: f.filename,
           isOffline,
           onRestored: onVersionRestored,
+          onCopy,
         }),
       );
     });
@@ -132,6 +150,8 @@ interface SlotPanelProps {
   onSlotSwitched: (newSlot: string, newStatus: SaveStatus) => void;
   onVersionRestored: () => void;
   onSlotDeleted: () => void;
+  /** Opens the copy-to-slot picker for a save row in this slot. */
+  onCopy: CopyToSlotHandler;
 }
 
 export const SlotPanel: FC<SlotPanelProps> = ({
@@ -145,6 +165,7 @@ export const SlotPanel: FC<SlotPanelProps> = ({
   onSlotSwitched,
   onVersionRestored,
   onSlotDeleted,
+  onCopy,
 }) => {
   const [expanded, setExpanded] = useState(defaultExpanded);
   const [slotFiles, setSlotFiles] = useState<SlotSaveFile[] | null>(null);
@@ -369,7 +390,9 @@ export const SlotPanel: FC<SlotPanelProps> = ({
       ? createElement(
           "div",
           { key: "body", className: "romm-slot-body" },
-          ...renderActiveSlotBody(saveStatus, conflicts, romId, slotName, isOffline, onVersionRestored).filter(Boolean),
+          ...renderActiveSlotBody(saveStatus, conflicts, romId, slotName, isOffline, onVersionRestored, onCopy).filter(
+            Boolean,
+          ),
         )
       : // eslint-disable-next-line react-hooks/refs -- createElement of an FC in a ternary branch trips the new react-hooks/refs rule; the component itself takes no ref.
         createElement(InactiveSlotBody, {
@@ -388,6 +411,8 @@ export const SlotPanel: FC<SlotPanelProps> = ({
           handleDelete: () => {
             detach(handleDelete());
           },
+          // Copy source = this (inactive/legacy) slot; the picker excludes it as a target.
+          copy: { onCopy, sourceSlot: slotName, isOffline },
         });
   }
 

--- a/src/components/saves/SlotPanel.tsx
+++ b/src/components/saves/SlotPanel.tsx
@@ -295,7 +295,13 @@ export const SlotPanel: FC<SlotPanelProps> = ({
 
   const { syncSummaryText, syncSummaryColor } = computeSyncSummary(isActive, saveStatus, conflicts);
 
-  const fileCount = isActive ? (saveStatus?.files.length ?? 0) : (slotFiles?.length ?? slot.count);
+  // Active slot: prefer the server-side save count (SaveSlotSummary.count, kept
+  // fresh by the parent's romm_data_changed → getSaveSlots refresh) so the header
+  // reflects every save in the slot — a copy adds a version that the tracked-file
+  // count (files.length, usually 1) would never show. Fall back to the tracked
+  // file count when the summary count is absent (0 — e.g. the synthesized
+  // active-slot placeholder before getSaveSlots resolves).
+  const fileCount = isActive ? slot.count || (saveStatus?.files.length ?? 0) : (slotFiles?.length ?? slot.count);
 
   // The slot-less legacy (web-player) bucket is read-only (#1276, #1478) and
   // demoted: muted styling + a read-only note; it sorts last (in SavesTab).

--- a/src/components/saves/VersionHistoryPanel.test.tsx
+++ b/src/components/saves/VersionHistoryPanel.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { render, fireEvent, waitFor } from "@testing-library/react";
+import { render, fireEvent, waitFor, act } from "@testing-library/react";
 import { createElement } from "react";
 import { VersionHistoryPanel } from "./VersionHistoryPanel";
 import * as backend from "../../api/backend";
@@ -413,5 +413,80 @@ describe("VersionHistoryPanel", () => {
     expect(getByText("Restoring...")).toBeDisabled();
     resolveRestore({ status: "ok" });
     await flushAsync();
+  });
+});
+
+describe("VersionHistoryPanel — self-refresh on romm_data_changed", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // romm_data_changed is a plain DOM CustomEvent (globalThis.dispatchEvent), not
+  // an @decky/api emit, so happy-dom routes it natively to the panel's listener.
+  function dispatchDataChanged(romId: number): void {
+    act(() => {
+      globalThis.dispatchEvent(new CustomEvent("romm_data_changed", { detail: { type: "save_sync", rom_id: romId } }));
+    });
+  }
+
+  it("reloads the version list when a save-change event fires for this ROM while expanded", async () => {
+    vi.mocked(backend.savesListFileVersions)
+      .mockResolvedValueOnce({ status: "ok", versions: [makeVersion({ id: 1 })] })
+      .mockResolvedValueOnce({ status: "ok", versions: [makeVersion({ id: 1 }), makeVersion({ id: 2 })] });
+    const { getByText, container } = render(<VersionHistoryPanel {...defaultProps()} />);
+    fireEvent.click(getByText("Previous Versions"));
+    await waitFor(() => expect(container.textContent).toContain("Previous Versions (1)"));
+    expect(vi.mocked(backend.savesListFileVersions)).toHaveBeenCalledTimes(1);
+
+    // A copy into this slot dispatches the event — the panel must refetch and
+    // render the new count, not keep its stale cache.
+    dispatchDataChanged(1);
+
+    await waitFor(() => expect(vi.mocked(backend.savesListFileVersions)).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(container.textContent).toContain("Previous Versions (2)"));
+  });
+
+  it("ignores a save-change event for a different ROM", async () => {
+    vi.mocked(backend.savesListFileVersions).mockResolvedValue({ status: "ok", versions: [makeVersion({ id: 1 })] });
+    const { getByText } = render(<VersionHistoryPanel {...defaultProps()} />);
+    fireEvent.click(getByText("Previous Versions"));
+    await waitFor(() => expect(vi.mocked(backend.savesListFileVersions)).toHaveBeenCalledTimes(1));
+
+    dispatchDataChanged(999);
+    await flushAsync();
+
+    // Non-vacuous: the mismatched rom_id triggered no reload.
+    expect(vi.mocked(backend.savesListFileVersions)).toHaveBeenCalledTimes(1);
+  });
+
+  it("invalidates the cache while collapsed so the next expand refetches", async () => {
+    vi.mocked(backend.savesListFileVersions).mockResolvedValue({ status: "ok", versions: [makeVersion({ id: 1 })] });
+    const { container } = render(<VersionHistoryPanel {...defaultProps()} />);
+    const button = container.querySelector("button");
+    if (!button) throw new Error("no toggle button");
+    fireEvent.click(button); // expand → load (1)
+    await waitFor(() => expect(vi.mocked(backend.savesListFileVersions)).toHaveBeenCalledTimes(1));
+    fireEvent.click(button); // collapse
+
+    dispatchDataChanged(1); // invalidate while collapsed — no reload yet
+    await flushAsync();
+    expect(vi.mocked(backend.savesListFileVersions)).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(button); // expand again → refetch because the cache was invalidated
+    await waitFor(() => expect(vi.mocked(backend.savesListFileVersions)).toHaveBeenCalledTimes(2));
+  });
+
+  it("removes the listener on unmount (a later event triggers no reload)", async () => {
+    vi.mocked(backend.savesListFileVersions).mockResolvedValue({ status: "ok", versions: [makeVersion({ id: 1 })] });
+    const { getByText, unmount } = render(<VersionHistoryPanel {...defaultProps()} />);
+    fireEvent.click(getByText("Previous Versions"));
+    await waitFor(() => expect(vi.mocked(backend.savesListFileVersions)).toHaveBeenCalledTimes(1));
+
+    unmount();
+    dispatchDataChanged(1);
+    await flushAsync();
+
+    // Cleanup ran: the post-unmount event reached no listener, so no refetch.
+    expect(vi.mocked(backend.savesListFileVersions)).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/saves/VersionHistoryPanel.tsx
+++ b/src/components/saves/VersionHistoryPanel.tsx
@@ -4,7 +4,7 @@
  * fallback to the standard sync-conflict modal).
  */
 
-import { useState, createElement, FC } from "react";
+import { useState, useEffect, createElement, FC } from "react";
 import { DialogButton } from "@decky/ui";
 import { toaster } from "@decky/api";
 import { debugLog, savesListFileVersions, savesRollbackToVersion } from "../../api/backend";
@@ -71,6 +71,27 @@ export const VersionHistoryPanel: FC<VersionHistoryPanelProps> = ({
       await loadVersions();
     }
   };
+
+  // Self-refresh when this ROM's saves change. A copy into this slot (or a sync
+  // / external rollback) adds or removes a version, but the list is cached on
+  // first expand — without this it stays stale in-session until the game page is
+  // re-entered. The signal is a DOM CustomEvent (`globalThis.dispatchEvent`),
+  // NOT an @decky/api emit, so we listen on `globalThis`. Invalidate on any
+  // change for this ROM; reload immediately when the panel is open, otherwise the
+  // next expand lazy-loads the fresh list. `expanded` is a dep so the handler
+  // always sees the live open/closed state (re-subscribing on toggle is cheap).
+  useEffect(() => {
+    const onDataChanged = (e: Event) => {
+      const detail = (e as CustomEvent).detail;
+      if (detail?.rom_id !== romId) return;
+      setVersions(null);
+      setLoadError(null);
+      if (expanded && !isOffline) detach(loadVersions());
+    };
+    globalThis.addEventListener("romm_data_changed", onDataChanged);
+    return () => globalThis.removeEventListener("romm_data_changed", onDataChanged);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- loadVersions is stable per (romId, slot, filename); romId/isOffline/expanded are the real deps
+  }, [romId, isOffline, expanded]);
 
   const handleRestore = async (version: SaveVersionEntry) => {
     setRestoring(version.id);

--- a/src/components/saves/VersionHistoryPanel.tsx
+++ b/src/components/saves/VersionHistoryPanel.tsx
@@ -13,6 +13,7 @@ import { showSyncConflictModal } from "../SyncConflictModal";
 import { scrollFocusedToCenter } from "../../utils/scrollHelpers";
 import { formatBytes, formatTimestamp } from "../../utils/formatters";
 import { formatAttributionSegment, formatRelativeTime, pickLastSyncer } from "./helpers";
+import { renderCopyToSlotButton, type CopyToSlotHandler } from "./CopyToSlotButton";
 import { detach } from "../../utils/detach";
 
 interface VersionHistoryPanelProps {
@@ -21,9 +22,18 @@ interface VersionHistoryPanelProps {
   filename: string;
   isOffline: boolean;
   onRestored: () => void;
+  /** Opens the copy-to-slot picker for a version row's save id (source = this slot). */
+  onCopy?: CopyToSlotHandler;
 }
 
-export const VersionHistoryPanel: FC<VersionHistoryPanelProps> = ({ romId, slot, filename, isOffline, onRestored }) => {
+export const VersionHistoryPanel: FC<VersionHistoryPanelProps> = ({
+  romId,
+  slot,
+  filename,
+  isOffline,
+  onRestored,
+  onCopy,
+}) => {
   const [expanded, setExpanded] = useState(false);
   const [versions, setVersions] = useState<SaveVersionEntry[] | null>(null);
   const [loading, setLoading] = useState(false);
@@ -197,25 +207,33 @@ export const VersionHistoryPanel: FC<VersionHistoryPanelProps> = ({ romId, slot,
           v.file_name,
         ),
       ),
-      // Restore button (fixed right, disabled when offline)
+      // Action column (fixed right): Restore + optional Copy-to-slot.
       createElement(
-        DialogButton,
-        {
-          style: {
-            padding: "2px 8px",
-            minWidth: "auto",
-            fontSize: "11px",
-            width: "auto",
-            flexShrink: 0,
+        "div",
+        { style: { display: "flex", flexDirection: "column" as const, gap: "4px", flexShrink: 0 } },
+        // Restore button (disabled when offline)
+        createElement(
+          DialogButton,
+          {
+            key: "restore",
+            style: {
+              padding: "2px 8px",
+              minWidth: "auto",
+              fontSize: "11px",
+              width: "auto",
+              flexShrink: 0,
+            },
+            noFocusRing: false,
+            onFocus: scrollFocusedToCenter,
+            disabled: isThisRestoring || restoring !== null || isOffline,
+            onClick: () => {
+              detach(handleRestore(v));
+            },
           },
-          noFocusRing: false,
-          onFocus: scrollFocusedToCenter,
-          disabled: isThisRestoring || restoring !== null || isOffline,
-          onClick: () => {
-            detach(handleRestore(v));
-          },
-        },
-        isThisRestoring ? "Restoring..." : "Restore",
+          isThisRestoring ? "Restoring..." : "Restore",
+        ),
+        // Copy-to-slot button (source = this slot); disabled offline via the shared helper.
+        onCopy ? renderCopyToSlotButton(`copy-ver-${v.id}`, v.id, { onCopy, sourceSlot: slot, isOffline }) : null,
       ),
     );
   };

--- a/src/components/saves/useCopyToSlot.test.tsx
+++ b/src/components/saves/useCopyToSlot.test.tsx
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { showModal } from "@decky/ui";
+import { toaster } from "@decky/api";
+import type { ReactElement } from "react";
+import { useCopyToSlot } from "./useCopyToSlot";
+import * as backend from "../../api/backend";
+import { showSyncConflictModal } from "../SyncConflictModal";
+import type { CopySaveToSlotStatus, SaveSlotSummary, SyncConflict } from "../../types";
+
+// Control the callable + the conflict modal directly; everything else (showModal,
+// toaster) comes from the global @decky/ui / @decky/api stubs.
+vi.mock("../../api/backend", () => ({
+  copySaveToSlot: vi.fn(),
+  debugLog: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("../SyncConflictModal", () => ({
+  showSyncConflictModal: vi.fn().mockResolvedValue("resolved"),
+}));
+
+const SLOTS: SaveSlotSummary[] = [
+  { slot: "autosave", source: "server", count: 1, latest_updated_at: null },
+  { slot: "backup", source: "server", count: 1, latest_updated_at: null },
+];
+
+const conflict: SyncConflict = {
+  type: "sync_conflict",
+  rom_id: 42,
+  filename: "save.srm",
+  server_save_id: 7,
+  server_updated_at: "2026-01-01T00:00:00Z",
+  server_size: 1024,
+  local_path: "/local/save.srm",
+  local_hash: "abc",
+  local_mtime: "2026-01-01T00:00:00Z",
+  local_size: 1024,
+  created_at: "2026-01-01T00:00:00Z",
+};
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+const dataChanged = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  globalThis.addEventListener("romm_data_changed", dataChanged);
+});
+afterEach(() => {
+  globalThis.removeEventListener("romm_data_changed", dataChanged);
+});
+
+// Open the picker for one source save, then drive its onSubmit with a target,
+// awaiting the detached copy flow.
+async function runCopy(result: CopySaveToSlotStatus, { saveId = 10, sourceSlot = "backup", target = "promoted" } = {}) {
+  vi.mocked(backend.copySaveToSlot).mockResolvedValue(result);
+  const hook = renderHook(() => useCopyToSlot(42, SLOTS));
+  await act(async () => {
+    hook.result.current(saveId, sourceSlot);
+  });
+  const calls = vi.mocked(showModal).mock.calls;
+  const el = calls[calls.length - 1]![0] as ReactElement;
+  const onSubmit = (el.props as { onSubmit: (t: string) => void }).onSubmit;
+  await act(async () => {
+    onSubmit(target);
+    await flush();
+  });
+}
+
+describe("useCopyToSlot", () => {
+  it("opens the picker modal for the source save", async () => {
+    const hook = renderHook(() => useCopyToSlot(42, SLOTS));
+    act(() => hook.result.current(10, "backup"));
+    expect(showModal).toHaveBeenCalledTimes(1);
+    const el = vi.mocked(showModal).mock.calls[0]![0] as ReactElement;
+    expect((el.props as { sourceSlot: string }).sourceSlot).toBe("backup");
+  });
+
+  it("ok (no-slot → new named slot): toasts and dispatches romm_data_changed", async () => {
+    await runCopy({ status: "ok" }, { saveId: 10, sourceSlot: "backup", target: "promoted" });
+
+    // Non-vacuous: the distinctive target value flowed through to the callable.
+    expect(backend.copySaveToSlot).toHaveBeenCalledWith(42, 10, "promoted");
+    expect(toaster.toast).toHaveBeenCalledWith(expect.objectContaining({ body: expect.stringContaining("promoted") }));
+    expect(dataChanged).toHaveBeenCalled();
+  });
+
+  it("ok (default → autosave): the autosave target value flows through", async () => {
+    await runCopy({ status: "ok" }, { saveId: 100, sourceSlot: "default", target: "autosave" });
+
+    expect(backend.copySaveToSlot).toHaveBeenCalledWith(42, 100, "autosave");
+    expect(toaster.toast).toHaveBeenCalledWith(expect.objectContaining({ body: expect.stringContaining("autosave") }));
+    expect(dataChanged).toHaveBeenCalled();
+  });
+
+  it("conflict_blocked: opens the sync-conflict modal on the first conflict, no toast, no refresh", async () => {
+    await runCopy({ status: "conflict_blocked", conflicts: [conflict] });
+
+    expect(showSyncConflictModal).toHaveBeenCalledWith(conflict);
+    // The modal owns the feedback — no stacked toast, and no refresh (unresolved).
+    expect(toaster.toast).not.toHaveBeenCalled();
+    expect(dataChanged).not.toHaveBeenCalled();
+  });
+
+  it("conflict_blocked with an empty conflict list: falls back to a toast", async () => {
+    await runCopy({ status: "conflict_blocked", conflicts: [] });
+
+    expect(showSyncConflictModal).not.toHaveBeenCalled();
+    expect(toaster.toast).toHaveBeenCalledWith(
+      expect.objectContaining({ body: expect.stringContaining("sync conflict") }),
+    );
+  });
+
+  it("target_slot_busy: toasts to resolve the target slot first, no refresh", async () => {
+    await runCopy({ status: "target_slot_busy", message: "busy" }, { target: "promoted" });
+
+    expect(toaster.toast).toHaveBeenCalledWith(
+      expect.objectContaining({ body: expect.stringContaining("sync it first") }),
+    );
+    expect(dataChanged).not.toHaveBeenCalled();
+  });
+
+  const REFUSALS: Array<{ result: CopySaveToSlotStatus; needle: string }> = [
+    { result: { status: "version_deleted" }, needle: "no longer exists" },
+    { result: { status: "rom_not_installed" }, needle: "no longer installed" },
+    { result: { status: "not_configured" }, needle: "Set up save slots" },
+    { result: { status: "invalid_slot_name" }, needle: "valid slot name" },
+    { result: { status: "server_unreachable", message: "boom" }, needle: "Couldn't reach RomM" },
+    { result: { status: "preflight_failed", errors: ["net"] }, needle: "Sync failed before copy" },
+    { result: { status: "copy_failed", message: "oops" }, needle: "Couldn't copy the save" },
+    { result: { status: "unsupported", reason: "savefiles_in_content_dir" }, needle: "writes saves next to the ROM" },
+    { result: { status: "unsupported" }, needle: "multi-file" },
+  ];
+
+  it.each(REFUSALS)("refusal $result.status surfaces a toast", async ({ result, needle }) => {
+    await runCopy(result);
+    expect(toaster.toast).toHaveBeenCalledWith(
+      needle ? expect.objectContaining({ body: expect.stringContaining(needle) }) : expect.anything(),
+    );
+    // A refusal never refreshes the views.
+    expect(dataChanged).not.toHaveBeenCalled();
+  });
+
+  it("swallows a rejected copy call and surfaces the generic failure toast", async () => {
+    vi.mocked(backend.copySaveToSlot).mockRejectedValue(new Error("network down"));
+    const hook = renderHook(() => useCopyToSlot(42, SLOTS));
+    await act(async () => {
+      hook.result.current(10, "backup");
+    });
+    const calls = vi.mocked(showModal).mock.calls;
+    const el = calls[calls.length - 1]![0] as ReactElement;
+    const onSubmit = (el.props as { onSubmit: (t: string) => void }).onSubmit;
+    await act(async () => {
+      onSubmit("promoted");
+      await flush();
+    });
+
+    // Post-catch state: the fallback toast fired and the error was debug-logged.
+    expect(toaster.toast).toHaveBeenCalledWith(
+      expect.objectContaining({ body: expect.stringContaining("Couldn't copy the save") }),
+    );
+    expect(backend.debugLog).toHaveBeenCalled();
+    expect(dataChanged).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/saves/useCopyToSlot.test.tsx
+++ b/src/components/saves/useCopyToSlot.test.tsx
@@ -92,6 +92,17 @@ describe("useCopyToSlot", () => {
     expect(dataChanged).toHaveBeenCalled();
   });
 
+  it("already_present: toasts the existing save location and does NOT refresh", async () => {
+    await runCopy({ status: "already_present", existing_id: 55 }, { target: "promoted" });
+
+    // Names the slot + the existing save id; the "copied" toast and the refresh
+    // are both withheld because nothing was copied.
+    expect(toaster.toast).toHaveBeenCalledWith(
+      expect.objectContaining({ body: expect.stringContaining("Already in slot 'promoted' as #55") }),
+    );
+    expect(dataChanged).not.toHaveBeenCalled();
+  });
+
   it("conflict_blocked: opens the sync-conflict modal on the first conflict, no toast, no refresh", async () => {
     await runCopy({ status: "conflict_blocked", conflicts: [conflict] });
 

--- a/src/components/saves/useCopyToSlot.ts
+++ b/src/components/saves/useCopyToSlot.ts
@@ -31,6 +31,11 @@ async function handleResult(result: CopySaveToSlotStatus, target: string, romId:
       toaster.toast({ title: TITLE, body: `Save copied to slot '${displaySlot(target)}'` });
       dispatchDataChanged(romId);
       return;
+    case "already_present":
+      // Content-identical to a save already in the target slot — nothing was
+      // copied (no churn), so no refresh either.
+      toaster.toast({ title: TITLE, body: `Already in slot '${displaySlot(target)}' as #${result.existing_id}` });
+      return;
     case "conflict_blocked": {
       // A real conflict on the ROM's current slot must be resolved first. The
       // modal owns the resolution feedback — don't stack a toast on top of it

--- a/src/components/saves/useCopyToSlot.ts
+++ b/src/components/saves/useCopyToSlot.ts
@@ -1,0 +1,110 @@
+/**
+ * Hook driving the per-save "Copy to slot…" flow. Returns an opener that shows
+ * the CopyToSlotModal for one source save, runs `copySaveToSlot`, and routes
+ * every discriminated status to the right feedback: `ok` toasts and dispatches
+ * `romm_data_changed` (so the parent re-fetches source AND target views);
+ * `conflict_blocked` opens the standard sync-conflict modal (as
+ * VersionHistoryPanel does); `target_slot_busy` and each refusal toast.
+ */
+
+import { useCallback, createElement } from "react";
+import { showModal } from "@decky/ui";
+import { toaster } from "@decky/api";
+import { copySaveToSlot, debugLog } from "../../api/backend";
+import type { CopySaveToSlotStatus, SaveSlotSummary } from "../../types";
+import { showSyncConflictModal } from "../SyncConflictModal";
+import { detach } from "../../utils/detach";
+import { displaySlot } from "./helpers";
+import { CopyToSlotModal } from "./CopyToSlotModal";
+import type { CopyToSlotHandler } from "./CopyToSlotButton";
+
+const TITLE = "RomM Sync";
+
+/** Refresh both the source and target slot views after a successful copy. */
+function dispatchDataChanged(romId: number): void {
+  globalThis.dispatchEvent(new CustomEvent("romm_data_changed", { detail: { type: "save_sync", rom_id: romId } }));
+}
+
+async function handleResult(result: CopySaveToSlotStatus, target: string, romId: number): Promise<void> {
+  switch (result.status) {
+    case "ok":
+      toaster.toast({ title: TITLE, body: `Save copied to slot '${displaySlot(target)}'` });
+      dispatchDataChanged(romId);
+      return;
+    case "conflict_blocked": {
+      // A real conflict on the ROM's current slot must be resolved first. The
+      // modal owns the resolution feedback — don't stack a toast on top of it
+      // (mirrors VersionHistoryPanel). The empty-list case has no modal to show.
+      const first = result.conflicts[0];
+      if (first) {
+        await showSyncConflictModal(first);
+      } else {
+        toaster.toast({ title: TITLE, body: "Copy blocked by a sync conflict. Sync this save, then try again." });
+      }
+      return;
+    }
+    case "target_slot_busy":
+      toaster.toast({
+        title: TITLE,
+        body: `Slot '${displaySlot(target)}' has newer changes on another device — sync it first, then copy again.`,
+      });
+      return;
+    case "preflight_failed":
+      toaster.toast({ title: TITLE, body: `Sync failed before copy: ${result.errors[0] ?? "preflight error"}` });
+      return;
+    case "server_unreachable":
+      toaster.toast({ title: TITLE, body: "Couldn't reach RomM. Check your connection and try again." });
+      return;
+    case "version_deleted":
+      toaster.toast({ title: TITLE, body: "This save no longer exists on the server." });
+      return;
+    case "rom_not_installed":
+      toaster.toast({ title: TITLE, body: "ROM is no longer installed locally. Reinstall and try again." });
+      return;
+    case "unsupported":
+      toaster.toast({
+        title: TITLE,
+        body:
+          result.reason === "savefiles_in_content_dir"
+            ? "Save sync is off for this game (RetroArch writes saves next to the ROM)."
+            : "Copying isn't available for multi-file saves yet.",
+      });
+      return;
+    case "not_configured":
+      toaster.toast({ title: TITLE, body: "Set up save slots for this game first, then copy." });
+      return;
+    case "copy_failed":
+      toaster.toast({ title: TITLE, body: `Couldn't copy the save: ${result.message}` });
+      return;
+    case "invalid_slot_name":
+      toaster.toast({ title: TITLE, body: "Enter a valid slot name." });
+      return;
+  }
+}
+
+/** Returns an opener `openCopyModal(saveId, sourceSlot)` for the copy-to-slot flow. */
+export function useCopyToSlot(romId: number, availableSlots: SaveSlotSummary[]): CopyToSlotHandler {
+  return useCallback(
+    (saveId: number, sourceSlot: string) => {
+      const runCopy = async (target: string): Promise<void> => {
+        try {
+          const result = await copySaveToSlot(romId, saveId, target);
+          await handleResult(result, target, romId);
+        } catch (e) {
+          detach(debugLog(`useCopyToSlot: copy failed for save ${saveId} into '${target}': ${e}`));
+          toaster.toast({ title: TITLE, body: "Couldn't copy the save. Check your connection and try again." });
+        }
+      };
+      showModal(
+        createElement(CopyToSlotModal, {
+          availableSlots,
+          sourceSlot,
+          onSubmit: (target: string) => {
+            detach(runCopy(target));
+          },
+        }),
+      );
+    },
+    [romId, availableSlots],
+  );
+}

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -147,11 +147,12 @@ vi.mock("@decky/ui", () => {
     },
     PanelSection: passthrough("section"),
     PanelSectionRow: passthrough("div"),
-    TextField: (p: AnyProps & { value?: string; onChange?: (e: unknown) => void }) =>
+    TextField: (p: AnyProps & { value?: string; onChange?: (e: unknown) => void; onKeyDown?: (e: unknown) => void }) =>
       createElement("input", {
         "data-testid": "text-field",
         value: p.value ?? "",
         onChange: (e: unknown) => p.onChange?.(e),
+        onKeyDown: (e: unknown) => p.onKeyDown?.(e),
       }),
     ToggleField: (p: AnyProps & { checked?: boolean; onChange?: (v: boolean) => void; label?: unknown }) =>
       createElement(

--- a/src/types/saves.ts
+++ b/src/types/saves.ts
@@ -233,3 +233,19 @@ export type ListFileVersionsResult =
   | { status: "ok"; versions: SaveVersionEntry[] }
   | { status: "multi_file_unsupported"; versions: SaveVersionEntry[] }
   | { status: "server_unreachable"; message: string };
+
+/** Discriminated-status result of `copySaveToSlot` — copies one server save into
+ *  a target slot, which becomes the ROM's active slot (the source is preserved).
+ *  Mirrors the backend `SaveCopyService.copy_save_to_slot` union. */
+export type CopySaveToSlotStatus =
+  | { status: "ok" }
+  | { status: "not_configured" }
+  | { status: "invalid_slot_name" }
+  | { status: "rom_not_installed" }
+  | { status: "version_deleted" }
+  | { status: "unsupported"; reason?: string }
+  | { status: "server_unreachable"; message: string }
+  | { status: "conflict_blocked"; conflicts: SyncConflict[] }
+  | { status: "preflight_failed"; errors: string[] }
+  | { status: "target_slot_busy"; message: string }
+  | { status: "copy_failed"; message: string };

--- a/src/types/saves.ts
+++ b/src/types/saves.ts
@@ -239,6 +239,7 @@ export type ListFileVersionsResult =
  *  Mirrors the backend `SaveCopyService.copy_save_to_slot` union. */
 export type CopySaveToSlotStatus =
   | { status: "ok" }
+  | { status: "already_present"; existing_id: number }
   | { status: "not_configured" }
   | { status: "invalid_slot_name" }
   | { status: "rom_not_installed" }

--- a/tests/services/saves/test_copies.py
+++ b/tests/services/saves/test_copies.py
@@ -1,0 +1,372 @@
+"""Tests for SaveCopyService — the per-save copy-to-slot flow.
+
+The copy takes one server save (a named slot or the legacy no-slot bucket)
+and copies its content into a target slot, which becomes the ROM's active
+slot with the copied save as its current save. The source save is never
+deleted. A distinctive target name (never the default "autosave" fallback)
+is used throughout so the tests prove the target value actually flows.
+"""
+
+from typing import Any
+
+import pytest
+
+from domain.save_layout import ContentDir
+from tests.services.saves._helpers import (
+    _create_save,
+    _enable_sync_with_device,
+    _file_md5,
+    _install_rom,
+    _require_save_state,
+    _seed_save_state_dict,
+    _server_save,
+    _server_save_with_syncs,
+    make_service,
+)
+
+# Distinctive target slot — never the "autosave" default, so a passing test
+# proves the value flowed through rather than a fallback landing on the default.
+TARGET = "promoted"
+
+
+def _setup_configured(
+    svc,
+    tmp_path,
+    *,
+    active_slot: str = "autosave",
+    tracked_id: int | None = 100,
+    last_sync_hash: str | None = None,
+    system: str = "gba",
+) -> None:
+    """Seed an installed, sync-enabled, CONFIRMED-slot ROM (rom 42).
+
+    Mirrors the rollback suite's ``_setup_state`` but sets ``slot_confirmed`` so
+    the copy flow's ``not_configured`` guard passes. ``last_sync_hash=None`` seeds
+    no per-file baseline (the matrix falls back to its in-memory default).
+    """
+    _install_rom(svc, tmp_path, system=system)
+    _enable_sync_with_device(svc)
+    files = (
+        {"pokemon.srm": {"tracked_save_id": tracked_id, "last_sync_hash": last_sync_hash}}
+        if last_sync_hash is not None
+        else {}
+    )
+    _seed_save_state_dict(
+        svc,
+        42,
+        {
+            "system": system,
+            "active_slot": active_slot,
+            "slot_confirmed": True,
+            "files": files,
+        },
+    )
+
+
+def _tracked_save(save_id: int, *, slot: str, updated_at: str = "2026-03-10T10:00:00Z") -> dict[str, Any]:
+    """A slot head with our device flagged ``is_current`` — a clean matrix pre-flight."""
+    return _server_save_with_syncs(
+        save_id=save_id,
+        slot=slot,
+        updated_at=updated_at,
+        device_syncs=[{"device_id": "device-1", "is_current": True, "last_synced_at": updated_at}],
+    )
+
+
+class TestCopySaveToSlotHappyPaths:
+    """The three happy paths from the spec: legacy→new named, default→autosave, inactive→active."""
+
+    @pytest.mark.asyncio
+    async def test_no_slot_save_into_new_named_slot(self, tmp_path):
+        """A legacy (slot:null) save copied into a brand-new named slot.
+
+        The original scope of the issue: promote a no-slot save into a named
+        slot. The new slot becomes active; the legacy source is preserved.
+        """
+        svc, fake = make_service(tmp_path)
+        _create_save(tmp_path)
+        local_hash = _file_md5(str(tmp_path / "saves" / "gba" / "pokemon.srm"))
+        _setup_configured(svc, tmp_path, active_slot="autosave", tracked_id=100, last_sync_hash=local_hash)
+        # Current-slot head (clean pre-flight) + a legacy no-slot save to copy.
+        fake.saves[100] = _tracked_save(100, slot="autosave")
+        fake.saves[10] = _server_save(save_id=10, rom_id=42, slot=None, updated_at="2026-02-01T10:00:00Z")
+        fake.set_server_save_content(10, b"legacy-save-bytes")
+
+        result = await svc.copy_save_to_slot(42, 10, TARGET)
+
+        assert result == {"status": "ok"}
+        state = _require_save_state(svc, 42)
+        assert state.active_slot == TARGET
+        assert state.slot_confirmed is True
+        # Source preserved (still a legacy no-slot save).
+        assert 10 in fake.saves
+        assert fake.saves[10].get("slot") is None
+        # A new save landed in the target slot.
+        assert [s for s in fake.saves.values() if s.get("slot") == TARGET]
+
+    @pytest.mark.asyncio
+    async def test_default_save_into_autosave(self, tmp_path):
+        """A save in the old ``default`` slot copied onto ``autosave`` (#1529 manual path).
+
+        ``default`` is the active slot; copying its save into ``autosave`` makes
+        autosave active. Uses the real default target name here (the value under
+        test IS "autosave"), distinct from the source "default".
+        """
+        svc, fake = make_service(tmp_path)
+        _create_save(tmp_path)
+        local_hash = _file_md5(str(tmp_path / "saves" / "gba" / "pokemon.srm"))
+        _setup_configured(svc, tmp_path, active_slot="default", tracked_id=100, last_sync_hash=local_hash)
+        fake.saves[100] = _tracked_save(100, slot="default")
+
+        result = await svc.copy_save_to_slot(42, 100, "autosave")
+
+        assert result == {"status": "ok"}
+        state = _require_save_state(svc, 42)
+        assert state.active_slot == "autosave"
+        assert state.slot_confirmed is True
+        # Source in "default" preserved.
+        assert fake.saves[100].get("slot") == "default"
+        # A new save landed in autosave.
+        assert [s for s in fake.saves.values() if s.get("slot") == "autosave"]
+
+    @pytest.mark.asyncio
+    async def test_inactive_slot_save_into_active_slot(self, tmp_path):
+        """A save from an INACTIVE slot copied into the active slot.
+
+        The active slot already holds a head we're synced to, so the target POST
+        stacks cleanly (no 409). The inactive source save is preserved.
+        """
+        svc, fake = make_service(tmp_path)
+        _create_save(tmp_path)
+        local_hash = _file_md5(str(tmp_path / "saves" / "gba" / "pokemon.srm"))
+        _setup_configured(svc, tmp_path, active_slot="autosave", tracked_id=100, last_sync_hash=local_hash)
+        fake.saves[100] = _tracked_save(100, slot="autosave")
+        # We're current on the active head per the ledger, so a POST into autosave
+        # does not 409 on it.
+        fake.stage_device_sync(100, "device-1", "2026-03-10T10:00:00Z")
+        # Inactive-slot source save.
+        fake.saves[50] = _server_save(save_id=50, rom_id=42, slot="backup", updated_at="2026-02-01T10:00:00Z")
+
+        result = await svc.copy_save_to_slot(42, 50, "autosave")
+
+        assert result == {"status": "ok"}
+        state = _require_save_state(svc, 42)
+        assert state.active_slot == "autosave"
+        # Source in the inactive slot preserved.
+        assert fake.saves[50].get("slot") == "backup"
+        # A new save was created (id from the fake's 1000+ range), distinct from
+        # both the source and the pre-existing head.
+        autosave_ids = {s["id"] for s in fake.saves.values() if s.get("slot") == "autosave"}
+        assert autosave_ids - {100} != set()  # at least one NEW save id in autosave
+
+    @pytest.mark.asyncio
+    async def test_source_preserved_and_target_becomes_active(self, tmp_path):
+        """Dedicated non-vacuous check: the source save survives AND the target is active."""
+        svc, fake = make_service(tmp_path)
+        _create_save(tmp_path)
+        local_hash = _file_md5(str(tmp_path / "saves" / "gba" / "pokemon.srm"))
+        _setup_configured(svc, tmp_path, active_slot="autosave", tracked_id=100, last_sync_hash=local_hash)
+        fake.saves[100] = _tracked_save(100, slot="autosave")
+        fake.saves[10] = _server_save(save_id=10, rom_id=42, slot=None, updated_at="2026-02-01T10:00:00Z")
+
+        before_ids = set(fake.saves)
+        result = await svc.copy_save_to_slot(42, 10, TARGET)
+
+        assert result == {"status": "ok"}
+        # The source id is still present (a copy, never a move/delete).
+        assert 10 in fake.saves
+        # The target is now the ROM's active slot.
+        assert _require_save_state(svc, 42).active_slot == TARGET
+        # A brand-new save id appeared for the copy (the source was not mutated in place).
+        assert set(fake.saves) - before_ids
+
+
+class TestCopySaveToSlotRefusals:
+    """Every refusal branch of the discriminated-status union."""
+
+    @pytest.mark.asyncio
+    async def test_invalid_slot_name_empty(self, tmp_path):
+        svc, _fake = make_service(tmp_path)
+        assert await svc.copy_save_to_slot(42, 10, "") == {"status": "invalid_slot_name"}
+
+    @pytest.mark.asyncio
+    async def test_invalid_slot_name_whitespace(self, tmp_path):
+        svc, _fake = make_service(tmp_path)
+        assert await svc.copy_save_to_slot(42, 10, "   ") == {"status": "invalid_slot_name"}
+
+    @pytest.mark.asyncio
+    async def test_not_configured_when_slot_unconfirmed(self, tmp_path):
+        """An installed ROM whose slot is not confirmed is refused up front (#1529 lesson)."""
+        svc, _fake = make_service(tmp_path)
+        _install_rom(svc, tmp_path)
+        _enable_sync_with_device(svc)
+        # active_slot set but slot_confirmed defaults False → not configured.
+        _seed_save_state_dict(svc, 42, {"system": "gba", "active_slot": "autosave"})
+
+        assert await svc.copy_save_to_slot(42, 10, TARGET) == {"status": "not_configured"}
+
+    @pytest.mark.asyncio
+    async def test_not_configured_when_legacy_active_slot(self, tmp_path):
+        """The legacy no-slot mode ("") is not a confirmed named slot — refused."""
+        svc, _fake = make_service(tmp_path)
+        _install_rom(svc, tmp_path)
+        _enable_sync_with_device(svc)
+        _seed_save_state_dict(svc, 42, {"system": "gba", "active_slot": "", "slot_confirmed": True})
+
+        assert await svc.copy_save_to_slot(42, 10, TARGET) == {"status": "not_configured"}
+
+    @pytest.mark.asyncio
+    async def test_rom_not_installed(self, tmp_path):
+        """A configured ROM that isn't installed locally → rom_not_installed."""
+        svc, _fake = make_service(tmp_path)
+        # Configured state but no rom_installs row.
+        _seed_save_state_dict(svc, 42, {"system": "gba", "active_slot": "autosave", "slot_confirmed": True})
+
+        result = await svc.copy_save_to_slot(42, 10, TARGET)
+        assert result == {"status": "rom_not_installed"}
+
+    @pytest.mark.asyncio
+    async def test_multi_file_slot_unsupported(self, tmp_path):
+        """A multi-file slot (e.g. Saturn .bkr/.bcr) refuses the copy (#908 guard)."""
+        svc, fake = make_service(tmp_path)
+        _install_rom(svc, tmp_path, system="saturn", file_name="rally.cue")
+        _enable_sync_with_device(svc)
+        _create_save(tmp_path, system="saturn", rom_name="rally", ext=".bkr")
+        _create_save(tmp_path, system="saturn", rom_name="rally", ext=".bcr")
+        _seed_save_state_dict(svc, 42, {"system": "saturn", "active_slot": "autosave", "slot_confirmed": True})
+        fake.saves[50] = _server_save(save_id=50, rom_id=42, slot="backup", updated_at="2026-02-01T10:00:00Z")
+
+        result = await svc.copy_save_to_slot(42, 50, TARGET)
+
+        assert result == {"status": "unsupported"}
+        # No destructive I/O ran — the guard fired before any list/download/upload.
+        assert not any(c[0] in ("upload_save", "download_save_content", "list_saves") for c in fake.call_log)
+
+    @pytest.mark.asyncio
+    async def test_content_dir_unsupported(self, tmp_path):
+        """RetroArch content-dir layout (#239) refuses the copy with the reason slug."""
+        svc, fake = make_service(tmp_path, detect_sort_change=lambda: ContentDir())
+        _install_rom(svc, tmp_path)
+        _enable_sync_with_device(svc)
+        _create_save(tmp_path)
+        _seed_save_state_dict(svc, 42, {"system": "gba", "active_slot": "autosave", "slot_confirmed": True})
+        fake.saves[50] = _server_save(save_id=50, rom_id=42, slot="backup", updated_at="2026-02-01T10:00:00Z")
+
+        result = await svc.copy_save_to_slot(42, 50, TARGET)
+
+        assert result == {"status": "unsupported", "reason": "savefiles_in_content_dir"}
+        # Gate fired before any I/O.
+        assert not any(c[0] in ("upload_save", "download_save_content", "list_saves") for c in fake.call_log)
+
+    @pytest.mark.asyncio
+    async def test_version_deleted_when_save_id_missing(self, tmp_path):
+        """A clean pre-flight, but the chosen save id is absent from the server list."""
+        svc, fake = make_service(tmp_path)
+        _create_save(tmp_path)
+        local_hash = _file_md5(str(tmp_path / "saves" / "gba" / "pokemon.srm"))
+        _setup_configured(svc, tmp_path, active_slot="autosave", tracked_id=100, last_sync_hash=local_hash)
+        fake.saves[100] = _tracked_save(100, slot="autosave")
+
+        result = await svc.copy_save_to_slot(42, 999, TARGET)
+
+        assert result == {"status": "version_deleted"}
+
+    @pytest.mark.asyncio
+    async def test_server_unreachable_on_post_preflight_list(self, tmp_path):
+        """A ``list_saves`` failure AFTER a clean pre-flight → server_unreachable."""
+        svc, fake = make_service(tmp_path)
+        _create_save(tmp_path)
+        local_hash = _file_md5(str(tmp_path / "saves" / "gba" / "pokemon.srm"))
+        _setup_configured(svc, tmp_path, active_slot="autosave", tracked_id=100, last_sync_hash=local_hash)
+        fake.saves[100] = _tracked_save(100, slot="autosave")
+
+        original_list = fake.list_saves
+        call_count = {"n": 0}
+
+        def fail_second_list(*args, **kwargs):
+            call_count["n"] += 1
+            if call_count["n"] >= 2:
+                raise OSError("server unreachable after preflight")
+            return original_list(*args, **kwargs)
+
+        fake.list_saves = fail_second_list  # type: ignore[method-assign]
+        try:
+            result = await svc.copy_save_to_slot(42, 100, TARGET)
+        finally:
+            fake.list_saves = original_list  # type: ignore[method-assign]
+
+        assert result["status"] == "server_unreachable"
+        assert "unreachable" in result.get("message", "").lower()
+        assert "error" not in result
+
+    @pytest.mark.asyncio
+    async def test_target_slot_busy_on_409(self, tmp_path):
+        """The target slot has a newer foreign save this device hasn't synced → 409 → target_slot_busy."""
+        svc, fake = make_service(tmp_path)
+        _create_save(tmp_path)
+        local_hash = _file_md5(str(tmp_path / "saves" / "gba" / "pokemon.srm"))
+        _setup_configured(svc, tmp_path, active_slot="autosave", tracked_id=100, last_sync_hash=local_hash)
+        fake.saves[100] = _tracked_save(100, slot="autosave")
+        # A legacy source to copy.
+        fake.saves[10] = _server_save(save_id=10, rom_id=42, slot=None, updated_at="2026-02-01T10:00:00Z")
+        # The target slot already holds a foreign head we've never synced.
+        fake.seed_foreign_save(42, save_id=77, slot=TARGET, uploaded_by="device-B")
+
+        result = await svc.copy_save_to_slot(42, 10, TARGET)
+
+        assert result["status"] == "target_slot_busy"
+        assert result.get("message")
+        # The source save is untouched.
+        assert 10 in fake.saves
+
+    @pytest.mark.asyncio
+    async def test_conflict_blocked_on_dirty_current_slot(self, tmp_path):
+        """A real conflict on the CURRENT slot blocks the copy before any copy I/O."""
+        svc, fake = make_service(tmp_path)
+        _enable_sync_with_device(svc)
+        _install_rom(svc, tmp_path)
+        _seed_save_state_dict(
+            svc,
+            42,
+            {
+                "system": "gba",
+                "active_slot": "autosave",
+                "slot_confirmed": True,
+                "files": {"pokemon.srm": {"tracked_save_id": 100, "last_sync_hash": "aabbcc001122334455667788"}},
+            },
+        )
+        # Local diverged from the baseline, and the server head moved past us
+        # (is_current False) → the matrix returns Conflict.
+        _create_save(tmp_path, content=b"\xff" * 1024)
+        fake.saves[100] = _server_save_with_syncs(
+            save_id=100,
+            slot="autosave",
+            updated_at="2026-03-15T10:00:00Z",
+            device_syncs=[{"device_id": "device-1", "is_current": False, "last_synced_at": "2026-03-10T10:00:00Z"}],
+        )
+        fake.saves[10] = _server_save(save_id=10, rom_id=42, slot=None, updated_at="2026-02-01T10:00:00Z")
+
+        result = await svc.copy_save_to_slot(42, 10, TARGET)
+
+        assert result["status"] == "conflict_blocked"
+        assert len(result["conflicts"]) == 1
+        # No copy download of the source ran, and the target slot never received a save.
+        download_ids = [c[1][0] for c in fake.call_log if c[0] == "download_save_content"]
+        assert 10 not in download_ids
+        assert not [s for s in fake.saves.values() if s.get("slot") == TARGET]
+
+    @pytest.mark.asyncio
+    async def test_preflight_failed_on_server_error(self, tmp_path):
+        """A non-conflict error during the pre-flight aborts with preflight_failed."""
+        svc, fake = make_service(tmp_path)
+        _install_rom(svc, tmp_path)
+        _enable_sync_with_device(svc)
+        _seed_save_state_dict(svc, 42, {"system": "gba", "active_slot": "autosave", "slot_confirmed": True})
+        fake.fail_on_next(Exception("network error"))
+
+        result = await svc.copy_save_to_slot(42, 10, TARGET)
+
+        assert result["status"] == "preflight_failed"
+        assert any("network" in err.lower() for err in result.get("errors", []))
+        # No copy ran — the target slot got no save.
+        assert not [s for s in fake.saves.values() if s.get("slot") == TARGET]

--- a/tests/services/saves/test_copies.py
+++ b/tests/services/saves/test_copies.py
@@ -181,6 +181,94 @@ class TestCopySaveToSlotHappyPaths:
         assert set(fake.saves) - before_ids
 
 
+class TestCopySaveToSlotDedup:
+    """The content-already-in-target dedup pre-check (no-churn guarantee)."""
+
+    @pytest.mark.asyncio
+    async def test_already_present_when_content_in_target_slot(self, tmp_path):
+        """The chosen save's content is already in the target slot → refuse the copy.
+
+        Copying content RomM would dedup server-side churns the tracked save for
+        no gain. The pre-check surfaces the existing save's id and touches no copy
+        state — no download, no new save, no make-current.
+        """
+        svc, fake = make_service(tmp_path)
+        _create_save(tmp_path)
+        local_hash = _file_md5(str(tmp_path / "saves" / "gba" / "pokemon.srm"))
+        _setup_configured(svc, tmp_path, active_slot="autosave", tracked_id=100, last_sync_hash=local_hash)
+        fake.saves[100] = _tracked_save(100, slot="autosave")
+        # A legacy source and a save already in the target slot share content.
+        fake.saves[10] = _server_save(save_id=10, rom_id=42, slot=None, updated_at="2026-02-01T10:00:00Z")
+        fake.saves[10]["content_hash"] = "SAME-CONTENT"
+        fake.saves[200] = _server_save(save_id=200, rom_id=42, slot=TARGET, updated_at="2026-01-01T10:00:00Z")
+        fake.saves[200]["content_hash"] = "SAME-CONTENT"
+
+        result = await svc.copy_save_to_slot(42, 10, TARGET)
+
+        assert result == {"status": "already_present", "existing_id": 200}
+        # No copy I/O: the source was never downloaded.
+        download_ids = [c[1][0] for c in fake.call_log if c[0] == "download_save_content"]
+        assert 10 not in download_ids
+        # No new save landed in the target slot — still just the pre-existing one.
+        assert {s["id"] for s in fake.saves.values() if s.get("slot") == TARGET} == {200}
+        # No make-current: the active slot and tracked save are unchanged.
+        state = _require_save_state(svc, 42)
+        assert state.active_slot == "autosave"
+        assert state.files["pokemon.srm"].tracked_save_id == 100
+
+    @pytest.mark.asyncio
+    async def test_falls_through_to_copy_when_content_hash_absent(self, tmp_path):
+        """A source save without a content_hash skips the pre-check and copies.
+
+        Older servers omit content_hash; the copy then relies on RomM's own
+        server-side dedup. A distinctive target proves the value flowed.
+        """
+        svc, fake = make_service(tmp_path)
+        _create_save(tmp_path)
+        local_hash = _file_md5(str(tmp_path / "saves" / "gba" / "pokemon.srm"))
+        _setup_configured(svc, tmp_path, active_slot="autosave", tracked_id=100, last_sync_hash=local_hash)
+        fake.saves[100] = _tracked_save(100, slot="autosave")
+        # Source carries no content_hash — even though a same-slot save exists, the
+        # pre-check can't compare, so the copy proceeds.
+        fake.saves[10] = _server_save(save_id=10, rom_id=42, slot=None, updated_at="2026-02-01T10:00:00Z")
+        fake.saves[200] = _server_save(save_id=200, rom_id=42, slot=TARGET, updated_at="2026-01-01T10:00:00Z")
+        fake.saves[200]["content_hash"] = "SOMETHING"
+        # We're synced to the target head, so the copy's POST stacks cleanly (no 409).
+        fake.stage_device_sync(200, "device-1", "2026-01-01T10:00:00Z")
+
+        result = await svc.copy_save_to_slot(42, 10, TARGET)
+
+        assert result == {"status": "ok"}
+        assert _require_save_state(svc, 42).active_slot == TARGET
+
+    @pytest.mark.asyncio
+    async def test_ok_copy_tracks_the_new_save_not_a_deduped_existing(self, tmp_path):
+        """A genuine copy tracks the newly-created target save (no churn artifact).
+
+        Regression lock: the tracked save becomes the new POST-created save, never
+        the source or a deduped existing head — so the current save is excluded
+        from its own version history (``list_file_versions`` excludes the tracked id).
+        """
+        svc, fake = make_service(tmp_path)
+        _create_save(tmp_path)
+        local_hash = _file_md5(str(tmp_path / "saves" / "gba" / "pokemon.srm"))
+        _setup_configured(svc, tmp_path, active_slot="autosave", tracked_id=100, last_sync_hash=local_hash)
+        fake.saves[100] = _tracked_save(100, slot="autosave")
+        # Source content is unique (target slot is empty) → a real copy.
+        fake.saves[10] = _server_save(save_id=10, rom_id=42, slot=None, updated_at="2026-02-01T10:00:00Z")
+        fake.saves[10]["content_hash"] = "UNIQUE-CONTENT"
+
+        result = await svc.copy_save_to_slot(42, 10, TARGET)
+
+        assert result == {"status": "ok"}
+        tracked_id = _require_save_state(svc, 42).files["pokemon.srm"].tracked_save_id
+        # The tracked save is the newly-created target save, not the source (10) or
+        # the old tracked head (100).
+        assert tracked_id not in (10, 100)
+        assert tracked_id is not None
+        assert fake.saves[tracked_id]["slot"] == TARGET
+
+
 class TestCopySaveToSlotRefusals:
     """Every refusal branch of the discriminated-status union."""
 


### PR DESCRIPTION
Adds a per-save "Copy to slot…" action on the SAVES tab: pick a specific save — from any slot, including the read-only no-slot bucket — and copy it into another slot, an existing named one or a new one.

The source save is left untouched (it's a copy, never a delete); the target slot becomes the ROM's active, tracked slot with the copied save as its current save. This covers promoting a specific no-slot save into a named slot, bringing a save from the old "default" slot onto "autosave", and copying a save from an inactive slot into the active one.

The action is online-only and refuses an unconfigured ROM (set save sync up through the wizard first). Copying into a slot another device changed since this device's last sync surfaces a "resolve conflicts first, then copy again" prompt rather than overwriting.

Closes #1523
