### PR TITLE
docs: put the mark on the landing page's heading line

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,4 @@
-<p align="center"><img src="assets/logo-animated.gif" alt="" width="150"></p>
-
-# decky-romm-sync
+# decky-romm-sync { .hero-title }
 
 A [Decky Loader](https://decky.xyz/) plugin that syncs your self-hosted [RomM](https://github.com/rommapp/romm) ROM
 library into Steam as Non-Steam shortcuts. Games launch through [RetroDECK](https://retrodeck.net/).

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -18,3 +18,33 @@
   --md-accent-fg-color--transparent: #66c0f41a;
   --md-typeset-a-color: #8fd0f7;
 }
+
+/* The landing page's mark sits beside its heading rather than above it, so the
+   two read as one line.
+
+   It comes in through ::before rather than as an <img> in the Markdown. The mark
+   is decorative — the heading it sits next to already says the name — and a CSS
+   background is decorative by construction: nothing to give alt text to, and
+   nothing for a screen reader to announce twice. It also keeps the Markdown a
+   plain heading, so the page title, the nav label and the anchor are untouched.
+
+   Sized in em so it tracks the heading, which Material already scales down on
+   narrow viewports; a px height would drift out of proportion there. Flex does
+   the centring, because the offset that would centre it by hand depends on the
+   font's cap height and would need re-deriving if the heading font changed. */
+.md-typeset h1.hero-title {
+  display: flex;
+  align-items: center;
+}
+
+.md-typeset h1.hero-title::before {
+  content: "";
+  background-image: url("../assets/logo-animated.gif");
+  background-size: contain;
+  background-repeat: no-repeat;
+  background-position: center;
+  width: 1.9em;
+  height: 1.9em;
+  margin-right: 0.28em;
+  flex: none;
+}


### PR DESCRIPTION
Brings the mark onto the landing page's heading line instead of sitting above it as a 150px block.

It comes in through `::before` rather than an `<img>`: the mark is decorative — the heading beside it already says the
name, so alt text would have a screen reader announce it twice — and a CSS background has nothing to announce. That also
keeps the Markdown a plain heading, so the page title, the nav label and the anchor are unchanged.

README is left as it is.
