### PR TITLE
feat(ui): confirm text-entry modals with the on-screen keyboard's Enter key

### DIFF
--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -74,6 +74,9 @@ After installation, you need to connect the plugin to your RomM server:
 5. The **RomM Account** row shows **Signed in** on success. Once signed in, tap **Test Connection** to re-verify at any
    time
 
+On a controller, any text field in the plugin can be confirmed with the on-screen keyboard's **Enter** key (or the
+**R2** shortcut) instead of navigating to the button — this applies to sign-in, save-slot names, and the artwork search.
+
 The plugin mints a RomM Client API Token from the credentials you enter and discards the password — it is never stored.
 The same applies if the plugin auto-migrates an older install that still had a saved password: the password is discarded
 as soon as a token is minted. If your RomM account is not allowed to create API tokens, the sign-in step reports that

--- a/src/components/SgdbGamePickerModal.test.tsx
+++ b/src/components/SgdbGamePickerModal.test.tsx
@@ -158,6 +158,22 @@ describe("SgdbGamePickerModal", () => {
       expect(container.textContent).toContain("Link's Awakening");
     });
 
+    it("Enter in the search field runs a search (on-screen keyboard)", async () => {
+      vi.mocked(backend.searchSgdbGames).mockResolvedValue({
+        success: true,
+        games: [{ id: 7, name: "Link's Awakening", release_year: 1993, thumb_url: null }],
+      });
+      const { container } = renderPicker();
+      const input = container.querySelector('input[data-testid="text-field"]') as HTMLInputElement;
+      await act(async () => {
+        fireEvent.keyDown(input, { key: "Enter" });
+      });
+      await flushAsync();
+      // Enter runs the search (not a close) — same as the Search button.
+      expect(vi.mocked(backend.searchSgdbGames)).toHaveBeenCalledWith("Zelda");
+      expect(container.textContent).toContain("Link's Awakening");
+    });
+
     it("selecting a search result applies (2-arg)", async () => {
       vi.mocked(backend.searchSgdbGames).mockResolvedValue({
         success: true,

--- a/src/components/SgdbGamePickerModal.tsx
+++ b/src/components/SgdbGamePickerModal.tsx
@@ -18,7 +18,7 @@
  * OK action, which would close the modal before the user can pick.
  */
 
-import { FC, useState } from "react";
+import { FC, useState, KeyboardEvent } from "react";
 import { ConfirmModal, DialogButton, Focusable, GamepadButton, TextField, Spinner, type GamepadEvent } from "@decky/ui";
 import { toaster } from "@decky/api";
 import { searchSgdbGames, applySgdbGameId, debugLog, type SgdbCandidate } from "../api/backend";
@@ -195,6 +195,12 @@ export const SgdbGamePickerModalContent: FC<SgdbGamePickerModalProps> = ({
               label="Search SteamGridDB"
               value={term}
               onChange={(e: { target: { value: string } }) => setTerm(e.target.value)}
+              // Enter (the on-screen keyboard's "Eingabe" key) runs the search,
+              // not a close — the modal stays open so the user can pick a result.
+              // Mirror the Search button's disabled={searching} guard.
+              onKeyDown={(e: KeyboardEvent<HTMLInputElement>) => {
+                if (e.key === "Enter" && !searching) detach(runSearch());
+              }}
               onFocus={scrollToTop}
             />
           </div>

--- a/src/components/SlotSetupWizard.test.tsx
+++ b/src/components/SlotSetupWizard.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { render, fireEvent, act } from "@testing-library/react";
-import { createElement, type ChangeEvent, type ReactElement } from "react";
+import { createElement, type ChangeEvent, type KeyboardEvent, type ReactElement } from "react";
 import { SlotSetupWizard } from "./SlotSetupWizard";
 import * as backend from "../api/backend";
 import { toaster } from "@decky/api";
@@ -34,6 +34,7 @@ interface ConfirmModalProps {
 interface TextFieldProps {
   value?: string;
   onChange?: (e: ChangeEvent<HTMLInputElement>) => void;
+  onKeyDown?: (e: KeyboardEvent<HTMLInputElement>) => void;
   label?: string;
   focusOnMount?: boolean;
 }
@@ -69,6 +70,7 @@ vi.mock("@decky/ui", () => {
         "data-testid": "text-field",
         value: p.value ?? "",
         onChange: (e: ChangeEvent<HTMLInputElement>) => p.onChange?.(e),
+        onKeyDown: (e: KeyboardEvent<HTMLInputElement>) => p.onKeyDown?.(e),
       }),
     showModal: vi.fn(),
   };
@@ -888,6 +890,56 @@ describe("SlotSetupWizard", () => {
       expect(vi.mocked(backend.confirmSlotChoice)).toHaveBeenCalledWith(21, "myslot", false, null, false);
       // Non-empty submit must NOT open the legacy-mode prompt.
       expect(vi.mocked(showModal)).toHaveBeenCalledTimes(1);
+      sub.unmount();
+    });
+
+    it("confirms the typed slot on Enter (on-screen keyboard)", async () => {
+      const info = makeSetupInfo({ server_slots: [] });
+      vi.mocked(applyWizardInitialSetupResult).mockImplementation(async (_r, deps) => {
+        deps.setInfo(info);
+      });
+      const { getByText } = render(<SlotSetupWizard {...defaultProps({ romId: 21 })} />);
+      await flushAsync();
+
+      fireEvent.click(getByText("Custom slot..."));
+      const modal = modalElementAt(0);
+      if (!modal) throw new Error("CustomSlotModal element not captured");
+
+      const sub = render(<>{modal}</>);
+      await act(async () => {
+        fireEvent.change(sub.getByTestId("text-field"), { target: { value: "  myslot  " } });
+      });
+      await act(async () => {
+        fireEvent.keyDown(sub.getByTestId("text-field"), { key: "Enter" });
+        await Promise.resolve();
+      });
+
+      // Enter trims and confirms, same as the OK button.
+      expect(vi.mocked(backend.confirmSlotChoice)).toHaveBeenCalledWith(21, "myslot", false, null, false);
+      sub.unmount();
+    });
+
+    it("ignores Enter on an empty custom slot (no confirm)", async () => {
+      const info = makeSetupInfo({ server_slots: [] });
+      vi.mocked(applyWizardInitialSetupResult).mockImplementation(async (_r, deps) => {
+        deps.setInfo(info);
+      });
+      const { getByText } = render(<SlotSetupWizard {...defaultProps({ romId: 8 })} />);
+      await flushAsync();
+
+      fireEvent.click(getByText("Custom slot..."));
+      const modal = modalElementAt(0);
+      if (!modal) throw new Error("CustomSlotModal element not captured");
+
+      const sub = render(<>{modal}</>);
+      // Don't type anything — a blank Enter must be a no-op (unlike the OK button,
+      // which sends "" straight to the backend guard).
+      await act(async () => {
+        fireEvent.keyDown(sub.getByTestId("text-field"), { key: "Enter" });
+        await Promise.resolve();
+      });
+
+      expect(vi.mocked(backend.confirmSlotChoice)).not.toHaveBeenCalled();
       sub.unmount();
     });
 

--- a/src/components/SlotSetupWizard.tsx
+++ b/src/components/SlotSetupWizard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, FC, createElement, ChangeEvent } from "react";
+import { useState, useEffect, useRef, FC, createElement, ChangeEvent, KeyboardEvent } from "react";
 import { toaster } from "@decky/api";
 import { DialogButton, ConfirmModal, ModalRoot, TextField, showModal } from "@decky/ui";
 import { getSaveSetupInfo, confirmSlotChoice, logError } from "../api/backend";
@@ -91,6 +91,16 @@ const CustomSlotModal: FC<{
       label: "Slot Name",
       value,
       onChange: (e: ChangeEvent<HTMLInputElement>) => setValue(e.target.value),
+      // Enter (the on-screen keyboard's "Eingabe" key) confirms, same as the OK
+      // button. Guard empty so a blank Enter is a no-op (the button itself
+      // doesn't guard, but a blank confirm must not fire). ConfirmModal doesn't
+      // auto-close this manual path.
+      onKeyDown: (e: KeyboardEvent<HTMLInputElement>) => {
+        if (e.key === "Enter" && value.trim() !== "") {
+          onSubmit(value.trim());
+          closeModal?.();
+        }
+      },
     }),
   );
 };

--- a/src/components/saves/NewSlotModal.test.tsx
+++ b/src/components/saves/NewSlotModal.test.tsx
@@ -32,10 +32,11 @@ vi.mock("@decky/ui", () => ({
     captured.strTitle = p.strTitle;
     return createElement("div", { "data-testid": "confirm-modal" }, p.children as never);
   },
-  TextField: (p: AnyProps & { value?: string; onChange?: (e: unknown) => void }) =>
+  TextField: (p: AnyProps & { value?: string; onChange?: (e: unknown) => void; onKeyDown?: (e: unknown) => void }) =>
     createElement("input", {
       value: p.value ?? "",
       onChange: (e: unknown) => p.onChange?.(e),
+      onKeyDown: (e: unknown) => p.onKeyDown?.(e),
     }),
 }));
 
@@ -103,6 +104,39 @@ describe("NewSlotModal", () => {
     fireEvent.change(input, { target: { value: "    " } });
     captured.onOK?.();
     expect(onSubmit).toHaveBeenCalledWith("");
+  });
+
+  it("confirms on Enter (on-screen keyboard) — submits the trimmed name and closes", () => {
+    const onSubmit = vi.fn();
+    const closeModal = vi.fn();
+    render(<NewSlotModal closeModal={closeModal} onSubmit={onSubmit} />);
+    const input = document.querySelector("input") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "  speedrun  " } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith("speedrun");
+    expect(closeModal).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores Enter while the name is empty (no submit, no close)", () => {
+    const onSubmit = vi.fn();
+    const closeModal = vi.fn();
+    render(<NewSlotModal closeModal={closeModal} onSubmit={onSubmit} />);
+    const input = document.querySelector("input") as HTMLInputElement;
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(closeModal).not.toHaveBeenCalled();
+  });
+
+  it("ignores Enter while the name is whitespace-only (no submit, no close)", () => {
+    const onSubmit = vi.fn();
+    const closeModal = vi.fn();
+    render(<NewSlotModal closeModal={closeModal} onSubmit={onSubmit} />);
+    const input = document.querySelector("input") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "   " } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(closeModal).not.toHaveBeenCalled();
   });
 
   it("forwards closeModal to the underlying ConfirmModal", () => {

--- a/src/components/saves/NewSlotModal.tsx
+++ b/src/components/saves/NewSlotModal.tsx
@@ -4,7 +4,7 @@
  * slot-creation side effects belong in the parent.
  */
 
-import { useState, createElement, FC, ChangeEvent } from "react";
+import { useState, createElement, FC, ChangeEvent, KeyboardEvent } from "react";
 import { ConfirmModal, TextField } from "@decky/ui";
 
 export const NewSlotModal: FC<{
@@ -29,6 +29,15 @@ export const NewSlotModal: FC<{
       label: "Slot Name",
       value,
       onChange: (e: ChangeEvent<HTMLInputElement>) => setValue(e.target.value),
+      // Enter (the on-screen keyboard's "Eingabe" key) confirms, same as the OK
+      // button — which is disabled while blank, so guard identically: a blank
+      // Enter is a no-op. ConfirmModal doesn't auto-close this manual path.
+      onKeyDown: (e: KeyboardEvent<HTMLInputElement>) => {
+        if (e.key === "Enter" && value.trim() !== "") {
+          onSubmit(value.trim());
+          closeModal?.();
+        }
+      },
     }),
   );
 };

--- a/src/components/settings/ConnectModal.test.tsx
+++ b/src/components/settings/ConnectModal.test.tsx
@@ -132,6 +132,46 @@ describe("ConnectModal", () => {
       expect(onConnectToken).not.toHaveBeenCalled();
     });
 
+    it("submits on Enter in the username field (on-screen keyboard) and closes", () => {
+      const onConnect = vi.fn();
+      const closeModal = vi.fn();
+      const { getByTestId } = render(
+        <ConnectModal
+          closeModal={closeModal}
+          onConnect={onConnect}
+          onConnectToken={vi.fn()}
+          onConnectPairing={vi.fn()}
+        />,
+      );
+      fireEvent.click(getByTestId("mode-credentials"));
+      fireEvent.change(getByTestId("field-Username"), { target: { value: "daniel" } });
+      fireEvent.change(getByTestId("field-Password"), { target: { value: "hunter2" } });
+      fireEvent.keyDown(getByTestId("field-Username"), { key: "Enter" });
+      expect(onConnect).toHaveBeenCalledTimes(1);
+      expect(onConnect).toHaveBeenCalledWith("daniel", "hunter2");
+      // ConfirmModal's OK auto-closes; the manual Enter path must close itself.
+      expect(closeModal).toHaveBeenCalledTimes(1);
+    });
+
+    it("submits on Enter in the password field", () => {
+      const onConnect = vi.fn();
+      const closeModal = vi.fn();
+      const { getByTestId } = render(
+        <ConnectModal
+          closeModal={closeModal}
+          onConnect={onConnect}
+          onConnectToken={vi.fn()}
+          onConnectPairing={vi.fn()}
+        />,
+      );
+      fireEvent.click(getByTestId("mode-credentials"));
+      fireEvent.change(getByTestId("field-Username"), { target: { value: "daniel" } });
+      fireEvent.change(getByTestId("field-Password"), { target: { value: "hunter2" } });
+      fireEvent.keyDown(getByTestId("field-Password"), { key: "Enter" });
+      expect(onConnect).toHaveBeenCalledWith("daniel", "hunter2");
+      expect(closeModal).toHaveBeenCalledTimes(1);
+    });
+
     it("passes empty strings to onConnect when nothing is entered", () => {
       const onConnect = vi.fn();
       const { getByTestId } = render(
@@ -176,6 +216,25 @@ describe("ConnectModal", () => {
       expect(onConnectToken).toHaveBeenCalledTimes(1);
       expect(onConnectToken).toHaveBeenCalledWith("rmm_pasted");
       expect(onConnect).not.toHaveBeenCalled();
+    });
+
+    it("submits the token on Enter in the API token field (on-screen keyboard) and closes", () => {
+      const onConnectToken = vi.fn();
+      const closeModal = vi.fn();
+      const { getByTestId } = render(
+        <ConnectModal
+          closeModal={closeModal}
+          onConnect={vi.fn()}
+          onConnectToken={onConnectToken}
+          onConnectPairing={vi.fn()}
+        />,
+      );
+      fireEvent.click(getByTestId("mode-token"));
+      fireEvent.change(getByTestId("field-API Token"), { target: { value: "rmm_pasted" } });
+      fireEvent.keyDown(getByTestId("field-API Token"), { key: "Enter" });
+      expect(onConnectToken).toHaveBeenCalledTimes(1);
+      expect(onConnectToken).toHaveBeenCalledWith("rmm_pasted");
+      expect(closeModal).toHaveBeenCalledTimes(1);
     });
 
     it("switches back to credentials mode and calls onConnect again", () => {
@@ -297,6 +356,45 @@ describe("ConnectModal", () => {
       expect(onConnectPairing).toHaveBeenCalledWith("ABCDEFGH");
       expect(onConnect).not.toHaveBeenCalled();
       expect(onConnectToken).not.toHaveBeenCalled();
+    });
+
+    it("submits the pairing code on Enter once all eight boxes are filled and closes", () => {
+      const onConnectPairing = vi.fn();
+      const closeModal = vi.fn();
+      const { getByTestId } = render(
+        <ConnectModal
+          closeModal={closeModal}
+          onConnect={vi.fn()}
+          onConnectToken={vi.fn()}
+          onConnectPairing={onConnectPairing}
+        />,
+      );
+      fireEvent.click(getByTestId("mode-pairing"));
+      // A full paste fills all eight boxes.
+      fireEvent.change(box(getByTestId, 0), { target: { value: "abcdefgh" } });
+      fireEvent.keyDown(box(getByTestId, 7), { key: "Enter" });
+      expect(onConnectPairing).toHaveBeenCalledTimes(1);
+      expect(onConnectPairing).toHaveBeenCalledWith("ABCDEFGH");
+      expect(closeModal).toHaveBeenCalledTimes(1);
+    });
+
+    it("ignores Enter while the pairing code is incomplete (no submit, no close)", () => {
+      const onConnectPairing = vi.fn();
+      const closeModal = vi.fn();
+      const { getByTestId } = render(
+        <ConnectModal
+          closeModal={closeModal}
+          onConnect={vi.fn()}
+          onConnectToken={vi.fn()}
+          onConnectPairing={onConnectPairing}
+        />,
+      );
+      fireEvent.click(getByTestId("mode-pairing"));
+      // Only the first four boxes are filled — the code is incomplete.
+      fireEvent.change(box(getByTestId, 0), { target: { value: "abcd" } });
+      fireEvent.keyDown(box(getByTestId, 3), { key: "Enter" });
+      expect(onConnectPairing).not.toHaveBeenCalled();
+      expect(closeModal).not.toHaveBeenCalled();
     });
 
     it("switches from pairing back to token mode and routes to onConnectToken only", () => {

--- a/src/components/settings/ConnectModal.tsx
+++ b/src/components/settings/ConnectModal.tsx
@@ -169,6 +169,14 @@ export const ConnectModal: FC<ConnectModalProps> = ({ closeModal, onConnect, onC
     // to the previous box with the caret at the end.
     if (e.key === "Backspace" && (code[index] ?? "") === "" && index > 0) {
       focusBoxAtEnd(index - 1);
+      return;
+    }
+    // Enter (the on-screen keyboard's "Eingabe" key) confirms once every box is
+    // filled — same submit as the OK button, plus the manual close ConfirmModal's
+    // OK button would do. An incomplete code is a no-op.
+    if (e.key === "Enter" && code.every((c) => c !== "")) {
+      submit();
+      closeModal?.();
     }
   };
 
@@ -180,6 +188,17 @@ export const ConnectModal: FC<ConnectModalProps> = ({ closeModal, onConnect, onC
       onConnectPairing(code.join(""));
     } else {
       onConnect(username, password);
+    }
+  };
+
+  // Enter (the on-screen keyboard's "Eingabe" key) on a single-value field
+  // confirms, same as the OK button. ConfirmModal auto-closes on its OK button
+  // but not on this manual path, so close here too. The pairing-code boxes are
+  // the exception — handleBoxKeyDown gates their Enter on a complete code.
+  const handleFieldKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      submit();
+      closeModal?.();
     }
   };
 
@@ -214,6 +233,7 @@ export const ConnectModal: FC<ConnectModalProps> = ({ closeModal, onConnect, onC
             value={token}
             bIsPassword
             onChange={(e: ChangeEvent<HTMLInputElement>) => setToken(e.target.value)}
+            onKeyDown={handleFieldKeyDown}
           />
         </>
       )}
@@ -256,12 +276,14 @@ export const ConnectModal: FC<ConnectModalProps> = ({ closeModal, onConnect, onC
             label="Username"
             value={username}
             onChange={(e: ChangeEvent<HTMLInputElement>) => setUsername(e.target.value)}
+            onKeyDown={handleFieldKeyDown}
           />
           <TextField
             label="Password"
             value={password}
             bIsPassword
             onChange={(e: ChangeEvent<HTMLInputElement>) => setPassword(e.target.value)}
+            onKeyDown={handleFieldKeyDown}
           />
         </>
       )}

--- a/src/components/settings/TextInputModal.test.tsx
+++ b/src/components/settings/TextInputModal.test.tsx
@@ -28,6 +28,7 @@ vi.mock("@decky/ui", () => ({
       value?: string;
       bIsPassword?: boolean;
       onChange?: (e: { target: { value: string } }) => void;
+      onKeyDown?: (e: unknown) => void;
     },
   ) => {
     captured.textFieldPassword = p.bIsPassword;
@@ -35,6 +36,7 @@ vi.mock("@decky/ui", () => ({
       value: p.value ?? "",
       type: p.bIsPassword ? "password" : "text",
       onChange: (e: unknown) => p.onChange?.(e as { target: { value: string } }),
+      onKeyDown: (e: unknown) => p.onKeyDown?.(e),
     });
   },
 }));
@@ -80,6 +82,19 @@ describe("TextInputModal", () => {
     captured.onOK?.();
     expect(onSubmit).toHaveBeenCalledTimes(1);
     expect(onSubmit).toHaveBeenCalledWith("edited");
+  });
+
+  it("confirms on Enter (on-screen keyboard) — submits the value and closes", () => {
+    const onSubmit = vi.fn();
+    const closeModal = vi.fn();
+    render(<TextInputModal label="x" value="initial" closeModal={closeModal} onSubmit={onSubmit} />);
+    const input = document.querySelector("input") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "edited" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith("edited");
+    // ConfirmModal's OK auto-closes; the manual Enter path must close itself.
+    expect(closeModal).toHaveBeenCalledTimes(1);
   });
 
   it("does NOT trim — submits whitespace as-is (parent is responsible)", () => {

--- a/src/components/settings/TextInputModal.tsx
+++ b/src/components/settings/TextInputModal.tsx
@@ -5,7 +5,7 @@
  * the modal.
  */
 
-import { useState, FC, ChangeEvent } from "react";
+import { useState, FC, ChangeEvent, KeyboardEvent } from "react";
 import { ConfirmModal, TextField } from "@decky/ui";
 
 /** Module-level state survives component remounts (modal close can remount QAM) */
@@ -29,15 +29,16 @@ export const TextInputModal: FC<TextInputModalProps> = ({
   onSubmit,
 }) => {
   const [value, setValue] = useState(initial);
+  const handleOK = () => {
+    if (field) {
+      pendingEdits[field] = value;
+    }
+    onSubmit(value);
+  };
   return (
     <ConfirmModal
       {...(closeModal !== undefined ? { closeModal } : {})}
-      onOK={() => {
-        if (field) {
-          pendingEdits[field] = value;
-        }
-        onSubmit(value);
-      }}
+      onOK={handleOK}
       strTitle={label}
       bDisableBackgroundDismiss={true}
     >
@@ -47,6 +48,15 @@ export const TextInputModal: FC<TextInputModalProps> = ({
         value={value}
         {...(bIsPassword !== undefined ? { bIsPassword } : {})}
         onChange={(e: ChangeEvent<HTMLInputElement>) => setValue(e.target.value)}
+        // Enter (the on-screen keyboard's "Eingabe" key) confirms, same as the OK
+        // button. ConfirmModal auto-closes on its OK button but not on this manual
+        // path, so close here too — handleOK is shared so the two never drift.
+        onKeyDown={(e: KeyboardEvent<HTMLInputElement>) => {
+          if (e.key === "Enter") {
+            handleOK();
+            closeModal?.();
+          }
+        }}
       />
     </ConfirmModal>
   );


### PR DESCRIPTION
Adds an on-screen-keyboard **Enter** confirm to every text-entry modal in the plugin. On the Steam Deck the OSK's "Eingabe" key — and the R2 shortcut that routes through it — now confirms the field, matching the copy-to-slot picker (#1556). Until now these fields could only be confirmed with the OK/Search button, so a controller user had to dismiss the keyboard and navigate to it.

Each field keeps its existing button; Enter is an additional path that reuses the same submit logic and the same empty/disabled guard:

- **Connection Settings** — API token, username, password, and the 8-box pairing code (Enter submits only when all eight boxes are filled)
- **New save slot** name (Saves tab) and the setup wizard's custom slot name — a blank/whitespace Enter is a no-op
- **Settings** text-edit modal (e.g. the server URL)
- **SteamGridDB** artwork search — Enter runs the search and does **not** close the modal

Live-filter fields (library and whitelist search) have nothing to confirm and are unchanged.

## Verification

Unit tests cover the DOM `keydown` contract for each field — a positive case plus the empty/incomplete negatives (blank slot name, incomplete pairing code). The real OSK-Enter / R2 dispatch can only be confirmed on hardware, so this **needs on-device testing in Game Mode / BPM, per modal**, before merge.

Closes #1562
