### PR TITLE
docs(readme): fit the badges on one row and drop a rule from the header

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -10,6 +10,7 @@
       "code",
       "details",
       "div",
+      "h3",
       "img",
       "p",
       "picture",

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # decky-romm-sync
 
-## Your self-hosted RomM library, in your Steam library
+<h3>Your self-hosted RomM library, in your Steam library</h3>
 
 [Getting Started](https://danielcopper.github.io/decky-romm-sync/user-guide/getting-started/) ·
 [Configuration](https://danielcopper.github.io/decky-romm-sync/user-guide/configuration/) ·
@@ -20,7 +20,6 @@
 <a href="https://github.com/danielcopper/decky-romm-sync/stargazers"><img alt="Stars" src="https://img.shields.io/github/stars/danielcopper/decky-romm-sync?style=for-the-badge&color=4795c9&labelColor=16202c"></a>
 <a href="https://github.com/danielcopper/decky-romm-sync/releases"><img alt="Downloads" src="https://img.shields.io/github/downloads/danielcopper/decky-romm-sync/total?style=for-the-badge&color=4795c9&labelColor=16202c"></a>
 <a href="https://github.com/rommapp/romm/releases"><img alt="Requires RomM 4.9.0 or newer" src="https://img.shields.io/badge/RomM-%E2%89%A5%204.9.0-4795c9?style=for-the-badge&labelColor=16202c"></a>
-<a href="https://github.com/danielcopper/decky-romm-sync/blob/main/LICENSE"><img alt="License" src="https://img.shields.io/badge/license-GPL--3.0-4795c9?style=for-the-badge&labelColor=16202c"></a>
 
 </div>
 


### PR DESCRIPTION
Two small fixes to the header that #1566 introduced.

**The badge row wrapped.** Six badges in the `for-the-badge` style are wider than a typical readme column, so the last one stranded on a second line, which reads as an accident rather than a layout. The **licence badge** is removed: GitHub already shows the licence as a tab directly above the readme, so it was the one badge carrying nothing the reader did not already have. Five remain and fit.

**The tagline had a rule under it.** GitHub draws one under `h1` and `h2`, which put a line between the tagline and the guide links for no reason. It becomes an `h3` element, which keeps the size without the rule; `markdownlint`'s allow-list gains `h3`.

docs: N/A — the readme is the change; no documentation page describes it.
