### PR TITLE
fix(settings): harden RomM sign-in and consolidate the connection/SteamGridDB UX

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -3,6 +3,6 @@
     "name": "dist/index.js (raw)",
     "path": "dist/index.js",
     "brotli": false,
-    "limit": "820 KB"
+    "limit": "830 KB"
   }
 ]

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -29,8 +29,10 @@ The Connection Settings page manages your RomM server connection.
   [Sign out](#sign-out)).
 - **Allow Insecure SSL** — shown only for `https://` URLs; skips certificate verification for self-signed certs (LAN
   only).
-- **Test Connection** — available once you are signed in; verifies the plugin can reach and authenticate with your RomM
-  server using the stored token.
+
+The plugin checks the connection for you — there is no manual "Test Connection" button. The **Connection** row on the
+plugin's main QAM panel shows the live status whenever you open it, and names the problem when it can't connect (for
+example _Sign-in rejected_, _Server unreachable_, or _No server URL_).
 
 ### Sign out
 
@@ -125,10 +127,11 @@ To set this up:
 
 1. Create a free account at [steamgriddb.com](https://www.steamgriddb.com/)
 2. Go to your [API preferences](https://www.steamgriddb.com/profile/preferences/api) and copy your API key
-3. In Connection Settings, paste it into the **API Key** field under "SteamGridDB"
-4. Tap **Verify Key** to confirm it works
+3. In Connection Settings, tap **Edit** next to **API Key** under "SteamGridDB" and paste your key
+4. Tap **Save** — the key is checked against SteamGridDB first, so an invalid key is rejected inline and only a working
+   key is stored
 
-<!-- Screenshot: SteamGridDB API Key section with Edit and Verify buttons -->
+<!-- Screenshot: SteamGridDB API Key section with the Edit button -->
 
 Without an API key, games will still have cover art from RomM but the hero banner, logo overlay, and wide grid image
 will be missing.

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -74,8 +74,10 @@ After installation, you need to connect the plugin to your RomM server:
 5. The **RomM Account** row shows **Signed in** on success. Once signed in, tap **Test Connection** to re-verify at any
    time
 
-On a controller, any text field in the plugin can be confirmed with the on-screen keyboard's **Enter** key (or the
-**R2** shortcut) instead of navigating to the button — this applies to sign-in, save-slot names, and the artwork search.
+On a controller you can confirm a text field with the on-screen keyboard's **Enter** key (or the **R2** shortcut)
+instead of navigating to the button — for example save-slot names and the artwork search. In the sign-in dialog, Enter
+moves from the username to the password field and confirms only once every required field is filled; an incomplete form
+can't be submitted, and **Cancel** leaves your existing sign-in untouched.
 
 The plugin mints a RomM Client API Token from the credentials you enter and discards the password — it is never stored.
 The same applies if the plugin auto-migrates an older install that still had a saved password: the password is discarded

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -71,8 +71,8 @@ After installation, you need to connect the plugin to your RomM server:
 2. Tap **Connection Settings**
 3. Enter your RomM server URL (e.g. `http://192.168.1.100:8080`) — this saves automatically
 4. Tap **Sign in**, enter your RomM username and password once, and confirm
-5. The **RomM Account** row shows **Signed in** on success. Once signed in, tap **Test Connection** to re-verify at any
-   time
+5. The **RomM Account** row shows **Signed in** on success. The plugin's main QAM panel has a **Connection** row that
+   shows the live connection status whenever you open it — there is no separate test button
 
 On a controller you can confirm a text field with the on-screen keyboard's **Enter** key (or the **R2** shortcut)
 instead of navigating to the button — for example save-slot names and the artwork search. In the sign-in dialog, Enter

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -54,8 +54,9 @@ config file.
 
 **Symptom**: Toast notifications say "RomM unreachable" or sync operations show in the Failed Syncs list.
 
-**Fix**: Check your network connection and verify the RomM server is running. Go to **Connection Settings** and tap
-**Test Connection**. Failed syncs are queued and retried automatically when the server is reachable again.
+**Fix**: Check your network connection and verify the RomM server is running. The **Connection** row on the plugin's
+main QAM panel shows the live status (and names the problem when it can't connect). Failed syncs are queued and retried
+automatically when the server is reachable again.
 
 ### Offline detection and recovery
 
@@ -175,8 +176,8 @@ For technical details, see [Steam Remote Play and Cross-Device Shortcuts](../arc
 
 ### Download shows no progress
 
-**Fix**: Check your connection to the RomM server (Connection Settings > Test Connection). If the server is reachable,
-try cancelling and restarting the download from the game detail page.
+**Fix**: Check your connection to the RomM server (the **Connection** row on the plugin's main QAM panel). If the server
+is reachable, try cancelling and restarting the download from the game detail page.
 
 ### Download failed
 

--- a/py_modules/services/connection.py
+++ b/py_modules/services/connection.py
@@ -62,6 +62,9 @@ _USER_TOKEN_INVALID_MESSAGE = "The API token is invalid or has been revoked. Cre
 _USER_TOKEN_SCOPE_MESSAGE = (
     "The API token is missing required permissions (scopes). Grant the scopes listed in the plugin docs and try again."
 )
+_USER_TOKEN_REJECTED_MESSAGE = (
+    "RomM rejected this token. Check you pasted it correctly and that it has the required scopes (see the plugin docs)."
+)
 
 # Pairing-code sign-in (``establish_paired_token``). The 60s single-use pairing
 # code is exchanged for a token over a public endpoint; each rejection carries a
@@ -366,6 +369,18 @@ class ConnectionService:
         except Exception as e:
             self._restore_auth_state(snapshot)
             self._romm_api.set_version(None)
+            # RomM answers the token-carrying probe with a 500 (a malformed token)
+            # or a 403 (a token-shaped but invalid/revoked one) instead of a clean
+            # 401, so a bad pasted token otherwise surfaces as a generic server
+            # error. The auth state is restored now (old token, or none), so a
+            # reachability probe that succeeds proves the server is up and the
+            # pasted token — not the server — is at fault.
+            if (await self.probe_reachability()).get("online"):
+                return {
+                    "success": False,
+                    "reason": ErrorCode.AUTH_FAILED.value,
+                    "message": _USER_TOKEN_REJECTED_MESSAGE,
+                }
             return error_response(e)
 
         version_error = self._version_gate_error(version)

--- a/py_modules/services/connection.py
+++ b/py_modules/services/connection.py
@@ -50,8 +50,8 @@ _NO_SERVER_URL_MESSAGE = "No server URL configured"
 _INVALID_URL_MESSAGE = "Enter a valid http(s):// server URL"
 
 _FORBIDDEN_TOKEN_MESSAGE = (
-    "Your RomM account cannot create API tokens — ask your admin to grant "
-    "token permissions or use an account with a higher role."
+    "RomM rejected the sign-in. Check your username and password — if they are correct, your account may not be "
+    "allowed to create API tokens (ask your admin or use an account with a higher role)."
 )
 
 # Pasted-token validation (``establish_user_token``): a 401 means the token
@@ -279,8 +279,10 @@ class ConnectionService:
             minted = await self._loop.run_in_executor(None, self._mint, username, password)
         except RommForbiddenError:
             # 403 on token mint: same AUTH_FAILED slug as a 401, but a distinct
-            # message — the account lacks token-creation permission (or a
-            # Cloudflare bot-fight 403 at the edge), not wrong credentials.
+            # message. RomM answers 403 indistinguishably for wrong credentials
+            # AND for an account that lacks token-creation permission (and a
+            # Cloudflare bot-fight 403 lands here too), so the message names both
+            # causes rather than asserting only the permission one.
             self._restore_auth_state(snapshot)
             return {"success": False, "reason": ErrorCode.AUTH_FAILED.value, "message": _FORBIDDEN_TOKEN_MESSAGE}
         except Exception as e:

--- a/src/components/MainPage.test.tsx
+++ b/src/components/MainPage.test.tsx
@@ -37,7 +37,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { render, fireEvent, act } from "@testing-library/react";
 import { createElement, type ReactElement } from "react";
-import { MainPage } from "./MainPage";
+import { MainPage, ConnectionIndicator } from "./MainPage";
 import * as backend from "../api/backend";
 import { useVersionError } from "./VersionErrorCard";
 import {
@@ -655,6 +655,56 @@ describe("MainPage", () => {
       const { container } = render(<MainPage onNavigate={vi.fn()} />);
       await flushAsync();
       expect(container.textContent).toContain("Not connected");
+    });
+
+    // A failed probe carries the backend's {reason, message}; the row shows a
+    // specific label instead of a bare "Not connected". version_error is not
+    // exercised here — a version failure short-circuits the whole panel to the
+    // VersionErrorCard (covered separately); the label mapping is covered by the
+    // direct-render cases below.
+    it.each([
+      ["auth_failed", "401 Unauthorized", "Sign-in rejected"],
+      ["server_unreachable", "timed out", "Server unreachable"],
+      ["config_error", "No server URL configured", "No server URL"],
+      ["config_error", "Not signed in — sign in to RomM first", "Not signed in"],
+      ["config_error", "some other config issue", "Not connected"],
+    ] as const)("a failed probe with reason=%s renders %s", async (reason, message, label) => {
+      vi.mocked(backend.testConnection).mockResolvedValue({ success: false, reason, message });
+      const { container } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+      expect(container.textContent).toContain(label);
+    });
+  });
+
+  // ===========================================================================
+  // D1. ConnectionIndicator — failure label mapping (direct render)
+  // ===========================================================================
+  describe("ConnectionIndicator failure labels", () => {
+    it.each([
+      ["auth_failed", "", "Sign-in rejected"],
+      ["server_unreachable", "", "Server unreachable"],
+      ["version_error", "server too old", "Unsupported RomM version"],
+      ["config_error", "No server URL configured", "No server URL"],
+      ["config_error", "Not signed in — sign in to RomM first", "Not signed in"],
+      ["config_error", "unclassified config problem", "Not connected"],
+      ["unknown", "", "Not connected"],
+    ] as const)("reason=%s / message=%s → %s", (reason, message, label) => {
+      const { container } = render(<ConnectionIndicator connected={false} failure={{ reason, message }} />);
+      expect(container.textContent).toContain(label);
+    });
+
+    it("falls back to 'Not connected' when no failure detail is present", () => {
+      const { container } = render(<ConnectionIndicator connected={false} failure={null} />);
+      expect(container.textContent).toContain("Not connected");
+    });
+
+    it("still renders the unchanged Connected / Checking… / Backend error states", () => {
+      const connected = render(<ConnectionIndicator connected={true} />);
+      expect(connected.container.textContent).toContain("Connected");
+      const checking = render(<ConnectionIndicator connected={null} />);
+      expect(checking.container.textContent).toContain("Checking...");
+      const failed = render(<ConnectionIndicator connected="backend_failed" />);
+      expect(failed.container.textContent).toContain("Backend error");
     });
   });
 

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -73,6 +73,7 @@ import type {
   SessionBudgetStatus,
   DownloadItem,
   MigrationStatus,
+  RommErrorCode,
 } from "../types";
 import { detach } from "../utils/detach";
 import { withTimeout } from "../utils/withTimeout";
@@ -98,6 +99,39 @@ const CONNECTION_CALLABLE_TIMEOUT = 5000;
 /** Backend never answered after the retry budget — distinct from `false` ("not connected"). */
 type BackendFailed = "backend_failed";
 
+/** A resolved-but-failed `test_connection()` probe. `reason`/`message` classify
+ *  why so the connection row shows a specific label instead of a bare "Not
+ *  connected"; both are absent when the probe never resolved (an unreachable
+ *  server that hung past every deadline), which reads as the generic label. */
+interface ConnectionFailure {
+  reason: RommErrorCode | undefined;
+  message: string;
+}
+
+/** The connection-row label for a failed probe, mapped from the backend's
+ *  `{reason, message}`. The two `config_error` sub-cases are split by message
+ *  text (the slug is shared). Anything unclassified falls back to the generic
+ *  "Not connected". `version_error` is included for completeness even though a
+ *  version failure short-circuits the whole panel to the VersionErrorCard. */
+function connectionFailureLabel(failure: ConnectionFailure | null | undefined): string {
+  const reason = failure?.reason;
+  const message = failure?.message ?? "";
+  switch (reason) {
+    case "auth_failed":
+      return "Sign-in rejected";
+    case "server_unreachable":
+      return "Server unreachable";
+    case "version_error":
+      return "Unsupported RomM version";
+    case "config_error":
+      if (/server url/i.test(message)) return "No server URL";
+      if (/not signed in/i.test(message)) return "Not signed in";
+      return "Not connected";
+    default:
+      return "Not connected";
+  }
+}
+
 /** Counted segments — ``[[count, word], …]`` → ``"353 new / 800 updated"``: every
  *  segment spells its word out, zero counts dropped, joined with `` / ``. Empty
  *  when every count is zero. The old ``+``/``~``/``−`` sigils were a legend the
@@ -109,7 +143,10 @@ function countedSegments(pairs: [number, string][]): string {
     .join(" / ");
 }
 
-const ConnectionIndicator: FC<{ connected: boolean | null | BackendFailed }> = ({ connected }) => {
+export const ConnectionIndicator: FC<{
+  connected: boolean | null | BackendFailed;
+  failure?: ConnectionFailure | null;
+}> = ({ connected, failure }) => {
   if (connected === "backend_failed") {
     return (
       <>
@@ -137,7 +174,7 @@ const ConnectionIndicator: FC<{ connected: boolean | null | BackendFailed }> = (
   return (
     <>
       <FaTimesCircle style={{ color: "#d4343c", fontSize: "14px" }} />
-      <span style={{ fontSize: "12px" }}>Not connected</span>
+      <span style={{ fontSize: "12px" }}>{connectionFailureLabel(failure)}</span>
     </>
   );
 };
@@ -423,6 +460,10 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
   const [stats, setStats] = useState<SyncStats | null>(null);
   const [budgetStatus, setBudgetStatus] = useState<SessionBudgetStatus | null>(null);
   const [connected, setConnected] = useState<boolean | null | BackendFailed>(null);
+  // Classifies a resolved-but-failed probe so the connection row can show a
+  // specific label (auth rejected / server unreachable / no URL / not signed
+  // in). Null for every non-failed state and for a probe that never resolved.
+  const [connectionFailure, setConnectionFailure] = useState<ConnectionFailure | null>(null);
   const versionError = useVersionError();
   const [syncing, setSyncing] = useState(false);
   // Disarmed "Cancelling…" state during the backend's RUNNING→CANCELLING→IDLE
@@ -499,6 +540,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
           const r = await withTimeout(testConnection(), CONNECTION_CALLABLE_TIMEOUT);
           if (isCancelled()) return;
           setConnected(r.success);
+          setConnectionFailure(r.success ? null : { reason: r.reason, message: r.message });
           setVersionError(r.reason === "version_error" ? r.message : null);
           return;
         } catch {
@@ -1289,7 +1331,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
             }
           >
             <div style={{ display: "flex", alignItems: "center", gap: "6px" }}>
-              <ConnectionIndicator connected={connected} />
+              <ConnectionIndicator connected={connected} failure={connectionFailure} />
             </div>
           </Field>
         </PanelSectionRow>

--- a/src/components/SettingsPage.test.tsx
+++ b/src/components/SettingsPage.test.tsx
@@ -619,9 +619,9 @@ describe("SettingsPage", () => {
       // Precondition: not yet connected.
       expect(capturedConnection[capturedConnection.length - 1]?.hasToken).toBe(false);
 
+      let result: { success: boolean; message: string } | undefined;
       await act(async () => {
-        capturedConnection[capturedConnection.length - 1]?.onConnect("daniel", "hunter2");
-        await Promise.resolve();
+        result = await capturedConnection[capturedConnection.length - 1]?.onConnect("daniel", "hunter2");
       });
 
       expect(vi.mocked(backend.connectWithCredentials)).toHaveBeenCalledWith(
@@ -630,12 +630,13 @@ describe("SettingsPage", () => {
         "hunter2",
         false,
       );
+      expect(result).toMatchObject({ success: true, message: "Connected!" });
       const conn = capturedConnection[capturedConnection.length - 1];
       expect(conn?.status).toBe("Connected!");
       expect(conn?.hasToken).toBe(true);
     });
 
-    it("surfaces the failure message without setting hasToken (e.g. 403 auth_failed)", async () => {
+    it("returns the failure to the modal without setting hasToken or the bottom status (e.g. 403 auth_failed)", async () => {
       vi.mocked(backend.getSettings).mockResolvedValue({
         ...defaultSettings(),
         has_token: false,
@@ -648,17 +649,19 @@ describe("SettingsPage", () => {
       render(<SettingsPage onBack={vi.fn()} />);
       await flushAsync();
 
+      let result: { success: boolean; message: string } | undefined;
       await act(async () => {
-        capturedConnection[capturedConnection.length - 1]?.onConnect("admin", "pw");
-        await Promise.resolve();
+        result = await capturedConnection[capturedConnection.length - 1]?.onConnect("admin", "pw");
       });
 
+      // The still-open modal surfaces the message; the bottom status stays clear.
+      expect(result).toMatchObject({ success: false, message: "This account cannot create API tokens." });
       const conn = capturedConnection[capturedConnection.length - 1];
-      expect(conn?.status).toBe("This account cannot create API tokens.");
+      expect(conn?.status).toBe("");
       expect(conn?.hasToken).toBe(false);
     });
 
-    it("rejects an invalid URL inline without calling connectWithCredentials", async () => {
+    it("returns an invalid-URL failure to the modal without calling connectWithCredentials", async () => {
       vi.mocked(backend.getSettings).mockResolvedValue({
         ...defaultSettings(),
         romm_url: "romm.local", // scheme-less — invalid
@@ -667,28 +670,28 @@ describe("SettingsPage", () => {
       render(<SettingsPage onBack={vi.fn()} />);
       await flushAsync();
 
+      let result: { success: boolean; message: string } | undefined;
       await act(async () => {
-        capturedConnection[capturedConnection.length - 1]?.onConnect("daniel", "hunter2");
-        await Promise.resolve();
+        result = await capturedConnection[capturedConnection.length - 1]?.onConnect("daniel", "hunter2");
       });
 
       expect(vi.mocked(backend.connectWithCredentials)).not.toHaveBeenCalled();
-      expect(capturedConnection[capturedConnection.length - 1]?.status).toBe(
-        "Enter a valid http:// or https:// server URL",
-      );
+      expect(result).toEqual({ success: false, message: "Enter a valid http:// or https:// server URL" });
+      expect(capturedConnection[capturedConnection.length - 1]?.status).toBe("");
     });
 
-    it("sets status='Sign-in failed' when connectWithCredentials throws", async () => {
+    it("returns a generic failure to the modal when connectWithCredentials throws", async () => {
       vi.mocked(backend.connectWithCredentials).mockRejectedValue(new Error("net"));
       render(<SettingsPage onBack={vi.fn()} />);
       await flushAsync();
 
+      let result: { success: boolean; message: string } | undefined;
       await act(async () => {
-        capturedConnection[capturedConnection.length - 1]?.onConnect("daniel", "hunter2");
-        await Promise.resolve();
+        result = await capturedConnection[capturedConnection.length - 1]?.onConnect("daniel", "hunter2");
       });
 
-      expect(capturedConnection[capturedConnection.length - 1]?.status).toBe("Sign-in failed");
+      expect(result).toEqual({ success: false, message: "Sign-in failed. Check your connection and try again." });
+      expect(capturedConnection[capturedConnection.length - 1]?.status).toBe("");
     });
   });
 
@@ -707,18 +710,19 @@ describe("SettingsPage", () => {
       await flushAsync();
       expect(capturedConnection[capturedConnection.length - 1]?.hasToken).toBe(false);
 
+      let result: { success: boolean; message: string } | undefined;
       await act(async () => {
-        capturedConnection[capturedConnection.length - 1]?.onConnectToken("rmm_pasted");
-        await Promise.resolve();
+        result = await capturedConnection[capturedConnection.length - 1]?.onConnectToken("rmm_pasted");
       });
 
       expect(vi.mocked(backend.connectWithToken)).toHaveBeenCalledWith("https://romm.local", "rmm_pasted", false);
+      expect(result).toMatchObject({ success: true, message: "Connected!" });
       const conn = capturedConnection[capturedConnection.length - 1];
       expect(conn?.status).toBe("Connected!");
       expect(conn?.hasToken).toBe(true);
     });
 
-    it("surfaces the failure message without setting hasToken (e.g. 403 scope error)", async () => {
+    it("returns the failure to the modal without setting hasToken or the bottom status (e.g. 403 scope error)", async () => {
       vi.mocked(backend.getSettings).mockResolvedValue({
         ...defaultSettings(),
         has_token: false,
@@ -731,17 +735,21 @@ describe("SettingsPage", () => {
       render(<SettingsPage onBack={vi.fn()} />);
       await flushAsync();
 
+      let result: { success: boolean; message: string } | undefined;
       await act(async () => {
-        capturedConnection[capturedConnection.length - 1]?.onConnectToken("rmm_readonly");
-        await Promise.resolve();
+        result = await capturedConnection[capturedConnection.length - 1]?.onConnectToken("rmm_readonly");
       });
 
+      expect(result).toMatchObject({
+        success: false,
+        message: "The API token is missing required permissions (scopes).",
+      });
       const conn = capturedConnection[capturedConnection.length - 1];
-      expect(conn?.status).toBe("The API token is missing required permissions (scopes).");
+      expect(conn?.status).toBe("");
       expect(conn?.hasToken).toBe(false);
     });
 
-    it("rejects an invalid URL inline without calling connectWithToken", async () => {
+    it("returns an invalid-URL failure to the modal without calling connectWithToken", async () => {
       vi.mocked(backend.getSettings).mockResolvedValue({
         ...defaultSettings(),
         romm_url: "romm.local", // scheme-less — invalid
@@ -750,28 +758,28 @@ describe("SettingsPage", () => {
       render(<SettingsPage onBack={vi.fn()} />);
       await flushAsync();
 
+      let result: { success: boolean; message: string } | undefined;
       await act(async () => {
-        capturedConnection[capturedConnection.length - 1]?.onConnectToken("rmm_pasted");
-        await Promise.resolve();
+        result = await capturedConnection[capturedConnection.length - 1]?.onConnectToken("rmm_pasted");
       });
 
       expect(vi.mocked(backend.connectWithToken)).not.toHaveBeenCalled();
-      expect(capturedConnection[capturedConnection.length - 1]?.status).toBe(
-        "Enter a valid http:// or https:// server URL",
-      );
+      expect(result).toEqual({ success: false, message: "Enter a valid http:// or https:// server URL" });
+      expect(capturedConnection[capturedConnection.length - 1]?.status).toBe("");
     });
 
-    it("sets status='Sign-in failed' when connectWithToken throws", async () => {
+    it("returns a generic failure to the modal when connectWithToken throws", async () => {
       vi.mocked(backend.connectWithToken).mockRejectedValue(new Error("net"));
       render(<SettingsPage onBack={vi.fn()} />);
       await flushAsync();
 
+      let result: { success: boolean; message: string } | undefined;
       await act(async () => {
-        capturedConnection[capturedConnection.length - 1]?.onConnectToken("rmm_pasted");
-        await Promise.resolve();
+        result = await capturedConnection[capturedConnection.length - 1]?.onConnectToken("rmm_pasted");
       });
 
-      expect(capturedConnection[capturedConnection.length - 1]?.status).toBe("Sign-in failed");
+      expect(result).toEqual({ success: false, message: "Sign-in failed. Check your connection and try again." });
+      expect(capturedConnection[capturedConnection.length - 1]?.status).toBe("");
     });
   });
 
@@ -790,20 +798,21 @@ describe("SettingsPage", () => {
       await flushAsync();
       expect(capturedConnection[capturedConnection.length - 1]?.hasToken).toBe(false);
 
+      let result: { success: boolean; message: string } | undefined;
       await act(async () => {
-        capturedConnection[capturedConnection.length - 1]?.onConnectPairing("ABCD2345");
-        await Promise.resolve();
+        result = await capturedConnection[capturedConnection.length - 1]?.onConnectPairing("ABCD2345");
       });
 
       expect(vi.mocked(backend.connectWithPairingCode)).toHaveBeenCalledWith("https://romm.local", "ABCD2345", false);
       // The paired flow must not fall through to the pasted-token callable.
       expect(vi.mocked(backend.connectWithToken)).not.toHaveBeenCalled();
+      expect(result).toMatchObject({ success: true, message: "Connected!" });
       const conn = capturedConnection[capturedConnection.length - 1];
       expect(conn?.status).toBe("Connected!");
       expect(conn?.hasToken).toBe(true);
     });
 
-    it("surfaces the failure message without setting hasToken (e.g. expired code)", async () => {
+    it("returns the failure to the modal without setting hasToken or the bottom status (e.g. expired code)", async () => {
       vi.mocked(backend.getSettings).mockResolvedValue({
         ...defaultSettings(),
         has_token: false,
@@ -816,17 +825,18 @@ describe("SettingsPage", () => {
       render(<SettingsPage onBack={vi.fn()} />);
       await flushAsync();
 
+      let result: { success: boolean; message: string } | undefined;
       await act(async () => {
-        capturedConnection[capturedConnection.length - 1]?.onConnectPairing("BADCODE1");
-        await Promise.resolve();
+        result = await capturedConnection[capturedConnection.length - 1]?.onConnectPairing("BADCODE1");
       });
 
+      expect(result).toMatchObject({ success: false, message: "Pairing code is invalid or has expired." });
       const conn = capturedConnection[capturedConnection.length - 1];
-      expect(conn?.status).toBe("Pairing code is invalid or has expired.");
+      expect(conn?.status).toBe("");
       expect(conn?.hasToken).toBe(false);
     });
 
-    it("rejects an invalid URL inline without calling connectWithPairingCode", async () => {
+    it("returns an invalid-URL failure to the modal without calling connectWithPairingCode", async () => {
       vi.mocked(backend.getSettings).mockResolvedValue({
         ...defaultSettings(),
         romm_url: "romm.local", // scheme-less — invalid
@@ -835,28 +845,28 @@ describe("SettingsPage", () => {
       render(<SettingsPage onBack={vi.fn()} />);
       await flushAsync();
 
+      let result: { success: boolean; message: string } | undefined;
       await act(async () => {
-        capturedConnection[capturedConnection.length - 1]?.onConnectPairing("ABCD2345");
-        await Promise.resolve();
+        result = await capturedConnection[capturedConnection.length - 1]?.onConnectPairing("ABCD2345");
       });
 
       expect(vi.mocked(backend.connectWithPairingCode)).not.toHaveBeenCalled();
-      expect(capturedConnection[capturedConnection.length - 1]?.status).toBe(
-        "Enter a valid http:// or https:// server URL",
-      );
+      expect(result).toEqual({ success: false, message: "Enter a valid http:// or https:// server URL" });
+      expect(capturedConnection[capturedConnection.length - 1]?.status).toBe("");
     });
 
-    it("sets status='Sign-in failed' when connectWithPairingCode throws", async () => {
+    it("returns a generic failure to the modal when connectWithPairingCode throws", async () => {
       vi.mocked(backend.connectWithPairingCode).mockRejectedValue(new Error("net"));
       render(<SettingsPage onBack={vi.fn()} />);
       await flushAsync();
 
+      let result: { success: boolean; message: string } | undefined;
       await act(async () => {
-        capturedConnection[capturedConnection.length - 1]?.onConnectPairing("ABCD2345");
-        await Promise.resolve();
+        result = await capturedConnection[capturedConnection.length - 1]?.onConnectPairing("ABCD2345");
       });
 
-      expect(capturedConnection[capturedConnection.length - 1]?.status).toBe("Sign-in failed");
+      expect(result).toEqual({ success: false, message: "Sign-in failed. Check your connection and try again." });
+      expect(capturedConnection[capturedConnection.length - 1]?.status).toBe("");
     });
   });
 

--- a/src/components/SettingsPage.test.tsx
+++ b/src/components/SettingsPage.test.tsx
@@ -597,7 +597,7 @@ describe("SettingsPage", () => {
       });
 
       // The .catch sets setStatus("Failed to save settings") — assert it
-      // surfaced via ConnectionSection.status (mirrors the handleTest throw test).
+      // surfaced via ConnectionSection.status.
       const last = capturedConnection[capturedConnection.length - 1];
       expect(last?.status).toBe("Failed to save settings");
     });
@@ -940,37 +940,6 @@ describe("SettingsPage", () => {
     });
   });
 
-  describe("handleTest", () => {
-    it("forwards the result message into ConnectionSection.status on success", async () => {
-      vi.mocked(backend.testConnection).mockResolvedValue({
-        success: true,
-        message: "Connected!",
-      });
-      render(<SettingsPage onBack={vi.fn()} />);
-      await flushAsync();
-
-      await act(async () => {
-        capturedConnection[capturedConnection.length - 1]?.onTestConnection();
-        await Promise.resolve();
-      });
-
-      expect(capturedConnection[capturedConnection.length - 1]?.status).toBe("Connected!");
-    });
-
-    it("sets status='Connection test failed' on throw", async () => {
-      vi.mocked(backend.testConnection).mockRejectedValue(new Error("boom"));
-      render(<SettingsPage onBack={vi.fn()} />);
-      await flushAsync();
-
-      await act(async () => {
-        capturedConnection[capturedConnection.length - 1]?.onTestConnection();
-        await Promise.resolve();
-      });
-
-      expect(capturedConnection[capturedConnection.length - 1]?.status).toBe("Connection test failed");
-    });
-  });
-
   describe("handleSaveSyncSettingChange", () => {
     it("does nothing when saveSyncSettings is still null", async () => {
       // Cause getSaveSyncSettings to never resolve — saveSyncSettings stays null.
@@ -1306,81 +1275,41 @@ describe("SettingsPage", () => {
   });
 
   describe("SteamGridDB handlers", () => {
-    it("handleSgdbKeySubmit success with a non-empty value sets sgdbApiKey='set' and surfaces result.message", async () => {
-      vi.mocked(backend.saveSgdbApiKey).mockResolvedValue({
-        success: true,
-        message: "Saved!",
-      });
+    it("wires onVerifyKey directly to the verifySgdbApiKey callable (tests the key without persisting)", async () => {
+      vi.mocked(backend.verifySgdbApiKey).mockResolvedValue({ success: true, message: "API key is valid" });
       render(<SettingsPage onBack={vi.fn()} />);
       await flushAsync();
-      await act(async () => {
-        capturedSgdb[capturedSgdb.length - 1]?.onSubmitKey("apikey123");
-      });
       const sgdb = capturedSgdb[capturedSgdb.length - 1];
-      expect(sgdb?.sgdbApiKey).toBe("set");
-      expect(sgdb?.sgdbStatus).toBe("Saved!");
+      await act(async () => {
+        await sgdb?.onVerifyKey("apikey123");
+      });
+      expect(vi.mocked(backend.verifySgdbApiKey)).toHaveBeenCalledWith("apikey123");
+      // Verifying never persists — that is the modal's second step (onSaveKey).
+      expect(vi.mocked(backend.saveSgdbApiKey)).not.toHaveBeenCalled();
     });
 
-    it("handleSgdbKeySubmit success with an empty value clears the masked sgdbApiKey", async () => {
-      vi.mocked(backend.saveSgdbApiKey).mockResolvedValue({
-        success: true,
-        message: "Cleared",
-      });
+    it("handleSaveSgdbKey persists via saveSgdbApiKey and flips the masked display to a configured key", async () => {
+      vi.mocked(backend.saveSgdbApiKey).mockResolvedValue({ success: true, message: "Saved!" });
       render(<SettingsPage onBack={vi.fn()} />);
       await flushAsync();
       await act(async () => {
-        capturedSgdb[capturedSgdb.length - 1]?.onSubmitKey("");
+        await capturedSgdb[capturedSgdb.length - 1]?.onSaveKey("apikey123");
       });
-      expect(capturedSgdb[capturedSgdb.length - 1]?.sgdbApiKey).toBe("");
+      expect(vi.mocked(backend.saveSgdbApiKey)).toHaveBeenCalledWith("apikey123");
+      // A configured key renders as the masked "••••" (sgdbApiKey truthy).
+      expect(capturedSgdb[capturedSgdb.length - 1]?.sgdbApiKey).toBe("set");
     });
 
-    it("handleSgdbKeySubmit sets sgdbStatus='Failed to save API key' on throw", async () => {
+    it("handleSaveSgdbKey lets a save rejection propagate so the modal can surface it", async () => {
       vi.mocked(backend.saveSgdbApiKey).mockRejectedValue(new Error("boom"));
       render(<SettingsPage onBack={vi.fn()} />);
       await flushAsync();
-      await act(async () => {
-        capturedSgdb[capturedSgdb.length - 1]?.onSubmitKey("k");
-      });
-      expect(capturedSgdb[capturedSgdb.length - 1]?.sgdbStatus).toBe("Failed to save API key");
-    });
-
-    it("handleSgdbVerify success=true sets sgdbStatus='Valid'", async () => {
-      vi.mocked(backend.verifySgdbApiKey).mockResolvedValue({
-        success: true,
-        message: "any",
-      });
-      render(<SettingsPage onBack={vi.fn()} />);
-      await flushAsync();
-      await act(async () => {
-        capturedSgdb[capturedSgdb.length - 1]?.onVerifyKey();
-        await Promise.resolve();
-      });
-      expect(capturedSgdb[capturedSgdb.length - 1]?.sgdbStatus).toBe("Valid");
-    });
-
-    it("handleSgdbVerify success=false surfaces result.message", async () => {
-      vi.mocked(backend.verifySgdbApiKey).mockResolvedValue({
-        success: false,
-        message: "Invalid key",
-      });
-      render(<SettingsPage onBack={vi.fn()} />);
-      await flushAsync();
-      await act(async () => {
-        capturedSgdb[capturedSgdb.length - 1]?.onVerifyKey();
-        await Promise.resolve();
-      });
-      expect(capturedSgdb[capturedSgdb.length - 1]?.sgdbStatus).toBe("Invalid key");
-    });
-
-    it("handleSgdbVerify throws → sgdbStatus='Verification failed'", async () => {
-      vi.mocked(backend.verifySgdbApiKey).mockRejectedValue(new Error("net"));
-      render(<SettingsPage onBack={vi.fn()} />);
-      await flushAsync();
-      await act(async () => {
-        capturedSgdb[capturedSgdb.length - 1]?.onVerifyKey();
-        await Promise.resolve();
-      });
-      expect(capturedSgdb[capturedSgdb.length - 1]?.sgdbStatus).toBe("Verification failed");
+      const sgdb = capturedSgdb[capturedSgdb.length - 1];
+      // The handler does not swallow — the modal's own try/catch owns the error
+      // UI, so onSaveKey must reject rather than resolve.
+      await expect(sgdb?.onSaveKey("k")).rejects.toThrow("boom");
+      // A failed save must not flip the masked display to configured.
+      expect(capturedSgdb[capturedSgdb.length - 1]?.sgdbApiKey).toBe("");
     });
   });
 

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -54,6 +54,12 @@ interface SettingsPageProps {
   onBack: () => void;
 }
 
+// Messages the connect handlers return to the ConnectModal (which surfaces them
+// inline) when the sign-in can't even be attempted or the callable throws. The
+// URL guard message mirrors the one the URL editor already shows.
+const INVALID_URL_MESSAGE = "Enter a valid http:// or https:// server URL";
+const GENERIC_SIGN_IN_ERROR = "Sign-in failed. Check your connection and try again.";
+
 export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
   // Connection state
   const [url, setUrl] = useState("");
@@ -297,55 +303,56 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
       setStatus("Failed to save settings");
     });
   };
-  const handleConnect = async (username: string, password: string) => {
-    setStatus("");
+  // The connect handlers return their result to the ConnectModal, which owns
+  // closing (on success) and error display (on failure). The bottom status line
+  // is only touched on success — a post-close confirmation — so a failed sign-in
+  // shows its message inside the still-open modal, never at the bottom.
+  const handleConnect = async (username: string, password: string): Promise<{ success: boolean; message: string }> => {
     const trimmed = trimServerUrl(url);
     if (!isValidServerUrl(trimmed)) {
-      setStatus("Enter a valid http:// or https:// server URL");
-      return;
+      return { success: false, message: INVALID_URL_MESSAGE };
     }
     try {
       const result = await connectWithCredentials(trimmed, username, password, allowInsecureSsl);
-      setStatus(result.message);
       if (result.success) {
         setHasToken(true);
+        setStatus(result.message);
       }
+      return result;
     } catch {
-      setStatus("Sign-in failed");
+      return { success: false, message: GENERIC_SIGN_IN_ERROR };
     }
   };
-  const handleConnectToken = async (token: string) => {
-    setStatus("");
+  const handleConnectToken = async (token: string): Promise<{ success: boolean; message: string }> => {
     const trimmed = trimServerUrl(url);
     if (!isValidServerUrl(trimmed)) {
-      setStatus("Enter a valid http:// or https:// server URL");
-      return;
+      return { success: false, message: INVALID_URL_MESSAGE };
     }
     try {
       const result = await connectWithToken(trimmed, token, allowInsecureSsl);
-      setStatus(result.message);
       if (result.success) {
         setHasToken(true);
+        setStatus(result.message);
       }
+      return result;
     } catch {
-      setStatus("Sign-in failed");
+      return { success: false, message: GENERIC_SIGN_IN_ERROR };
     }
   };
-  const handleConnectPairing = async (code: string) => {
-    setStatus("");
+  const handleConnectPairing = async (code: string): Promise<{ success: boolean; message: string }> => {
     const trimmed = trimServerUrl(url);
     if (!isValidServerUrl(trimmed)) {
-      setStatus("Enter a valid http:// or https:// server URL");
-      return;
+      return { success: false, message: INVALID_URL_MESSAGE };
     }
     try {
       const result = await connectWithPairingCode(trimmed, code, allowInsecureSsl);
-      setStatus(result.message);
       if (result.success) {
         setHasToken(true);
+        setStatus(result.message);
       }
+      return result;
     } catch {
-      setStatus("Sign-in failed");
+      return { success: false, message: GENERIC_SIGN_IN_ERROR };
     }
   };
   const handleSignOut = async () => {
@@ -534,15 +541,9 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
         onUrlChange={(value) => {
           detach(handleUrlChange(value));
         }}
-        onConnect={(username, password) => {
-          detach(handleConnect(username, password));
-        }}
-        onConnectToken={(token) => {
-          detach(handleConnectToken(token));
-        }}
-        onConnectPairing={(code) => {
-          detach(handleConnectPairing(code));
-        }}
+        onConnect={handleConnect}
+        onConnectToken={handleConnectToken}
+        onConnectPairing={handleConnectPairing}
         onAllowInsecureSslChange={handleAllowInsecureSslChange}
         onTestConnection={() => {
           detach(handleTest());

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -8,7 +8,6 @@ import {
   connectWithToken,
   connectWithPairingCode,
   signOut,
-  testConnection,
   saveSgdbApiKey,
   verifySgdbApiKey,
   saveSteamInputSetting,
@@ -65,13 +64,10 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
   const [url, setUrl] = useState("");
   const [hasToken, setHasToken] = useState(false);
   const [status, setStatus] = useState("");
-  const [loading, setLoading] = useState(false);
   const [allowInsecureSsl, setAllowInsecureSsl] = useState(false);
 
   // SteamGridDB state
   const [sgdbApiKey, setSgdbApiKey] = useState("");
-  const [sgdbStatus, setSgdbStatus] = useState("");
-  const [sgdbVerifying, setSgdbVerifying] = useState(false);
 
   // Save Sync state
   const [saveSyncSettings, setSaveSyncSettings] = useState<SaveSyncSettingsType | null>(null);
@@ -186,18 +182,6 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
         setDevicesLoading(false);
       });
   }
-
-  const handleTest = async () => {
-    setLoading(true);
-    setStatus("");
-    try {
-      const result = await testConnection();
-      setStatus(result.message);
-    } catch {
-      setStatus("Connection test failed");
-    }
-    setLoading(false);
-  };
 
   const handleSaveSyncSettingChange = async (partial: Partial<SaveSyncSettingsType>) => {
     if (!saveSyncSettings) return;
@@ -369,26 +353,13 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
   };
 
   // --- SteamGridDB handlers ---
-  const handleSgdbKeySubmit = async (value: string) => {
-    setSgdbStatus("");
-    try {
-      const result = await saveSgdbApiKey(value);
-      setSgdbApiKey(value ? "set" : "");
-      setSgdbStatus(result.message);
-    } catch {
-      setSgdbStatus("Failed to save API key");
-    }
-  };
-  const handleSgdbVerify = async () => {
-    setSgdbVerifying(true);
-    setSgdbStatus("");
-    try {
-      const result = await verifySgdbApiKey("");
-      setSgdbStatus(result.success ? "Valid" : result.message);
-    } catch {
-      setSgdbStatus("Verification failed");
-    }
-    setSgdbVerifying(false);
+  // SgdbApiKeyModal orchestrates verify-then-save: it tests the entered key
+  // (verifySgdbApiKey) and only persists a valid one (handleSaveSgdbKey). The
+  // modal always submits a non-empty key, so a successful save means a
+  // configured key — reflect it as the masked "••••" display.
+  const handleSaveSgdbKey = async (value: string) => {
+    await saveSgdbApiKey(value);
+    setSgdbApiKey("set");
   };
 
   // --- Save-sync default-slot handlers ---
@@ -537,7 +508,6 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
         hasToken={hasToken}
         allowInsecureSsl={allowInsecureSsl}
         status={status}
-        loading={loading}
         onUrlChange={(value) => {
           detach(handleUrlChange(value));
         }}
@@ -545,24 +515,11 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
         onConnectToken={handleConnectToken}
         onConnectPairing={handleConnectPairing}
         onAllowInsecureSslChange={handleAllowInsecureSslChange}
-        onTestConnection={() => {
-          detach(handleTest());
-        }}
         onSignOut={() => {
           detach(handleSignOut());
         }}
       />
-      <SteamGridDBSection
-        sgdbApiKey={sgdbApiKey}
-        sgdbStatus={sgdbStatus}
-        sgdbVerifying={sgdbVerifying}
-        onSubmitKey={(value: string) => {
-          detach(handleSgdbKeySubmit(value));
-        }}
-        onVerifyKey={() => {
-          detach(handleSgdbVerify());
-        }}
-      />
+      <SteamGridDBSection sgdbApiKey={sgdbApiKey} onVerifyKey={verifySgdbApiKey} onSaveKey={handleSaveSgdbKey} />
       <SaveSyncSection
         saveSyncSettings={saveSyncSettings}
         saveSyncToggleKey={saveSyncToggleKey}
@@ -591,7 +548,9 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
         steamInputStatus={steamInputStatus}
         retroarchWarning={retroarchWarning}
         retroarchFixStatus={retroarchFixStatus}
-        loading={loading}
+        // No manual connection test remains to drive a shared loading flag; the
+        // Apply button is never gated on one.
+        loading={false}
         onModeChange={handleSteamInputModeChange}
         onApplyMode={() => {
           detach(handleApplySteamInput());

--- a/src/components/settings/ConnectModal.test.tsx
+++ b/src/components/settings/ConnectModal.test.tsx
@@ -331,14 +331,27 @@ describe("ConnectModal", () => {
       expect(closeModal).toHaveBeenCalledTimes(1);
     });
 
-    it("ignores Enter in the token field while it is empty", () => {
+    it("ignores Enter on an empty token field and consumes the event so the modal cannot close", () => {
       const onConnectToken = ok();
+      const closeModal = vi.fn();
       const { getByTestId } = render(
-        <ConnectModal onConnect={ok()} onConnectToken={onConnectToken} onConnectPairing={ok()} />,
+        <ConnectModal
+          closeModal={closeModal}
+          onConnect={ok()}
+          onConnectToken={onConnectToken}
+          onConnectPairing={ok()}
+        />,
       );
       fireEvent.click(getByTestId("mode-token"));
-      fireEvent.keyDown(getByTestId("field-API Token"), { key: "Enter" });
+      // fireEvent returns false when a handler called preventDefault. The handler
+      // must consume the Enter so Steam's ModalRoot cannot fire its own default
+      // confirm/close on the empty field — the Deck regression. The real close
+      // can't be reproduced in happy-dom, so a consumed event is the observable
+      // proxy that the fix is in place, alongside the no-submit/no-close effects.
+      const notPrevented = fireEvent.keyDown(getByTestId("field-API Token"), { key: "Enter" });
+      expect(notPrevented).toBe(false);
       expect(onConnectToken).not.toHaveBeenCalled();
+      expect(closeModal).not.toHaveBeenCalled();
     });
 
     it("switches back to credentials mode and calls onConnect again", async () => {

--- a/src/components/settings/ConnectModal.test.tsx
+++ b/src/components/settings/ConnectModal.test.tsx
@@ -1,20 +1,19 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, fireEvent } from "@testing-library/react";
+import { render, fireEvent, act } from "@testing-library/react";
 import { createElement, forwardRef } from "react";
 import { ConnectModal } from "./ConnectModal";
 
-// Local @decky/ui mock: ConfirmModal exposes its OK button (driving onOK) so
-// the submit path is exercised; TextField forwards label + value + onChange +
+// Local @decky/ui mock: ModalRoot passes its children through (the modal owns its
+// own footer buttons); DialogButton renders a real <button> forwarding onClick +
+// disabled + children so the Sign in / Cancel buttons are clickable and their
+// disabled state is assertable (a disabled button swallows the click in happy-dom,
+// mirroring the real gate); TextField forwards label + value + onChange +
 // onKeyDown to a real <input> (mirroring the real component's typed contract —
 // TextFieldProps extends HTMLAttributes<HTMLInputElement>) so each field can be
-// typed into, receive key events, and be focused; DropdownItem renders one
-// button per option (data-testid `mode-<data>`) that drives onChange so a test
-// can flip the sign-in mode.
+// typed into, receive key events, and be focused; DropdownItem renders one button
+// per option (data-testid `mode-<data>`) that drives onChange so a test can flip
+// the sign-in mode.
 type AnyProps = Record<string, unknown> & { children?: unknown };
-interface ConfirmModalProps extends AnyProps {
-  onOK?: () => void;
-  strOKButtonText?: string;
-}
 interface TextFieldProps {
   label?: string;
   value?: string;
@@ -36,6 +35,9 @@ interface DropdownItemProps {
 const textFields: TextFieldProps[] = [];
 
 vi.mock("@decky/ui", () => ({
+  // ModalRoot is the bare shell — it renders its children and nothing else (no
+  // strTitle, no OK button), so the modal supplies its own footer.
+  ModalRoot: (p: AnyProps) => createElement("div", { "data-testid": "modal-root" }, p.children as never),
   // Focusable forwards its ref to the wrapping div so the component's
   // querySelectorAll('input') focus-advance resolves against the boxes.
   Focusable: forwardRef<HTMLDivElement, AnyProps>((p, ref) =>
@@ -45,13 +47,8 @@ vi.mock("@decky/ui", () => ({
       p.children as never,
     ),
   ),
-  ConfirmModal: (p: ConfirmModalProps) =>
-    createElement(
-      "div",
-      {},
-      p.children as never,
-      createElement("button", { "data-testid": "ok-button", onClick: () => p.onOK?.() }, p.strOKButtonText ?? "OK"),
-    ),
+  DialogButton: ({ children, onClick, disabled }: AnyProps & { onClick?: () => void; disabled?: boolean }) =>
+    createElement("button", { onClick, disabled }, children as never),
   TextField: (p: TextFieldProps) => {
     textFields.push(p);
     return createElement("input", {
@@ -76,6 +73,22 @@ vi.mock("@decky/ui", () => ({
     ),
 }));
 
+// Resolved-success default so a click that reaches submit() closes the modal.
+const ok = (message = "Connected!") => vi.fn().mockResolvedValue({ success: true, message });
+const fail = (message: string) => vi.fn().mockResolvedValue({ success: false, message });
+
+// Flush the floating submit() promise (onClick fires `void submit()`), then let
+// React apply the resulting state updates. Two microtask ticks cover the single
+// `await onConnect(...)` plus its finally block.
+async function flushSubmit() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+const signInButton = (getByText: (t: string) => HTMLElement): HTMLElement => getByText("Sign in");
+
 describe("ConnectModal", () => {
   beforeEach(() => {
     textFields.length = 0;
@@ -83,16 +96,14 @@ describe("ConnectModal", () => {
   });
 
   it("lists the sign-in methods in order: pairing, token, credentials", () => {
-    const { getByTestId } = render(
-      <ConnectModal onConnect={vi.fn()} onConnectToken={vi.fn()} onConnectPairing={vi.fn()} />,
-    );
+    const { getByTestId } = render(<ConnectModal onConnect={ok()} onConnectToken={ok()} onConnectPairing={ok()} />);
     const options = Array.from(getByTestId("mode-dropdown").querySelectorAll("button")).map((b) => b.textContent);
     expect(options).toEqual(["Pairing code", "API token", "Username & password"]);
   });
 
   it("opens in pairing mode by default", () => {
     const { getByTestId, queryByTestId } = render(
-      <ConnectModal onConnect={vi.fn()} onConnectToken={vi.fn()} onConnectPairing={vi.fn()} />,
+      <ConnectModal onConnect={ok()} onConnectToken={ok()} onConnectPairing={ok()} />,
     );
     // No dropdown interaction — the pairing-code boxes are the ones shown on first render.
     expect(getByTestId("mode-dropdown").getAttribute("data-selected")).toBe("pairing");
@@ -101,11 +112,98 @@ describe("ConnectModal", () => {
     expect(queryByTestId("field-API Token")).toBeNull();
   });
 
+  it("renders a Sign in and a Cancel footer button; Cancel closes the modal", () => {
+    const closeModal = vi.fn();
+    const { getByText } = render(
+      <ConnectModal closeModal={closeModal} onConnect={ok()} onConnectToken={ok()} onConnectPairing={ok()} />,
+    );
+    expect(getByText("Sign in")).toBeTruthy();
+    fireEvent.click(getByText("Cancel"));
+    expect(closeModal).toHaveBeenCalledTimes(1);
+  });
+
+  describe("Sign in gating (fields required before submit)", () => {
+    it("disables Sign in in pairing mode until all eight boxes are filled", () => {
+      const { getByTestId, getByText } = render(
+        <ConnectModal onConnect={ok()} onConnectToken={ok()} onConnectPairing={ok()} />,
+      );
+      fireEvent.click(getByTestId("mode-pairing"));
+      const inputs = () => getByTestId("pairing-code-row").querySelectorAll("input");
+      expect(signInButton(getByText)).toBeDisabled();
+      // A partial code (first four boxes) is still not enough.
+      fireEvent.change(inputs()[0]!, { target: { value: "abcd" } });
+      expect(signInButton(getByText)).toBeDisabled();
+      // Fill the remaining four (the paste left focus on box 4) — now enabled.
+      fireEvent.change(inputs()[4]!, { target: { value: "efgh" } });
+      expect(signInButton(getByText)).not.toBeDisabled();
+    });
+
+    it("disables Sign in in token mode until the token is non-empty", () => {
+      const { getByTestId, getByText } = render(
+        <ConnectModal onConnect={ok()} onConnectToken={ok()} onConnectPairing={ok()} />,
+      );
+      fireEvent.click(getByTestId("mode-token"));
+      expect(signInButton(getByText)).toBeDisabled();
+      fireEvent.change(getByTestId("field-API Token"), { target: { value: "rmm_pasted" } });
+      expect(signInButton(getByText)).not.toBeDisabled();
+    });
+
+    it("disables Sign in in credentials mode until both username and password are filled", () => {
+      const { getByTestId, getByText } = render(
+        <ConnectModal onConnect={ok()} onConnectToken={ok()} onConnectPairing={ok()} />,
+      );
+      fireEvent.click(getByTestId("mode-credentials"));
+      expect(signInButton(getByText)).toBeDisabled();
+      fireEvent.change(getByTestId("field-Username"), { target: { value: "daniel" } });
+      // Username alone is not enough.
+      expect(signInButton(getByText)).toBeDisabled();
+      fireEvent.change(getByTestId("field-Password"), { target: { value: "hunter2" } });
+      expect(signInButton(getByText)).not.toBeDisabled();
+    });
+
+    it("keeps Sign in disabled for a whitespace-only username or token, and a blank password", () => {
+      const { getByTestId, getByText } = render(
+        <ConnectModal onConnect={ok()} onConnectToken={ok()} onConnectPairing={ok()} />,
+      );
+      // Whitespace-only token — trimmed to empty, stays disabled.
+      fireEvent.click(getByTestId("mode-token"));
+      fireEvent.change(getByTestId("field-API Token"), { target: { value: "   " } });
+      expect(signInButton(getByText)).toBeDisabled();
+      // Whitespace-only username + a real password — username trims to empty.
+      fireEvent.click(getByTestId("mode-credentials"));
+      fireEvent.change(getByTestId("field-Username"), { target: { value: "   " } });
+      fireEvent.change(getByTestId("field-Password"), { target: { value: "hunter2" } });
+      expect(signInButton(getByText)).toBeDisabled();
+      // A real username but a blank password — password blank stays disabled.
+      fireEvent.change(getByTestId("field-Username"), { target: { value: "daniel" } });
+      fireEvent.change(getByTestId("field-Password"), { target: { value: "" } });
+      expect(signInButton(getByText)).toBeDisabled();
+    });
+
+    it("allows a password made only of spaces (password is not trimmed)", () => {
+      const { getByTestId, getByText } = render(
+        <ConnectModal onConnect={ok()} onConnectToken={ok()} onConnectPairing={ok()} />,
+      );
+      fireEvent.click(getByTestId("mode-credentials"));
+      fireEvent.change(getByTestId("field-Username"), { target: { value: "daniel" } });
+      fireEvent.change(getByTestId("field-Password"), { target: { value: "   " } });
+      expect(signInButton(getByText)).not.toBeDisabled();
+    });
+
+    it("does not call onConnect when Sign in is clicked with empty fields (disabled swallows the click)", () => {
+      const onConnect = ok();
+      const { getByTestId, getByText } = render(
+        <ConnectModal onConnect={onConnect} onConnectToken={ok()} onConnectPairing={ok()} />,
+      );
+      fireEvent.click(getByTestId("mode-credentials"));
+      fireEvent.click(signInButton(getByText));
+      expect(onConnect).not.toHaveBeenCalled();
+    });
+  });
+
   describe("credentials mode", () => {
     it("renders a username and an obscured password field, both empty (write-only)", () => {
-      const { getByTestId } = render(
-        <ConnectModal onConnect={vi.fn()} onConnectToken={vi.fn()} onConnectPairing={vi.fn()} />,
-      );
+      const { getByTestId } = render(<ConnectModal onConnect={ok()} onConnectToken={ok()} onConnectPairing={ok()} />);
       fireEvent.click(getByTestId("mode-credentials"));
       const user = getByTestId("field-Username") as HTMLInputElement;
       const pass = getByTestId("field-Password") as HTMLInputElement;
@@ -114,77 +212,72 @@ describe("ConnectModal", () => {
       expect(pass.getAttribute("data-is-password")).toBe("true");
     });
 
-    it("calls onConnect with the entered username + password on Sign in", () => {
-      const onConnect = vi.fn();
-      const onConnectToken = vi.fn();
-      const onConnectPairing = vi.fn();
-      const { getByTestId } = render(
-        <ConnectModal onConnect={onConnect} onConnectToken={onConnectToken} onConnectPairing={onConnectPairing} />,
+    it("calls onConnect with the entered username + password on Sign in", async () => {
+      const onConnect = ok();
+      const onConnectToken = ok();
+      const { getByTestId, getByText } = render(
+        <ConnectModal onConnect={onConnect} onConnectToken={onConnectToken} onConnectPairing={ok()} />,
       );
 
       fireEvent.click(getByTestId("mode-credentials"));
       fireEvent.change(getByTestId("field-Username"), { target: { value: "daniel" } });
       fireEvent.change(getByTestId("field-Password"), { target: { value: "hunter2" } });
-      fireEvent.click(getByTestId("ok-button"));
+      fireEvent.click(signInButton(getByText));
+      await flushSubmit();
 
       expect(onConnect).toHaveBeenCalledTimes(1);
       expect(onConnect).toHaveBeenCalledWith("daniel", "hunter2");
       expect(onConnectToken).not.toHaveBeenCalled();
     });
 
-    it("submits on Enter in the username field (on-screen keyboard) and closes", () => {
-      const onConnect = vi.fn();
+    it("advances to the password field on Enter in the username field and does NOT submit", () => {
+      const onConnect = ok();
       const closeModal = vi.fn();
       const { getByTestId } = render(
-        <ConnectModal
-          closeModal={closeModal}
-          onConnect={onConnect}
-          onConnectToken={vi.fn()}
-          onConnectPairing={vi.fn()}
-        />,
+        <ConnectModal closeModal={closeModal} onConnect={onConnect} onConnectToken={ok()} onConnectPairing={ok()} />,
       );
       fireEvent.click(getByTestId("mode-credentials"));
+      // Both fields filled, so a wrongful submit WOULD be possible — Enter on the
+      // first field must still advance, never fire the action.
       fireEvent.change(getByTestId("field-Username"), { target: { value: "daniel" } });
       fireEvent.change(getByTestId("field-Password"), { target: { value: "hunter2" } });
       fireEvent.keyDown(getByTestId("field-Username"), { key: "Enter" });
-      expect(onConnect).toHaveBeenCalledTimes(1);
-      expect(onConnect).toHaveBeenCalledWith("daniel", "hunter2");
-      // ConfirmModal's OK auto-closes; the manual Enter path must close itself.
-      expect(closeModal).toHaveBeenCalledTimes(1);
+      expect(onConnect).not.toHaveBeenCalled();
+      expect(closeModal).not.toHaveBeenCalled();
+      // Focus moved to the password field.
+      expect(document.activeElement).toBe(getByTestId("field-Password"));
     });
 
-    it("submits on Enter in the password field", () => {
-      const onConnect = vi.fn();
+    it("submits on Enter in the password field once both fields are filled and closes on success", async () => {
+      const onConnect = ok();
       const closeModal = vi.fn();
       const { getByTestId } = render(
-        <ConnectModal
-          closeModal={closeModal}
-          onConnect={onConnect}
-          onConnectToken={vi.fn()}
-          onConnectPairing={vi.fn()}
-        />,
+        <ConnectModal closeModal={closeModal} onConnect={onConnect} onConnectToken={ok()} onConnectPairing={ok()} />,
       );
       fireEvent.click(getByTestId("mode-credentials"));
       fireEvent.change(getByTestId("field-Username"), { target: { value: "daniel" } });
       fireEvent.change(getByTestId("field-Password"), { target: { value: "hunter2" } });
       fireEvent.keyDown(getByTestId("field-Password"), { key: "Enter" });
+      await flushSubmit();
       expect(onConnect).toHaveBeenCalledWith("daniel", "hunter2");
       expect(closeModal).toHaveBeenCalledTimes(1);
     });
 
-    it("passes empty strings to onConnect when nothing is entered", () => {
-      const onConnect = vi.fn();
+    it("ignores Enter in the password field while the fields are incomplete", () => {
+      const onConnect = ok();
       const { getByTestId } = render(
-        <ConnectModal onConnect={onConnect} onConnectToken={vi.fn()} onConnectPairing={vi.fn()} />,
+        <ConnectModal onConnect={onConnect} onConnectToken={ok()} onConnectPairing={ok()} />,
       );
       fireEvent.click(getByTestId("mode-credentials"));
-      fireEvent.click(getByTestId("ok-button"));
-      expect(onConnect).toHaveBeenCalledWith("", "");
+      // Password entered but username still blank — the mode is not submittable.
+      fireEvent.change(getByTestId("field-Password"), { target: { value: "hunter2" } });
+      fireEvent.keyDown(getByTestId("field-Password"), { key: "Enter" });
+      expect(onConnect).not.toHaveBeenCalled();
     });
 
     it("does not render the API token field until token mode is selected", () => {
       const { getByTestId, queryByTestId } = render(
-        <ConnectModal onConnect={vi.fn()} onConnectToken={vi.fn()} onConnectPairing={vi.fn()} />,
+        <ConnectModal onConnect={ok()} onConnectToken={ok()} onConnectPairing={ok()} />,
       );
       fireEvent.click(getByTestId("mode-credentials"));
       expect(queryByTestId("field-API Token")).toBeNull();
@@ -194,7 +287,7 @@ describe("ConnectModal", () => {
   describe("token mode", () => {
     it("shows an obscured API token field and hides the credential fields after switching", () => {
       const { getByTestId, queryByTestId } = render(
-        <ConnectModal onConnect={vi.fn()} onConnectToken={vi.fn()} onConnectPairing={vi.fn()} />,
+        <ConnectModal onConnect={ok()} onConnectToken={ok()} onConnectPairing={ok()} />,
       );
       fireEvent.click(getByTestId("mode-token"));
       const token = getByTestId("field-API Token") as HTMLInputElement;
@@ -203,52 +296,64 @@ describe("ConnectModal", () => {
       expect(queryByTestId("field-Password")).toBeNull();
     });
 
-    it("calls onConnectToken with the entered token on Sign in", () => {
-      const onConnect = vi.fn();
-      const onConnectToken = vi.fn();
-      const onConnectPairing = vi.fn();
-      const { getByTestId } = render(
-        <ConnectModal onConnect={onConnect} onConnectToken={onConnectToken} onConnectPairing={onConnectPairing} />,
+    it("calls onConnectToken with the entered token on Sign in", async () => {
+      const onConnect = ok();
+      const onConnectToken = ok();
+      const { getByTestId, getByText } = render(
+        <ConnectModal onConnect={onConnect} onConnectToken={onConnectToken} onConnectPairing={ok()} />,
       );
       fireEvent.click(getByTestId("mode-token"));
       fireEvent.change(getByTestId("field-API Token"), { target: { value: "rmm_pasted" } });
-      fireEvent.click(getByTestId("ok-button"));
+      fireEvent.click(signInButton(getByText));
+      await flushSubmit();
       expect(onConnectToken).toHaveBeenCalledTimes(1);
       expect(onConnectToken).toHaveBeenCalledWith("rmm_pasted");
       expect(onConnect).not.toHaveBeenCalled();
     });
 
-    it("submits the token on Enter in the API token field (on-screen keyboard) and closes", () => {
-      const onConnectToken = vi.fn();
+    it("submits the token on Enter in the API token field and closes on success", async () => {
+      const onConnectToken = ok();
       const closeModal = vi.fn();
       const { getByTestId } = render(
         <ConnectModal
           closeModal={closeModal}
-          onConnect={vi.fn()}
+          onConnect={ok()}
           onConnectToken={onConnectToken}
-          onConnectPairing={vi.fn()}
+          onConnectPairing={ok()}
         />,
       );
       fireEvent.click(getByTestId("mode-token"));
       fireEvent.change(getByTestId("field-API Token"), { target: { value: "rmm_pasted" } });
       fireEvent.keyDown(getByTestId("field-API Token"), { key: "Enter" });
+      await flushSubmit();
       expect(onConnectToken).toHaveBeenCalledTimes(1);
       expect(onConnectToken).toHaveBeenCalledWith("rmm_pasted");
       expect(closeModal).toHaveBeenCalledTimes(1);
     });
 
-    it("switches back to credentials mode and calls onConnect again", () => {
-      const onConnect = vi.fn();
-      const onConnectToken = vi.fn();
-      const onConnectPairing = vi.fn();
+    it("ignores Enter in the token field while it is empty", () => {
+      const onConnectToken = ok();
       const { getByTestId } = render(
-        <ConnectModal onConnect={onConnect} onConnectToken={onConnectToken} onConnectPairing={onConnectPairing} />,
+        <ConnectModal onConnect={ok()} onConnectToken={onConnectToken} onConnectPairing={ok()} />,
+      );
+      fireEvent.click(getByTestId("mode-token"));
+      fireEvent.keyDown(getByTestId("field-API Token"), { key: "Enter" });
+      expect(onConnectToken).not.toHaveBeenCalled();
+    });
+
+    it("switches back to credentials mode and calls onConnect again", async () => {
+      const onConnect = ok();
+      const onConnectToken = ok();
+      const { getByTestId, getByText } = render(
+        <ConnectModal onConnect={onConnect} onConnectToken={onConnectToken} onConnectPairing={ok()} />,
       );
       fireEvent.click(getByTestId("mode-token"));
       fireEvent.click(getByTestId("mode-credentials"));
       fireEvent.change(getByTestId("field-Username"), { target: { value: "daniel" } });
-      fireEvent.click(getByTestId("ok-button"));
-      expect(onConnect).toHaveBeenCalledWith("daniel", "");
+      fireEvent.change(getByTestId("field-Password"), { target: { value: "hunter2" } });
+      fireEvent.click(signInButton(getByText));
+      await flushSubmit();
+      expect(onConnect).toHaveBeenCalledWith("daniel", "hunter2");
       expect(onConnectToken).not.toHaveBeenCalled();
     });
   });
@@ -268,7 +373,7 @@ describe("ConnectModal", () => {
 
     it("renders exactly eight single-character (non-obscured) code boxes and hides the other modes' fields", () => {
       const { getByTestId, queryByTestId } = render(
-        <ConnectModal onConnect={vi.fn()} onConnectToken={vi.fn()} onConnectPairing={vi.fn()} />,
+        <ConnectModal onConnect={ok()} onConnectToken={ok()} onConnectPairing={ok()} />,
       );
       fireEvent.click(getByTestId("mode-pairing"));
       const boxes = codeBoxes(getByTestId);
@@ -283,9 +388,7 @@ describe("ConnectModal", () => {
     });
 
     it("uppercases a typed character and advances focus to the next box", () => {
-      const { getByTestId } = render(
-        <ConnectModal onConnect={vi.fn()} onConnectToken={vi.fn()} onConnectPairing={vi.fn()} />,
-      );
+      const { getByTestId } = render(<ConnectModal onConnect={ok()} onConnectToken={ok()} onConnectPairing={ok()} />);
       fireEvent.click(getByTestId("mode-pairing"));
       fireEvent.change(box(getByTestId, 0), { target: { value: "a" } });
       expect(box(getByTestId, 0).value).toBe("A");
@@ -294,9 +397,7 @@ describe("ConnectModal", () => {
     });
 
     it("ignores a non-alphanumeric character, leaving the box empty and focus put", () => {
-      const { getByTestId } = render(
-        <ConnectModal onConnect={vi.fn()} onConnectToken={vi.fn()} onConnectPairing={vi.fn()} />,
-      );
+      const { getByTestId } = render(<ConnectModal onConnect={ok()} onConnectToken={ok()} onConnectPairing={ok()} />);
       fireEvent.click(getByTestId("mode-pairing"));
       fireEvent.change(box(getByTestId, 0), { target: { value: "!" } });
       expect(box(getByTestId, 0).value).toBe("");
@@ -305,9 +406,7 @@ describe("ConnectModal", () => {
     });
 
     it("distributes a two-character entry across two boxes (never crams two into one)", () => {
-      const { getByTestId } = render(
-        <ConnectModal onConnect={vi.fn()} onConnectToken={vi.fn()} onConnectPairing={vi.fn()} />,
-      );
+      const { getByTestId } = render(<ConnectModal onConnect={ok()} onConnectToken={ok()} onConnectPairing={ok()} />);
       fireEvent.click(getByTestId("mode-pairing"));
       fireEvent.change(box(getByTestId, 0), { target: { value: "zq" } });
       expect(box(getByTestId, 0).value).toBe("Z");
@@ -316,9 +415,7 @@ describe("ConnectModal", () => {
     });
 
     it("returns focus to the previous box when Backspace is pressed on an empty box", () => {
-      const { getByTestId } = render(
-        <ConnectModal onConnect={vi.fn()} onConnectToken={vi.fn()} onConnectPairing={vi.fn()} />,
-      );
+      const { getByTestId } = render(<ConnectModal onConnect={ok()} onConnectToken={ok()} onConnectPairing={ok()} />);
       fireEvent.click(getByTestId("mode-pairing"));
       // Fill the first box (auto-advances to the second, which stays empty).
       fireEvent.change(box(getByTestId, 0), { target: { value: "a" } });
@@ -333,24 +430,23 @@ describe("ConnectModal", () => {
       ["a hyphenated eight-character paste", "abcd-efgh", ["A", "B", "C", "D", "E", "F", "G", "H"]],
       ["a mixed-case paste (uppercased as it fills)", "aB2d-Ef4h", ["A", "B", "2", "D", "E", "F", "4", "H"]],
     ] as const)("splits %s across all eight boxes", (_name, pasted, expected) => {
-      const { getByTestId } = render(
-        <ConnectModal onConnect={vi.fn()} onConnectToken={vi.fn()} onConnectPairing={vi.fn()} />,
-      );
+      const { getByTestId } = render(<ConnectModal onConnect={ok()} onConnectToken={ok()} onConnectPairing={ok()} />);
       fireEvent.click(getByTestId("mode-pairing"));
       fireEvent.change(box(getByTestId, 0), { target: { value: pasted } });
       expect(codeBoxes(getByTestId).map((b) => b.value)).toEqual([...expected]);
     });
 
-    it("calls onConnectPairing with the concatenated eight characters on Sign in and leaks to no other handler", () => {
-      const onConnect = vi.fn();
-      const onConnectToken = vi.fn();
-      const onConnectPairing = vi.fn();
-      const { getByTestId } = render(
+    it("calls onConnectPairing with the concatenated eight characters on Sign in and leaks to no other handler", async () => {
+      const onConnect = ok();
+      const onConnectToken = ok();
+      const onConnectPairing = ok();
+      const { getByTestId, getByText } = render(
         <ConnectModal onConnect={onConnect} onConnectToken={onConnectToken} onConnectPairing={onConnectPairing} />,
       );
       fireEvent.click(getByTestId("mode-pairing"));
       fireEvent.change(box(getByTestId, 0), { target: { value: "abcdefgh" } });
-      fireEvent.click(getByTestId("ok-button"));
+      fireEvent.click(signInButton(getByText));
+      await flushSubmit();
       expect(onConnectPairing).toHaveBeenCalledTimes(1);
       // Bare eight characters in order — the backend normalizes, so no hyphen is sent.
       expect(onConnectPairing).toHaveBeenCalledWith("ABCDEFGH");
@@ -358,14 +454,14 @@ describe("ConnectModal", () => {
       expect(onConnectToken).not.toHaveBeenCalled();
     });
 
-    it("submits the pairing code on Enter once all eight boxes are filled and closes", () => {
-      const onConnectPairing = vi.fn();
+    it("submits the pairing code on Enter once all eight boxes are filled and closes on success", async () => {
+      const onConnectPairing = ok();
       const closeModal = vi.fn();
       const { getByTestId } = render(
         <ConnectModal
           closeModal={closeModal}
-          onConnect={vi.fn()}
-          onConnectToken={vi.fn()}
+          onConnect={ok()}
+          onConnectToken={ok()}
           onConnectPairing={onConnectPairing}
         />,
       );
@@ -373,19 +469,20 @@ describe("ConnectModal", () => {
       // A full paste fills all eight boxes.
       fireEvent.change(box(getByTestId, 0), { target: { value: "abcdefgh" } });
       fireEvent.keyDown(box(getByTestId, 7), { key: "Enter" });
+      await flushSubmit();
       expect(onConnectPairing).toHaveBeenCalledTimes(1);
       expect(onConnectPairing).toHaveBeenCalledWith("ABCDEFGH");
       expect(closeModal).toHaveBeenCalledTimes(1);
     });
 
-    it("ignores Enter while the pairing code is incomplete (no submit, no close)", () => {
-      const onConnectPairing = vi.fn();
+    it("ignores Enter while the pairing code is incomplete (no submit, no close)", async () => {
+      const onConnectPairing = ok();
       const closeModal = vi.fn();
       const { getByTestId } = render(
         <ConnectModal
           closeModal={closeModal}
-          onConnect={vi.fn()}
-          onConnectToken={vi.fn()}
+          onConnect={ok()}
+          onConnectToken={ok()}
           onConnectPairing={onConnectPairing}
         />,
       );
@@ -393,29 +490,116 @@ describe("ConnectModal", () => {
       // Only the first four boxes are filled — the code is incomplete.
       fireEvent.change(box(getByTestId, 0), { target: { value: "abcd" } });
       fireEvent.keyDown(box(getByTestId, 3), { key: "Enter" });
+      await flushSubmit();
       expect(onConnectPairing).not.toHaveBeenCalled();
       expect(closeModal).not.toHaveBeenCalled();
     });
 
-    it("switches from pairing back to token mode and routes to onConnectToken only", () => {
-      const onConnectToken = vi.fn();
-      const onConnectPairing = vi.fn();
-      const { getByTestId } = render(
-        <ConnectModal onConnect={vi.fn()} onConnectToken={onConnectToken} onConnectPairing={onConnectPairing} />,
+    it("switches from pairing back to token mode and routes to onConnectToken only", async () => {
+      const onConnectToken = ok();
+      const onConnectPairing = ok();
+      const { getByTestId, getByText } = render(
+        <ConnectModal onConnect={ok()} onConnectToken={onConnectToken} onConnectPairing={onConnectPairing} />,
       );
       fireEvent.click(getByTestId("mode-pairing"));
       fireEvent.click(getByTestId("mode-token"));
       fireEvent.change(getByTestId("field-API Token"), { target: { value: "rmm_pasted" } });
-      fireEvent.click(getByTestId("ok-button"));
+      fireEvent.click(signInButton(getByText));
+      await flushSubmit();
       expect(onConnectToken).toHaveBeenCalledWith("rmm_pasted");
       expect(onConnectPairing).not.toHaveBeenCalled();
     });
   });
 
-  it("uses 'Sign in' as the OK button label", () => {
-    const { getByTestId } = render(
-      <ConnectModal onConnect={vi.fn()} onConnectToken={vi.fn()} onConnectPairing={vi.fn()} />,
-    );
-    expect(getByTestId("ok-button").textContent).toBe("Sign in");
+  describe("success vs failure (modal stays open on failure)", () => {
+    it("closes the modal and shows no error when the connect handler resolves success", async () => {
+      const closeModal = vi.fn();
+      const { getByTestId, getByText, queryByTestId } = render(
+        <ConnectModal
+          closeModal={closeModal}
+          onConnect={ok()}
+          onConnectToken={ok("Signed in!")}
+          onConnectPairing={ok()}
+        />,
+      );
+      fireEvent.click(getByTestId("mode-token"));
+      fireEvent.change(getByTestId("field-API Token"), { target: { value: "rmm_pasted" } });
+      fireEvent.click(signInButton(getByText));
+      await flushSubmit();
+      expect(closeModal).toHaveBeenCalledTimes(1);
+      expect(queryByTestId("signin-error")).toBeNull();
+    });
+
+    it("stays open and shows the returned message when the connect handler resolves failure", async () => {
+      const closeModal = vi.fn();
+      const onConnectToken = fail("The API token is missing required permissions (scopes).");
+      const { getByTestId, getByText } = render(
+        <ConnectModal
+          closeModal={closeModal}
+          onConnect={ok()}
+          onConnectToken={onConnectToken}
+          onConnectPairing={ok()}
+        />,
+      );
+      fireEvent.click(getByTestId("mode-token"));
+      fireEvent.change(getByTestId("field-API Token"), { target: { value: "rmm_readonly" } });
+      fireEvent.click(signInButton(getByText));
+      await flushSubmit();
+      expect(closeModal).not.toHaveBeenCalled();
+      expect(getByTestId("signin-error").textContent).toBe("The API token is missing required permissions (scopes).");
+    });
+
+    it("shows a generic error and stays open when the connect handler rejects", async () => {
+      const closeModal = vi.fn();
+      const onConnectToken = vi.fn().mockRejectedValue(new Error("network"));
+      const { getByTestId, getByText } = render(
+        <ConnectModal
+          closeModal={closeModal}
+          onConnect={ok()}
+          onConnectToken={onConnectToken}
+          onConnectPairing={ok()}
+        />,
+      );
+      fireEvent.click(getByTestId("mode-token"));
+      fireEvent.change(getByTestId("field-API Token"), { target: { value: "rmm_pasted" } });
+      fireEvent.click(signInButton(getByText));
+      await flushSubmit();
+      expect(closeModal).not.toHaveBeenCalled();
+      expect(getByTestId("signin-error").textContent).toBe("Sign-in failed. Check your connection and try again.");
+    });
+
+    it("clears a stale error when the user edits a field", async () => {
+      const onConnectToken = fail("Pairing code is invalid or has expired.");
+      const { getByTestId, getByText, queryByTestId } = render(
+        <ConnectModal onConnect={ok()} onConnectToken={onConnectToken} onConnectPairing={ok()} />,
+      );
+      fireEvent.click(getByTestId("mode-token"));
+      fireEvent.change(getByTestId("field-API Token"), { target: { value: "bad" } });
+      fireEvent.click(signInButton(getByText));
+      await flushSubmit();
+      expect(getByTestId("signin-error")).toBeTruthy();
+      // Editing the field clears the stale error.
+      fireEvent.change(getByTestId("field-API Token"), { target: { value: "bad2" } });
+      expect(queryByTestId("signin-error")).toBeNull();
+    });
+
+    it("clears a stale error when the user switches mode", async () => {
+      const onConnectToken = fail("bad token");
+      const { getByTestId, getByText, queryByTestId } = render(
+        <ConnectModal onConnect={ok()} onConnectToken={onConnectToken} onConnectPairing={ok()} />,
+      );
+      fireEvent.click(getByTestId("mode-token"));
+      fireEvent.change(getByTestId("field-API Token"), { target: { value: "bad" } });
+      fireEvent.click(signInButton(getByText));
+      await flushSubmit();
+      expect(getByTestId("signin-error")).toBeTruthy();
+      fireEvent.click(getByTestId("mode-credentials"));
+      expect(queryByTestId("signin-error")).toBeNull();
+    });
+  });
+
+  it("labels the primary footer button 'Sign in'", () => {
+    const { getByText } = render(<ConnectModal onConnect={ok()} onConnectToken={ok()} onConnectPairing={ok()} />);
+    expect(signInButton(getByText).textContent).toBe("Sign in");
   });
 });

--- a/src/components/settings/ConnectModal.tsx
+++ b/src/components/settings/ConnectModal.tsx
@@ -238,11 +238,16 @@ export const ConnectModal: FC<ConnectModalProps> = ({ closeModal, onConnect, onC
       focusBoxAtEnd(index - 1);
       return;
     }
-    // Enter (the on-screen keyboard's "Eingabe" key) confirms once every box is
-    // filled — an incomplete code is a no-op. submit() owns closing on success,
-    // so this path must not close the modal itself.
-    if (e.key === "Enter" && code.every((c) => c !== "")) {
-      void submit();
+    if (e.key === "Enter") {
+      // Consume the event so Steam's ModalRoot cannot fire its own default
+      // confirm/close — regardless of whether the code is complete enough to
+      // submit (an incomplete field must be an inert no-op, not a close).
+      e.preventDefault();
+      e.stopPropagation();
+      // Enter (the on-screen keyboard's "Eingabe" key) confirms once every box
+      // is filled — an incomplete code is a no-op. submit() owns closing on
+      // success, so this path must not close the modal itself.
+      if (code.every((c) => c !== "")) void submit();
     }
   };
 
@@ -251,13 +256,24 @@ export const ConnectModal: FC<ConnectModalProps> = ({ closeModal, onConnect, onC
   // action. If the password input can't be found, it's a no-op (never a submit).
   const handleUsernameKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.key !== "Enter") return;
+    // Consume the event so Steam's ModalRoot cannot fire its own default
+    // confirm/close before focus advances to the password field.
+    e.preventDefault();
+    e.stopPropagation();
     credentialsRowRef.current?.querySelectorAll("input")[1]?.focus();
   };
 
   // Enter on a completing field (password / token) submits, but only when the
   // mode's fields are complete — otherwise it's a no-op.
   const handleCompletingKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Enter" && canSubmit) void submit();
+    if (e.key !== "Enter") return;
+    // Consume the event so Steam's ModalRoot cannot fire its own default
+    // confirm/close on an incomplete field — regardless of whether we submit.
+    // (On the Deck, R2/OSK-Enter on the empty token field otherwise closed the
+    // modal even though this handler correctly no-ops when canSubmit is false.)
+    e.preventDefault();
+    e.stopPropagation();
+    if (canSubmit) void submit();
   };
 
   const handleModeChange = (option: { data: string }) => {
@@ -301,14 +317,23 @@ export const ConnectModal: FC<ConnectModalProps> = ({ closeModal, onConnect, onC
               scopes listed in the plugin docs so downloads, saves, and device sync work. The plugin never deletes a
               pasted token; you manage it in RomM.
             </div>
-            <TextField
-              focusOnMount={true}
-              label="API Token"
-              value={token}
-              bIsPassword
-              onChange={handleTokenChange}
-              onKeyDown={handleCompletingKeyDown}
-            />
+            {/* The token field is the only input in this mode and, unwrapped, is a
+                direct child of the modal body. On the Deck, R2/OSK-Enter on the
+                empty field closes the ModalRoot even though handleCompletingKeyDown
+                no-ops (canSubmit false). The pairing boxes' <Focusable> wrapper is
+                the one structure proven not to close on an incomplete field, so the
+                token field is wrapped the same way. flow-children is irrelevant for
+                a single field, so it is omitted. */}
+            <Focusable>
+              <TextField
+                focusOnMount={true}
+                label="API Token"
+                value={token}
+                bIsPassword
+                onChange={handleTokenChange}
+                onKeyDown={handleCompletingKeyDown}
+              />
+            </Focusable>
           </>
         )}
         {mode === "pairing" && (

--- a/src/components/settings/ConnectModal.tsx
+++ b/src/components/settings/ConnectModal.tsx
@@ -22,7 +22,8 @@
  */
 
 import { FC, Fragment, useState, useRef, ChangeEvent, KeyboardEvent } from "react";
-import { ModalRoot, TextField, DropdownItem, DialogButton, Focusable } from "@decky/ui";
+import { TextField, DropdownItem, Focusable } from "@decky/ui";
+import { ValidatingModalShell } from "./ValidatingModalShell";
 
 type SignInMode = "credentials" | "token" | "pairing";
 
@@ -47,16 +48,6 @@ const CODE_GROUP = 4;
 const CODE_INDICES = Array.from({ length: CODE_LENGTH }, (_unused, i) => i);
 
 const GENERIC_SIGN_IN_ERROR = "Sign-in failed. Check your connection and try again.";
-
-// ModalRoot renders only the shell + a close affordance (unlike ConfirmModal, it
-// has no strTitle / OK button), so the title, body, error line, and footer are
-// all rendered as content here — mirroring CopyToSlotModal.
-const modalBodyStyle = { padding: "16px", minWidth: "360px" } as const;
-const titleStyle = { fontSize: "16px", fontWeight: "bold", marginBottom: "12px", color: "#fff" } as const;
-// A failed sign-in surfaces here, above the footer, in a red-ish tone.
-const errorStyle = { color: "#d94126", fontSize: "13px", marginTop: "12px", marginBottom: "4px" } as const;
-const footerStyle = { display: "flex", gap: "8px", marginTop: "16px" } as const;
-const footerButtonStyle = { flex: "1 1 0px", minWidth: 0 } as const;
 
 const helperTextStyle = { fontSize: "12px", marginBottom: "12px", color: "rgba(255,255,255,0.6)" } as const;
 const codeLabelStyle = {
@@ -177,12 +168,12 @@ export const ConnectModal: FC<ConnectModalProps> = ({ closeModal, onConnect, onC
   // Whether the selected mode's required fields are complete enough to submit.
   // The password is checked untrimmed (a leading/trailing space can be a real
   // character); everything else is trimmed so whitespace-only never enables it.
-  const canSubmit =
-    mode === "credentials"
-      ? username.trim() !== "" && password !== ""
-      : mode === "token"
-        ? token.trim() !== ""
-        : code.every((c) => c !== "");
+  const computeCanSubmit = (): boolean => {
+    if (mode === "credentials") return username.trim() !== "" && password !== "";
+    if (mode === "token") return token.trim() !== "";
+    return code.every((c) => c !== "");
+  };
+  const canSubmit = computeCanSubmit();
 
   // Run the selected mode's sign-in to completion. Success closes the modal;
   // failure keeps it open and shows the returned message so the user can retry.
@@ -297,124 +288,107 @@ export const ConnectModal: FC<ConnectModalProps> = ({ closeModal, onConnect, onC
   };
 
   return (
-    <ModalRoot {...(closeModal === undefined ? {} : { closeModal })}>
-      <div style={modalBodyStyle}>
-        <div style={titleStyle}>Sign in to RomM</div>
-        <DropdownItem
-          label="Sign-in method"
-          rgOptions={[
-            { data: "pairing", label: "Pairing code" },
-            { data: "token", label: "API token" },
-            { data: "credentials", label: "Username & password" },
-          ]}
-          selectedOption={mode}
-          onChange={handleModeChange}
-        />
-        {mode === "token" && (
-          <>
-            <div style={helperTextStyle}>
-              Create a token in RomM&apos;s web UI (Settings → API Tokens) and paste it here. Make sure it has the
-              scopes listed in the plugin docs so downloads, saves, and device sync work. The plugin never deletes a
-              pasted token; you manage it in RomM.
-            </div>
-            {/* The token field is the only input in this mode and, unwrapped, is a
+    <ValidatingModalShell
+      {...(closeModal === undefined ? {} : { closeModal })}
+      title="Sign in to RomM"
+      error={error}
+      errorTestId="signin-error"
+      submitLabel={submitting ? "Signing in…" : "Sign in"}
+      submitDisabled={!canSubmit || submitting}
+      onSubmit={() => {
+        void submit();
+      }}
+    >
+      <DropdownItem
+        label="Sign-in method"
+        rgOptions={[
+          { data: "pairing", label: "Pairing code" },
+          { data: "token", label: "API token" },
+          { data: "credentials", label: "Username & password" },
+        ]}
+        selectedOption={mode}
+        onChange={handleModeChange}
+      />
+      {mode === "token" && (
+        <>
+          <div style={helperTextStyle}>
+            Create a token in RomM&apos;s web UI (Settings → API Tokens) and paste it here. Make sure it has the scopes
+            listed in the plugin docs so downloads, saves, and device sync work. The plugin never deletes a pasted
+            token; you manage it in RomM.
+          </div>
+          {/* The token field is the only input in this mode and, unwrapped, is a
                 direct child of the modal body. On the Deck, R2/OSK-Enter on the
                 empty field closes the ModalRoot even though handleCompletingKeyDown
                 no-ops (canSubmit false). The pairing boxes' <Focusable> wrapper is
                 the one structure proven not to close on an incomplete field, so the
                 token field is wrapped the same way. flow-children is irrelevant for
                 a single field, so it is omitted. */}
-            <Focusable>
-              <TextField
-                focusOnMount={true}
-                label="API Token"
-                value={token}
-                bIsPassword
-                onChange={handleTokenChange}
-                onKeyDown={handleCompletingKeyDown}
-              />
-            </Focusable>
-          </>
-        )}
-        {mode === "pairing" && (
-          <>
-            <div style={helperTextStyle}>
-              In RomM&apos;s web UI open your API token and click <strong>Pair</strong>, then enter the 8-character code
-              here within 60 seconds. The plugin fetches the token itself — nothing to copy or paste.
-            </div>
-            <div style={codeLabelStyle}>Pairing code</div>
-            {/* Focusable + flow-children="horizontal" tells Steam's gamepad nav to
+          <Focusable>
+            <TextField
+              focusOnMount={true}
+              label="API Token"
+              value={token}
+              bIsPassword
+              onChange={handleTokenChange}
+              onKeyDown={handleCompletingKeyDown}
+            />
+          </Focusable>
+        </>
+      )}
+      {mode === "pairing" && (
+        <>
+          <div style={helperTextStyle}>
+            In RomM&apos;s web UI open your API token and click <strong>Pair</strong>, then enter the 8-character code
+            here within 60 seconds. The plugin fetches the token itself — nothing to copy or paste.
+          </div>
+          <div style={codeLabelStyle}>Pairing code</div>
+          {/* Focusable + flow-children="horizontal" tells Steam's gamepad nav to
                 step between the boxes left/right (the analog stick/d-pad), not
                 up/down — a plain div defaults to vertical traversal. */}
-            <Focusable flow-children="horizontal" ref={codeRowRef} style={codeRowStyle} data-testid="pairing-code-row">
-              {CODE_INDICES.map((i) => (
-                <Fragment key={i}>
-                  {i === CODE_GROUP && <span style={codeSeparatorStyle}>-</span>}
-                  <div style={codeBoxWrapperStyle}>
-                    <TextField
-                      focusOnMount={i === 0}
-                      style={codeBoxFieldStyle}
-                      value={code[i] ?? ""}
-                      onChange={handleBoxChange(i)}
-                      onKeyDown={handleBoxKeyDown(i)}
-                    />
-                  </div>
-                </Fragment>
-              ))}
-            </Focusable>
-          </>
-        )}
-        {mode === "credentials" && (
-          <>
-            <div style={helperTextStyle}>
-              Enter your RomM username and password once. The plugin exchanges them for an API token and never stores
-              your password.
-            </div>
-            {/* A plain wrapping div carries the ref used to advance Enter from the
-                username field to the password field (querySelectorAll('input')[1]). */}
-            <div ref={credentialsRowRef} data-testid="credentials-row">
-              <TextField
-                focusOnMount={true}
-                label="Username"
-                value={username}
-                onChange={handleUsernameChange}
-                onKeyDown={handleUsernameKeyDown}
-              />
-              <TextField
-                label="Password"
-                value={password}
-                bIsPassword
-                onChange={handlePasswordChange}
-                onKeyDown={handleCompletingKeyDown}
-              />
-            </div>
-          </>
-        )}
-        {error !== null && (
-          <div style={errorStyle} data-testid="signin-error">
-            {error}
+          <Focusable flow-children="horizontal" ref={codeRowRef} style={codeRowStyle} data-testid="pairing-code-row">
+            {CODE_INDICES.map((i) => (
+              <Fragment key={i}>
+                {i === CODE_GROUP && <span style={codeSeparatorStyle}>-</span>}
+                <div style={codeBoxWrapperStyle}>
+                  <TextField
+                    focusOnMount={i === 0}
+                    style={codeBoxFieldStyle}
+                    value={code[i] ?? ""}
+                    onChange={handleBoxChange(i)}
+                    onKeyDown={handleBoxKeyDown(i)}
+                  />
+                </div>
+              </Fragment>
+            ))}
+          </Focusable>
+        </>
+      )}
+      {mode === "credentials" && (
+        <>
+          <div style={helperTextStyle}>
+            Enter your RomM username and password once. The plugin exchanges them for an API token and never stores your
+            password.
           </div>
-        )}
-        <div style={footerStyle}>
-          <DialogButton
-            style={footerButtonStyle}
-            disabled={!canSubmit || submitting}
-            onClick={() => {
-              void submit();
-            }}
-          >
-            {submitting ? "Signing in…" : "Sign in"}
-          </DialogButton>
-          <DialogButton
-            style={footerButtonStyle}
-            onClick={() => {
-              closeModal?.();
-            }}
-          >
-            Cancel
-          </DialogButton>
-        </div>
-      </div>
-    </ModalRoot>
+          {/* A plain wrapping div carries the ref used to advance Enter from the
+                username field to the password field (querySelectorAll('input')[1]). */}
+          <div ref={credentialsRowRef} data-testid="credentials-row">
+            <TextField
+              focusOnMount={true}
+              label="Username"
+              value={username}
+              onChange={handleUsernameChange}
+              onKeyDown={handleUsernameKeyDown}
+            />
+            <TextField
+              label="Password"
+              value={password}
+              bIsPassword
+              onChange={handlePasswordChange}
+              onKeyDown={handleCompletingKeyDown}
+            />
+          </div>
+        </>
+      )}
+    </ValidatingModalShell>
   );
 };

--- a/src/components/settings/ConnectModal.tsx
+++ b/src/components/settings/ConnectModal.tsx
@@ -9,24 +9,35 @@
  * single-use, so it is entered in the clear across eight single-character boxes
  * (an OTP-style input grouped 4 – 4 around a hyphen, auto-advancing as you type)
  * — typability matters more than obscuring a value that expires almost
- * immediately. On submit the parent's matching handler runs —
- * `connect_with_credentials` (exchanges the credentials for a scoped token and
- * discards the password), `connect_with_token` (validates and stores the pasted
- * token), or `connect_with_pairing_code` (exchanges the code for a token). This
- * modal owns only the in-flight field values and the selected mode; token
- * minting/validation, status, and persistence live in the parent (SettingsPage).
+ * immediately. Sign in is gated until the selected mode's fields are complete,
+ * and the sign-in attempt runs to completion inside the modal: on success the
+ * parent's matching handler resolved truthy and the modal closes; on failure the
+ * modal stays open and shows the returned message so the user can correct and
+ * retry. The parent's handlers — `connect_with_credentials` (exchanges the
+ * credentials for a scoped token and discards the password), `connect_with_token`
+ * (validates and stores the pasted token), or `connect_with_pairing_code`
+ * (exchanges the code for a token) — own token minting/validation, status, and
+ * persistence; this modal owns only the in-flight field values, the selected
+ * mode, and the in-flight/error UI state.
  */
 
 import { FC, Fragment, useState, useRef, ChangeEvent, KeyboardEvent } from "react";
-import { ConfirmModal, TextField, DropdownItem, Focusable } from "@decky/ui";
+import { ModalRoot, TextField, DropdownItem, DialogButton, Focusable } from "@decky/ui";
 
 type SignInMode = "credentials" | "token" | "pairing";
 
+/** The subset of the backend connect result the modal needs to decide whether
+ * to close (success) or surface an error and stay open (failure). */
+export interface SignInResult {
+  success: boolean;
+  message: string;
+}
+
 interface ConnectModalProps {
   closeModal?: () => void;
-  onConnect: (username: string, password: string) => void;
-  onConnectToken: (token: string) => void;
-  onConnectPairing: (code: string) => void;
+  onConnect: (username: string, password: string) => Promise<SignInResult>;
+  onConnectToken: (token: string) => Promise<SignInResult>;
+  onConnectPairing: (code: string) => Promise<SignInResult>;
 }
 
 // The pairing code is eight characters, shown as eight single-character boxes
@@ -34,6 +45,18 @@ interface ConnectModalProps {
 const CODE_LENGTH = 8;
 const CODE_GROUP = 4;
 const CODE_INDICES = Array.from({ length: CODE_LENGTH }, (_unused, i) => i);
+
+const GENERIC_SIGN_IN_ERROR = "Sign-in failed. Check your connection and try again.";
+
+// ModalRoot renders only the shell + a close affordance (unlike ConfirmModal, it
+// has no strTitle / OK button), so the title, body, error line, and footer are
+// all rendered as content here — mirroring CopyToSlotModal.
+const modalBodyStyle = { padding: "16px", minWidth: "360px" } as const;
+const titleStyle = { fontSize: "16px", fontWeight: "bold", marginBottom: "12px", color: "#fff" } as const;
+// A failed sign-in surfaces here, above the footer, in a red-ish tone.
+const errorStyle = { color: "#d94126", fontSize: "13px", marginTop: "12px", marginBottom: "4px" } as const;
+const footerStyle = { display: "flex", gap: "8px", marginTop: "16px" } as const;
+const footerButtonStyle = { flex: "1 1 0px", minWidth: 0 } as const;
 
 const helperTextStyle = { fontSize: "12px", marginBottom: "12px", color: "rgba(255,255,255,0.6)" } as const;
 const codeLabelStyle = {
@@ -44,7 +67,7 @@ const codeLabelStyle = {
 } as const;
 // A single non-wrapping row: eight fixed-size boxes plus the hyphen must always
 // stay on one line (8·36 (boxes) + 8·6 (gaps between the 9 flex children) + ~8
-// (hyphen) ≈ 344px, comfortably inside the ConfirmModal's content width), so each
+// (hyphen) ≈ 344px, comfortably inside the modal body's 360px min width), so each
 // box is a fixed size and never shrinks or grows as characters are typed.
 const codeRowStyle = {
   display: "flex",
@@ -102,12 +125,16 @@ export const ConnectModal: FC<ConnectModalProps> = ({ closeModal, onConnect, onC
   const [password, setPassword] = useState("");
   const [token, setToken] = useState("");
   const [code, setCode] = useState<string[]>(() => new Array<string>(CODE_LENGTH).fill(""));
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   // The @decky/ui TextField is a plain FC with no ref to its underlying input,
-  // so focus is moved via the wrapping row (querySelectorAll('input')[i] — the
+  // so focus is moved via a wrapping element (querySelectorAll('input')[i] — the
   // same DOM pattern the QAM uses for buttons) rather than a forwarded ref. The
-  // eight inputs sit in DOM order inside the row, so index maps to box.
+  // pairing row holds the eight code inputs in DOM order; the credentials row
+  // holds [username, password] so Enter on username can advance to password.
   const codeRowRef = useRef<HTMLDivElement>(null);
+  const credentialsRowRef = useRef<HTMLDivElement>(null);
 
   const boxInputAt = (index: number): HTMLInputElement | null =>
     codeRowRef.current?.querySelectorAll("input")[index] ?? null;
@@ -147,7 +174,47 @@ export const ConnectModal: FC<ConnectModalProps> = ({ closeModal, onConnect, onC
     }
   };
 
+  // Whether the selected mode's required fields are complete enough to submit.
+  // The password is checked untrimmed (a leading/trailing space can be a real
+  // character); everything else is trimmed so whitespace-only never enables it.
+  const canSubmit =
+    mode === "credentials"
+      ? username.trim() !== "" && password !== ""
+      : mode === "token"
+        ? token.trim() !== ""
+        : code.every((c) => c !== "");
+
+  // Run the selected mode's sign-in to completion. Success closes the modal;
+  // failure keeps it open and shows the returned message so the user can retry.
+  const submit = async () => {
+    if (!canSubmit || submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      let result: SignInResult;
+      if (mode === "token") {
+        result = await onConnectToken(token);
+      } else if (mode === "pairing") {
+        // Backend normalizes, so the bare eight characters in order are enough.
+        result = await onConnectPairing(code.join(""));
+      } else {
+        result = await onConnect(username, password);
+      }
+      if (result.success) {
+        closeModal?.();
+      } else {
+        setError(result.message);
+      }
+    } catch {
+      setError(GENERIC_SIGN_IN_ERROR);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
   const handleBoxChange = (index: number) => (e: ChangeEvent<HTMLInputElement>) => {
+    // Any edit clears a stale error so it doesn't linger past a correction.
+    setError(null);
     const incoming = normalizePairingCode(e.target.value);
     if (incoming.length <= 1) {
       // A single character (or a deletion, which leaves the box empty). Advancing
@@ -172,121 +239,157 @@ export const ConnectModal: FC<ConnectModalProps> = ({ closeModal, onConnect, onC
       return;
     }
     // Enter (the on-screen keyboard's "Eingabe" key) confirms once every box is
-    // filled — same submit as the OK button, plus the manual close ConfirmModal's
-    // OK button would do. An incomplete code is a no-op.
+    // filled — an incomplete code is a no-op. submit() owns closing on success,
+    // so this path must not close the modal itself.
     if (e.key === "Enter" && code.every((c) => c !== "")) {
-      submit();
-      closeModal?.();
+      void submit();
     }
   };
 
-  const submit = () => {
-    if (mode === "token") {
-      onConnectToken(token);
-    } else if (mode === "pairing") {
-      // Backend normalizes, so the bare eight characters in order are enough.
-      onConnectPairing(code.join(""));
-    } else {
-      onConnect(username, password);
-    }
+  // Enter on the username field advances to the password field rather than
+  // submitting — the first field of a two-field form should never fire the
+  // action. If the password input can't be found, it's a no-op (never a submit).
+  const handleUsernameKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key !== "Enter") return;
+    credentialsRowRef.current?.querySelectorAll("input")[1]?.focus();
   };
 
-  // Enter (the on-screen keyboard's "Eingabe" key) on a single-value field
-  // confirms, same as the OK button. ConfirmModal auto-closes on its OK button
-  // but not on this manual path, so close here too. The pairing-code boxes are
-  // the exception — handleBoxKeyDown gates their Enter on a complete code.
-  const handleFieldKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Enter") {
-      submit();
-      closeModal?.();
-    }
+  // Enter on a completing field (password / token) submits, but only when the
+  // mode's fields are complete — otherwise it's a no-op.
+  const handleCompletingKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter" && canSubmit) void submit();
+  };
+
+  const handleModeChange = (option: { data: string }) => {
+    setMode(option.data as SignInMode);
+    setError(null);
+  };
+
+  const handleUsernameChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setUsername(e.target.value);
+    setError(null);
+  };
+
+  const handlePasswordChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setPassword(e.target.value);
+    setError(null);
+  };
+
+  const handleTokenChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setToken(e.target.value);
+    setError(null);
   };
 
   return (
-    <ConfirmModal
-      {...(closeModal === undefined ? {} : { closeModal })}
-      onOK={submit}
-      strTitle="Sign in to RomM"
-      strOKButtonText="Sign in"
-      bDisableBackgroundDismiss={true}
-    >
-      <DropdownItem
-        label="Sign-in method"
-        rgOptions={[
-          { data: "pairing", label: "Pairing code" },
-          { data: "token", label: "API token" },
-          { data: "credentials", label: "Username & password" },
-        ]}
-        selectedOption={mode}
-        onChange={(option) => setMode(option.data as SignInMode)}
-      />
-      {mode === "token" && (
-        <>
-          <div style={helperTextStyle}>
-            Create a token in RomM&apos;s web UI (Settings → API Tokens) and paste it here. Make sure it has the scopes
-            listed in the plugin docs so downloads, saves, and device sync work. The plugin never deletes a pasted
-            token; you manage it in RomM.
+    <ModalRoot {...(closeModal === undefined ? {} : { closeModal })}>
+      <div style={modalBodyStyle}>
+        <div style={titleStyle}>Sign in to RomM</div>
+        <DropdownItem
+          label="Sign-in method"
+          rgOptions={[
+            { data: "pairing", label: "Pairing code" },
+            { data: "token", label: "API token" },
+            { data: "credentials", label: "Username & password" },
+          ]}
+          selectedOption={mode}
+          onChange={handleModeChange}
+        />
+        {mode === "token" && (
+          <>
+            <div style={helperTextStyle}>
+              Create a token in RomM&apos;s web UI (Settings → API Tokens) and paste it here. Make sure it has the
+              scopes listed in the plugin docs so downloads, saves, and device sync work. The plugin never deletes a
+              pasted token; you manage it in RomM.
+            </div>
+            <TextField
+              focusOnMount={true}
+              label="API Token"
+              value={token}
+              bIsPassword
+              onChange={handleTokenChange}
+              onKeyDown={handleCompletingKeyDown}
+            />
+          </>
+        )}
+        {mode === "pairing" && (
+          <>
+            <div style={helperTextStyle}>
+              In RomM&apos;s web UI open your API token and click <strong>Pair</strong>, then enter the 8-character code
+              here within 60 seconds. The plugin fetches the token itself — nothing to copy or paste.
+            </div>
+            <div style={codeLabelStyle}>Pairing code</div>
+            {/* Focusable + flow-children="horizontal" tells Steam's gamepad nav to
+                step between the boxes left/right (the analog stick/d-pad), not
+                up/down — a plain div defaults to vertical traversal. */}
+            <Focusable flow-children="horizontal" ref={codeRowRef} style={codeRowStyle} data-testid="pairing-code-row">
+              {CODE_INDICES.map((i) => (
+                <Fragment key={i}>
+                  {i === CODE_GROUP && <span style={codeSeparatorStyle}>-</span>}
+                  <div style={codeBoxWrapperStyle}>
+                    <TextField
+                      focusOnMount={i === 0}
+                      style={codeBoxFieldStyle}
+                      value={code[i] ?? ""}
+                      onChange={handleBoxChange(i)}
+                      onKeyDown={handleBoxKeyDown(i)}
+                    />
+                  </div>
+                </Fragment>
+              ))}
+            </Focusable>
+          </>
+        )}
+        {mode === "credentials" && (
+          <>
+            <div style={helperTextStyle}>
+              Enter your RomM username and password once. The plugin exchanges them for an API token and never stores
+              your password.
+            </div>
+            {/* A plain wrapping div carries the ref used to advance Enter from the
+                username field to the password field (querySelectorAll('input')[1]). */}
+            <div ref={credentialsRowRef} data-testid="credentials-row">
+              <TextField
+                focusOnMount={true}
+                label="Username"
+                value={username}
+                onChange={handleUsernameChange}
+                onKeyDown={handleUsernameKeyDown}
+              />
+              <TextField
+                label="Password"
+                value={password}
+                bIsPassword
+                onChange={handlePasswordChange}
+                onKeyDown={handleCompletingKeyDown}
+              />
+            </div>
+          </>
+        )}
+        {error !== null && (
+          <div style={errorStyle} data-testid="signin-error">
+            {error}
           </div>
-          <TextField
-            focusOnMount={true}
-            label="API Token"
-            value={token}
-            bIsPassword
-            onChange={(e: ChangeEvent<HTMLInputElement>) => setToken(e.target.value)}
-            onKeyDown={handleFieldKeyDown}
-          />
-        </>
-      )}
-      {mode === "pairing" && (
-        <>
-          <div style={helperTextStyle}>
-            In RomM&apos;s web UI open your API token and click <strong>Pair</strong>, then enter the 8-character code
-            here within 60 seconds. The plugin fetches the token itself — nothing to copy or paste.
-          </div>
-          <div style={codeLabelStyle}>Pairing code</div>
-          {/* Focusable + flow-children="horizontal" tells Steam's gamepad nav to
-              step between the boxes left/right (the analog stick/d-pad), not
-              up/down — a plain div defaults to vertical traversal. */}
-          <Focusable flow-children="horizontal" ref={codeRowRef} style={codeRowStyle} data-testid="pairing-code-row">
-            {CODE_INDICES.map((i) => (
-              <Fragment key={i}>
-                {i === CODE_GROUP && <span style={codeSeparatorStyle}>-</span>}
-                <div style={codeBoxWrapperStyle}>
-                  <TextField
-                    focusOnMount={i === 0}
-                    style={codeBoxFieldStyle}
-                    value={code[i] ?? ""}
-                    onChange={handleBoxChange(i)}
-                    onKeyDown={handleBoxKeyDown(i)}
-                  />
-                </div>
-              </Fragment>
-            ))}
-          </Focusable>
-        </>
-      )}
-      {mode === "credentials" && (
-        <>
-          <div style={helperTextStyle}>
-            Enter your RomM username and password once. The plugin exchanges them for an API token and never stores your
-            password.
-          </div>
-          <TextField
-            focusOnMount={true}
-            label="Username"
-            value={username}
-            onChange={(e: ChangeEvent<HTMLInputElement>) => setUsername(e.target.value)}
-            onKeyDown={handleFieldKeyDown}
-          />
-          <TextField
-            label="Password"
-            value={password}
-            bIsPassword
-            onChange={(e: ChangeEvent<HTMLInputElement>) => setPassword(e.target.value)}
-            onKeyDown={handleFieldKeyDown}
-          />
-        </>
-      )}
-    </ConfirmModal>
+        )}
+        <div style={footerStyle}>
+          <DialogButton
+            style={footerButtonStyle}
+            disabled={!canSubmit || submitting}
+            onClick={() => {
+              void submit();
+            }}
+          >
+            {submitting ? "Signing in…" : "Sign in"}
+          </DialogButton>
+          <DialogButton
+            style={footerButtonStyle}
+            onClick={() => {
+              closeModal?.();
+            }}
+          >
+            Cancel
+          </DialogButton>
+        </div>
+      </div>
+    </ModalRoot>
   );
 };

--- a/src/components/settings/ConnectionSection.test.tsx
+++ b/src/components/settings/ConnectionSection.test.tsx
@@ -8,7 +8,7 @@ import { showModal } from "@decky/ui";
 // so Field renders its `label` + `description` (those copy strings stay
 // queryable via field-label/field-desc) and DialogButton renders its
 // `children` ("Edit"/"Sign in") forwarding `onClick`; ButtonItem stays for the
-// layout="below" Test Connection row, forwarding `disabled` + `description` +
+// layout="below" Sign out row, forwarding `disabled` + `description` +
 // `children`; ToggleField forwards `checked` + a usable onChange that mirrors
 // the global stub's (boolean) signature.
 type AnyProps = Record<string, unknown> & { children?: unknown };
@@ -92,13 +92,11 @@ function defaultProps(overrides: Partial<React.ComponentProps<typeof ConnectionS
     hasToken: false,
     allowInsecureSsl: false,
     status: "",
-    loading: false,
     onUrlChange: vi.fn(),
     onConnect: vi.fn(),
     onConnectToken: vi.fn(),
     onConnectPairing: vi.fn(),
     onAllowInsecureSslChange: vi.fn(),
-    onTestConnection: vi.fn(),
     onSignOut: vi.fn(),
     ...overrides,
   };
@@ -282,32 +280,15 @@ describe("ConnectionSection", () => {
     });
   });
 
-  describe("Test Connection button", () => {
-    it("fires onTestConnection when clicked", () => {
-      const onTestConnection = vi.fn();
-      const { getByText } = render(<ConnectionSection {...defaultProps({ hasToken: true, onTestConnection })} />);
-      fireEvent.click(getByText("Test Connection"));
-      expect(onTestConnection).toHaveBeenCalledTimes(1);
+  describe("Test Connection button (removed)", () => {
+    it("no longer renders a Test Connection button (the QAM row probes automatically)", () => {
+      const { queryByText } = render(<ConnectionSection {...defaultProps({ hasToken: true })} />);
+      expect(queryByText("Test Connection")).toBeNull();
     });
 
-    it("is disabled while loading", () => {
-      const { getByText } = render(<ConnectionSection {...defaultProps({ hasToken: true, loading: true })} />);
-      expect(getByText("Test Connection")).toBeDisabled();
-    });
-
-    it("is disabled and shows the sign-in hint when not signed in", () => {
-      const { getByText } = render(<ConnectionSection {...defaultProps({ hasToken: false })} />);
-      const button = getByText("Test Connection");
-      expect(button).toBeDisabled();
-      expect(button.getAttribute("data-description")).toBe("Sign in to RomM first to test the connection.");
-    });
-
-    it("is enabled with no hint once signed in", () => {
-      const { getByText } = render(<ConnectionSection {...defaultProps({ hasToken: true })} />);
-      const button = getByText("Test Connection");
-      expect(button).not.toBeDisabled();
-      // `description={undefined}` renders no data-description attribute.
-      expect(button.getAttribute("data-description")).toBeNull();
+    it("stays absent when signed out too", () => {
+      const { queryByText } = render(<ConnectionSection {...defaultProps({ hasToken: false })} />);
+      expect(queryByText("Test Connection")).toBeNull();
     });
   });
 

--- a/src/components/settings/ConnectionSection.tsx
+++ b/src/components/settings/ConnectionSection.tsx
@@ -1,8 +1,8 @@
 /**
- * RomM server connection settings — URL, account sign-in/token, SSL toggle,
- * and the "Test Connection" affordance. Pure renderer: the parent owns the
- * field values, the has-token flag, the status string, and the
- * save/sign-in/test logic.
+ * RomM server connection settings — URL, account sign-in/token, and SSL toggle.
+ * Pure renderer: the parent owns the field values, the has-token flag, the
+ * status string, and the save/sign-in logic. The QAM connection row probes the
+ * server automatically, so there is no manual test affordance here.
  */
 
 import { FC } from "react";
@@ -31,13 +31,11 @@ interface ConnectionSectionProps {
   hasToken: boolean;
   allowInsecureSsl: boolean;
   status: string;
-  loading: boolean;
   onUrlChange: (value: string) => void;
   onConnect: (username: string, password: string) => Promise<SignInResult>;
   onConnectToken: (token: string) => Promise<SignInResult>;
   onConnectPairing: (code: string) => Promise<SignInResult>;
   onAllowInsecureSslChange: (value: boolean) => void;
-  onTestConnection: () => void;
   onSignOut: () => void;
 }
 
@@ -46,13 +44,11 @@ export const ConnectionSection: FC<ConnectionSectionProps> = ({
   hasToken,
   allowInsecureSsl,
   status,
-  loading,
   onUrlChange,
   onConnect,
   onConnectToken,
   onConnectPairing,
   onAllowInsecureSslChange,
-  onTestConnection,
   onSignOut,
 }) => {
   return (
@@ -118,16 +114,6 @@ export const ConnectionSection: FC<ConnectionSectionProps> = ({
           />
         </PanelSectionRow>
       )}
-      <PanelSectionRow>
-        <ButtonItem
-          layout="below"
-          onClick={onTestConnection}
-          disabled={loading || !hasToken}
-          description={hasToken ? undefined : "Sign in to RomM first to test the connection."}
-        >
-          Test Connection
-        </ButtonItem>
-      </PanelSectionRow>
       {status && (
         <PanelSectionRow>
           <Field label={status} />

--- a/src/components/settings/ConnectionSection.tsx
+++ b/src/components/settings/ConnectionSection.tsx
@@ -18,6 +18,7 @@ import {
 } from "@decky/ui";
 import { TextInputModal } from "./TextInputModal";
 import { ConnectModal } from "./ConnectModal";
+import type { SignInResult } from "./ConnectModal";
 import { isHttpsUrl } from "../../utils/serverUrl";
 
 // Sign-out only forgets the token on this device; it never revokes it in RomM.
@@ -32,9 +33,9 @@ interface ConnectionSectionProps {
   status: string;
   loading: boolean;
   onUrlChange: (value: string) => void;
-  onConnect: (username: string, password: string) => void;
-  onConnectToken: (token: string) => void;
-  onConnectPairing: (code: string) => void;
+  onConnect: (username: string, password: string) => Promise<SignInResult>;
+  onConnectToken: (token: string) => Promise<SignInResult>;
+  onConnectPairing: (code: string) => Promise<SignInResult>;
   onAllowInsecureSslChange: (value: boolean) => void;
   onTestConnection: () => void;
   onSignOut: () => void;

--- a/src/components/settings/SgdbApiKeyModal.test.tsx
+++ b/src/components/settings/SgdbApiKeyModal.test.tsx
@@ -1,0 +1,217 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, fireEvent, act } from "@testing-library/react";
+import { createElement, forwardRef } from "react";
+import { SgdbApiKeyModal } from "./SgdbApiKeyModal";
+
+// Local @decky/ui mock (mirrors ConnectModal.test.tsx): ModalRoot passes its
+// children through (the modal owns its own footer buttons); DialogButton renders
+// a real <button> forwarding onClick + disabled + children so Save / Cancel are
+// clickable and their disabled state is assertable (a disabled button swallows
+// the click in happy-dom, mirroring the real gate); TextField forwards label +
+// value + onChange + onKeyDown to a real <input>; Focusable forwards its ref to
+// a wrapping div.
+type AnyProps = Record<string, unknown> & { children?: unknown };
+interface TextFieldProps {
+  label?: string;
+  value?: string;
+  bIsPassword?: boolean;
+  onChange?: (e: { target: { value: string } }) => void;
+  onKeyDown?: (e: unknown) => void;
+}
+
+vi.mock("@decky/ui", () => ({
+  ModalRoot: (p: AnyProps) => createElement("div", { "data-testid": "modal-root" }, p.children as never),
+  Focusable: forwardRef<HTMLDivElement, AnyProps>((p, ref) =>
+    createElement("div", { ref, style: p.style }, p.children as never),
+  ),
+  DialogButton: ({ children, onClick, disabled }: AnyProps & { onClick?: () => void; disabled?: boolean }) =>
+    createElement("button", { onClick, disabled }, children as never),
+  TextField: (p: TextFieldProps) =>
+    createElement("input", {
+      "data-testid": `field-${p.label ?? ""}`,
+      "data-is-password": p.bIsPassword ? "true" : "false",
+      value: p.value ?? "",
+      onChange: (e: unknown) => p.onChange?.(e as { target: { value: string } }),
+      onKeyDown: (e: unknown) => p.onKeyDown?.(e),
+    }),
+}));
+
+// Resolved handlers: onVerify defaults to a valid key, onSave to a no-op.
+const verifyOk = (message = "API key is valid") => vi.fn().mockResolvedValue({ success: true, message });
+const verifyFail = (message: string) => vi.fn().mockResolvedValue({ success: false, message });
+const saveOk = () => vi.fn().mockResolvedValue(undefined);
+
+// Flush the floating submit() promise (onClick fires `void submit()`), then let
+// React apply the resulting state updates. A few microtask ticks cover the
+// `await onVerify(...)` + `await onSave(...)` + finally.
+async function flushSubmit() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+const field = (getByTestId: (id: string) => HTMLElement): HTMLInputElement =>
+  getByTestId("field-API Key") as HTMLInputElement;
+
+describe("SgdbApiKeyModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders an obscured, empty API-key field (write-only) plus Save and Cancel", () => {
+    const { getByTestId, getByText } = render(<SgdbApiKeyModal onVerify={verifyOk()} onSave={saveOk()} />);
+    const input = field(getByTestId);
+    expect(input.value).toBe("");
+    expect(input.getAttribute("data-is-password")).toBe("true");
+    expect(getByText("Save")).toBeTruthy();
+    expect(getByText("Cancel")).toBeTruthy();
+  });
+
+  it("Cancel closes the modal without verifying or saving", () => {
+    const closeModal = vi.fn();
+    const onVerify = verifyOk();
+    const onSave = saveOk();
+    const { getByText } = render(<SgdbApiKeyModal closeModal={closeModal} onVerify={onVerify} onSave={onSave} />);
+    fireEvent.click(getByText("Cancel"));
+    expect(closeModal).toHaveBeenCalledTimes(1);
+    expect(onVerify).not.toHaveBeenCalled();
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  describe("submit gating", () => {
+    it("disables Save until the field is non-empty", () => {
+      const { getByTestId, getByText } = render(<SgdbApiKeyModal onVerify={verifyOk()} onSave={saveOk()} />);
+      expect(getByText("Save")).toBeDisabled();
+      fireEvent.change(field(getByTestId), { target: { value: "sgdb_key" } });
+      expect(getByText("Save")).not.toBeDisabled();
+    });
+
+    it("keeps Save disabled for a whitespace-only value", () => {
+      const { getByTestId, getByText } = render(<SgdbApiKeyModal onVerify={verifyOk()} onSave={saveOk()} />);
+      fireEvent.change(field(getByTestId), { target: { value: "   " } });
+      expect(getByText("Save")).toBeDisabled();
+    });
+
+    it("does not verify when Save is clicked with an empty field (disabled swallows the click)", () => {
+      const onVerify = verifyOk();
+      const { getByText } = render(<SgdbApiKeyModal onVerify={onVerify} onSave={saveOk()} />);
+      fireEvent.click(getByText("Save"));
+      expect(onVerify).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("success path (valid key)", () => {
+    it("verifies the entered key, then saves it, then closes — no error shown", async () => {
+      const closeModal = vi.fn();
+      const onVerify = verifyOk();
+      const onSave = saveOk();
+      const { getByTestId, getByText, queryByTestId } = render(
+        <SgdbApiKeyModal closeModal={closeModal} onVerify={onVerify} onSave={onSave} />,
+      );
+      fireEvent.change(field(getByTestId), { target: { value: "good_key" } });
+      fireEvent.click(getByText("Save"));
+      await flushSubmit();
+      expect(onVerify).toHaveBeenCalledTimes(1);
+      expect(onVerify).toHaveBeenCalledWith("good_key");
+      expect(onSave).toHaveBeenCalledTimes(1);
+      expect(onSave).toHaveBeenCalledWith("good_key");
+      expect(closeModal).toHaveBeenCalledTimes(1);
+      expect(queryByTestId("sgdb-key-error")).toBeNull();
+    });
+  });
+
+  describe("failure path (modal stays open, key not saved)", () => {
+    it("shows the returned message and does NOT save when verification fails", async () => {
+      const closeModal = vi.fn();
+      const onVerify = verifyFail("API key rejected by SteamGridDB");
+      const onSave = saveOk();
+      const { getByTestId, getByText } = render(
+        <SgdbApiKeyModal closeModal={closeModal} onVerify={onVerify} onSave={onSave} />,
+      );
+      fireEvent.change(field(getByTestId), { target: { value: "bad_key" } });
+      fireEvent.click(getByText("Save"));
+      await flushSubmit();
+      expect(getByTestId("sgdb-key-error").textContent).toBe("API key rejected by SteamGridDB");
+      expect(onSave).not.toHaveBeenCalled();
+      expect(closeModal).not.toHaveBeenCalled();
+    });
+
+    it("shows a generic error and stays open when verification rejects", async () => {
+      const closeModal = vi.fn();
+      const onVerify = vi.fn().mockRejectedValue(new Error("network"));
+      const onSave = saveOk();
+      const { getByTestId, getByText } = render(
+        <SgdbApiKeyModal closeModal={closeModal} onVerify={onVerify} onSave={onSave} />,
+      );
+      fireEvent.change(field(getByTestId), { target: { value: "any_key" } });
+      fireEvent.click(getByText("Save"));
+      await flushSubmit();
+      expect(getByTestId("sgdb-key-error").textContent).toBe(
+        "Could not verify the key. Check your connection and try again.",
+      );
+      expect(onSave).not.toHaveBeenCalled();
+      expect(closeModal).not.toHaveBeenCalled();
+    });
+
+    it("shows a save-specific error (not the verify error) and stays open when the save rejects", async () => {
+      const closeModal = vi.fn();
+      const onVerify = verifyOk();
+      const onSave = vi.fn().mockRejectedValue(new Error("disk full"));
+      const { getByTestId, getByText } = render(
+        <SgdbApiKeyModal closeModal={closeModal} onVerify={onVerify} onSave={onSave} />,
+      );
+      fireEvent.change(field(getByTestId), { target: { value: "good_key" } });
+      fireEvent.click(getByText("Save"));
+      await flushSubmit();
+      expect(onSave).toHaveBeenCalledTimes(1);
+      // The verify succeeded, so the message must not claim it couldn't be verified.
+      expect(getByTestId("sgdb-key-error").textContent).toBe(
+        "The key is valid, but saving it failed. Check your connection and try again.",
+      );
+      expect(closeModal).not.toHaveBeenCalled();
+    });
+
+    it("clears a stale error when the user edits the field", async () => {
+      const onVerify = verifyFail("API key rejected by SteamGridDB");
+      const { getByTestId, getByText, queryByTestId } = render(
+        <SgdbApiKeyModal onVerify={onVerify} onSave={saveOk()} />,
+      );
+      fireEvent.change(field(getByTestId), { target: { value: "bad" } });
+      fireEvent.click(getByText("Save"));
+      await flushSubmit();
+      expect(getByTestId("sgdb-key-error")).toBeTruthy();
+      fireEvent.change(field(getByTestId), { target: { value: "bad2" } });
+      expect(queryByTestId("sgdb-key-error")).toBeNull();
+    });
+  });
+
+  describe("Enter key", () => {
+    it("submits on Enter once the field is non-empty and closes on success, consuming the event", async () => {
+      const closeModal = vi.fn();
+      const onVerify = verifyOk();
+      const onSave = saveOk();
+      const { getByTestId } = render(<SgdbApiKeyModal closeModal={closeModal} onVerify={onVerify} onSave={onSave} />);
+      fireEvent.change(field(getByTestId), { target: { value: "good_key" } });
+      // fireEvent returns false when a handler called preventDefault — the Enter
+      // is consumed so Steam's ModalRoot cannot fire its own default close.
+      const notPrevented = fireEvent.keyDown(field(getByTestId), { key: "Enter" });
+      expect(notPrevented).toBe(false);
+      await flushSubmit();
+      expect(onVerify).toHaveBeenCalledWith("good_key");
+      expect(onSave).toHaveBeenCalledWith("good_key");
+      expect(closeModal).toHaveBeenCalledTimes(1);
+    });
+
+    it("ignores Enter on an empty field (no verify, no close) but still consumes the event", () => {
+      const closeModal = vi.fn();
+      const onVerify = verifyOk();
+      const { getByTestId } = render(<SgdbApiKeyModal closeModal={closeModal} onVerify={onVerify} onSave={saveOk()} />);
+      const notPrevented = fireEvent.keyDown(field(getByTestId), { key: "Enter" });
+      expect(notPrevented).toBe(false);
+      expect(onVerify).not.toHaveBeenCalled();
+      expect(closeModal).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/components/settings/SgdbApiKeyModal.tsx
+++ b/src/components/settings/SgdbApiKeyModal.tsx
@@ -1,0 +1,148 @@
+/**
+ * Prompt for entering a SteamGridDB API key, validated inline before it is
+ * saved. On submit the entered key is first tested against SteamGridDB
+ * (``onVerify``); only a valid key is persisted (``onSave``) and the modal
+ * closes. A rejected key keeps the modal open and shows the returned message so
+ * the user can correct and retry — the generic TextInputModal saved without
+ * validating, which let an invalid key sit silently. The key is write-only:
+ * never pre-filled, never echoed back. This modal owns only the in-flight field
+ * value and the in-flight/error UI state; ``onVerify`` / ``onSave`` own the
+ * backend calls and persistence.
+ */
+
+import { FC, useState, ChangeEvent, KeyboardEvent } from "react";
+import { ModalRoot, TextField, DialogButton, Focusable } from "@decky/ui";
+
+/** The subset of the verify result the modal needs to decide whether to save
+ *  (success) or surface an error and stay open (failure). */
+export interface VerifyKeyResult {
+  success: boolean;
+  message: string;
+}
+
+interface SgdbApiKeyModalProps {
+  closeModal?: () => void;
+  /** Tests the entered key against SteamGridDB without persisting it. */
+  onVerify: (key: string) => Promise<VerifyKeyResult>;
+  /** Persists the entered key. Only called after ``onVerify`` succeeds. */
+  onSave: (key: string) => Promise<void>;
+}
+
+// ModalRoot renders only the shell + a close affordance (no strTitle / OK
+// button), so the title, body, error line, and footer are all rendered as
+// content here — mirroring ConnectModal.
+const modalBodyStyle = { padding: "16px", minWidth: "360px" } as const;
+const titleStyle = { fontSize: "16px", fontWeight: "bold", marginBottom: "12px", color: "#fff" } as const;
+const helperTextStyle = { fontSize: "12px", marginBottom: "12px", color: "rgba(255,255,255,0.6)" } as const;
+// A failed verification surfaces here, above the footer, in a red-ish tone.
+const errorStyle = { color: "#d94126", fontSize: "13px", marginTop: "12px", marginBottom: "4px" } as const;
+const footerStyle = { display: "flex", gap: "8px", marginTop: "16px" } as const;
+const footerButtonStyle = { flex: "1 1 0px", minWidth: 0 } as const;
+
+const GENERIC_VERIFY_ERROR = "Could not verify the key. Check your connection and try again.";
+const GENERIC_SAVE_ERROR = "The key is valid, but saving it failed. Check your connection and try again.";
+
+export const SgdbApiKeyModal: FC<SgdbApiKeyModalProps> = ({ closeModal, onVerify, onSave }) => {
+  const [value, setValue] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Trimmed so a whitespace-only value never counts as submittable.
+  const canSubmit = value.trim() !== "";
+
+  // Verify the entered key; on success persist it and close, on failure keep the
+  // modal open with the returned message so the user can correct and retry.
+  const submit = async () => {
+    if (!canSubmit || submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      let check: VerifyKeyResult;
+      try {
+        check = await onVerify(value);
+      } catch {
+        setError(GENERIC_VERIFY_ERROR);
+        return;
+      }
+      if (!check.success) {
+        setError(check.message);
+        return;
+      }
+      // The key is valid; persist it. A save failure is distinct from a verify
+      // failure, so it must not claim the key couldn't be verified.
+      try {
+        await onSave(value);
+      } catch {
+        setError(GENERIC_SAVE_ERROR);
+        return;
+      }
+      closeModal?.();
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setValue(e.target.value);
+    // Any edit clears a stale error so it doesn't linger past a correction.
+    setError(null);
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key !== "Enter") return;
+    // Consume the event so Steam's ModalRoot cannot fire its own default
+    // confirm/close on an incomplete field — regardless of whether we submit.
+    e.preventDefault();
+    e.stopPropagation();
+    if (canSubmit) void submit();
+  };
+
+  return (
+    <ModalRoot {...(closeModal === undefined ? {} : { closeModal })}>
+      <div style={modalBodyStyle}>
+        <div style={titleStyle}>SteamGridDB API Key</div>
+        <div style={helperTextStyle}>
+          Paste the key from your SteamGridDB profile (Preferences &rarr; API). It is checked against SteamGridDB before
+          it is saved.
+        </div>
+        {/* Wrapped in <Focusable> like ConnectModal's token field: on the Deck,
+            R2/OSK-Enter on an unwrapped single field otherwise closes the
+            ModalRoot even when the Enter handler no-ops on an incomplete field. */}
+        <Focusable>
+          <TextField
+            focusOnMount={true}
+            label="API Key"
+            value={value}
+            bIsPassword
+            onChange={handleChange}
+            onKeyDown={handleKeyDown}
+          />
+        </Focusable>
+        {error !== null && (
+          <div style={errorStyle} data-testid="sgdb-key-error">
+            {error}
+          </div>
+        )}
+        <div style={footerStyle}>
+          <DialogButton
+            style={footerButtonStyle}
+            disabled={!canSubmit || submitting}
+            onClick={() => {
+              void submit();
+            }}
+          >
+            {submitting ? "Verifying…" : "Save"}
+          </DialogButton>
+          <DialogButton
+            style={footerButtonStyle}
+            onClick={() => {
+              closeModal?.();
+            }}
+          >
+            Cancel
+          </DialogButton>
+        </div>
+      </div>
+    </ModalRoot>
+  );
+};

--- a/src/components/settings/SgdbApiKeyModal.tsx
+++ b/src/components/settings/SgdbApiKeyModal.tsx
@@ -11,7 +11,8 @@
  */
 
 import { FC, useState, ChangeEvent, KeyboardEvent } from "react";
-import { ModalRoot, TextField, DialogButton, Focusable } from "@decky/ui";
+import { TextField, Focusable } from "@decky/ui";
+import { ValidatingModalShell } from "./ValidatingModalShell";
 
 /** The subset of the verify result the modal needs to decide whether to save
  *  (success) or surface an error and stay open (failure). */
@@ -28,16 +29,7 @@ interface SgdbApiKeyModalProps {
   onSave: (key: string) => Promise<void>;
 }
 
-// ModalRoot renders only the shell + a close affordance (no strTitle / OK
-// button), so the title, body, error line, and footer are all rendered as
-// content here — mirroring ConnectModal.
-const modalBodyStyle = { padding: "16px", minWidth: "360px" } as const;
-const titleStyle = { fontSize: "16px", fontWeight: "bold", marginBottom: "12px", color: "#fff" } as const;
 const helperTextStyle = { fontSize: "12px", marginBottom: "12px", color: "rgba(255,255,255,0.6)" } as const;
-// A failed verification surfaces here, above the footer, in a red-ish tone.
-const errorStyle = { color: "#d94126", fontSize: "13px", marginTop: "12px", marginBottom: "4px" } as const;
-const footerStyle = { display: "flex", gap: "8px", marginTop: "16px" } as const;
-const footerButtonStyle = { flex: "1 1 0px", minWidth: 0 } as const;
 
 const GENERIC_VERIFY_ERROR = "Could not verify the key. Check your connection and try again.";
 const GENERIC_SAVE_ERROR = "The key is valid, but saving it failed. Check your connection and try again.";
@@ -98,51 +90,34 @@ export const SgdbApiKeyModal: FC<SgdbApiKeyModalProps> = ({ closeModal, onVerify
   };
 
   return (
-    <ModalRoot {...(closeModal === undefined ? {} : { closeModal })}>
-      <div style={modalBodyStyle}>
-        <div style={titleStyle}>SteamGridDB API Key</div>
-        <div style={helperTextStyle}>
-          Paste the key from your SteamGridDB profile (Preferences &rarr; API). It is checked against SteamGridDB before
-          it is saved.
-        </div>
-        {/* Wrapped in <Focusable> like ConnectModal's token field: on the Deck,
-            R2/OSK-Enter on an unwrapped single field otherwise closes the
-            ModalRoot even when the Enter handler no-ops on an incomplete field. */}
-        <Focusable>
-          <TextField
-            focusOnMount={true}
-            label="API Key"
-            value={value}
-            bIsPassword
-            onChange={handleChange}
-            onKeyDown={handleKeyDown}
-          />
-        </Focusable>
-        {error !== null && (
-          <div style={errorStyle} data-testid="sgdb-key-error">
-            {error}
-          </div>
-        )}
-        <div style={footerStyle}>
-          <DialogButton
-            style={footerButtonStyle}
-            disabled={!canSubmit || submitting}
-            onClick={() => {
-              void submit();
-            }}
-          >
-            {submitting ? "Verifying…" : "Save"}
-          </DialogButton>
-          <DialogButton
-            style={footerButtonStyle}
-            onClick={() => {
-              closeModal?.();
-            }}
-          >
-            Cancel
-          </DialogButton>
-        </div>
+    <ValidatingModalShell
+      {...(closeModal === undefined ? {} : { closeModal })}
+      title="SteamGridDB API Key"
+      error={error}
+      errorTestId="sgdb-key-error"
+      submitLabel={submitting ? "Verifying…" : "Save"}
+      submitDisabled={!canSubmit || submitting}
+      onSubmit={() => {
+        void submit();
+      }}
+    >
+      <div style={helperTextStyle}>
+        Paste the key from your SteamGridDB profile (Preferences &rarr; API). It is checked against SteamGridDB before
+        it is saved.
       </div>
-    </ModalRoot>
+      {/* Wrapped in <Focusable> like ConnectModal's token field: on the Deck,
+          R2/OSK-Enter on an unwrapped single field otherwise closes the
+          ModalRoot even when the Enter handler no-ops on an incomplete field. */}
+      <Focusable>
+        <TextField
+          focusOnMount={true}
+          label="API Key"
+          value={value}
+          bIsPassword
+          onChange={handleChange}
+          onKeyDown={handleKeyDown}
+        />
+      </Focusable>
+    </ValidatingModalShell>
   );
 };

--- a/src/components/settings/SteamGridDBSection.test.tsx
+++ b/src/components/settings/SteamGridDBSection.test.tsx
@@ -1,17 +1,13 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, fireEvent } from "@testing-library/react";
 import { createElement, type ReactElement } from "react";
 import { SteamGridDBSection } from "./SteamGridDBSection";
 import { showModal } from "@decky/ui";
 
-// Local re-mock — we need:
-//  - Field to render its `label` + `description` (the API Key row is a
-//    Field + DialogButton again) so masked-key vs. "Not configured" can be
-//    asserted via field-desc, plus the (Field-based) status row.
-//  - DialogButton to render its `children` ("Edit") and forward `onClick` so
-//    the modal-open wiring stays drivable.
-//  - ButtonItem to forward `onClick` + `disabled` and render its `children`
-//    (the Verify Key row stays a layout="below" ButtonItem).
+// Local re-mock — the API Key row is a Field + DialogButton, so Field renders
+// its `label` + `description` (masked "••••" vs. "Not configured" assertable via
+// field-desc) and DialogButton renders its `children` ("Edit") forwarding
+// `onClick` so the modal-open wiring stays drivable.
 type AnyProps = Record<string, unknown> & { children?: unknown };
 vi.mock("@decky/ui", () => ({
   PanelSection: (p: AnyProps) => createElement("section", {}, p.children as never),
@@ -26,38 +22,28 @@ vi.mock("@decky/ui", () => ({
     ),
   DialogButton: ({ children, onClick, disabled }: AnyProps & { onClick?: () => void; disabled?: boolean }) =>
     createElement("button", { onClick, disabled }, children as never),
-  ButtonItem: ({
-    children,
-    onClick,
-    disabled,
-  }: AnyProps & {
-    onClick?: () => void;
-    disabled?: boolean;
-  }) => createElement("button", { onClick, disabled }, children as never),
   showModal: vi.fn(),
 }));
 
-interface TextInputProps {
-  label: string;
-  value: string;
-  bIsPassword?: boolean;
-  onSubmit: (value: string) => void;
+// The Edit button opens SgdbApiKeyModal; capture the props it was constructed
+// with so the verify/save wiring is assertable without rendering the modal.
+interface SgdbModalProps {
+  onVerify?: (key: string) => Promise<{ success: boolean; message: string }>;
+  onSave?: (key: string) => Promise<void>;
 }
 
-function lastShownModalProps(): TextInputProps | null {
+function lastShownModalProps(): SgdbModalProps | null {
   const calls = vi.mocked(showModal).mock.calls;
   if (calls.length === 0) return null;
-  const el = calls[calls.length - 1]?.[0] as ReactElement<TextInputProps> | undefined;
+  const el = calls[calls.length - 1]?.[0] as ReactElement<SgdbModalProps> | undefined;
   return el?.props ?? null;
 }
 
 function defaultProps(overrides: Partial<React.ComponentProps<typeof SteamGridDBSection>> = {}) {
   return {
     sgdbApiKey: "",
-    sgdbStatus: "",
-    sgdbVerifying: false,
-    onSubmitKey: vi.fn(),
-    onVerifyKey: vi.fn(),
+    onVerifyKey: vi.fn(async () => ({ success: true, message: "" })),
+    onSaveKey: vi.fn(async () => {}),
     ...overrides,
   };
 }
@@ -79,69 +65,39 @@ describe("SteamGridDBSection", () => {
       const descs = getAllByTestId("field-desc").map((el) => el.textContent);
       expect(descs).toContain("Not configured");
     });
+  });
 
-    it("opens a TextInputModal when Edit is clicked, prefilled empty and password-typed", () => {
-      const onSubmitKey = vi.fn();
-      const { getByText } = render(<SteamGridDBSection {...defaultProps({ sgdbApiKey: "stored", onSubmitKey })} />);
+  describe("Edit opens the inline-validating modal", () => {
+    it("opens SgdbApiKeyModal wired to onVerifyKey + onSaveKey when Edit is clicked", () => {
+      const onVerifyKey = vi.fn(async () => ({ success: true, message: "" }));
+      const onSaveKey = vi.fn(async () => {});
+      const { getByText } = render(
+        <SteamGridDBSection {...defaultProps({ sgdbApiKey: "stored", onVerifyKey, onSaveKey })} />,
+      );
       fireEvent.click(getByText("Edit"));
       const props = lastShownModalProps();
       expect(props).not.toBeNull();
-      expect(props?.label).toBe("SteamGridDB API Key");
-      expect(props?.value).toBe("");
-      expect(props?.bIsPassword).toBe(true);
-      expect(props?.onSubmit).toBe(onSubmitKey);
+      // The modal owns the verify-then-save orchestration; the section only
+      // threads the parent's handlers into it.
+      expect(props?.onVerify).toBe(onVerifyKey);
+      expect(props?.onSave).toBe(onSaveKey);
+    });
+
+    it("does not open a modal until Edit is clicked", () => {
+      render(<SteamGridDBSection {...defaultProps({ sgdbApiKey: "stored" })} />);
+      expect(vi.mocked(showModal)).not.toHaveBeenCalled();
     });
   });
 
-  describe("verify button", () => {
-    it("is disabled while verifying", () => {
-      const { getByText } = render(
-        <SteamGridDBSection {...defaultProps({ sgdbApiKey: "stored", sgdbVerifying: true })} />,
-      );
-      const btn = getByText("Verifying...");
-      expect(btn).toBeDisabled();
+  describe("removed affordances", () => {
+    it("no longer renders a Verify Key button", () => {
+      const { queryByText } = render(<SteamGridDBSection {...defaultProps({ sgdbApiKey: "stored" })} />);
+      expect(queryByText("Verify Key")).toBeNull();
+      expect(queryByText("Verifying...")).toBeNull();
     });
 
-    it("is disabled when no key is configured (even if not verifying)", () => {
-      const { getByText } = render(<SteamGridDBSection {...defaultProps()} />);
-      const btn = getByText("Verify Key");
-      expect(btn).toBeDisabled();
-    });
-
-    it("is enabled when a key is set and not verifying", () => {
-      const { getByText } = render(<SteamGridDBSection {...defaultProps({ sgdbApiKey: "stored" })} />);
-      const btn = getByText("Verify Key");
-      expect(btn).not.toBeDisabled();
-    });
-
-    it("fires onVerifyKey when clicked", () => {
-      const onVerifyKey = vi.fn();
-      const { getByText } = render(<SteamGridDBSection {...defaultProps({ sgdbApiKey: "stored", onVerifyKey })} />);
-      fireEvent.click(getByText("Verify Key"));
-      expect(onVerifyKey).toHaveBeenCalledTimes(1);
-    });
-
-    it("renders 'Verifying...' label while sgdbVerifying is true", () => {
-      const { getByText } = render(
-        <SteamGridDBSection {...defaultProps({ sgdbApiKey: "stored", sgdbVerifying: true })} />,
-      );
-      expect(getByText("Verifying...")).toBeInTheDocument();
-    });
-  });
-
-  describe("status row", () => {
-    it("renders a status Field when sgdbStatus is non-empty", () => {
-      const { getAllByTestId } = render(<SteamGridDBSection {...defaultProps({ sgdbStatus: "Valid key ✓" })} />);
-      const labels = getAllByTestId("field-label").map((el) => el.textContent);
-      expect(labels).toContain("Valid key ✓");
-      // API Key row + status row.
-      expect(getAllByTestId("field")).toHaveLength(2);
-    });
-
-    it("omits the status row when sgdbStatus is empty", () => {
-      const { getAllByTestId } = render(<SteamGridDBSection {...defaultProps()} />);
-      // The API Key row is a Field + DialogButton, so with no status the only
-      // remaining Field is the API Key row — exactly one, labelled "API Key".
+    it("renders exactly one Field (the API Key row) — no status line of its own", () => {
+      const { getAllByTestId } = render(<SteamGridDBSection {...defaultProps({ sgdbApiKey: "stored" })} />);
       const labels = getAllByTestId("field-label").map((el) => el.textContent);
       expect(labels).toEqual(["API Key"]);
     });

--- a/src/components/settings/SteamGridDBSection.tsx
+++ b/src/components/settings/SteamGridDBSection.tsx
@@ -1,51 +1,34 @@
 /**
- * SteamGridDB API key + verify-key affordance. Pure renderer: parent owns
- * the masked-key display value, the verifying flag, and the status message.
+ * SteamGridDB API key entry. Pure renderer: the parent owns the masked-key
+ * display value and the verify/save handlers. The key is entered through
+ * SgdbApiKeyModal, which validates it against SteamGridDB before saving, so this
+ * section carries no status line of its own.
  */
 
 import { FC } from "react";
-import { PanelSection, PanelSectionRow, ButtonItem, DialogButton, Field, showModal } from "@decky/ui";
-import { TextInputModal } from "./TextInputModal";
+import { PanelSection, PanelSectionRow, DialogButton, Field, showModal } from "@decky/ui";
+import { SgdbApiKeyModal } from "./SgdbApiKeyModal";
+import type { VerifyKeyResult } from "./SgdbApiKeyModal";
 
 interface SteamGridDBSectionProps {
   sgdbApiKey: string;
-  sgdbStatus: string;
-  sgdbVerifying: boolean;
-  onSubmitKey: (value: string) => void;
-  onVerifyKey: () => void;
+  onVerifyKey: (key: string) => Promise<VerifyKeyResult>;
+  onSaveKey: (key: string) => Promise<void>;
 }
 
-export const SteamGridDBSection: FC<SteamGridDBSectionProps> = ({
-  sgdbApiKey,
-  sgdbStatus,
-  sgdbVerifying,
-  onSubmitKey,
-  onVerifyKey,
-}) => {
+export const SteamGridDBSection: FC<SteamGridDBSectionProps> = ({ sgdbApiKey, onVerifyKey, onSaveKey }) => {
   return (
     <PanelSection title="SteamGridDB">
       <PanelSectionRow>
         <Field label="API Key" description={sgdbApiKey ? "••••" : "Not configured"}>
           <DialogButton
             style={{ minWidth: "auto", width: "auto" }}
-            onClick={() =>
-              showModal(<TextInputModal label="SteamGridDB API Key" value="" bIsPassword onSubmit={onSubmitKey} />)
-            }
+            onClick={() => showModal(<SgdbApiKeyModal onVerify={onVerifyKey} onSave={onSaveKey} />)}
           >
             Edit
           </DialogButton>
         </Field>
       </PanelSectionRow>
-      <PanelSectionRow>
-        <ButtonItem layout="below" onClick={onVerifyKey} disabled={sgdbVerifying || !sgdbApiKey}>
-          {sgdbVerifying ? "Verifying..." : "Verify Key"}
-        </ButtonItem>
-      </PanelSectionRow>
-      {sgdbStatus && (
-        <PanelSectionRow>
-          <Field label={sgdbStatus} />
-        </PanelSectionRow>
-      )}
     </PanelSection>
   );
 };

--- a/src/components/settings/TextInputModal.test.tsx
+++ b/src/components/settings/TextInputModal.test.tsx
@@ -10,6 +10,7 @@ type AnyProps = Record<string, unknown> & { children?: unknown };
 interface CapturedConfirm {
   onOK?: (() => void) | undefined;
   bDisableBackgroundDismiss?: boolean | undefined;
+  bOKDisabled?: boolean | undefined;
   closeModal?: unknown;
   strTitle?: string | undefined;
 }
@@ -19,6 +20,7 @@ vi.mock("@decky/ui", () => ({
   ConfirmModal: (p: AnyProps & CapturedConfirm) => {
     captured.onOK = p.onOK;
     captured.bDisableBackgroundDismiss = p.bDisableBackgroundDismiss;
+    captured.bOKDisabled = p.bOKDisabled;
     captured.closeModal = p.closeModal;
     captured.strTitle = p.strTitle;
     return createElement("div", { "data-testid": "confirm-modal" }, p.children as never);
@@ -95,6 +97,49 @@ describe("TextInputModal", () => {
     expect(onSubmit).toHaveBeenCalledWith("edited");
     // ConfirmModal's OK auto-closes; the manual Enter path must close itself.
     expect(closeModal).toHaveBeenCalledTimes(1);
+  });
+
+  describe("non-empty requirement", () => {
+    it("disables OK when the value is empty", () => {
+      render(<TextInputModal label="x" value="" onSubmit={vi.fn()} />);
+      expect(captured.bOKDisabled).toBe(true);
+    });
+
+    it("disables OK when the value is whitespace-only", () => {
+      render(<TextInputModal label="x" value="" onSubmit={vi.fn()} />);
+      const input = document.querySelector("input") as HTMLInputElement;
+      fireEvent.change(input, { target: { value: "   " } });
+      expect(captured.bOKDisabled).toBe(true);
+    });
+
+    it("enables OK once the value is non-empty", () => {
+      render(<TextInputModal label="x" value="" onSubmit={vi.fn()} />);
+      expect(captured.bOKDisabled).toBe(true);
+      const input = document.querySelector("input") as HTMLInputElement;
+      fireEvent.change(input, { target: { value: "x" } });
+      expect(captured.bOKDisabled).toBe(false);
+    });
+
+    it("ignores Enter on an empty field — no submit, no close", () => {
+      const onSubmit = vi.fn();
+      const closeModal = vi.fn();
+      render(<TextInputModal label="x" value="" closeModal={closeModal} onSubmit={onSubmit} />);
+      const input = document.querySelector("input") as HTMLInputElement;
+      fireEvent.keyDown(input, { key: "Enter" });
+      expect(onSubmit).not.toHaveBeenCalled();
+      expect(closeModal).not.toHaveBeenCalled();
+    });
+
+    it("ignores Enter on a whitespace-only field — no submit, no close", () => {
+      const onSubmit = vi.fn();
+      const closeModal = vi.fn();
+      render(<TextInputModal label="x" value="" closeModal={closeModal} onSubmit={onSubmit} />);
+      const input = document.querySelector("input") as HTMLInputElement;
+      fireEvent.change(input, { target: { value: "   " } });
+      fireEvent.keyDown(input, { key: "Enter" });
+      expect(onSubmit).not.toHaveBeenCalled();
+      expect(closeModal).not.toHaveBeenCalled();
+    });
   });
 
   it("does NOT trim — submits whitespace as-is (parent is responsible)", () => {

--- a/src/components/settings/TextInputModal.tsx
+++ b/src/components/settings/TextInputModal.tsx
@@ -29,6 +29,9 @@ export const TextInputModal: FC<TextInputModalProps> = ({
   onSubmit,
 }) => {
   const [value, setValue] = useState(initial);
+  // Every field this modal edits (SteamGridDB API key, RomM URL, Default Save
+  // Slot) must be non-empty, so a whitespace-only value never counts as a submit.
+  const canSubmit = value.trim() !== "";
   const handleOK = () => {
     if (field) {
       pendingEdits[field] = value;
@@ -39,6 +42,7 @@ export const TextInputModal: FC<TextInputModalProps> = ({
     <ConfirmModal
       {...(closeModal !== undefined ? { closeModal } : {})}
       onOK={handleOK}
+      bOKDisabled={!canSubmit}
       strTitle={label}
       bDisableBackgroundDismiss={true}
     >
@@ -51,8 +55,11 @@ export const TextInputModal: FC<TextInputModalProps> = ({
         // Enter (the on-screen keyboard's "Eingabe" key) confirms, same as the OK
         // button. ConfirmModal auto-closes on its OK button but not on this manual
         // path, so close here too — handleOK is shared so the two never drift.
+        // Gated on canSubmit so an empty/whitespace field is a no-op on Enter,
+        // matching the disabled OK button (on the Deck, R2/Enter would otherwise
+        // confirm an empty value and close the modal).
         onKeyDown={(e: KeyboardEvent<HTMLInputElement>) => {
-          if (e.key === "Enter") {
+          if (e.key === "Enter" && canSubmit) {
             handleOK();
             closeModal?.();
           }

--- a/src/components/settings/ValidatingModalShell.test.tsx
+++ b/src/components/settings/ValidatingModalShell.test.tsx
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import { createElement } from "react";
+import { ValidatingModalShell } from "./ValidatingModalShell";
+
+// Local @decky/ui mock (mirrors ConnectModal.test.tsx): ModalRoot passes its
+// children through (the shell owns its own footer buttons); DialogButton renders
+// a real <button> forwarding onClick + disabled + children so the primary and
+// Cancel buttons are clickable and their disabled state is assertable (a disabled
+// button swallows the click in happy-dom, mirroring the real gate).
+type AnyProps = Record<string, unknown> & { children?: unknown };
+
+vi.mock("@decky/ui", () => ({
+  ModalRoot: (p: AnyProps) => createElement("div", { "data-testid": "modal-root" }, p.children as never),
+  DialogButton: ({ children, onClick, disabled }: AnyProps & { onClick?: () => void; disabled?: boolean }) =>
+    createElement("button", { onClick, disabled }, children as never),
+}));
+
+// A minimal, always-present body so children rendering is observable and distinct
+// from the title.
+const child = () => createElement("div", { "data-testid": "shell-child" }, "field content");
+
+describe("ValidatingModalShell", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the title, the children, and the primary + Cancel buttons", () => {
+    const { getByText, getByTestId } = render(
+      <ValidatingModalShell
+        title="My Title"
+        error={null}
+        errorTestId="shell-error"
+        submitLabel="Save"
+        submitDisabled={false}
+        onSubmit={vi.fn()}
+      >
+        {child()}
+      </ValidatingModalShell>,
+    );
+    expect(getByText("My Title")).toBeTruthy();
+    expect(getByTestId("shell-child").textContent).toBe("field content");
+    expect(getByText("Save")).toBeTruthy();
+    expect(getByText("Cancel")).toBeTruthy();
+  });
+
+  it("hides the error line when error is null", () => {
+    const { queryByTestId } = render(
+      <ValidatingModalShell
+        title="My Title"
+        error={null}
+        errorTestId="shell-error"
+        submitLabel="Save"
+        submitDisabled={false}
+        onSubmit={vi.fn()}
+      >
+        {child()}
+      </ValidatingModalShell>,
+    );
+    expect(queryByTestId("shell-error")).toBeNull();
+  });
+
+  it("shows the error under the given test id when error is non-null", () => {
+    const { getByTestId } = render(
+      <ValidatingModalShell
+        title="My Title"
+        error="Something went wrong"
+        errorTestId="shell-error"
+        submitLabel="Save"
+        submitDisabled={false}
+        onSubmit={vi.fn()}
+      >
+        {child()}
+      </ValidatingModalShell>,
+    );
+    expect(getByTestId("shell-error").textContent).toBe("Something went wrong");
+  });
+
+  it("renders the given submit label on the primary button", () => {
+    const { getByText, queryByText } = render(
+      <ValidatingModalShell
+        title="My Title"
+        error={null}
+        errorTestId="shell-error"
+        submitLabel="Verifying…"
+        submitDisabled={true}
+        onSubmit={vi.fn()}
+      >
+        {child()}
+      </ValidatingModalShell>,
+    );
+    expect(getByText("Verifying…")).toBeTruthy();
+    expect(queryByText("Save")).toBeNull();
+  });
+
+  it("calls onSubmit when the enabled primary button is clicked", () => {
+    const onSubmit = vi.fn();
+    const { getByText } = render(
+      <ValidatingModalShell
+        title="My Title"
+        error={null}
+        errorTestId="shell-error"
+        submitLabel="Save"
+        submitDisabled={false}
+        onSubmit={onSubmit}
+      >
+        {child()}
+      </ValidatingModalShell>,
+    );
+    fireEvent.click(getByText("Save"));
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables the primary button and swallows the click when submitDisabled is true", () => {
+    const onSubmit = vi.fn();
+    const { getByText } = render(
+      <ValidatingModalShell
+        title="My Title"
+        error={null}
+        errorTestId="shell-error"
+        submitLabel="Save"
+        submitDisabled={true}
+        onSubmit={onSubmit}
+      >
+        {child()}
+      </ValidatingModalShell>,
+    );
+    expect(getByText("Save")).toBeDisabled();
+    fireEvent.click(getByText("Save"));
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("calls closeModal when Cancel is clicked", () => {
+    const closeModal = vi.fn();
+    const { getByText } = render(
+      <ValidatingModalShell
+        closeModal={closeModal}
+        title="My Title"
+        error={null}
+        errorTestId="shell-error"
+        submitLabel="Save"
+        submitDisabled={false}
+        onSubmit={vi.fn()}
+      >
+        {child()}
+      </ValidatingModalShell>,
+    );
+    fireEvent.click(getByText("Cancel"));
+    expect(closeModal).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not throw when Cancel is clicked with no closeModal provided", () => {
+    const { getByText } = render(
+      <ValidatingModalShell
+        title="My Title"
+        error={null}
+        errorTestId="shell-error"
+        submitLabel="Save"
+        submitDisabled={false}
+        onSubmit={vi.fn()}
+      >
+        {child()}
+      </ValidatingModalShell>,
+    );
+    expect(() => fireEvent.click(getByText("Cancel"))).not.toThrow();
+  });
+});

--- a/src/components/settings/ValidatingModalShell.tsx
+++ b/src/components/settings/ValidatingModalShell.tsx
@@ -1,0 +1,77 @@
+/**
+ * The shared shell for the plugin's inline-validating prompt modals (ConnectModal,
+ * SgdbApiKeyModal): a bare {@link ModalRoot} carrying a title, the caller's field
+ * content, an inline error line above the footer, and a footer with a primary
+ * submit button plus a Cancel button. Owns only the shell chrome and its style
+ * constants — the field content, gating, and submit/validation logic stay with
+ * each modal, passed in as `children` and the labelled props. A modal that shows
+ * fields, gates a primary action, and surfaces a returned error inline belongs
+ * here rather than re-copying the scaffolding.
+ */
+
+import { FC, ReactNode } from "react";
+import { ModalRoot, DialogButton } from "@decky/ui";
+
+// ModalRoot renders only the shell + a close affordance (unlike ConfirmModal, it
+// has no strTitle / OK button), so the title, body, error line, and footer are
+// all rendered as content here.
+const modalBodyStyle = { padding: "16px", minWidth: "360px" } as const;
+const titleStyle = { fontSize: "16px", fontWeight: "bold", marginBottom: "12px", color: "#fff" } as const;
+// A failed submit surfaces here, above the footer, in a red-ish tone.
+const errorStyle = { color: "#d94126", fontSize: "13px", marginTop: "12px", marginBottom: "4px" } as const;
+const footerStyle = { display: "flex", gap: "8px", marginTop: "16px" } as const;
+const footerButtonStyle = { flex: "1 1 0px", minWidth: 0 } as const;
+
+interface ValidatingModalShellProps {
+  closeModal?: () => void;
+  /** Heading shown at the top of the modal body. */
+  title: string;
+  /** The returned error message to surface above the footer, or null to hide it. */
+  error: string | null;
+  /** `data-testid` for the inline error line (per-modal, e.g. "signin-error"). */
+  errorTestId: string;
+  /** Label for the primary button (typically flips to an in-flight variant). */
+  submitLabel: string;
+  /** Whether the primary button is disabled (gate incomplete or in flight). */
+  submitDisabled: boolean;
+  /** Invoked when the primary button is clicked. */
+  onSubmit: () => void;
+  /** The modal's field content, rendered between the title and the error line. */
+  children: ReactNode;
+}
+
+export const ValidatingModalShell: FC<ValidatingModalShellProps> = ({
+  closeModal,
+  title,
+  error,
+  errorTestId,
+  submitLabel,
+  submitDisabled,
+  onSubmit,
+  children,
+}) => (
+  <ModalRoot {...(closeModal === undefined ? {} : { closeModal })}>
+    <div style={modalBodyStyle}>
+      <div style={titleStyle}>{title}</div>
+      {children}
+      {error !== null && (
+        <div style={errorStyle} data-testid={errorTestId}>
+          {error}
+        </div>
+      )}
+      <div style={footerStyle}>
+        <DialogButton style={footerButtonStyle} disabled={submitDisabled} onClick={onSubmit}>
+          {submitLabel}
+        </DialogButton>
+        <DialogButton
+          style={footerButtonStyle}
+          onClick={() => {
+            closeModal?.();
+          }}
+        >
+          Cancel
+        </DialogButton>
+      </div>
+    </div>
+  </ModalRoot>
+);

--- a/tests/services/test_connection.py
+++ b/tests/services/test_connection.py
@@ -19,7 +19,12 @@ from lib.errors import (
     RommForbiddenError,
     RommServerError,
 )
-from services.connection import ConnectionService, ConnectionServiceConfig
+from lib.list_result import ErrorCode
+from services.connection import (
+    _USER_TOKEN_REJECTED_MESSAGE,
+    ConnectionService,
+    ConnectionServiceConfig,
+)
 
 _MIN_VERSION = (4, 9, 0)
 
@@ -848,7 +853,11 @@ class TestEstablishUserTokenBadPath:
         romm_api.get_current_user.assert_not_called()
 
     def test_unreachable_server_returns_error_no_validation(self, event_loop, romm_api, logger):
+        # A genuinely unreachable server fails BOTH the version probe and the
+        # post-restore reachability re-probe (#1564), so the generic
+        # server-unreachable error surfaces rather than the token-rejected one.
         romm_api.heartbeat.side_effect = RommConnectionError("refused")
+        romm_api.heartbeat_once.side_effect = RommConnectionError("refused")
         service = _make_service(settings={}, romm_api=romm_api, loop=event_loop, logger=logger)
         result = event_loop.run_until_complete(service.establish_user_token("http://romm.local", "rmm_x"))
         assert result["success"] is False
@@ -906,6 +915,74 @@ class TestEstablishUserTokenBadPath:
         assert result["success"] is False
         assert result["reason"] == "unknown"
         assert "disk full" in result["message"]
+
+
+class TestEstablishUserTokenProbeRejection:
+    """#1564: RomM 5.0 answers the token-carrying version probe with a 500 (a
+    malformed token) or a 403 (a token-shaped but invalid/revoked one) rather
+    than a clean 401, so a bad pasted token otherwise surfaces as a generic
+    server error. A probe failure is disambiguated by a post-restore
+    reachability re-probe: a reachable server proves the pasted token — not the
+    server — is at fault, so the token-rejected auth failure is returned instead
+    of the misleading generic server error."""
+
+    def test_bad_token_reachable_server_returns_token_rejected(self, event_loop, romm_api, logger, settings_persister):
+        """Probe fails with a 500 but the reachability re-probe reaches the
+        server → the pasted token is rejected, and the old state is restored."""
+        # The token-carrying version probe raises RomM's 500-for-a-bad-token.
+        romm_api.heartbeat.side_effect = RommServerError("bad token", status_code=500)
+        # The post-restore reachability re-probe (heartbeat_once) succeeds.
+        romm_api.heartbeat_once.return_value = {"SYSTEM": {"VERSION": "5.0.0"}}
+        settings = _working_settings()
+        service = _make_service(
+            settings=settings,
+            romm_api=romm_api,
+            loop=event_loop,
+            logger=logger,
+            settings_persister=settings_persister,
+        )
+        result = event_loop.run_until_complete(service.establish_user_token("https://new.server", "rmm_bad"))
+        assert result == {
+            "success": False,
+            "reason": ErrorCode.AUTH_FAILED.value,
+            "message": _USER_TOKEN_REJECTED_MESSAGE,
+        }
+        # The pasted token never reached the /api/users/me validation.
+        romm_api.get_current_user.assert_not_called()
+        # The previous working state is restored; nothing is persisted.
+        assert settings["romm_url"] == "https://old.server"
+        assert settings["romm_api_token"] == "rmm_old"
+        assert settings["romm_api_token_id"] == 7
+        assert settings["romm_api_token_origin"] == "https://old.server"
+        settings_persister.save_settings.assert_not_called()
+
+    def test_probe_fails_and_server_unreachable_returns_real_error(
+        self, event_loop, romm_api, logger, settings_persister
+    ):
+        """Probe fails AND the reachability re-probe also fails → the genuine
+        server error surfaces, NOT the token-rejected message."""
+        romm_api.heartbeat.side_effect = RommServerError("boom", status_code=500)
+        romm_api.heartbeat_once.side_effect = RommConnectionError("refused")
+        settings = _working_settings()
+        service = _make_service(
+            settings=settings,
+            romm_api=romm_api,
+            loop=event_loop,
+            logger=logger,
+            settings_persister=settings_persister,
+        )
+        result = event_loop.run_until_complete(service.establish_user_token("https://new.server", "rmm_bad"))
+        assert result["success"] is False
+        # error_response(e) carries the ORIGINAL probe exception's classification.
+        assert result["reason"] == "server_unreachable"
+        assert result["message"] != _USER_TOKEN_REJECTED_MESSAGE
+        assert "Server error (500)" in result["message"]
+        romm_api.get_current_user.assert_not_called()
+        # The previous working state is restored; nothing is persisted.
+        assert settings["romm_url"] == "https://old.server"
+        assert settings["romm_api_token"] == "rmm_old"
+        assert settings["romm_api_token_origin"] == "https://old.server"
+        settings_persister.save_settings.assert_not_called()
 
 
 class TestEstablishUserTokenSnapshotRestore:

--- a/tests/services/test_connection.py
+++ b/tests/services/test_connection.py
@@ -681,7 +681,10 @@ class TestEstablishTokenBadPath:
         result = event_loop.run_until_complete(service.establish_token("http://romm.local", "u", "p"))
         assert result["success"] is False
         assert result["reason"] == "auth_failed"
-        assert "cannot create API tokens" in result["message"]
+        # The 403 is indistinguishable between wrong credentials and a missing
+        # token-creation permission, so the message names both causes.
+        assert "username and password" in result["message"]
+        assert "create API tokens" in result["message"]
 
     def test_auth_error_mint_returns_auth_error(self, event_loop, romm_api, logger):
         romm_api.mint_client_token.side_effect = RommAuthError("401")


### PR DESCRIPTION
Hardens the RomM sign-in flow and consolidates the connection / SteamGridDB settings UX after on-device testing.

**Sign-in (RomM):**

- Every mode's fields are required — username **and** password, the API token, or all eight pairing-code boxes. The Sign-in button stays disabled until they're filled; an empty form can only be cancelled, which leaves the existing sign-in untouched.
- Enter / R2 is placed logically: in the username field it advances to the password field, and it confirms only from a completing field once every required field is filled — never submitting an incomplete form. A single-field modal no longer closes on an empty Enter/R2.
- A failed sign-in keeps the dialog open and shows the error inline, closing only on success — so the message sits where you typed, and a failed re-sign-in no longer silently leaves the previous token presenting as a fresh success.
- A rejected token is reported plainly ("RomM rejected this token…") instead of a generic "Server error", and a wrong username/password no longer wrongly claims the account can't create API tokens — RomM returns an indistinguishable 403 for both, so the message names both causes.

**SteamGridDB key:** validated inline in its own modal — the entered key is tested against SteamGridDB before it is saved; a rejected key keeps the modal open with the reason, and only a valid key is persisted.

**Fewer redundant buttons:** removed the settings-page **Test Connection** and **Verify Key** buttons — the QAM Connection row already probes on open, and both modals now validate inline.

**Clearer QAM status:** the Connection row surfaces the specific reason on failure (Not signed in / Sign-in rejected / Server unreachable / No server URL) instead of a bare "Not connected".

All settings text inputs (RomM URL, SteamGridDB key, default save slot) now require a non-empty value.

Needs on-device verification in Game Mode — the on-screen-keyboard Enter/R2 dispatch and gamepad focus traversal can't be exercised by the unit tests.

Closes #1564
