### PR TITLE
feat(collections): add a collection naming mode to keep same-named types separate

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -294,3 +294,15 @@ The ownership filter over the collection list on a shared RomM server — the `c
 collections). Orthogonal to the collection kind axis: it filters by owner (`is_own` / `user_id` vs `romm_user_id`), not
 by kind, and virtual collections have no owner so they always survive. The stored value stays `own` / `all`; only the
 QAM label is **Mine** / **All** (the value was left `own` to avoid a settings migration, #1539).
+
+### Collection naming mode (merge / by_label)
+
+How the Steam-collection **name** is formed when RomM collections share a display name across kinds — the
+`collection_naming_mode` setting valued `merge` (default) or `by_label`. Under **`merge`**, same-named collections union
+into one `RomM: [<name>] (<host>)` Steam collection (#1503). Under **`by_label`**, each name carries its **fine type
+label** so distinct groupings stay separate: `RomM: [<name> (Franchise)]`, `RomM: [<name> (IGDB Collection)]`,
+`RomM: [<name> (Smart)]`, `RomM: [<name> (Standard)]`. The label is the fine label, not the coarse kind — franchise and
+IGDB-collection are both `kind="virtual"`, distinguished by `virtual_type` (see the **Collection kind** entry above).
+Computed backend-side at the reporter's union key (`domain/collection_label.py`), so the wire payload stays name→appIds
+and the frontend needs no change; the mode flip is applied by the ordinary complete-set reconcile on the next normal
+sync (no Force Full Sync). Same-name-**within-one-label** still unions.

--- a/docs/architecture/steam-non-steam-shortcuts.md
+++ b/docs/architecture/steam-non-steam-shortcuts.md
@@ -285,6 +285,18 @@ normal sync: the reporter re-emits the complete set of enabled collections under
 the new-named collections and deletes any old-named collection absent from the new complete set. No skip-state
 invalidation is involved (same mechanism owner-scope reshaping uses).
 
+**Name identity is case-insensitive (#1569).** Steam collapses collection names by a **case-insensitive** identity — two
+collections whose display names differ only in case (`RomM: [7 up]` vs `RomM: [7 Up]`) are the same Steam collection, so
+creating the second silently overwrites the first and loses its games. To match, collection **and** platform name
+identity is treated case-insensitively **everywhere** the plugin compares names: the reporter groups both
+`romm_collection_app_ids` and `platform_app_ids` by a case-folded key (`str.casefold()`), keeping the first-seen
+original casing for display (which exact casing wins is irrelevant — Steam uppercases collection names anyway); the
+frontend create/find (`createOrUpdateCollections` / `createOrUpdateRomMCollections`), the cleanup matchers
+(`clearPlatformCollection` / `clearAllRomMCollections`), and the `onSyncComplete` stale-delete comparisons all match by
+`toLowerCase()`. This is always safe precisely because Steam's identity is case-insensitive: two collections differing
+only by case can never coexist, so there is never an ambiguous match to disambiguate. The DB is unaffected —
+`collection_sync_state` is keyed by `(collection_id, collection_kind)`, never by name — so there is no migration.
+
 ## App IDs and Artwork
 
 `SteamClient.Apps.AddShortcut()` returns the real `appId`, so the plugin does **not** compute shortcut app IDs itself —

--- a/docs/architecture/steam-non-steam-shortcuts.md
+++ b/docs/architecture/steam-non-steam-shortcuts.md
@@ -253,6 +253,38 @@ wipe the entire library organization. The additive create/update path stays unga
 still get their collections; only the destructive deletion is skipped on cancel. Steam collections are not backed up, so
 the safe behavior on a partial/cancelled run is to delete nothing.
 
+### Collection naming mode — `merge` vs `by_label` (#1539)
+
+The `romm_collection_app_ids` wire payload is `name → appIds` **only** — kind/virtual_type are collapsed away before the
+frontend sees them, and the frontend simply wraps each key as `RomM: [<key>] (<hostname>)`. So the Steam-collection name
+is decided **entirely by the reporter's dict key**, computed backend-side in
+`SyncReporter._resolve_collection_memberships` (`services/library/reporter.py`) from the `collection_naming_mode`
+setting:
+
+- **`merge`** (default) — the key is the bare collection display name. Same-named RomM collections of any kind union
+  into one `RomM: [<name>]` Steam collection (RomM permits same-named collections across kinds/users, #1503).
+- **`by_label`** (opt-in) — the key is `"<name> (<FineLabel>)"`, where the fine label comes from the pure
+  `domain/collection_label.py` kernel: `Standard` / `Smart` for those kinds, and the virtual sub-type label (`Franchise`
+  / `IGDB Collection`) for `kind == "virtual"`. So a franchise and an IGDB collection that share a name become
+  `RomM: [<name> (Franchise)]` and `RomM: [<name> (IGDB Collection)]` — separate Steam collections. Two collections that
+  share **both** name and label still union.
+
+The label strings **must** match the frontend collection-type vocabulary (`SUB_TAB_LABELS` / `VIRTUAL_TYPE_LABELS` in
+`src/components/LibraryPage.tsx`) so the type a user sees on the Collections page is the type baked into the Steam name.
+The reporter needs the kind/virtual_type at its union key, so `WorkUnit.virtual_type` and `CollectionMembership.kind` +
+`CollectionMembership.virtual_type` thread that identity through the fetcher → orchestrator → reporter.
+
+**Label-format constraint:** the reconcile parses the collection name with `/^RomM: \[([^\]]+)\]/` (`src/index.tsx`), so
+a label must contain **no** `]` character — it sits inside the single existing bracket pair. Parens (`(Franchise)`) are
+safe; a bracket would truncate the parsed name and orphan the collection. Every produced label is bracket-free (asserted
+in `tests/domain/test_collection_label.py`).
+
+**No Force Full Sync on a mode flip.** Because the create-name and the reconcile's `activeNames` both derive from the
+same `romm_collection_app_ids` keys, flipping the mode is applied by the ordinary **complete-set reconcile** on the next
+normal sync: the reporter re-emits the complete set of enabled collections under the new keys, `onSyncComplete` creates
+the new-named collections and deletes any old-named collection absent from the new complete set. No skip-state
+invalidation is involved (same mechanism owner-scope reshaping uses).
+
 ## App IDs and Artwork
 
 `SteamClient.Apps.AddShortcut()` returns the real `appId`, so the plugin does **not** compute shortcut app IDs itself —

--- a/docs/user-guide/syncing-your-library.md
+++ b/docs/user-guide/syncing-your-library.md
@@ -271,7 +271,8 @@ called the same thing, or (on a shared server) another account's public collecti
 
 - **Off** (default) — the same-named collections **merge into a single Steam collection** carrying the combined set of
   games. RomM allows collections to share a name, but Steam identifies a collection by its name, so the plugin unions
-  their members rather than dropping one.
+  their members rather than dropping one. Names that differ only in **capitalisation** ("7 up" vs "7 Up") count as the
+  same name and merge too — Steam itself treats collection names case-insensitively.
 - **On** — the plugin appends the collection **type** to the Steam name, so same-named collections of different types
   stay **separate**. A franchise and an IGDB collection that share a name become `RomM: [<name> (Franchise)]` and
   `RomM: [<name> (IGDB Collection)]` — matching the Franchise / IGDB Collection / Smart / Standard labels you see on the

--- a/docs/user-guide/syncing-your-library.md
+++ b/docs/user-guide/syncing-your-library.md
@@ -263,10 +263,23 @@ On a **shared RomM server** the collection list includes every other user's _pub
 first time you sign in (existing sign-ins pick it up on the next connection check). Until then, **Mine** behaves exactly
 like **All** — it never hides a collection it can't yet attribute.
 
+#### Collections that share a name
+
 If two enabled collections share the same name — for example a personal collection and a smart or virtual collection
-called the same thing, or (on a shared server) another account's public collection — they **merge into a single Steam
-collection** carrying the combined set of games. RomM allows collections to share a name, but Steam identifies a
-collection by its name, so the plugin unions their members rather than dropping one.
+called the same thing, or (on a shared server) another account's public collection — what happens depends on the
+**Distinguish collection types in Steam names** setting on the **Settings** page under **Library**:
+
+- **Off** (default) — the same-named collections **merge into a single Steam collection** carrying the combined set of
+  games. RomM allows collections to share a name, but Steam identifies a collection by its name, so the plugin unions
+  their members rather than dropping one.
+- **On** — the plugin appends the collection **type** to the Steam name, so same-named collections of different types
+  stay **separate**. A franchise and an IGDB collection that share a name become `RomM: [<name> (Franchise)]` and
+  `RomM: [<name> (IGDB Collection)]` — matching the Franchise / IGDB Collection / Smart / Standard labels you see on the
+  Collections page. Collections that share both a name **and** a type still merge.
+
+The setting applies on the **next normal sync** — no Force Full Sync is needed. After flipping it, run a sync and the
+plugin renames the affected Steam collections (and removes the old-named ones) as part of its normal end-of-sync
+housekeeping.
 
 ## Artwork
 

--- a/main.py
+++ b/main.py
@@ -346,6 +346,9 @@ class Plugin:
     async def set_collection_owner_scope(self, scope):
         return self._settings_service.set_collection_owner_scope(scope)
 
+    async def set_collection_naming_mode(self, mode):
+        return self._settings_service.set_collection_naming_mode(mode)
+
     @migration_blocked
     async def start_sync(self):
         return self._sync_service.start_sync()

--- a/py_modules/adapters/persistence.py
+++ b/py_modules/adapters/persistence.py
@@ -54,6 +54,12 @@ DEFAULT_SETTINGS: dict[str, Any] = {
     # server lists) or ``"own"`` (only the signed-in user's own collections;
     # virtual collections have no owner and always survive).
     "collection_owner_scope": "all",
+    # Steam-collection naming mode: ``"merge"`` (default — same-named collections
+    # of any kind union into one ``RomM: [<name>]`` collection) or ``"by_label"``
+    # (the fine type label is appended, ``RomM: [<name> (Franchise)]``, so
+    # same-named collections of different types stay separate). Applies on the
+    # next normal sync via the reporter key + complete-set reconcile.
+    "collection_naming_mode": "merge",
     "preferred_region": "auto",
     "steam_input_mode": "default",
     "steamgriddb_api_key": "",

--- a/py_modules/domain/collection_label.py
+++ b/py_modules/domain/collection_label.py
@@ -1,0 +1,59 @@
+"""Fine display label for a RomM collection, keyed by kind + virtual type.
+
+The pure kernel behind the ``by_label`` Steam-collection naming mode: it maps a
+collection's ``kind`` (``standard`` / ``smart`` / ``virtual``) and, for the
+virtual kind, its ``virtual_type`` (``franchise`` / ``collection``) onto the
+short human label the reporter appends to a collection name so same-named
+collections of different types stay separate Steam collections
+(``RomM: [<name> (Franchise)] (host)``). No I/O, no state.
+
+The label strings MUST match the frontend vocabulary exactly — ``SUB_TAB_LABELS``
+and ``VIRTUAL_TYPE_LABELS`` in ``src/components/LibraryPage.tsx`` — so the type a
+user sees on the Collections page is the type baked into the Steam name. Keep the
+two in sync.
+
+Label-format safety: a label is appended inside the single bracket pair of
+``RomM: [<name> (<label>)]``, and the frontend reconcile parses that name with
+``/^RomM: \\[([^\\]]+)\\]/`` (``src/index.tsx``). So a label must contain **no**
+``]`` character (parens are safe, brackets would truncate the parsed name and
+orphan the collection). Every label below is bracket-free; the fallback
+capitalises a controlled kind literal, which is too.
+"""
+
+from __future__ import annotations
+
+# Coarse kind → label. Mirrors ``SUB_TAB_LABELS`` in LibraryPage.tsx.
+_KIND_LABELS: dict[str, str] = {
+    "standard": "Standard",
+    "smart": "Smart",
+    "virtual": "Virtual",
+}
+
+# Virtual sub-type → label. Mirrors ``VIRTUAL_TYPE_LABELS`` in LibraryPage.tsx:
+# "IGDB Collection" (not "Collection") disambiguates from the Collections page
+# it lives inside.
+_VIRTUAL_TYPE_LABELS: dict[str, str] = {
+    "franchise": "Franchise",
+    "collection": "IGDB Collection",
+}
+
+
+def collection_label(kind: str, virtual_type: str | None) -> str:
+    """Return the fine display label for a collection of ``kind`` / ``virtual_type``.
+
+    ``standard`` → ``"Standard"``, ``smart`` → ``"Smart"``. A ``virtual``
+    collection resolves to its virtual-type label — ``franchise`` →
+    ``"Franchise"``, ``collection`` → ``"IGDB Collection"`` — falling back to
+    ``"Virtual"`` when the type is missing or unrecognised (an older backend, a
+    virtual type the plugin does not sync). An unknown ``kind`` degrades to the
+    capitalised kind string (never expected for the ``standard`` / ``smart`` /
+    ``virtual`` set), and an empty kind to ``"Collection"``. Every branch is
+    free of ``]`` so the reconcile name-parse stays intact.
+    """
+    if kind == "virtual":
+        if virtual_type is not None and virtual_type in _VIRTUAL_TYPE_LABELS:
+            return _VIRTUAL_TYPE_LABELS[virtual_type]
+        return _KIND_LABELS["virtual"]
+    if kind in _KIND_LABELS:
+        return _KIND_LABELS[kind]
+    return kind.capitalize() if kind else "Collection"

--- a/py_modules/domain/work_unit.py
+++ b/py_modules/domain/work_unit.py
@@ -31,6 +31,13 @@ class WorkUnit:
     # Collection-only: dispatches the correct list-roms endpoint at fetch time.
     # ``None`` is only valid when ``type == "platform"``.
     collection_kind: CollectionKind | None = None
+    # Virtual-collection-only: which virtual type this unit is (``"franchise"``
+    # or ``"collection"``), stamped from the query type at fetch time. Threaded
+    # so the reporter can build the fine display label for the ``by_label``
+    # Steam-collection naming mode (a ``kind == "virtual"`` unit needs the
+    # sub-type to distinguish Franchise from IGDB Collection). ``None`` for a
+    # platform or a standard/smart collection (their kind alone names them).
+    virtual_type: str | None = None
     # Collection-only: the collection's server ``updated_at`` from the listing,
     # threaded so the incremental-skip gate can compare it against the stored
     # ``CollectionSyncState`` stamp (#742). RomM bumps this on any membership

--- a/py_modules/services/library/_state.py
+++ b/py_modules/services/library/_state.py
@@ -54,10 +54,18 @@ class CollectionMembership:
     memberships and UNIONs their resolved appIds into the one
     ``RomM: [<name>] (host)`` Steam collection (RomM permits same-named collections
     across kinds/users, so the plugin merges rather than owner-filters, #1503).
+
+    ``kind`` (``"standard"`` / ``"smart"`` / ``"virtual"``) and — for the virtual
+    kind — ``virtual_type`` (``"franchise"`` / ``"collection"``) ride here too so
+    the reporter can build the fine display label under the ``by_label`` naming
+    mode (``domain.collection_label``); in the default ``merge`` mode they are
+    unused and same-named collections still union by name.
     """
 
     name: str
     rom_ids: list[int]
+    kind: str
+    virtual_type: str | None = None
 
 
 @dataclass(frozen=True)

--- a/py_modules/services/library/fetcher.py
+++ b/py_modules/services/library/fetcher.py
@@ -97,6 +97,7 @@ def _collection_units(
     enabled_ids: set[str],
     kind: CollectionKind,
     *,
+    virtual_type: str | None = None,
     own_user_id: int | None = None,
     filter_to_own: bool = False,
 ) -> list[WorkUnit]:
@@ -107,6 +108,12 @@ def _collection_units(
     queue even if it is enabled, so a scope selected over an earlier enable never
     syncs someone else's collection. Virtual collections have no owner and
     always survive (:func:`is_own_collection`).
+
+    *virtual_type* stamps the unit's virtual sub-type (``"franchise"`` /
+    ``"collection"``) for the ``kind == "virtual"`` caller, which fetches one
+    type at a time and so knows it authoritatively — the same source the QAM
+    listing uses. ``None`` for standard/smart callers (their kind alone labels
+    them).
     """
     units: list[WorkUnit] = []
     for c in collections:
@@ -123,6 +130,7 @@ def _collection_units(
                 slug=c.get("slug", ""),
                 rom_count=int(c.get("rom_count", len(c.get("rom_ids", [])))),
                 collection_kind=kind,
+                virtual_type=virtual_type,
                 # RomM bumps the collection's updated_at on any membership change
                 # (#742). Threaded so the skip gate compares it against the stamp;
                 # ``None`` for a listing that omits it (e.g. virtual, never
@@ -610,15 +618,17 @@ class LibraryFetcher:
         """
         if not enabled_ids:
             return []
-        collections: list[dict[str, Any]] = []
+        units: list[WorkUnit] = []
         for virtual_type in _SUPPORTED_VIRTUAL_TYPES:
             try:
-                collections.extend(
-                    await self._loop.run_in_executor(None, self._romm_api.list_virtual_collections, virtual_type)
+                collections = await self._loop.run_in_executor(
+                    None, self._romm_api.list_virtual_collections, virtual_type
                 )
             except Exception as e:
                 self._logger.warning(f"Failed to fetch {virtual_type} collections for work queue: {e}")
-        return _collection_units(collections, enabled_ids, "virtual")
+                continue
+            units.extend(_collection_units(collections, enabled_ids, "virtual", virtual_type=virtual_type))
+        return units
 
     async def _attach_plan_estimates(self, platform_units: list[WorkUnit]) -> list[WorkUnit]:
         """Stamp each platform unit with its plan-time estimate riders (#1382).

--- a/py_modules/services/library/reporter.py
+++ b/py_modules/services/library/reporter.py
@@ -22,6 +22,7 @@ import json
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+from domain.collection_label import collection_label
 from domain.platform_names import decode_platform_names
 from domain.rom import Rom
 from domain.rom_metadata_mapping import build_rom_metadata
@@ -136,9 +137,11 @@ class SyncReporter:
         favouriting / collecting ANY version of a game puts the game's single
         shortcut into the Steam collection. Per-collection appIds are
         de-duplicated — several siblings of one group collapse onto the one
-        shortcut — and same-named collections UNION into the one by-name Steam
-        collection (#1503). The platform loop still excludes rows whose
-        ``shortcut_app_id`` is ``None``.
+        shortcut — and collections sharing a resolved key UNION into the one Steam
+        collection (the key is name-only under ``merge`` (#1503) or name + fine
+        type label under ``by_label`` (#1539); see
+        :meth:`_resolve_collection_memberships`). The platform loop still excludes
+        rows whose ``shortcut_app_id`` is ``None``.
         """
         platform_app_ids, group_bound_app_id = self._scan_bound_rows(uow, pending_platform_rom_ids, platform_names)
         romm_collection_app_ids = self._resolve_collection_memberships(
@@ -185,30 +188,54 @@ class SyncReporter:
         pending_collection_memberships: dict[tuple[str, str], CollectionMembership],
         group_bound_app_id: dict[str, int],
     ) -> dict[str, list[int]]:
-        """Resolve each collection's member rom_ids to de-duplicated appIds, UNION by name.
+        """Resolve each collection's member rom_ids to de-duplicated appIds, UNION by key.
 
         A bound member uses its own binding; an unbound member falls back to its
         sibling group's bound appId (ADR-0021). Steam's collection namespace is
-        by-name, so same-named RomM collections (permitted across kinds/users,
-        #1503) merge into one entry: their resolved appIds are UNIONed,
-        order-preserving and de-duplicated ACROSS collections (each collection's
-        own resolution already dedups within). The accumulator is keyed by a
-        collision-free identity, so a same-named pair never overwrote either
-        member set upstream. Names that resolve to no appId are omitted; the
-        common single-collection case unions a set of one and is byte-for-byte
-        identical to the pre-#1503 output.
+        by-name, so collections that share the resolved key merge into one entry:
+        their resolved appIds are UNIONed, order-preserving and de-duplicated
+        ACROSS collections (each collection's own resolution already dedups
+        within). Names that resolve to no appId are omitted.
+
+        The key is the Steam-collection name-part built from the
+        ``collection_naming_mode`` setting (:meth:`_collection_key`): under
+        ``merge`` (default) it is the bare display name, so same-named
+        collections of any kind union into one ``RomM: [<name>]`` collection
+        (#1503) — byte-for-byte the pre-mode output. Under ``by_label`` the fine
+        type label is appended (``"<name> (Franchise)"``) so collections that
+        share a name but differ in type land in separate Steam collections; two
+        collections of the SAME name AND label still union. Injecting the label
+        here (not in the frontend) keeps the create-name and the reconcile
+        ``activeNames`` derived from this one key.
         """
+        naming_mode = self._settings.get("collection_naming_mode", "merge")
         romm_collection_app_ids: dict[str, list[int]] = {}
-        seen_by_name: dict[str, set[int]] = {}
+        seen_by_key: dict[str, set[int]] = {}
         for membership in pending_collection_memberships.values():
-            app_ids = romm_collection_app_ids.setdefault(membership.name, [])
-            seen = seen_by_name.setdefault(membership.name, set())
+            key = self._collection_key(membership, naming_mode)
+            app_ids = romm_collection_app_ids.setdefault(key, [])
+            seen = seen_by_key.setdefault(key, set())
             for rid in membership.rom_ids:
                 app_id = self._member_app_id(uow, rid, group_bound_app_id)
                 if app_id is not None and app_id not in seen:
                     seen.add(app_id)
                     app_ids.append(app_id)
-        return {name: app_ids for name, app_ids in romm_collection_app_ids.items() if app_ids}
+        return {key: app_ids for key, app_ids in romm_collection_app_ids.items() if app_ids}
+
+    @staticmethod
+    def _collection_key(membership: CollectionMembership, naming_mode: str) -> str:
+        """The Steam-collection name-part for a membership under *naming_mode*.
+
+        ``merge`` (default / unknown) → the bare display name. ``by_label`` →
+        ``"<name> (<FineLabel>)"`` where the label comes from
+        :func:`domain.collection_label.collection_label`, so distinct collection
+        types that share a name stay separate. The label is bracket-free, so the
+        frontend's ``RomM: [<key>]`` name-parse (``/^RomM: \\[([^\\]]+)\\]/``)
+        stays intact.
+        """
+        if naming_mode == "by_label":
+            return f"{membership.name} ({collection_label(membership.kind, membership.virtual_type)})"
+        return membership.name
 
     @staticmethod
     def _member_app_id(uow: UnitOfWork, rid: int, group_bound_app_id: dict[str, int]) -> int | None:

--- a/py_modules/services/library/reporter.py
+++ b/py_modules/services/library/reporter.py
@@ -159,17 +159,29 @@ class SyncReporter:
 
         When a group carries several bound rows (grandfathered duplicates) the
         smallest rom_id's binding wins, deterministically.
+
+        Platform display names are grouped **case-insensitively** (keyed by
+        ``display.casefold()``, first-seen original casing kept for display): Steam
+        collapses collection names by a case-insensitive identity, so two display
+        names differing only in case must land in one Steam collection or the
+        second create overwrites the first. Two distinct slugs colliding this way
+        is rare, but the union keeps it lossless and matches the collection-map
+        rule (:meth:`_resolve_collection_memberships`).
         """
         create_groups = self._settings.get("collection_create_platform_groups", False)
-        platform_app_ids: dict[str, list[int]] = {}
+        display_by_fold: dict[str, str] = {}
+        platform_app_ids_by_fold: dict[str, list[int]] = {}
         group_bound: dict[str, tuple[int, int]] = {}
         for rom in uow.roms.iter_all():
             if rom.shortcut_app_id is None:
                 continue
             if should_include_in_platform_collection(rom.rom_id, pending_platform_rom_ids, create_groups):
                 display = platform_names.get(rom.platform_slug, rom.platform_slug)
-                platform_app_ids.setdefault(display, []).append(rom.shortcut_app_id)
+                fold = display.casefold()
+                display_by_fold.setdefault(fold, display)
+                platform_app_ids_by_fold.setdefault(fold, []).append(rom.shortcut_app_id)
             self._note_group_binding(group_bound, rom)
+        platform_app_ids = {display_by_fold[fold]: app_ids for fold, app_ids in platform_app_ids_by_fold.items()}
         return platform_app_ids, {key: app_id for key, (_rid, app_id) in group_bound.items()}
 
     @staticmethod
@@ -207,20 +219,31 @@ class SyncReporter:
         collections of the SAME name AND label still union. Injecting the label
         here (not in the frontend) keeps the create-name and the reconcile
         ``activeNames`` derived from this one key.
+
+        Grouping is **case-insensitive** (keyed by ``key.casefold()``, first-seen
+        original casing kept for display): Steam collapses collection names by a
+        case-insensitive identity, so two keys differing only in case ("7 up" vs
+        "7 Up") must union or the second Steam create overwrites the first and its
+        games are lost (#1569). Under ``by_label`` this merges same-type case
+        variants (label matches) while different-type variants stay separate (the
+        label differs, so the folded keys differ).
         """
         naming_mode = self._settings.get("collection_naming_mode", "merge")
-        romm_collection_app_ids: dict[str, list[int]] = {}
-        seen_by_key: dict[str, set[int]] = {}
+        display_key_by_fold: dict[str, str] = {}
+        app_ids_by_fold: dict[str, list[int]] = {}
+        seen_by_fold: dict[str, set[int]] = {}
         for membership in pending_collection_memberships.values():
             key = self._collection_key(membership, naming_mode)
-            app_ids = romm_collection_app_ids.setdefault(key, [])
-            seen = seen_by_key.setdefault(key, set())
+            fold = key.casefold()
+            display_key_by_fold.setdefault(fold, key)
+            app_ids = app_ids_by_fold.setdefault(fold, [])
+            seen = seen_by_fold.setdefault(fold, set())
             for rid in membership.rom_ids:
                 app_id = self._member_app_id(uow, rid, group_bound_app_id)
                 if app_id is not None and app_id not in seen:
                     seen.add(app_id)
                     app_ids.append(app_id)
-        return {key: app_ids for key, app_ids in romm_collection_app_ids.items() if app_ids}
+        return {display_key_by_fold[fold]: app_ids for fold, app_ids in app_ids_by_fold.items() if app_ids}
 
     @staticmethod
     def _collection_key(membership: CollectionMembership, naming_mode: str) -> str:

--- a/py_modules/services/library/sync_orchestrator.py
+++ b/py_modules/services/library/sync_orchestrator.py
@@ -500,7 +500,10 @@ class SyncOrchestrator:
             )
             if all_collection_rom_ids:
                 collection_memberships[_collection_membership_key(unit)] = CollectionMembership(
-                    name=unit.name, rom_ids=all_collection_rom_ids
+                    name=unit.name,
+                    rom_ids=all_collection_rom_ids,
+                    kind=str(unit.collection_kind),
+                    virtual_type=unit.virtual_type,
                 )
             all_roms.extend(unit_roms)
 
@@ -1769,7 +1772,10 @@ class SyncOrchestrator:
         )
         if all_collection_rom_ids:
             collection_memberships[_collection_membership_key(unit)] = CollectionMembership(
-                name=unit.name, rom_ids=all_collection_rom_ids
+                name=unit.name,
+                rom_ids=all_collection_rom_ids,
+                kind=str(unit.collection_kind),
+                virtual_type=unit.virtual_type,
             )
         return unit_roms, skipped
 

--- a/py_modules/services/settings.py
+++ b/py_modules/services/settings.py
@@ -107,6 +107,7 @@ class SettingsService:
             "romm_allow_insecure_ssl": self._settings.get("romm_allow_insecure_ssl", False),
             "collection_create_platform_groups": self._settings.get("collection_create_platform_groups", False),
             "collection_owner_scope": self._settings.get("collection_owner_scope", "all"),
+            "collection_naming_mode": self._settings.get("collection_naming_mode", "merge"),
             "preferred_region": self._settings.get("preferred_region", AUTO_REGION),
         }
 
@@ -255,6 +256,24 @@ class SettingsService:
         if scope not in ("own", "all"):
             return {"success": False, "reason": "invalid_scope", "message": f"Invalid owner scope: {scope}"}
         self._settings["collection_owner_scope"] = scope
+        self._settings_persister.save_settings()
+        return {"success": True}
+
+    def set_collection_naming_mode(self, mode: object) -> dict[str, Any]:
+        """Validate and persist the Steam-collection naming mode (``"merge"`` / ``"by_label"``).
+
+        ``"merge"`` (the default) unions same-named collections of any kind into
+        one ``RomM: [<name>]`` Steam collection; ``"by_label"`` appends the fine
+        type label (``RomM: [<name> (Franchise)]``) so same-named collections of
+        different types stay separate. The change takes effect on the next normal
+        sync — the reporter rebuilds the complete collection set under the new
+        key and the frontend reconcile renames accordingly (no Force Full Sync).
+        An unrecognised value from the untrusted frontend wire is rejected with
+        the canonical failure shape so a bad call cannot corrupt the setting.
+        """
+        if mode not in ("merge", "by_label"):
+            return {"success": False, "reason": "invalid_mode", "message": f"Invalid naming mode: {mode}"}
+        self._settings["collection_naming_mode"] = mode
         self._settings_persister.save_settings()
         return {"success": True}
 

--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -10,6 +10,7 @@ import type {
   CollectionSyncSetting,
   CollectionKind,
   CollectionOwnerScope,
+  CollectionNamingMode,
   RegistryPlatform,
   FirmwareStatus,
   FirmwareDownloadResult,
@@ -182,6 +183,13 @@ export const setCollectionOwnerScope = callable<
   [CollectionOwnerScope],
   { success: boolean; reason?: string; message?: string }
 >("set_collection_owner_scope");
+// Steam-collection naming mode (#1539). "merge" (default) unions same-named
+// collections; "by_label" appends the fine type label so they stay separate.
+// Read via getSettings().collection_naming_mode; applies on the next sync.
+export const setCollectionNamingMode = callable<
+  [CollectionNamingMode],
+  { success: boolean; reason?: string; message?: string }
+>("set_collection_naming_mode");
 export const getRegistryPlatforms = callable<[], { platforms: RegistryPlatform[] }>("get_registry_platforms");
 export const removePlatformShortcuts = callable<
   [string],

--- a/src/components/SettingsPage.test.tsx
+++ b/src/components/SettingsPage.test.tsx
@@ -1584,6 +1584,48 @@ describe("SettingsPage", () => {
       // CATCH-REJECTION assert: rolled back to false.
       expect(capturedLibrary[capturedLibrary.length - 1]?.platformGroups).toBe(false);
     });
+
+    it("hydrates namingMode from getSettings", async () => {
+      vi.mocked(backend.getSettings).mockResolvedValue({
+        ...defaultSettings(),
+        collection_naming_mode: "by_label",
+      });
+      render(<SettingsPage onBack={vi.fn()} />);
+      await flushAsync();
+      expect(capturedLibrary[capturedLibrary.length - 1]?.namingMode).toBe("by_label");
+    });
+
+    it("defaults namingMode to merge when getSettings omits it", async () => {
+      render(<SettingsPage onBack={vi.fn()} />);
+      await flushAsync();
+      expect(capturedLibrary[capturedLibrary.length - 1]?.namingMode).toBe("merge");
+    });
+
+    it("onNamingModeChange persists via setCollectionNamingMode and flips the value", async () => {
+      vi.mocked(backend.setCollectionNamingMode).mockResolvedValue({ success: true });
+      render(<SettingsPage onBack={vi.fn()} />);
+      await flushAsync();
+      await act(async () => {
+        capturedLibrary[capturedLibrary.length - 1]?.onNamingModeChange("by_label");
+        await Promise.resolve();
+      });
+      expect(vi.mocked(backend.setCollectionNamingMode)).toHaveBeenCalledWith("by_label");
+      expect(capturedLibrary[capturedLibrary.length - 1]?.namingMode).toBe("by_label");
+    });
+
+    it("reverts namingMode to its prior value when setCollectionNamingMode rejects", async () => {
+      vi.mocked(backend.setCollectionNamingMode).mockRejectedValue(new Error("boom"));
+      render(<SettingsPage onBack={vi.fn()} />);
+      await flushAsync();
+      await act(async () => {
+        capturedLibrary[capturedLibrary.length - 1]?.onNamingModeChange("by_label");
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      // CATCH-REJECTION assert: rolled back to the pre-toggle "merge".
+      expect(capturedLibrary[capturedLibrary.length - 1]?.namingMode).toBe("merge");
+    });
   });
 
   describe("save-sort migration handlers", () => {

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -19,6 +19,7 @@ import {
   saveLogLevel,
   savePreferredRegion,
   saveCollectionPlatformGroups,
+  setCollectionNamingMode,
   getKnownRegions,
   fixRetroarchInputDriver,
   ensureDeviceRegistered,
@@ -28,7 +29,7 @@ import {
   dismissSaveSortMigration,
   logError,
 } from "../api/backend";
-import type { SaveSortMigrationStatus, RegisteredDevice } from "../types";
+import type { SaveSortMigrationStatus, RegisteredDevice, CollectionNamingMode } from "../types";
 import {
   getSaveSortMigrationState,
   setSaveSortMigrationStatus as setStoreSaveSortStatus,
@@ -98,6 +99,8 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
   const [libraryRegions, setLibraryRegions] = useState<string[]>([]);
   // Collection platform-groups toggle (relocated from the Collections tab, #1539).
   const [platformGroups, setPlatformGroups] = useState(false);
+  // Steam-collection naming mode (#1539): "merge" (default) or "by_label".
+  const [namingMode, setNamingMode] = useState<CollectionNamingMode>("merge");
 
   useEffect(() => {
     getSettings()
@@ -111,6 +114,7 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
         setLogLevel(s.log_level);
         setPreferredRegion(s.preferred_region ?? AUTO_REGION);
         setPlatformGroups(!!s.collection_create_platform_groups);
+        setNamingMode(s.collection_naming_mode ?? "merge");
         if (s.retroarch_input_check) {
           setRetroarchWarning(s.retroarch_input_check);
         }
@@ -470,6 +474,21 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
     );
   };
 
+  // --- Collection naming-mode handler (#1539) ---
+  const handleNamingModeChange = (mode: CollectionNamingMode) => {
+    const previous = namingMode;
+    setNamingMode(mode);
+    detach(
+      (async () => {
+        try {
+          await setCollectionNamingMode(mode);
+        } catch {
+          setNamingMode(previous);
+        }
+      })(),
+    );
+  };
+
   // --- Save sort migration handlers ---
   const handleMigrateSaveSort = async () => {
     setSaveSortMigrating(true);
@@ -605,6 +624,8 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
         onPreferredRegionChange={handlePreferredRegionChange}
         platformGroups={platformGroups}
         onPlatformGroupsChange={handlePlatformGroupsChange}
+        namingMode={namingMode}
+        onNamingModeChange={handleNamingModeChange}
       />
 
       <AdvancedSection logLevel={logLevel} onLogLevelChange={handleLogLevelChange} />

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -29,7 +29,13 @@ import {
   dismissSaveSortMigration,
   logError,
 } from "../api/backend";
-import type { SaveSortMigrationStatus, RegisteredDevice, CollectionNamingMode } from "../types";
+import type {
+  SaveSortMigrationStatus,
+  RegisteredDevice,
+  CollectionNamingMode,
+  SaveSyncSettings as SaveSyncSettingsType,
+  RetroArchInputCheck,
+} from "../types";
 import {
   getSaveSortMigrationState,
   setSaveSortMigrationStatus as setStoreSaveSortStatus,
@@ -39,7 +45,6 @@ import {
 import { scrollToTop } from "../utils/scrollHelpers";
 import { detach } from "../utils/detach";
 import { trimServerUrl, isValidServerUrl } from "../utils/serverUrl";
-import type { SaveSyncSettings as SaveSyncSettingsType, RetroArchInputCheck } from "../types";
 import { pendingEdits } from "./settings/TextInputModal";
 import { SaveSortMigrationSection } from "./settings/SaveSortMigrationSection";
 import { ConnectionSection } from "./settings/ConnectionSection";

--- a/src/components/settings/LibrarySection.test.tsx
+++ b/src/components/settings/LibrarySection.test.tsx
@@ -93,6 +93,8 @@ describe("LibrarySection", () => {
         onPreferredRegionChange={vi.fn()}
         platformGroups={false}
         onPlatformGroupsChange={vi.fn()}
+        namingMode="merge"
+        onNamingModeChange={vi.fn()}
       />,
     );
     expect(captured.items).toHaveLength(1);
@@ -109,6 +111,8 @@ describe("LibrarySection", () => {
         onPreferredRegionChange={vi.fn()}
         platformGroups={false}
         onPlatformGroupsChange={vi.fn()}
+        namingMode="merge"
+        onNamingModeChange={vi.fn()}
       />,
     );
     expect(captured.items[0]?.selectedOption).toBe("Japan");
@@ -123,6 +127,8 @@ describe("LibrarySection", () => {
         onPreferredRegionChange={onChange}
         platformGroups={false}
         onPlatformGroupsChange={vi.fn()}
+        namingMode="merge"
+        onNamingModeChange={vi.fn()}
       />,
     );
     captured.items[0]?.onChange?.({ data: "Japan", label: "Japan" });
@@ -139,6 +145,8 @@ describe("LibrarySection", () => {
         onPreferredRegionChange={onChange}
         platformGroups={false}
         onPlatformGroupsChange={vi.fn()}
+        namingMode="merge"
+        onNamingModeChange={vi.fn()}
       />,
     );
     captured.items[0]?.onChange?.({ data: AUTO_REGION, label: DEFAULT_REGION_LABEL });
@@ -153,6 +161,8 @@ describe("LibrarySection", () => {
         onPreferredRegionChange={vi.fn()}
         platformGroups={true}
         onPlatformGroupsChange={vi.fn()}
+        namingMode="merge"
+        onNamingModeChange={vi.fn()}
       />,
     );
     const toggle = container.querySelector<HTMLInputElement>(
@@ -171,6 +181,8 @@ describe("LibrarySection", () => {
         onPreferredRegionChange={vi.fn()}
         platformGroups={false}
         onPlatformGroupsChange={onChange}
+        namingMode="merge"
+        onNamingModeChange={vi.fn()}
       />,
     );
     const toggle = container.querySelector<HTMLInputElement>(
@@ -179,5 +191,84 @@ describe("LibrarySection", () => {
     fireEvent.click(toggle);
     expect(onChange).toHaveBeenCalledTimes(1);
     expect(onChange).toHaveBeenCalledWith(true);
+  });
+
+  it("renders the naming-mode toggle checked when namingMode is by_label", () => {
+    const { container } = render(
+      <LibrarySection
+        preferredRegion={AUTO_REGION}
+        libraryRegions={[]}
+        onPreferredRegionChange={vi.fn()}
+        platformGroups={false}
+        onPlatformGroupsChange={vi.fn()}
+        namingMode="by_label"
+        onNamingModeChange={vi.fn()}
+      />,
+    );
+    const toggle = container.querySelector<HTMLInputElement>(
+      '[data-label="Distinguish collection types in Steam names"] input',
+    );
+    expect(toggle).not.toBeNull();
+    expect(toggle?.checked).toBe(true);
+  });
+
+  it("renders the naming-mode toggle unchecked when namingMode is merge", () => {
+    const { container } = render(
+      <LibrarySection
+        preferredRegion={AUTO_REGION}
+        libraryRegions={[]}
+        onPreferredRegionChange={vi.fn()}
+        platformGroups={false}
+        onPlatformGroupsChange={vi.fn()}
+        namingMode="merge"
+        onNamingModeChange={vi.fn()}
+      />,
+    );
+    const toggle = container.querySelector<HTMLInputElement>(
+      '[data-label="Distinguish collection types in Steam names"] input',
+    );
+    expect(toggle?.checked).toBe(false);
+  });
+
+  it("maps the naming-mode toggle to by_label when switched on", () => {
+    const onChange = vi.fn();
+    const { container } = render(
+      <LibrarySection
+        preferredRegion={AUTO_REGION}
+        libraryRegions={[]}
+        onPreferredRegionChange={vi.fn()}
+        platformGroups={false}
+        onPlatformGroupsChange={vi.fn()}
+        namingMode="merge"
+        onNamingModeChange={onChange}
+      />,
+    );
+    const toggle = container.querySelector<HTMLInputElement>(
+      '[data-label="Distinguish collection types in Steam names"] input',
+    )!;
+    fireEvent.click(toggle);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith("by_label");
+  });
+
+  it("maps the naming-mode toggle to merge when switched off", () => {
+    const onChange = vi.fn();
+    const { container } = render(
+      <LibrarySection
+        preferredRegion={AUTO_REGION}
+        libraryRegions={[]}
+        onPreferredRegionChange={vi.fn()}
+        platformGroups={false}
+        onPlatformGroupsChange={vi.fn()}
+        namingMode="by_label"
+        onNamingModeChange={onChange}
+      />,
+    );
+    const toggle = container.querySelector<HTMLInputElement>(
+      '[data-label="Distinguish collection types in Steam names"] input',
+    )!;
+    fireEvent.click(toggle);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith("merge");
   });
 });

--- a/src/components/settings/LibrarySection.tsx
+++ b/src/components/settings/LibrarySection.tsx
@@ -8,6 +8,7 @@
 
 import { FC } from "react";
 import { PanelSection, PanelSectionRow, DropdownItem, ToggleField } from "@decky/ui";
+import type { CollectionNamingMode } from "../../types";
 
 interface LibrarySectionProps {
   preferredRegion: string;
@@ -20,6 +21,12 @@ interface LibrarySectionProps {
   // than on the per-sync Collections tab.
   platformGroups: boolean;
   onPlatformGroupsChange: (enabled: boolean) => void;
+  // Steam-collection naming mode (#1539). "by_label" appends the fine type
+  // label to the Steam collection name so same-named collections of different
+  // types stay separate; "merge" (default) unions them. Rendered as a boolean
+  // toggle (checked === "by_label").
+  namingMode: CollectionNamingMode;
+  onNamingModeChange: (mode: CollectionNamingMode) => void;
 }
 
 // The internal sentinel for "no preference — use the fixed build-time order".
@@ -65,6 +72,8 @@ export const LibrarySection: FC<LibrarySectionProps> = ({
   onPreferredRegionChange,
   platformGroups,
   onPlatformGroupsChange,
+  namingMode,
+  onNamingModeChange,
 }) => {
   return (
     <PanelSection title="Library">
@@ -83,6 +92,14 @@ export const LibrarySection: FC<LibrarySectionProps> = ({
           description="When syncing a collection, also add its games to their platform-specific Steam group."
           checked={platformGroups}
           onChange={onPlatformGroupsChange}
+        />
+      </PanelSectionRow>
+      <PanelSectionRow>
+        <ToggleField
+          label="Distinguish collection types in Steam names"
+          description="Adds the collection type (e.g. Franchise, IGDB Collection) to the Steam collection name so collections that share a name stay separate instead of merging into one. Applies on the next sync."
+          checked={namingMode === "by_label"}
+          onChange={(v) => onNamingModeChange(v ? "by_label" : "merge")}
         />
       </PanelSectionRow>
     </PanelSection>

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -720,6 +720,45 @@ describe("index.tsx — sync_complete stale-collection cleanup (#1040)", () => {
     plugin.onDismount();
   });
 
+  it("keeps a case-variant ACTIVE RomM collection (does not delete it) (#1569)", async () => {
+    const { snes, faves } = seedCollections();
+    const plugin = pluginFactory();
+
+    // The live collection is "[Faves]"; the active map keys it as "faves" (the
+    // reporter's folded-first-seen casing). Case-insensitive identity → it is
+    // ACTIVE and must survive. SNES has no active platform → still stale.
+    emitSyncComplete({
+      platform_app_ids: { "Nintendo 64": [1] },
+      romm_collection_app_ids: { faves: [1] },
+      total_games: 1,
+    });
+    await flush();
+
+    expect(faves.Delete).not.toHaveBeenCalled();
+    // Non-vacuous: the stale SNES platform IS still cleaned, so cleanup ran.
+    expect(clearPlatformCollection).toHaveBeenCalledWith("Super Nintendo");
+    expect(snes.Delete).not.toHaveBeenCalled(); // platform delete routes via clearPlatformCollection
+    plugin.onDismount();
+  });
+
+  it("keeps a case-variant ACTIVE platform collection (does not clear it) (#1569)", async () => {
+    const { faves } = seedCollections();
+    const plugin = pluginFactory();
+
+    // Live "RomM: Super Nintendo (steamdeck)"; active map keys it "super nintendo".
+    // Case-insensitive → ACTIVE, must not be cleared. [Faves] has no active RomM
+    // entry → stale and removed (non-vacuous: cleanup ran).
+    emitSyncComplete({
+      platform_app_ids: { "super nintendo": [1] },
+      total_games: 1,
+    });
+    await flush();
+
+    expect(clearPlatformCollection).not.toHaveBeenCalled();
+    expect(faves.Delete).toHaveBeenCalledTimes(1);
+    plugin.onDismount();
+  });
+
   it("skips the stale cleanup on a cancelled sync with a partial map (regression)", async () => {
     const { snes, faves } = seedCollections();
     const plugin = pluginFactory();

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -445,15 +445,18 @@ export default definePlugin(() => {
             const hostname = await getHostname();
             const suffix = ` (${hostname})`;
 
-            // Clean stale platform collections
-            const activePlatforms = new Set(Object.keys(data.platform_app_ids));
+            // Clean stale platform collections. Name comparison is
+            // case-insensitive: Steam's collection identity is case-insensitive,
+            // so a case-variant that IS active must not be treated as stale and
+            // deleted (which would orphan its games, #1569).
+            const activePlatforms = new Set(Object.keys(data.platform_app_ids).map((n) => n.toLowerCase()));
             const stalePlatform = collectionStore.userCollections.filter((c) => {
               if (!c.displayName.startsWith("RomM: ")) return false;
               const afterPrefix = c.displayName.slice(6);
               if (afterPrefix.startsWith("[")) return false; // Skip RomM collections
               if (!c.displayName.endsWith(suffix)) return false; // Only this machine
               const platformName = afterPrefix.replace(/\s\([^)]+\)$/, "");
-              return !activePlatforms.has(platformName);
+              return !activePlatforms.has(platformName.toLowerCase());
             });
             for (const c of stalePlatform) {
               const afterPrefix = c.displayName.slice(6);
@@ -462,14 +465,16 @@ export default definePlugin(() => {
               await clearPlatformCollection(platformName);
             }
 
-            // Clean stale RomM collection-based collections
-            const activeNames = new Set(Object.keys(data.romm_collection_app_ids ?? {}));
+            // Clean stale RomM collection-based collections. Name comparison is
+            // case-insensitive (Steam's case-insensitive collection identity), so a
+            // case-variant that IS active is kept, not deleted/orphaned (#1569).
+            const activeNames = new Set(Object.keys(data.romm_collection_app_ids ?? {}).map((n) => n.toLowerCase()));
             const rommCollectionPattern = /^RomM: \[([^\]]+)\]/;
             const staleRomm = collectionStore.userCollections.filter((c) => {
               if (!c.displayName.startsWith("RomM: [")) return false;
               if (!c.displayName.endsWith(suffix)) return false;
               const match = rommCollectionPattern.exec(c.displayName);
-              return match ? !activeNames.has(match[1]!) : false; // group 1 present whenever match is non-null
+              return match ? !activeNames.has(match[1]!.toLowerCase()) : false; // group 1 present whenever match is non-null
             });
             for (const c of staleRomm) {
               logInfo(`Removing stale RomM collection "${c.displayName}"`);

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -67,6 +67,11 @@ export interface PluginSettings {
   // signed-in user's own collections). Optional: older payloads may omit it,
   // treated as "all". Mirrors the CollectionOwnerScope type in sync.ts.
   collection_owner_scope?: "own" | "all";
+  // Steam-collection naming mode (#1539): "merge" (default) unions same-named
+  // collections into one; "by_label" appends the fine type label so they stay
+  // separate. Optional: older payloads may omit it, treated as "merge". Mirrors
+  // the CollectionNamingMode type in sync.ts.
+  collection_naming_mode?: "merge" | "by_label";
   // Preferred sibling-group region (ADR-0021 §3). "auto" = the fixed build-time
   // default order (World > USA > Europe > Japan); any other value heads the
   // ranking with that region on the next sync. Optional: the backend always

--- a/src/types/sync.ts
+++ b/src/types/sync.ts
@@ -38,6 +38,16 @@ export type VirtualCollectionType = "franchise" | "collection";
  */
 export type CollectionOwnerScope = "own" | "all";
 
+/**
+ * Steam-collection naming mode. `"merge"` (default) unions same-named
+ * collections of any kind into one `RomM: [<name>]` Steam collection;
+ * `"by_label"` appends the fine collection-type label (`RomM: [<name>
+ * (Franchise)]`) so same-named collections of different types stay separate.
+ * The label is computed backend-side at the reporter key — the wire payload is
+ * name→appIds only.
+ */
+export type CollectionNamingMode = "merge" | "by_label";
+
 export interface CollectionSyncSetting {
   id: string;
   name: string;

--- a/src/utils/collections.test.ts
+++ b/src/utils/collections.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createOrUpdateRomMCollections, createOrUpdateCollections, clearPlatformCollection } from "./collections";
+
+// Steam's collection identity is case-insensitive, so a collection whose
+// displayName differs only by case from the one we're syncing is the SAME Steam
+// collection. These tests pin that our create/find + cleanup match it
+// case-insensitively — otherwise a colliding new create overwrites it and its
+// games are lost (#1569). The getHostname mock (test-setup) resolves "test".
+
+interface FakeDnd {
+  RemoveApps: ReturnType<typeof vi.fn>;
+  AddApps: ReturnType<typeof vi.fn>;
+}
+interface FakeCollection {
+  id: string;
+  displayName: string;
+  allApps: unknown[];
+  AsDragDropCollection: () => FakeDnd;
+  Save: ReturnType<typeof vi.fn>;
+  Delete: ReturnType<typeof vi.fn>;
+  dnd: FakeDnd;
+}
+
+function fakeCollection(displayName: string): FakeCollection {
+  const dnd: FakeDnd = { RemoveApps: vi.fn(), AddApps: vi.fn() };
+  return {
+    id: `id-${displayName}`,
+    displayName,
+    allApps: [],
+    AsDragDropCollection: () => dnd,
+    Save: vi.fn().mockResolvedValue(undefined),
+    Delete: vi.fn().mockResolvedValue(undefined),
+    dnd,
+  };
+}
+
+describe("createOrUpdateRomMCollections — case-insensitive identity (#1569)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("updates an existing case-variant collection instead of creating a duplicate", async () => {
+    // Steam already holds "RomM: [7 Up] (test)"; the reporter now emits the
+    // folded-first-seen casing "7 up". Must UPDATE the existing one, not create a
+    // colliding "7 up" that Steam merges over the top of.
+    const existing = fakeCollection("RomM: [7 Up] (test)");
+    const NewUnsavedCollection = vi.fn();
+    vi.stubGlobal("collectionStore", { userCollections: [existing], NewUnsavedCollection });
+
+    await createOrUpdateRomMCollections({ "7 up": [1001, 1002] });
+
+    expect(NewUnsavedCollection).not.toHaveBeenCalled();
+    expect(existing.Save).toHaveBeenCalledTimes(1);
+    expect(existing.dnd.AddApps).toHaveBeenCalledTimes(1);
+  });
+
+  it("creates a new collection when nothing matches even case-insensitively", async () => {
+    // Non-vacuous complement: the find isn't matching everything — a genuinely
+    // new name still creates.
+    const created = fakeCollection("RomM: [brand new] (test)");
+    const NewUnsavedCollection = vi.fn(() => created);
+    vi.stubGlobal("collectionStore", { userCollections: [], NewUnsavedCollection });
+
+    await createOrUpdateRomMCollections({ "brand new": [1] });
+
+    expect(NewUnsavedCollection).toHaveBeenCalledTimes(1);
+    expect(created.Save).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("createOrUpdateCollections (platform) — case-insensitive identity (#1569)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("updates an existing case-variant platform collection instead of creating a duplicate", async () => {
+    const existing = fakeCollection("RomM: Game Boy (test)");
+    const NewUnsavedCollection = vi.fn();
+    vi.stubGlobal("collectionStore", { userCollections: [existing], NewUnsavedCollection });
+
+    await createOrUpdateCollections({ "game boy": [1001] });
+
+    expect(NewUnsavedCollection).not.toHaveBeenCalled();
+    expect(existing.Save).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("clearPlatformCollection — case-insensitive identity (#1569)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("deletes a case-variant scoped collection", async () => {
+    // We ask to clear "game boy"; the live collection is "RomM: Game Boy (test)".
+    const scoped = fakeCollection("RomM: Game Boy (test)");
+    vi.stubGlobal("collectionStore", { userCollections: [scoped] });
+
+    await clearPlatformCollection("game boy");
+
+    expect(scoped.Delete).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/utils/collections.ts
+++ b/src/utils/collections.ts
@@ -61,7 +61,12 @@ export async function createOrUpdateCollections(
       const overviews = getOverviews(appIds);
 
       try {
-        const existing = collectionStore.userCollections.find((c) => c.displayName === collectionName);
+        // Case-insensitive match: Steam collapses collection names by a
+        // case-insensitive identity, so a case-variant collection ("RomM: [7 Up]
+        // (host)" vs "RomM: [7 up] (host)") must be UPDATED, not shadowed by a
+        // colliding new create that then overwrites it and loses its games (#1569).
+        const target = collectionName.toLowerCase();
+        const existing = collectionStore.userCollections.find((c) => c.displayName.toLowerCase() === target);
 
         if (existing) {
           logInfo(`Updating collection "${collectionName}" with ${appIds.length} apps`);
@@ -109,7 +114,12 @@ export async function createOrUpdateRomMCollections(
       const overviews = getOverviews(appIds);
 
       try {
-        const existing = collectionStore.userCollections.find((c) => c.displayName === collectionName);
+        // Case-insensitive match: Steam collapses collection names by a
+        // case-insensitive identity, so a case-variant collection ("RomM: [7 Up]
+        // (host)" vs "RomM: [7 up] (host)") must be UPDATED, not shadowed by a
+        // colliding new create that then overwrites it and loses its games (#1569).
+        const target = collectionName.toLowerCase();
+        const existing = collectionStore.userCollections.find((c) => c.displayName.toLowerCase() === target);
 
         if (existing) {
           logInfo(`Updating RomM collection "${collectionName}" with ${appIds.length} apps`);
@@ -145,15 +155,21 @@ export async function clearPlatformCollection(platformName: string): Promise<voi
     const scopedName = `RomM: ${platformName} (${hostname})`;
     const legacyName = `RomM: ${platformName}`;
 
+    // Case-insensitive match on the full name: Steam's collection identity is
+    // case-insensitive, so a case-variant of this platform's collection is the
+    // SAME Steam collection and must still be found for deletion (#1569).
+    const scopedTarget = scopedName.toLowerCase();
+    const legacyTarget = legacyName.toLowerCase();
+
     // Delete the machine-scoped collection
-    const scoped = collectionStore.userCollections.find((c) => c.displayName === scopedName);
+    const scoped = collectionStore.userCollections.find((c) => c.displayName.toLowerCase() === scopedTarget);
     if (scoped) {
       logInfo(`Deleting collection "${scopedName}" (id=${scoped.id})`);
       await scoped.Delete();
     }
 
     // Also clean up legacy collection (without hostname suffix) if it exists
-    const legacy = collectionStore.userCollections.find((c) => c.displayName === legacyName);
+    const legacy = collectionStore.userCollections.find((c) => c.displayName.toLowerCase() === legacyTarget);
     if (legacy) {
       logInfo(`Deleting legacy collection "${legacyName}" (id=${legacy.id})`);
       await legacy.Delete();
@@ -175,16 +191,21 @@ export async function clearAllRomMCollections(): Promise<void> {
     }
     const hostname = await getHostname();
     const suffix = ` (${hostname})`;
+    const lowerSuffix = suffix.toLowerCase();
 
     // Match collections belonging to this machine OR legacy ones without any hostname suffix.
     // Covers both platform collections ("RomM: PlatformName (hostname)") and
     // RomM collection-based collections ("RomM: [CollectionName] (hostname)").
     // Legacy collections match "RomM: ..." but do NOT have a parenthesized suffix.
     // This avoids deleting collections from other devices like "RomM: N64 (othermachine)".
+    // Prefix + host-suffix are compared case-insensitively (Steam's collection
+    // identity is case-insensitive, so a case-variant of one of our names is the
+    // same collection and must still be swept, #1569).
     const rommCollections = collectionStore.userCollections.filter((c) => {
-      if (!c.displayName.startsWith("RomM: ")) return false;
+      const lower = c.displayName.toLowerCase();
+      if (!lower.startsWith("romm: ")) return false;
       // This machine's scoped collections (both platform and RomM collection style)
-      if (c.displayName.endsWith(suffix)) return true;
+      if (lower.endsWith(lowerSuffix)) return true;
       // Legacy collections: start with "RomM: " but have no " (...)" suffix at all
       if (!/\s\([^)]+\)$/.test(c.displayName)) return true;
       return false;

--- a/tests/adapters/test_persistence.py
+++ b/tests/adapters/test_persistence.py
@@ -118,6 +118,10 @@ class TestSettingsSchema:
         assert DEFAULT_SETTINGS["romm_user_id"] is None
         assert DEFAULT_SETTINGS["collection_owner_scope"] == "all"
 
+    def test_default_naming_mode_is_merge(self):
+        # by_label is opt-in; a fresh install keeps today's merge behaviour (#1539).
+        assert DEFAULT_SETTINGS["collection_naming_mode"] == "merge"
+
     def test_mutable_default_is_not_aliased_to_template(self, adapter):
         """A missing key is backfilled with a COPY of its mutable default.
 

--- a/tests/contract/test_sync_read.py
+++ b/tests/contract/test_sync_read.py
@@ -309,6 +309,29 @@ async def test_set_collection_owner_scope_rejects_invalid(harness):
     assert harness.plugin.settings.get("collection_owner_scope", "all") == "all"
 
 
+async def test_set_collection_naming_mode_persists(harness):
+    """set_collection_naming_mode stores the value and get_settings reports it back."""
+    result = await harness.plugin.set_collection_naming_mode("by_label")
+    assert result == {"success": True}
+    assert harness.plugin.settings["collection_naming_mode"] == "by_label"
+    assert (await harness.plugin.get_settings())["collection_naming_mode"] == "by_label"
+
+    result = await harness.plugin.set_collection_naming_mode("merge")
+    assert result == {"success": True}
+    assert harness.plugin.settings["collection_naming_mode"] == "merge"
+
+
+async def test_set_collection_naming_mode_rejects_invalid(harness):
+    """An unrecognised mode returns the canonical failure shape and stores nothing."""
+    result = await harness.plugin.set_collection_naming_mode("fancy")
+    assert result["success"] is False
+    assert result["reason"] == "invalid_mode"
+    assert isinstance(result["message"], str) and result["message"]
+    assert "error" not in result
+    assert "error_code" not in result
+    assert harness.plugin.settings.get("collection_naming_mode", "merge") == "merge"
+
+
 async def test_get_collections_server_failure_shape(harness):
     """User-collection fetch failure → canonical failure shape."""
     harness.romm.list_collections_side_effect = RommConnectionError("offline")

--- a/tests/domain/test_collection_label.py
+++ b/tests/domain/test_collection_label.py
@@ -1,0 +1,69 @@
+"""Tests for domain.collection_label.collection_label.
+
+The fine display label appended to a Steam collection name under the ``by_label``
+naming mode. The strings MUST match the frontend vocabulary (``SUB_TAB_LABELS`` /
+``VIRTUAL_TYPE_LABELS`` in ``src/components/LibraryPage.tsx``), and no label may
+contain ``]`` (it sits inside the ``RomM: [<name> (<label>)]`` bracket pair the
+frontend reconcile parses).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from domain.collection_label import collection_label
+
+# The known (kind, virtual_type) → label mapping, mirroring the frontend labels.
+_KNOWN_CASES = [
+    ("standard", None, "Standard"),
+    ("smart", None, "Smart"),
+    ("virtual", "franchise", "Franchise"),
+    ("virtual", "collection", "IGDB Collection"),
+]
+
+
+class TestKnownLabels:
+    @pytest.mark.parametrize(("kind", "virtual_type", "expected"), _KNOWN_CASES)
+    def test_known_kind_and_type_map_to_frontend_label(self, kind, virtual_type, expected):
+        assert collection_label(kind, virtual_type) == expected
+
+    def test_standard_ignores_a_stray_virtual_type(self):
+        # A non-virtual kind never consults virtual_type — a spurious value is harmless.
+        assert collection_label("standard", "franchise") == "Standard"
+
+    def test_smart_ignores_a_stray_virtual_type(self):
+        assert collection_label("smart", "collection") == "Smart"
+
+
+class TestVirtualFallback:
+    """A virtual collection with a missing/unrecognised type degrades to 'Virtual'."""
+
+    def test_virtual_without_type_falls_back(self):
+        assert collection_label("virtual", None) == "Virtual"
+
+    def test_virtual_with_unknown_type_falls_back(self):
+        # A virtual type the plugin does not sync (genre/company/mode) → 'Virtual'.
+        assert collection_label("virtual", "genre") == "Virtual"
+
+
+class TestUnknownKindFallback:
+    def test_unknown_kind_capitalised(self):
+        assert collection_label("weird", None) == "Weird"
+
+    def test_empty_kind_degrades_to_collection(self):
+        assert collection_label("", None) == "Collection"
+
+
+class TestNoClosingBracketInLabel:
+    """A label must never contain ']' — it would truncate the reconcile name-parse."""
+
+    @pytest.mark.parametrize(("kind", "virtual_type", "expected"), _KNOWN_CASES)
+    def test_known_labels_have_no_closing_bracket(self, kind, virtual_type, expected):
+        assert "]" not in collection_label(kind, virtual_type)
+
+    @pytest.mark.parametrize(
+        ("kind", "virtual_type"),
+        [("virtual", None), ("virtual", "genre"), ("weird", None), ("", None)],
+    )
+    def test_fallback_labels_have_no_closing_bracket(self, kind, virtual_type):
+        assert "]" not in collection_label(kind, virtual_type)

--- a/tests/domain/test_work_unit.py
+++ b/tests/domain/test_work_unit.py
@@ -60,6 +60,26 @@ class TestToEventPayload:
         assert "bound_count" not in payload
         assert "new_shortcut_count" not in payload
 
+    def test_virtual_type_defaults_to_none_and_stays_off_the_wire(self):
+        """virtual_type is reporter-internal (#1539): defaults None, never in the payload."""
+        unit = WorkUnit(type="collection", id="7", name="Faves", slug="", rom_count=4, collection_kind="standard")
+        assert unit.virtual_type is None
+        assert "virtual_type" not in unit.to_event_payload()
+
+    def test_virtual_type_carried_when_set(self):
+        unit = WorkUnit(
+            type="collection",
+            id="vc-1",
+            name="coll-fr",
+            slug="",
+            rom_count=3,
+            collection_kind="virtual",
+            virtual_type="franchise",
+        )
+        assert unit.virtual_type == "franchise"
+        # Still internal — the sync_plan / sync_apply_unit payload carries only kind.
+        assert "virtual_type" not in unit.to_event_payload()
+
 
 class TestEstimatedItems:
     """The unit's weight in the plan's skip-aware totals (estimate-only, ADR-0023)."""

--- a/tests/services/library/test_fetcher.py
+++ b/tests/services/library/test_fetcher.py
@@ -259,6 +259,30 @@ class TestBuildWorkQueueErrorPaths:
         assert [u.collection_kind for u in units] == ["virtual"]
 
     @pytest.mark.asyncio
+    async def test_virtual_type_threads_onto_work_units(self, plugin, fake_romm_api):
+        """Each virtual unit carries its query virtual_type; standard units carry None (#1539)."""
+        _wire_fake(plugin, fake_romm_api)
+        plugin.settings["enabled_platforms"] = {}
+        plugin.settings["enabled_collections"] = {
+            "standard": {"7": True},
+            "smart": {},
+            "virtual": {"fr-1": True, "vc-1": True},
+        }
+        fake_romm_api.collections = [{"id": "7", "name": "Faves", "slug": "faves", "rom_count": 4}]
+        fake_romm_api.virtual_collections = {
+            "franchise": [{"id": "fr-1", "name": "coll-fr", "slug": "coll-fr", "rom_count": 3}],
+            "collection": [{"id": "vc-1", "name": "coll-vc", "slug": "coll-vc", "rom_count": 2}],
+        }
+
+        units = await plugin._sync_service._fetcher.build_work_queue()
+
+        by_name = {u.name: u for u in units}
+        assert by_name["coll-fr"].virtual_type == "franchise"
+        assert by_name["coll-vc"].virtual_type == "collection"
+        # A standard collection has no virtual sub-type.
+        assert by_name["Faves"].virtual_type is None
+
+    @pytest.mark.asyncio
     async def test_smart_collection_list_failure_continues_with_empty(self, plugin, fake_romm_api):
         """Smart-collection fetch raises => warning logged, treated as empty."""
         _wire_fake(plugin, fake_romm_api)

--- a/tests/services/library/test_reporter.py
+++ b/tests/services/library/test_reporter.py
@@ -1404,7 +1404,9 @@ class TestFinalizePerUnitRun:
         _seed_rom(uow, 2, app_id=None, platform_slug="snes", name="B (unbound)")
 
         await plugin._sync_service._reporter.finalize_per_unit_run(
-            pending_collection_memberships={("standard", "7"): CollectionMembership(name="Faves", rom_ids=[1, 2])},
+            pending_collection_memberships={
+                ("standard", "7"): CollectionMembership(name="Faves", rom_ids=[1, 2], kind="standard")
+            },
             pending_platform_rom_ids={1},
             platform_names={"n64": "Nintendo 64"},
         )
@@ -1428,7 +1430,9 @@ class TestFinalizePerUnitRun:
 
         await plugin._sync_service._reporter.finalize_per_unit_run(
             # the UNBOUND sibling is collected
-            pending_collection_memberships={("standard", "7"): CollectionMembership(name="Faves", rom_ids=[2])},
+            pending_collection_memberships={
+                ("standard", "7"): CollectionMembership(name="Faves", rom_ids=[2], kind="standard")
+            },
             pending_platform_rom_ids={1},
             platform_names={"n64": "Nintendo 64"},
         )
@@ -1450,7 +1454,9 @@ class TestFinalizePerUnitRun:
 
         await plugin._sync_service._reporter.finalize_per_unit_run(
             # BOTH siblings collected
-            pending_collection_memberships={("standard", "7"): CollectionMembership(name="Faves", rom_ids=[1, 2])},
+            pending_collection_memberships={
+                ("standard", "7"): CollectionMembership(name="Faves", rom_ids=[1, 2], kind="standard")
+            },
             pending_platform_rom_ids={1},
             platform_names={"n64": "Nintendo 64"},
         )
@@ -1476,8 +1482,8 @@ class TestFinalizePerUnitRun:
 
         await plugin._sync_service._reporter.finalize_per_unit_run(
             pending_collection_memberships={
-                ("standard", "7"): CollectionMembership(name="X", rom_ids=[1]),
-                ("smart", "9"): CollectionMembership(name="X", rom_ids=[2]),
+                ("standard", "7"): CollectionMembership(name="X", rom_ids=[1], kind="standard"),
+                ("smart", "9"): CollectionMembership(name="X", rom_ids=[2], kind="smart"),
             },
             pending_platform_rom_ids={1, 2},
             platform_names={"n64": "Nintendo 64", "snes": "Super Nintendo"},
@@ -1499,8 +1505,8 @@ class TestFinalizePerUnitRun:
 
         await plugin._sync_service._reporter.finalize_per_unit_run(
             pending_collection_memberships={
-                ("standard", "7"): CollectionMembership(name="X", rom_ids=[1, 2]),
-                ("smart", "9"): CollectionMembership(name="X", rom_ids=[1]),
+                ("standard", "7"): CollectionMembership(name="X", rom_ids=[1, 2], kind="standard"),
+                ("smart", "9"): CollectionMembership(name="X", rom_ids=[1], kind="smart"),
             },
             pending_platform_rom_ids={1, 2},
             platform_names={"n64": "Nintendo 64", "snes": "Super Nintendo"},
@@ -1527,8 +1533,8 @@ class TestFinalizePerUnitRun:
 
         await plugin._sync_service._reporter.finalize_per_unit_run(
             pending_collection_memberships={
-                ("standard", "7"): CollectionMembership(name="Alpha", rom_ids=[1]),
-                ("smart", "9"): CollectionMembership(name="Beta", rom_ids=[2]),
+                ("standard", "7"): CollectionMembership(name="Alpha", rom_ids=[1], kind="standard"),
+                ("smart", "9"): CollectionMembership(name="Beta", rom_ids=[2], kind="smart"),
             },
             pending_platform_rom_ids={1, 2},
             platform_names={"n64": "Nintendo 64", "snes": "Super Nintendo"},
@@ -1536,6 +1542,151 @@ class TestFinalizePerUnitRun:
 
         payload = next(c for c in decky.emit.call_args_list if c[0][0] == "sync_collections")[0][1]
         assert payload["romm_collection_app_ids"] == {"Alpha": [1001], "Beta": [1002]}
+
+    @pytest.mark.asyncio
+    async def test_by_label_keys_a_single_collection_with_its_fine_label(self, plugin):
+        """``by_label`` mode appends the fine type label to the reporter key.
+
+        The key becomes ``"<name> (<Label>)"`` so the frontend builds
+        ``RomM: [<name> (Label)]``. Default ``merge`` would key by the bare name.
+        """
+        import decky
+
+        decky.emit.reset_mock()
+        plugin.settings["collection_naming_mode"] = "by_label"
+        uow = plugin._uow
+        _seed_rom(uow, 1, app_id=1001, platform_slug="n64", name="A")
+
+        await plugin._sync_service._reporter.finalize_per_unit_run(
+            pending_collection_memberships={
+                ("virtual", "vc-1"): CollectionMembership(
+                    name="coll-a", rom_ids=[1], kind="virtual", virtual_type="franchise"
+                )
+            },
+            pending_platform_rom_ids={1},
+            platform_names={"n64": "Nintendo 64"},
+        )
+
+        payload = next(c for c in decky.emit.call_args_list if c[0][0] == "sync_collections")[0][1]
+        assert payload["romm_collection_app_ids"] == {"coll-a (Franchise)": [1001]}
+
+    @pytest.mark.asyncio
+    async def test_by_label_keeps_same_name_different_label_separate(self, plugin):
+        """A standard and a virtual collection sharing a name stay SEPARATE under by_label.
+
+        The load-bearing behavior: same name + different type → two distinct Steam
+        collections, not a union (which is what ``merge`` does).
+        """
+        import decky
+
+        decky.emit.reset_mock()
+        plugin.settings["collection_naming_mode"] = "by_label"
+        uow = plugin._uow
+        _seed_rom(uow, 1, app_id=1001, platform_slug="n64", name="A")
+        _seed_rom(uow, 2, app_id=1002, platform_slug="snes", name="B")
+
+        await plugin._sync_service._reporter.finalize_per_unit_run(
+            pending_collection_memberships={
+                ("standard", "7"): CollectionMembership(name="shared-name", rom_ids=[1], kind="standard"),
+                ("virtual", "vc-9"): CollectionMembership(
+                    name="shared-name", rom_ids=[2], kind="virtual", virtual_type="collection"
+                ),
+            },
+            pending_platform_rom_ids={1, 2},
+            platform_names={"n64": "Nintendo 64", "snes": "Super Nintendo"},
+        )
+
+        payload = next(c for c in decky.emit.call_args_list if c[0][0] == "sync_collections")[0][1]
+        assert payload["romm_collection_app_ids"] == {
+            "shared-name (Standard)": [1001],
+            "shared-name (IGDB Collection)": [1002],
+        }
+
+    @pytest.mark.asyncio
+    async def test_by_label_franchise_vs_igdb_collection_same_name_two_keys(self, plugin):
+        """Two virtual collections of the same name but different virtual_type split apart."""
+        import decky
+
+        decky.emit.reset_mock()
+        plugin.settings["collection_naming_mode"] = "by_label"
+        uow = plugin._uow
+        _seed_rom(uow, 1, app_id=1001, platform_slug="n64", name="A")
+        _seed_rom(uow, 2, app_id=1002, platform_slug="snes", name="B")
+
+        await plugin._sync_service._reporter.finalize_per_unit_run(
+            pending_collection_memberships={
+                ("virtual", "vc-f"): CollectionMembership(
+                    name="shared-name", rom_ids=[1], kind="virtual", virtual_type="franchise"
+                ),
+                ("virtual", "vc-c"): CollectionMembership(
+                    name="shared-name", rom_ids=[2], kind="virtual", virtual_type="collection"
+                ),
+            },
+            pending_platform_rom_ids={1, 2},
+            platform_names={"n64": "Nintendo 64", "snes": "Super Nintendo"},
+        )
+
+        payload = next(c for c in decky.emit.call_args_list if c[0][0] == "sync_collections")[0][1]
+        assert payload["romm_collection_app_ids"] == {
+            "shared-name (Franchise)": [1001],
+            "shared-name (IGDB Collection)": [1002],
+        }
+
+    @pytest.mark.asyncio
+    async def test_by_label_same_name_same_label_still_unions(self, plugin):
+        """Two collections of the SAME name AND same label still UNION under by_label.
+
+        Same-name-within-one-label is accepted as merged (two standard "Faves"),
+        so the key ``"Faves (Standard)"`` unions both member sets.
+        """
+        import decky
+
+        decky.emit.reset_mock()
+        plugin.settings["collection_naming_mode"] = "by_label"
+        uow = plugin._uow
+        _seed_rom(uow, 1, app_id=1001, platform_slug="n64", name="A")
+        _seed_rom(uow, 2, app_id=1002, platform_slug="snes", name="B")
+
+        await plugin._sync_service._reporter.finalize_per_unit_run(
+            pending_collection_memberships={
+                ("standard", "7"): CollectionMembership(name="Faves", rom_ids=[1], kind="standard"),
+                ("standard", "8"): CollectionMembership(name="Faves", rom_ids=[2], kind="standard"),
+            },
+            pending_platform_rom_ids={1, 2},
+            platform_names={"n64": "Nintendo 64", "snes": "Super Nintendo"},
+        )
+
+        payload = next(c for c in decky.emit.call_args_list if c[0][0] == "sync_collections")[0][1]
+        assert payload["romm_collection_app_ids"] == {"Faves (Standard)": [1001, 1002]}
+
+    @pytest.mark.asyncio
+    async def test_merge_mode_unions_same_name_across_kinds(self, plugin):
+        """Default ``merge`` still unions the same-named standard + virtual pair by bare name.
+
+        The complement to ``test_by_label_keeps_same_name_different_label_separate``:
+        with the default mode the exact same input collapses onto one bare-name key.
+        """
+        import decky
+
+        decky.emit.reset_mock()
+        plugin.settings["collection_naming_mode"] = "merge"
+        uow = plugin._uow
+        _seed_rom(uow, 1, app_id=1001, platform_slug="n64", name="A")
+        _seed_rom(uow, 2, app_id=1002, platform_slug="snes", name="B")
+
+        await plugin._sync_service._reporter.finalize_per_unit_run(
+            pending_collection_memberships={
+                ("standard", "7"): CollectionMembership(name="shared-name", rom_ids=[1], kind="standard"),
+                ("virtual", "vc-9"): CollectionMembership(
+                    name="shared-name", rom_ids=[2], kind="virtual", virtual_type="collection"
+                ),
+            },
+            pending_platform_rom_ids={1, 2},
+            platform_names={"n64": "Nintendo 64", "snes": "Super Nintendo"},
+        )
+
+        payload = next(c for c in decky.emit.call_args_list if c[0][0] == "sync_collections")[0][1]
+        assert payload["romm_collection_app_ids"] == {"shared-name": [1001, 1002]}
 
     @pytest.mark.asyncio
     async def test_emit_sync_complete_terminal(self, plugin):

--- a/tests/services/library/test_reporter.py
+++ b/tests/services/library/test_reporter.py
@@ -1689,6 +1689,116 @@ class TestFinalizePerUnitRun:
         assert payload["romm_collection_app_ids"] == {"shared-name": [1001, 1002]}
 
     @pytest.mark.asyncio
+    async def test_merge_unions_case_differing_names(self, plugin):
+        """Two names differing ONLY by case union into ONE key under merge (#1569).
+
+        The data-loss guard: Steam collapses "7 up" and "7 Up" onto one
+        case-insensitive collection, so the reporter must emit a single key with
+        BOTH member sets — otherwise the second Steam create overwrites the first
+        and its games are lost. First-seen casing wins for display.
+        """
+        import decky
+
+        decky.emit.reset_mock()
+        plugin.settings["collection_naming_mode"] = "merge"
+        uow = plugin._uow
+        # collection A ("7 up") → 2 apps; collection B ("7 Up") → 5 apps.
+        for rid, aid in [(1, 1001), (2, 1002), (3, 1003), (4, 1004), (5, 1005), (6, 1006), (7, 1007)]:
+            _seed_rom(uow, rid, app_id=aid, platform_slug="n64", name=f"g{rid}")
+
+        await plugin._sync_service._reporter.finalize_per_unit_run(
+            pending_collection_memberships={
+                ("standard", "7"): CollectionMembership(name="7 up", rom_ids=[1, 2], kind="standard"),
+                ("virtual", "vc-1"): CollectionMembership(
+                    name="7 Up", rom_ids=[3, 4, 5, 6, 7], kind="virtual", virtual_type="franchise"
+                ),
+            },
+            pending_platform_rom_ids=set(range(1, 8)),
+            platform_names={"n64": "Nintendo 64"},
+        )
+
+        payload = next(c for c in decky.emit.call_args_list if c[0][0] == "sync_collections")[0][1]
+        # ONE key (first-seen casing "7 up"), 2 + 5 = 7 apps unioned, neither set dropped.
+        assert payload["romm_collection_app_ids"] == {"7 up": [1001, 1002, 1003, 1004, 1005, 1006, 1007]}
+
+    @pytest.mark.asyncio
+    async def test_by_label_merges_same_type_case_variants(self, plugin):
+        """Under by_label, same-TYPE case variants merge (labels match → folded keys match)."""
+        import decky
+
+        decky.emit.reset_mock()
+        plugin.settings["collection_naming_mode"] = "by_label"
+        uow = plugin._uow
+        _seed_rom(uow, 1, app_id=1001, platform_slug="n64", name="A")
+        _seed_rom(uow, 2, app_id=1002, platform_slug="snes", name="B")
+
+        await plugin._sync_service._reporter.finalize_per_unit_run(
+            pending_collection_memberships={
+                ("standard", "7"): CollectionMembership(name="abc", rom_ids=[1], kind="standard"),
+                ("standard", "8"): CollectionMembership(name="ABC", rom_ids=[2], kind="standard"),
+            },
+            pending_platform_rom_ids={1, 2},
+            platform_names={"n64": "Nintendo 64", "snes": "Super Nintendo"},
+        )
+
+        payload = next(c for c in decky.emit.call_args_list if c[0][0] == "sync_collections")[0][1]
+        # One key ("abc (Standard)", first-seen casing), both apps unioned.
+        assert payload["romm_collection_app_ids"] == {"abc (Standard)": [1001, 1002]}
+
+    @pytest.mark.asyncio
+    async def test_by_label_keeps_different_type_case_variants_separate(self, plugin):
+        """Under by_label, DIFFERENT-type case variants stay separate (labels differ)."""
+        import decky
+
+        decky.emit.reset_mock()
+        plugin.settings["collection_naming_mode"] = "by_label"
+        uow = plugin._uow
+        _seed_rom(uow, 1, app_id=1001, platform_slug="n64", name="A")
+        _seed_rom(uow, 2, app_id=1002, platform_slug="snes", name="B")
+
+        await plugin._sync_service._reporter.finalize_per_unit_run(
+            pending_collection_memberships={
+                ("standard", "7"): CollectionMembership(name="abc", rom_ids=[1], kind="standard"),
+                ("virtual", "vc-9"): CollectionMembership(
+                    name="ABC", rom_ids=[2], kind="virtual", virtual_type="collection"
+                ),
+            },
+            pending_platform_rom_ids={1, 2},
+            platform_names={"n64": "Nintendo 64", "snes": "Super Nintendo"},
+        )
+
+        payload = next(c for c in decky.emit.call_args_list if c[0][0] == "sync_collections")[0][1]
+        assert payload["romm_collection_app_ids"] == {
+            "abc (Standard)": [1001],
+            "ABC (IGDB Collection)": [1002],
+        }
+
+    @pytest.mark.asyncio
+    async def test_platform_names_union_case_insensitively(self, plugin):
+        """Two platform display names differing only by case union into one bucket (#1569)."""
+        import decky
+
+        decky.emit.reset_mock()
+        uow = plugin._uow
+        # Two distinct slugs whose live display names collide only by case.
+        _seed_rom(uow, 1, app_id=1001, platform_slug="a", name="A")
+        _seed_rom(uow, 2, app_id=1002, platform_slug="b", name="B")
+
+        await plugin._sync_service._reporter.finalize_per_unit_run(
+            pending_collection_memberships={},
+            pending_platform_rom_ids={1, 2},
+            platform_names={"a": "Retro", "b": "retro"},
+        )
+
+        payload = next(c for c in decky.emit.call_args_list if c[0][0] == "sync_collections")[0][1]
+        platform_map = payload["platform_app_ids"]
+        # ONE bucket, both appIds present, keyed by a case-variant of "retro".
+        assert len(platform_map) == 1
+        (display, app_ids) = next(iter(platform_map.items()))
+        assert display.casefold() == "retro"
+        assert set(app_ids) == {1001, 1002}
+
+    @pytest.mark.asyncio
     async def test_emit_sync_complete_terminal(self, plugin):
         import decky
 

--- a/tests/services/library/test_service.py
+++ b/tests/services/library/test_service.py
@@ -1216,7 +1216,7 @@ class TestCollectionSyncEdgeCases:
             platform_app_ids, _ = svc._reporter._build_collection_app_ids(
                 uow,
                 platform_rom_ids,
-                {("standard", "3"): CollectionMembership(name="Favorites", rom_ids=[1, 2])},
+                {("standard", "3"): CollectionMembership(name="Favorites", rom_ids=[1, 2], kind="standard")},
                 names,
             )
 
@@ -1254,7 +1254,9 @@ class TestCollectionSyncEdgeCases:
         _seed_rom(plugin._uow, 1, app_id=1001, platform_slug="gba", name="ROM A")
         names = {"gba": "Game Boy Advance"}
         platform_rom_ids = {1}
-        collection_memberships = {("standard", "3"): CollectionMembership(name="Favorites", rom_ids=[1])}
+        collection_memberships = {
+            ("standard", "3"): CollectionMembership(name="Favorites", rom_ids=[1], kind="standard")
+        }
 
         with plugin._uow as uow:
             platform_app_ids, romm_collection_app_ids = svc._reporter._build_collection_app_ids(
@@ -1318,7 +1320,10 @@ class TestCollectionSyncEdgeCases:
 
         with plugin._uow as uow:
             _platform_app_ids, romm_collection_app_ids = svc._reporter._build_collection_app_ids(
-                uow, {1}, {("standard", "3"): CollectionMembership(name="Favorites", rom_ids=[1, 99])}, {"gba": "GBA"}
+                uow,
+                {1},
+                {("standard", "3"): CollectionMembership(name="Favorites", rom_ids=[1, 99], kind="standard")},
+                {"gba": "GBA"},
             )
 
         assert "Favorites" in romm_collection_app_ids

--- a/tests/services/library/test_sync_orchestrator.py
+++ b/tests/services/library/test_sync_orchestrator.py
@@ -3606,6 +3606,51 @@ class TestSyncOneUnitCollectionAndCancel:
         assert len(complete) == 1
 
     @pytest.mark.asyncio
+    async def test_sync_collection_unit_threads_kind_and_virtual_type(self, plugin):
+        """_sync_collection_unit stamps the unit's kind + virtual_type onto the membership (#1539)."""
+        orch = plugin._sync_service._orchestrator
+        orch._fetcher.fetch_collection_unit = AsyncMock(return_value=([{"id": 1}], [1, 2], False))  # type: ignore[method-assign]
+        unit = WorkUnit(
+            type="collection",
+            id="vc-1",
+            name="coll-fr",
+            slug="coll-fr",
+            rom_count=2,
+            collection_kind="virtual",
+            virtual_type="franchise",
+        )
+        memberships: dict[tuple[str, str], Any] = {}
+
+        await orch._sync_collection_unit(unit, synced_rom_ids=set(), collection_memberships=memberships)
+
+        membership = memberships[("virtual", "vc-1")]
+        assert membership.name == "coll-fr"
+        assert membership.rom_ids == [1, 2]
+        assert membership.kind == "virtual"
+        assert membership.virtual_type == "franchise"
+
+    @pytest.mark.asyncio
+    async def test_sync_collection_unit_standard_has_no_virtual_type(self, plugin):
+        """A standard collection membership carries kind='standard' and virtual_type=None (#1539)."""
+        orch = plugin._sync_service._orchestrator
+        orch._fetcher.fetch_collection_unit = AsyncMock(return_value=([{"id": 1}], [1], False))  # type: ignore[method-assign]
+        unit = WorkUnit(
+            type="collection",
+            id="7",
+            name="Faves",
+            slug="faves",
+            rom_count=1,
+            collection_kind="standard",
+        )
+        memberships: dict[tuple[str, str], Any] = {}
+
+        await orch._sync_collection_unit(unit, synced_rom_ids=set(), collection_memberships=memberships)
+
+        membership = memberships[("standard", "7")]
+        assert membership.kind == "standard"
+        assert membership.virtual_type is None
+
+    @pytest.mark.asyncio
     async def test_cancel_after_fetch_returns_zero_applied(self, plugin, fake_romm_api):
         """CANCELLING flipped after fetch_platform_unit → unit returns 0."""
         plugin.loop = asyncio.get_event_loop()

--- a/tests/services/test_settings.py
+++ b/tests/services/test_settings.py
@@ -141,6 +141,7 @@ class TestGetSettings:
                 "romm_allow_insecure_ssl": True,
                 "collection_create_platform_groups": True,
                 "collection_owner_scope": "own",
+                "collection_naming_mode": "by_label",
                 "preferred_region": "USA",
             }
         )
@@ -154,6 +155,7 @@ class TestGetSettings:
         assert result["romm_allow_insecure_ssl"] is True
         assert result["collection_create_platform_groups"] is True
         assert result["collection_owner_scope"] == "own"
+        assert result["collection_naming_mode"] == "by_label"
         assert result["preferred_region"] == "USA"
         assert result["retroarch_input_check"] == {"warning": False}
 
@@ -203,6 +205,7 @@ class TestGetSettings:
         assert result["romm_allow_insecure_ssl"] is False
         assert result["collection_create_platform_groups"] is False
         assert result["collection_owner_scope"] == "all"
+        assert result["collection_naming_mode"] == "merge"
         assert result["preferred_region"] == "auto"
 
     def test_includes_retroarch_input_check_payload(self, service, steam_config):
@@ -545,6 +548,30 @@ class TestSetCollectionOwnerScope:
         result = service.set_collection_owner_scope(None)  # type: ignore[arg-type]
         assert result["success"] is False
         assert "collection_owner_scope" not in settings
+        settings_persister.save_settings.assert_not_called()
+
+
+class TestSetCollectionNamingMode:
+    @pytest.mark.parametrize("mode", ["merge", "by_label"])
+    def test_valid_modes_persist(self, service, settings, settings_persister, mode):
+        result = service.set_collection_naming_mode(mode)
+        assert result == {"success": True}
+        assert settings["collection_naming_mode"] == mode
+        settings_persister.save_settings.assert_called_once_with()
+
+    def test_invalid_mode_rejected_with_canonical_failure(self, service, settings, settings_persister):
+        result = service.set_collection_naming_mode("fancy")
+        assert result["success"] is False
+        assert result["reason"] == "invalid_mode"
+        assert "Invalid naming mode" in result["message"]
+        assert "collection_naming_mode" not in settings
+        settings_persister.save_settings.assert_not_called()
+
+    def test_non_string_rejected(self, service, settings, settings_persister):
+        result = service.set_collection_naming_mode(None)  # type: ignore[arg-type]
+        assert result["success"] is False
+        assert result["reason"] == "invalid_mode"
+        assert "collection_naming_mode" not in settings
         settings_persister.save_settings.assert_not_called()
 
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -730,6 +730,9 @@ _MIGRATION_BLOCKED_WHITELIST: set[str] = {
     # Collection owner-scope (#1532) — a settings.json-only write, never touches
     # RetroDECK state; takes effect on the next sync's work-queue build.
     "set_collection_owner_scope",
+    # Collection naming mode (#1539) — a settings.json-only write, never touches
+    # RetroDECK state; takes effect on the next sync's reporter-key build.
+    "set_collection_naming_mode",
     # Preferred sibling-group region — a settings.json-only write (ADR-0021 §3),
     # never touches RetroDECK state; takes effect on the next sync. Its companion
     # read (distinct regions in the local library) is a pure local DB read.


### PR DESCRIPTION
Now that franchise and IGDB-collection virtual types both sync, collections of different types that share a name silently merge into one Steam collection (#1503's by-name union) — two enabled rows collapse into one Steam collection with no way to tell them apart. This adds a user setting to opt out of that merge, and fixes a related case-collision that could drop games.

## `collection_naming_mode`

A new setting in Settings → Library, default `merge` (unchanged behaviour):

- **`merge`** (default) — same-named collections union into one `RomM: [<name>] (<host>)`.
- **`by_label`** — each Steam collection name carries its type label so distinct groupings stay separate: `RomM: [<name> (Franchise)] (<host>)`, `RomM: [<name> (IGDB Collection)] (<host>)`, `RomM: [<name> (Smart)] (<host>)`, `RomM: [<name> (Standard)] (<host>)`. Collections that share both name and type still union.

The label is injected at the reporter's union key, so the frontend create-name and the stale-collection reconcile stay derived from a single key. Switching modes renames every collection on the next normal sync — the existing complete-set reconcile deletes the old-named collections and recreates them under the new scheme; no Force Full Sync is needed.

Toggle copy: "Distinguish collection types in Steam names — Adds the collection type (e.g. Franchise, IGDB Collection) to the Steam collection name so collections that share a name stay separate instead of merging into one. Applies on the next sync."

## Case-insensitive name identity

Collections whose names differ only by case previously produced two separate keys under `merge`, which Steam then collapsed by its own case-insensitive collection identity — silently overwriting one with the other and dropping its games. Collection and platform name identity is now case-insensitive throughout (the reporter union, the frontend create/find, the stale-collection reconcile, and the cleanup paths), so case-variants union into a single collection instead of clobbering each other. First-seen casing is kept for display (Steam uppercases the name regardless).

## Migrations

- Settings migrate to v13: the `enabled_collections` bucket keyed `user` is renamed to `standard` (lossless; merged into an existing `standard` bucket if present).
- A database migration renames the stored kind on existing collection sync-state rows, so no standard collection is needlessly re-fetched after the update.

Docs (syncing guide, Steam-shortcuts architecture) and the glossary are updated in the same change.

Closes #1539.
