### PR TITLE
build(frontend): strip comments from the production bundle

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "outDir": "dist",
     "module": "ESNext",
+    "removeComments": true,
     "target": "ES2020",
     "jsx": "react-jsx",
     "declaration": false,


### PR DESCRIPTION
The `@decky/rollup` preset ships an **unminified** ESM bundle and pipes `src/` comments verbatim into `dist/index.js` via `@rollup/plugin-typescript`, whose `removeComments` defaults to `false`. The plugin's dense doc-comments therefore counted against the 800 kB `size-limit` 1:1 — a budget taxing comment quality. `main` sits at ~3.2 kB of headroom, and #1570 has five more PRs queued behind it.

Set `removeComments` in `tsconfig.json` so the TypeScript transpile drops comments from the **emitted bundle only**. Source is untouched; `tsc --noEmit` (typecheck) and vitest (own transform) are unaffected — only the Rollup build output changes. No functional comments exist in `src/` (verified: no `@license` / `@preserve` / `__PURE__` / webpack magic), so nothing load-bearing is lost.

**Bundle: 799.74 kB → 512.01 kB** — ~290 kB was comment text. Headroom goes from ~260 B to ~288 kB.

`mise run gate` green: build, typecheck, `pnpm size` (512 kB under the 800 kB limit), 2132 frontend + 6260 backend tests, all `check_*` gates.

docs: N/A — build tooling only, no user-visible change and no architecture shift.