### PR TITLE
chore(rules): path-scope the coding conventions and ratchet module size

### DIFF
--- a/.claude/rules/adapters-domain.md
+++ b/.claude/rules/adapters-domain.md
@@ -1,0 +1,35 @@
+---
+paths:
+  - "py_modules/adapters/**"
+  - "py_modules/domain/**"
+  - "py_modules/lib/**"
+  - "py_modules/models/**"
+---
+
+# Adapters, domain, and aggregates
+
+`[CP]` marks a canonical Cosmic Python rule — a hard rule, breaking it is an architectural regression. `[ours]` marks a
+project convention layered on top — flag deviations in review, but the rule itself can be debated.
+
+Backend layout: `services/` (orchestration) / `adapters/` (I/O) / `domain/` (pure compute) / `lib/` (cross-cutting
+utilities) / `models/` (data shapes). `import-linter` enforces direction. `[CP]`
+
+**Adapters**: `[CP]` Own all I/O. Never import from `services/`. Implement Protocols defined in `services/protocols/`.
+
+**Domain**: `[CP]` Pure compute only. No I/O, no state mutation, no service or adapter imports. Anything stateless and
+I/O-free currently in a service belongs here.
+
+## Aggregates
+
+The aggregate roots, their tables, and the enforcement layers are canonical in
+[database-design.md](../../docs/architecture/database-design.md). Config-shaped toggles live in `settings.json`, not
+SQLite. Rules for the relational state that _does_ live in SQLite:
+
+- `[CP]` One Repository Protocol per aggregate root, not per table.
+- `[CP]` Aggregate methods are the **only** mutation API for the aggregate's state. No external field assignment from
+  services. Field access for reads is fine.
+- `[ours]` **Mutation methods are verb-named after the domain event they represent.** `adopt_baseline(filename, hash)`
+  not `update_baseline(...)`; `mark_installed(path)` not `set_installed(...)`; `promote_slot(slot, source)` not
+  `update_slot_source(...)`. The method name becomes the implicit event name if events are added later.
+- `[ours]` Domain events + message bus are out of scope. Revisit when handler diversity ≥3 kinds for the same state
+  change, or a non-Steam consumer becomes concrete, or telemetry needs to subscribe.

--- a/.claude/rules/bootstrap-wiring.md
+++ b/.claude/rules/bootstrap-wiring.md
@@ -1,0 +1,22 @@
+---
+paths:
+  - "py_modules/bootstrap.py"
+  - "main.py"
+---
+
+# Composition root and process boundaries
+
+**Bootstrap (`bootstrap.py`)**: `[CP]` The composition root — the only place concrete adapters meet services. `[ours]`
+`WiringConfig` holds the wiring; protocols in, services out. Adapter instantiation never happens in `main.py` — a
+Protocol-wrapped persister is built in `bootstrap()` and passed through `CallbackBundle`.
+
+**Process boundaries — `main.py` vs `bootstrap.py`**: `[ours]` `main.py` owns the Decky lifecycle (`_main`, `_unload`)
+and the callable surface (one `async def` per `@callable`). `bootstrap.py` owns adapter instantiation and service
+wiring. The split is binding — no callables in `bootstrap.py`, no service wiring in `main.py`.
+
+`main.py` grows with the callable surface it describes; that is unavoidable density, not god-class, and it is
+deliberately out of scope for the module-size gate.
+
+`bootstrap.py` is **not** exempt. It is already past the ~700-LOC split trigger and is pinned at its current size by
+`scripts/check_module_size.py`, so it cannot grow further: new wiring means splitting it into
+`bootstrap/{adapters,services}.py` first.

--- a/.claude/rules/callables.md
+++ b/.claude/rules/callables.md
@@ -1,0 +1,30 @@
+---
+paths:
+  - "main.py"
+  - "src/api/**"
+---
+
+# Callable response shapes `[ours]`
+
+Callables returning a plain `dict` that can fail use `{success: False, reason: ErrorCode | str, message: str}`. Both
+`reason` and `message` are **required**. Reuse `lib.list_result.ErrorCode` for coarse categories; bespoke guards
+(`config_error`, `sync_disabled`, `not_installed`, …) stay plain-string reasons. Transport failures collapse onto
+`SERVER_UNREACHABLE`; 401 and 403 collapse onto `AUTH_FAILED` (same slug, distinct `message`). The legacy `error_code`
+key and a second `error` key are **forbidden**. Enforced by `scripts/check_failure_shape.py --check`.
+
+Two carve-outs (pattern-exempt in the gate):
+
+- **Discriminated-status unions** (`status: "ok" | "server_unreachable" | …`, used by the saves version-history
+  callables) keep the `status` discriminant instead of `success` — more than two outcomes. Failure branches still carry
+  `message: str`.
+- **Partial-success responses** returning a full payload alongside a failure flag (`get_save_status`'s
+  `server_query_failed: bool`, `get_save_setup_info`'s `recommended_action`) keep the additive flag.
+
+Full convention paragraph: the `lib/list_result.py` module docstring.
+
+Two adjacent rules that bite when adding or changing a callable:
+
+- **Decky callables must be async** — even if the body is synchronous, Decky's callable framework requires `async def`.
+- **Frontend↔backend parity** (name + arity) is enforced by `scripts/check_callable_manifest.py`, which derives the
+  frontend surface from every `callable<[Args], Return>("name")` in `src/**/*.ts`. A rename lands on both sides or not
+  at all.

--- a/.claude/rules/python-conventions.md
+++ b/.claude/rules/python-conventions.md
@@ -1,0 +1,63 @@
+---
+paths:
+  - "py_modules/**/*.py"
+  - "main.py"
+---
+
+# Python conventions — naming, docstrings, layout
+
+None of the rules below has a mechanical check. They hold only if they are carried at the point of writing.
+
+## Protocol naming — suffix by shape `[ours]`
+
+- `…Reader` — object-shaped Protocols with multiple methods (`RetroArchConfigReader`).
+- `…Provider` / `…Fn` — call-shaped (`__call__`-only) Protocols (`RetroArchSaveSortingProvider`, `CoreNameProviderFn`).
+- `…Store` — file-store Protocols (`CoverArtFileStore`).
+- `…Cache` — cache Protocols (`SgdbArtworkCache`).
+- `…Persister` — persistence Protocols (`SettingsPersister`).
+- Bare names — pervasive cross-cutting primitives (`Clock`, `Sleeper`, `UuidGen`, `DebugLogger`).
+
+A sibling set that mixes suffixes reflects a shape difference, not an inconsistency.
+
+## Async/sync method naming `[ours]`
+
+- Async methods carry the bare domain-verb name — no `_async` / `Async` suffix.
+- A **synchronous twin** (typically a lock-free worker run via `run_in_executor` that a peer calls directly to avoid
+  re-entering a lock) is named `do_<verb>` if public/peer-called, `_<verb>_io` if private/internal-only. The async
+  public method keeps the bare verb.
+
+The two idioms coexist by access level; converging them is open work, so match the idiom already used in the file you
+are editing rather than introducing the other one.
+
+## Docstrings — intent over behavior
+
+**Module and class docstrings** describe **what belongs here** (the contract), not what is currently in the file
+(behavior). Behavior listings rot when methods change; contracts don't.
+
+- Bad (class): `"""Owns save_sync_state.json — persistence, migrations, default construction."""` (rots when a 4th
+  responsibility lands)
+- Good (class): `"""Owns save_sync_state.json — single source of truth for on-disk save-sync state."""`
+
+**Method docstrings are different** — one method's contract is naturally scoped, so describing behavior, parameters, and
+return value is fine and stays in sync with the signature.
+
+Avoid: "mechanical extraction from X", "during the transition", "moved from Y", "added for the Z flow", "see PR #123" —
+commit-message content that rots in source.
+
+## Subfolder layout `[ours]`
+
+Layer top-level folders are flat by default — one file per concept. A subfolder is justified **only when the modules
+within share an internal type, helper, or state**, not when they share a brand-name prefix. `adapters/romm/` qualifies
+(`http.py` is the internal transport for the public `romm_api.py`); `adapters/retroarch/` would not (a config reader and
+a core lookup share only a brand name). Service decompositions with shared state qualify — `services/saves/`,
+`services/library/`.
+
+## Sub-package `__init__.py` `[ours]`
+
+- **Top-level layer namespace** (`adapters/`, `services/`, `domain/`, `lib/`, `models/`): empty (docstring optional).
+  Consumers deep-import.
+- **Consumed via package import** (`from package import X`): contract-style module docstring, re-exports of the public
+  class(es), optional `__all__`. Examples: `services/saves/`, `services/saves/sync_engine/`.
+- **Consumed only via deep-import**: empty or docstring, no re-exports. Example: `adapters/romm/`.
+
+Implementation never lives in `__init__.py` — it is a namespace marker plus re-exports.

--- a/.claude/rules/services.md
+++ b/.claude/rules/services.md
@@ -1,0 +1,49 @@
+---
+paths:
+  - "py_modules/services/**"
+---
+
+# Services — Cosmic Python rules
+
+Cosmic Python ("Architecture Patterns with Python", Percival & Gregory) is our north star, adapted for a single-user
+Decky plugin domain. `[CP]` marks a canonical Cosmic Python rule — a hard rule, breaking it is an architectural
+regression. `[ours]` marks a project convention layered on top — flag deviations in review, but the rule itself can be
+debated.
+
+Backend layout: `services/` (orchestration) / `adapters/` (I/O) / `domain/` (pure compute) / `lib/` (cross-cutting
+utilities) / `models/` (data shapes). `import-linter` enforces direction. `[CP]`
+
+## Rules
+
+- `[CP]` Depend on Protocols (defined in `services/protocols/`, imported as `from services.protocols import X`), never
+  on concrete adapter classes. Carve-out: sub-services within one bounded context (e.g. all of `services/saves/`) may
+  hold concrete peer-service refs in their `*ServiceConfig` when they share an aggregate. `[ours]` A method a peer calls
+  is part of that peer's **public** surface — no leading underscore.
+- `[CP]` No raw I/O. `[ours]` Forbidden in `services/`: `os.*` (except pure path algebra: `relpath`, `join`, `splitext`,
+  `basename`, `dirname`), `open(...)`, `pathlib.Path(...).read_*` / `write_*`, `fcntl.*`, `urllib.*`, `shutil.*`,
+  `subprocess.*`, `hashlib.<x>(open(...))`.
+- `[CP]` No clocks or randomness — inject `Clock` / `UuidGen` / `Sleeper`. `time.time()` / `time.monotonic()` /
+  `datetime.now()` / `uuid.uuid4()` / `asyncio.sleep()` / `random.*` are banned at the call site.
+- `[CP]` No service-to-service concrete imports — services are independent; cross-service deps are Protocol-typed.
+- `[ours]` Module functions from `domain/` are still a coupling — if tests need `patch("services.X.module_name.fn")`,
+  wrap the module behind a Protocol and inject it.
+- `[ours]` **Constructor shape: every service takes a single `config: XxxServiceConfig` keyword argument.** Frozen
+  dataclass. Outer services keep the `Service` token in both names (`SteamGridService` + `SteamGridServiceConfig`);
+  sub-services may use role-based names (`SyncEngine` + `SyncEngineConfig`). All deps live in the config: Protocol-typed
+  adapters, infrastructure (loop, logger, clock, uuid_gen, sleeper), persistence callbacks, settings-derived values. No
+  bare-param ctors, no mixed ctors.
+- `[ours]` **Debug logging: inject the `DebugLogger` Protocol.** No per-service `_log_debug` that re-reads settings at
+  call time; no `decky.logger.info` to bypass log-level filtering.
+- `[ours]` God-class signal: services > ~700 LOC — decompose into sub-services with constructor injection
+  (`services/saves/` is the reference). Enforced by `scripts/check_module_size.py`: a new module may not cross the
+  threshold at all, and the modules that predate the gate are pinned at their exact size and may not grow.
+
+## Reference shape for new service-level work
+
+A Protocol (in `services/protocols/`) + an adapter implementing it + a `FakeXxxAdapter` in `conftest` + `*ServiceConfig`
+ctor decomposition. `services/saves/` and `services/library/` are the reference decompositions for shared-state
+sub-services. Sequencing for a new vertical: cross-cutting Protocols first, domain extraction next, the biggest service
+last.
+
+If a refactor breaks a `[CP]` rule, that's an architectural regression — call it out and fix it in the same PR or open a
+follow-up. `[ours]` deviations should be flagged in review but can be debated.

--- a/.claude/rules/testing-backend.md
+++ b/.claude/rules/testing-backend.md
@@ -1,0 +1,71 @@
+---
+paths:
+  - "tests/**"
+---
+
+# Backend testing
+
+Every backend feature or callable where testing makes sense MUST have unit tests: **happy path**, **bad path** (invalid
+input, missing data, API errors, network failures), and **edge cases** (empty strings, None, masked values `"••••"`,
+boundaries). Tests mirror the source structure (`tests/services/`, `tests/adapters/`, …), one test file per source
+module. Shared mocks live in `tests/conftest.py`.
+
+## Property-based tests — pure decision kernels (hypothesis)
+
+The pure save-sync decision kernels (`domain/sync_action.py`, `domain/save_path.py`, `domain/iso_time.py`) carry a
+property tier on top of hand-enumerated cases, in `tests/domain/test_*_property.py`. Properties state the safety
+invariant directly (no destructive action without a recovery source; decisions stable under timestamp-format variation;
+replay determinism). `hypothesis` is dev-only and never ships.
+
+**A property states the TRUE invariant, never a watered-down one.** If the invariant's fix is still open, the property
+FAILS today — pin it `@pytest.mark.xfail(strict=True, reason="#<issue>: <one-line>")`. When the fix lands the property
+passes → XPASS → CI fails → the marker must be removed. A property is never weakened to go green.
+
+## Contract tests — real `Plugin` over real `bootstrap`
+
+`tests/contract/` crosses the frontend↔backend wire: it builds the **real** `Plugin` through the **real** `bootstrap()`
+and `wire_services()` (real settings dict, real SQLite + migrations, real file-store adapters, all under `tmp_path`) and
+drives the actual `main.py` callables. Only the outermost edges are faked (`romm_api`, `sgdb_adapter`,
+Clock/UuidGen/Sleeper, `emit`, and `http_adapter.with_retry` as a single-attempt pass-through). Harness lives in
+`tests/contract/_harness.py`; seeding helpers in `tests/contract/_seed.py`.
+
+- **Call callables exactly as the frontend does** — positional, JSON-shaped arguments with the arg types declared in
+  `src/api/backend.ts` (literal `None` where the TS type says `null`).
+- **Assert the response SHAPE + behavior, not delegation.** Pin the literal dict keys, the canonical failure shape, the
+  discriminated-status union, and the partial-success carve-outs. Where a callable has a server-reachable failure mode,
+  exercise BOTH the happy path AND the failure path.
+- The `harness` fixture is **async** so it binds the test's running event loop. Each test gets a fresh `tmp_path`.
+
+`scripts/check_callable_manifest.py` derives the frontend surface from every `callable<[Args], Return>("name")` in
+`src/**/*.ts` and the backend surface from the public `async def` methods on `Plugin`, failing on any name or arity
+divergence. It runs standalone in CI and inside pytest via `tests/contract/test_callable_manifest.py`.
+
+## Gate tests — `tests/scripts/`
+
+Every `scripts/check_*` gate carries its own test file. The gate is loaded via `importlib` (`scripts/` is not on
+`sys.path`), its module constants are monkeypatched at a `tmp_path` tree, and the real walk runs against that layout. A
+gate test that only asserts "passes on the real repo" is vacuous — pin each failure mode the gate is supposed to catch,
+and its boundaries.
+
+## Gavel conformance vectors — vendored contract tier
+
+Two [romm-gavel](https://github.com/danielcopper/romm-gavel) vector families run against the production save-sync
+kernels: **ladder** against `domain/sync_action.resolve_upload_conflict`, **decision-table** against
+`compute_sync_action`. The vectors are vendored verbatim under `tests/domain/gavel_vectors/` at a pinned upstream commit
+(no submodule, no network in CI), so a contract change lands as a reviewable diff. **Never edit a vector to make the
+kernel pass** — updating means deliberately re-copying the JSON and bumping the commit reference in that folder's
+`README.md`.
+
+## emu-atlas conformance vectors — vendored contract tier
+
+The same self-conformance pattern proves the plugin's save-path kernel agrees with
+[emu-atlas](https://github.com/danielcopper/emu-atlas), the config-aware emulator-knowledge library extracted from this
+plugin, where the two overlap. Its `machines` vector family (16 fixture machines in, detected installations + save
+placements out) runs against the real adapters (`RetroDeckPathsAdapter` + `RetroArchConfigAdapter`) and domain functions
+(`resolve_save_dir` / `compute_local_save_target`) in `tests/test_atlas_machine_vectors.py`. The overlap is partial by
+design — the plugin has no standalone-RetroArch saves-root concept (its saves base always comes from RetroDECK paths) —
+so every vector carries an explicit `_CHECK_LEVELS` entry: `full` (end-to-end dir + filename), `layout-only` (only the
+`retroarch.cfg` interpretation — sort flags or the `ContentDir` classification), or `n/a` (no overlap). No vector is
+silently skipped: a new upstream vector without an allowlist entry fails at collection. Vectors are vendored verbatim
+under `tests/atlas_vectors/machines/` at a pinned upstream release tag; **never edit a vector to make the kernel pass**
+— updating means re-copying the JSON and bumping the tag in that folder's `README.md`.

--- a/.claude/rules/testing-frontend.md
+++ b/.claude/rules/testing-frontend.md
@@ -1,0 +1,21 @@
+---
+paths:
+  - "src/**/*.test.ts"
+  - "src/**/*.test.tsx"
+  - "src/test-utils/**"
+---
+
+# Frontend component tests — `@decky/api` event harness
+
+Run with `mise run test:frontend` (Vitest + happy-dom); `mise run test:frontend:coverage` for coverage.
+
+`src/test-utils/decky-api-mock.ts` exposes an in-memory event bus that `addEventListener` / `removeEventListener` route
+through. Tests dispatch backend events via `emitDeckyEvent` instead of mocking `@decky/api` per file;
+`src/components/CustomPlayButton.test.tsx` is the reference shape. The bus resets between tests; use
+`deckyEventListenerCount(name)` to assert `useEffect` cleanup ran. DOM-level `globalThis.dispatchEvent` flows bypass the
+harness — happy-dom handles them natively. Prefer the harness over extracting listener bodies into `src/utils/*.ts`
+purely for testability.
+
+**Catch coverage assertions must be non-vacuous.** A test claiming `.catch` coverage MUST assert the post-catch state —
+the fallback return value, the toast body, the `debugLog` message, the surfaced status. Asserting only that the
+rejecting call was invoked is vacuous: it passes with or without the `.catch`.

--- a/.claude/rules/vendored-assets.md
+++ b/.claude/rules/vendored-assets.md
@@ -1,0 +1,29 @@
+---
+paths:
+  - "py_modules/_vendor/**"
+  - "py_modules/native/**"
+  - "defaults/**"
+---
+
+# Vendored code, binaries, and data `[ours]`
+
+**Vendored deps (`_vendor/`)**: Third-party runtime deps are vendored under `py_modules/_vendor/<package>/` (Decky has
+no plugin-level package manager) and imported as `from _vendor import <package>`. Only adapters import `_vendor.*`;
+services/domain/lib stay third-party-free (`domain-stdlib-only` contract in `.importlinter`). `_vendor/` is excluded
+from ruff, basedpyright, and Sonar. Every vendored package ships its upstream `LICENSE` and a provenance entry in
+[`_vendor/README.md`](../../py_modules/_vendor/README.md).
+
+**Compiled binaries** (no source in this repo) are vendored under `py_modules/native/` instead (inside one of the fixed
+directories the Decky CLI packs into the plugin zip) — downloaded verbatim from an upstream release with a pinned
+SHA-256 (CI re-verifies it; the release smoke test asserts the artifact ships in the zip), loaded by an adapter via
+`ctypes` with no Python fallback; provenance and the update procedure live in
+[`native/README.md`](../../py_modules/native/README.md).
+
+**Vendored data** (no source in this repo) follows the same discipline: `defaults/bios_registry.json` is copied verbatim
+from an [emu-atlas](https://github.com/danielcopper/emu-atlas) release with a pinned SHA-256
+(`defaults/bios_registry.json.sha256`, CI-verified via `mise run gate`; the release smoke test asserts it ships in the
+zip) — never hand-edit it, regeneration happens upstream; provenance and the update procedure live in
+[`defaults/README.md`](../../defaults/README.md).
+
+The shared rule across all three: **the artifact is a verbatim copy pinned by checksum.** Editing one in place to fix a
+problem is always wrong — the fix belongs upstream, followed by a deliberate re-copy and a checksum bump.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,9 @@ jobs:
       - name: Check Cosmic Python call bans
         run: bash scripts/check_cosmic_call_bans.sh
 
+      - name: Check module-size ratchet (no new god classes, no growth)
+        run: python scripts/check_module_size.py
+
       - name: Check aggregate field-assignment ban
         run: python scripts/check_aggregate_field_assignment.py
 

--- a/.gitignore
+++ b/.gitignore
@@ -37,8 +37,12 @@ __pycache__/
 *.log
 log.txt
 
-# Claude Code
-.claude/
+# Claude Code — everything is local (worktrees, agents, settings.local.json)
+# except the checked-in path-scoped coding rules. Ignoring the contents rather
+# than the directory itself is what makes the negation below reachable: git does
+# not descend into an ignored directory.
+.claude/*
+!.claude/rules/
 .venv/
 
 # Git worktrees

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,8 +13,9 @@ Three things, and nothing else:
 2. **Cross-cutting invariants** — rules that span files, so no single diff shows the whole rule.
 3. **Workflow** — how we work here; not derivable from the code.
 
-Everything else is topic depth and lives in `docs/`. A rule with a mechanical check needs only its one-line statement
-here (CI carries the enforcement); a rule without one needs its full statement here, because nothing else will catch it.
+Everything else is topic depth: `docs/` for humans, `.claude/rules/` for path-scoped coding conventions. A rule with a
+mechanical check needs only its one-line statement here (CI carries the enforcement); a rule without one needs its full
+statement here or in the rule file that owns its area, because nothing else will catch it.
 
 ## Where the details live
 
@@ -22,6 +23,8 @@ Each page below is the current-truth owner of its area, and most carry their own
 in the area. **Do not cite ADRs from this file** — an ADR is frozen history (and may be `Proposed` or superseded, which
 is invisible at the citation site), so reach it through the page that owns the topic.
 
+- Domain vocabulary — the canonical meaning of project terms — [CONTEXT.md](CONTEXT.md). A glossary, not a spec: use its
+  wording in code, issues, and PRs, and add a term there the moment it resolves in discussion.
 - Steam shortcuts — appIds, artwork, launch-option writes, removal churn —
   [steam-non-steam-shortcuts.md](docs/architecture/steam-non-steam-shortcuts.md)
 - Save-file sync — slots, conflict resolution, negotiate transport, version history —
@@ -36,6 +39,27 @@ is invisible at the citation site), so reach it through the page that owns the t
 - **End-user-facing behavior and UI** — setup, configuration, syncing, save-sync, BIOS, troubleshooting —
   `docs/user-guide/`
 - Dev setup, dependency management, frontend loop — `docs/contributing/`
+
+## Path-scoped rules — `.claude/rules/`
+
+Coding conventions live in `.claude/rules/*.md`, each carrying a `paths:` frontmatter glob. They are plain Markdown, not
+a harness-specific format: an agent that supports path-scoped rules gets one loaded when a matching file is read, and
+**every other agent must open the file itself**. Either way it arrives a beat late for code you are **creating** rather
+than editing, so the entries below lead with what goes wrong unnoticed. Read the rule that owns an area before writing
+new code in it.
+
+- `services.md` — a new service takes **one `config: XxxServiceConfig` kwarg** (frozen, all deps inside); debug logging
+  is the injected `DebugLogger`. Neither is checked.
+- `python-conventions.md` — Protocol suffixes by shape, `do_<verb>` vs. `_<verb>_io`, docstrings stating the contract
+  rather than the behavior, and when a subfolder is justified. **No mechanical check exists for any of it.**
+- `adapters-domain.md` — adapters own I/O, domain is pure, aggregate mutations are verb-named after the event
+  (`adopt_baseline`, not `update_baseline`). The field-assignment ban is checked; the naming is not.
+- `bootstrap-wiring.md` — the `main.py` / `bootstrap.py` split, and why `bootstrap.py` may no longer grow.
+- `callables.md` — the `{success, reason, message}` failure shape and its two carve-outs. Checked.
+- `vendored-assets.md` — `_vendor/`, `native/`, `defaults/` are checksum-pinned verbatim copies. The checksums are
+  checked; the reflex to fix the upstream artifact instead of the copy is not.
+- `testing-backend.md` — test tiers, gate tests, vendored conformance vectors.
+- `testing-frontend.md` — the `@decky/api` event harness, non-vacuous catch assertions.
 
 ## Documentation
 
@@ -91,8 +115,12 @@ Latest release and shipped features: see `git tag --sort=-v:refname` and GitHub 
 ## Development
 
 - **Build**: `pnpm build` (Rollup -> dist/index.js)
-- **Tests**: `python -m pytest tests/ -q` or `mise run test`
-- **Coverage**: `python -m pytest tests/ -q --cov=py_modules --cov=main --cov-report=term --cov-branch`
+- **Tests**: backend — `python -m pytest tests/ -q` or `mise run test`; frontend — `mise run test:frontend` (Vitest +
+  happy-dom)
+- **Coverage**: backend — `python -m pytest tests/ -q --cov=py_modules --cov=main --cov-report=term --cov-branch`;
+  frontend — `mise run test:frontend:coverage`
+- **Lint**: `mise run lint` (import-linter, the `scripts/check_*` gates, markdownlint). Ruff and basedpyright run only
+  inside `mise run gate`.
 - **Gate**: `mise run gate` (the full CI battery in one command — mirrors every PR check; slow. Run before pushing.)
 - **Setup**: `mise run setup` (installs JS + Python dependencies)
 - **Dev reload**: `mise run dev [display]` (build + restart plugin_loader; a display like `dp4` / `internal` also opens
@@ -144,6 +172,9 @@ Format: **invariant** — tier — enforced by.
   same path** — check — `scripts/check_uow_seam_nesting.py`
 - **Services never call clocks / sleep / uuid / random directly (inject the Protocol)** — check —
   `scripts/check_cosmic_call_bans.sh`
+- **No module in `services/` or `bootstrap.py` crosses the ~700-LOC decomposition threshold, and the ones already over
+  it may not grow** — check — `scripts/check_module_size.py` (the modules that predate the gate are grandfathered at
+  their exact size; that list only ever gets shorter)
 - **Service-independence contract list stays complete** — check — `scripts/check_service_independence_contract.py`
 - **Layer import direction (services ↛ adapters, adapters ↛ services, …)** — check — `.importlinter` (`lint-imports`)
 - **No bare `# type: ignore` / blanket suppressions** — check — `scripts/check_no_bare_ignores.sh`
@@ -155,22 +186,22 @@ Format: **invariant** — tier — enforced by.
   `scripts/check_romm_min_version.py` (ADRs excluded: frozen history)
 - **Server-supplied path components pass `safe_join` (`lib/path_safety.py`)** — test + prompt-only — traversal tests per
   path builder; new call sites are prompt-only
-- **No sentinel objects on the wire — explicit JSON-representable tagged values only** — prompt-only — mechanize with
-  #1032 (after tagged values replace the sentinels)
+- **No sentinel objects on the wire — explicit JSON-representable tagged values only** — prompt-only — mechanizable once
+  tagged values have replaced the sentinels
 - **Every destructive op has backup-or-confirm; never delete data that exists nowhere else** — prompt-only — save-file
-  removals route through `MatrixExecutor.quarantine_local_file` (the `.romm-backup` funnel — #965/#1058 done); mechanize
-  the rest via the #794 delete-path fixes (#974 / #1005 / #1062)
+  removals route through `MatrixExecutor.quarantine_local_file` (the `.romm-backup` funnel); every other delete path
+  carries the rule unmechanized
 - **Every read-mutate-write of a `RomSaveSyncState` runs under `SyncEngine.rom_lock(rom_id)`** — prompt-only — sync
-  paths + `get_save_status` + the four slot mutations hold the lock (#1057); mechanize via a `rom_save_sync_states.save`
+  paths, `get_save_status`, and the four slot mutations hold the lock; mechanize via a `rom_save_sync_states.save`
   call-site audit
 - **Per-slot server reads/deletes go through `domain/save_slot.py` (legacy omits `&slot=`, client-filters)** —
   prompt-only — `get_slot_saves` / `get_slot_delete_info` / `delete_slot` / `list_file_versions` / `rollback_to_version`
-  use `slot_query_param` + `save_in_slot` (#1061); RomM can't address `slot:null` via the param, so legacy MUST omit
-  it + filter client-side (legacy delete refused up-front, #1478)
+  use `slot_query_param` + `save_in_slot`; RomM can't address `slot:null` via the param, so legacy MUST omit it + filter
+  client-side, and a legacy delete is refused up-front
 - **Every save-sync decision comes from `compute_sync_action` (via `list_saves`), never the `negotiate` op list; every
   automatic upload POSTs `overwrite=false` (409-backstopped); `overwrite=true` only from an explicit `keep_local`** —
   test + prompt-only — domain property tests (`resolve_upload_conflict`, row-11 split, Inv7/Inv8) + contract 409 tests
-  (`tests/contract/`); new upload/dispatch call sites are prompt-only (#1276)
+  (`tests/contract/`); new upload/dispatch call sites are prompt-only
 - **`applied_launch_options` is written only by the five recorded-state writer sites (sync ack-commit,
   download-complete, uninstall, home-migration, version-switch), each recording the exact command the frontend wrote;
   excluded from the sync UPSERT; the only sanctioned reset is Force Full Sync's clear-to-NULL (a wrong recorded value is
@@ -179,241 +210,11 @@ Format: **invariant** — tier — enforced by.
   `record_applied_launch_options` call-site audit
 - **An abandoned-chunk stash's whole-unit apply staging (`pending_sync` / `pending_all_roms` / `pending_cover_sources`)
   is never mutated while the stash is pending (box IDLE) — every run-entry path passes `try_begin_run`, which clears the
-  stash before any staging write (#1367)** — prompt-only — verified closed in #1367 review; mechanize via a
-  staging-writer call-site audit
+  stash before any staging write** — prompt-only — the invariant holds today rather than being aspirational; mechanize
+  via a staging-writer call-site audit
 
 When a change applies a guard / sanitize / backup / grouping pattern, sweep for sibling sites of the same pattern — the
 register is what that sweep checks against.
-
-## Architecture — Cosmic Python rules
-
-Cosmic Python ("Architecture Patterns with Python", Percival & Gregory) is our north star, adapted for a single-user
-Decky plugin domain. Each rule carries a tag:
-
-- `[CP]` — Canonical Cosmic Python. Hard rule. Breaking it is an architectural regression.
-- `[ours]` — Project convention layered on top. Flag deviations in review, but the rule itself can be debated.
-
-Backend layout: `services/` (orchestration) / `adapters/` (I/O) / `domain/` (pure compute) / `lib/` (cross-cutting
-utilities) / `models/` (data shapes). `import-linter` enforces direction. `[CP]`
-
-**Services**:
-
-- `[CP]` Depend on Protocols (defined in `services/protocols/`, imported as `from services.protocols import X`), never
-  on concrete adapter classes. Carve-out: sub-services within one bounded context (e.g. all of `services/saves/`) may
-  hold concrete peer-service refs in their `*ServiceConfig` when they share an aggregate. `[ours]` A method a peer calls
-  is part of that peer's **public** surface — no leading underscore.
-- `[CP]` No raw I/O. `[ours]` Forbidden in `services/`: `os.*` (except pure path algebra: `relpath`, `join`, `splitext`,
-  `basename`, `dirname`), `open(...)`, `pathlib.Path(...).read_*` / `write_*`, `fcntl.*`, `urllib.*`, `shutil.*`,
-  `subprocess.*`, `hashlib.<x>(open(...))`.
-- `[CP]` No clocks or randomness — inject `Clock` / `UuidGen` / `Sleeper`. `time.time()` / `time.monotonic()` /
-  `datetime.now()` / `uuid.uuid4()` / `asyncio.sleep()` / `random.*` are banned at the call site.
-- `[CP]` No service-to-service concrete imports — services are independent; cross-service deps are Protocol-typed.
-- `[ours]` Module functions from `domain/` are still a coupling — if tests need `patch("services.X.module_name.fn")`,
-  wrap the module behind a Protocol and inject it.
-- `[ours]` **Constructor shape: every service takes a single `config: XxxServiceConfig` keyword argument.** Frozen
-  dataclass. Outer services keep the `Service` token in both names (`SteamGridService` + `SteamGridServiceConfig`);
-  sub-services may use role-based names (`SyncEngine` + `SyncEngineConfig`). All deps live in the config: Protocol-typed
-  adapters, infrastructure (loop, logger, clock, uuid_gen, sleeper), persistence callbacks, settings-derived values. No
-  bare-param ctors, no mixed ctors.
-- `[ours]` **Debug logging: inject the `DebugLogger` Protocol.** No per-service `_log_debug` that re-reads settings at
-  call time; no `decky.logger.info` to bypass log-level filtering.
-- `[ours]` God-class signal: services > ~700 LOC — decompose into sub-services with constructor injection
-  (`services/saves/` is the reference).
-
-**Adapters**: `[CP]` Own all I/O. Never import from `services/`. Implement Protocols defined in `services/protocols/`.
-
-**Domain**: `[CP]` Pure compute only. No I/O, no state mutation, no service or adapter imports. Anything stateless and
-I/O-free currently in a service belongs here.
-
-**Aggregates**: the aggregate roots, their tables, and the enforcement layers are canonical in
-[database-design.md](docs/architecture/database-design.md). Config-shaped toggles live in `settings.json`, not SQLite.
-Rules for the relational state that _does_ live in SQLite:
-
-- `[CP]` One Repository Protocol per aggregate root, not per table.
-- `[CP]` Aggregate methods are the **only** mutation API for the aggregate's state. No external field assignment from
-  services. Field access for reads is fine.
-- `[ours]` **Mutation methods are verb-named after the domain event they represent.** `adopt_baseline(filename, hash)`
-  not `update_baseline(...)`; `mark_installed(path)` not `set_installed(...)`; `promote_slot(slot, source)` not
-  `update_slot_source(...)`. The method name becomes the implicit event name if events are added later.
-- `[ours]` Domain events + message bus are out of scope. Revisit when handler diversity ≥3 kinds for the same state
-  change, or a non-Steam consumer becomes concrete, or telemetry needs to subscribe.
-
-**Bootstrap (`bootstrap.py`)**: `[CP]` The composition root — the only place concrete adapters meet services. `[ours]`
-`WiringConfig` holds the wiring; protocols in, services out. Adapter instantiation never happens in `main.py` — a
-Protocol-wrapped persister is built in `bootstrap()` and passed through `CallbackBundle`.
-
-**Vendored deps (`_vendor/`)**: `[ours]` Third-party runtime deps are vendored under `py_modules/_vendor/<package>/`
-(Decky has no plugin-level package manager) and imported as `from _vendor import <package>`. Only adapters import
-`_vendor.*`; services/domain/lib stay third-party-free (`domain-stdlib-only` contract in `.importlinter`). `_vendor/` is
-excluded from ruff, basedpyright, and Sonar. Every vendored package ships its upstream `LICENSE` and a provenance entry
-in [`_vendor/README.md`](py_modules/_vendor/README.md). Compiled binaries (no source in this repo) are vendored under
-`py_modules/native/` instead (inside one of the fixed directories the Decky CLI packs into the plugin zip) — downloaded
-verbatim from an upstream release with a pinned SHA-256 (CI re-verifies it; the release smoke test asserts the artifact
-ships in the zip), loaded by an adapter via `ctypes` with no Python fallback; provenance and the update procedure live
-in [`native/README.md`](py_modules/native/README.md). Vendored **data** (no source in this repo) follows the same
-discipline: `defaults/bios_registry.json` is copied verbatim from an
-[emu-atlas](https://github.com/danielcopper/emu-atlas) release with a pinned SHA-256
-(`defaults/bios_registry.json.sha256`, CI-verified via `mise run gate`; the release smoke test asserts it ships in the
-zip) — never hand-edit it, regeneration happens upstream; provenance and the update procedure live in
-[`defaults/README.md`](defaults/README.md).
-
-**Process boundaries — `main.py` vs `bootstrap.py`**: `[ours]` `main.py` owns the Decky lifecycle (`_main`, `_unload`)
-and the callable surface (one `async def` per `@callable`). `bootstrap.py` owns adapter instantiation and service
-wiring. The split is binding — no callables in `bootstrap.py`, no service wiring in `main.py`. Both files grow with the
-surface they describe; that is unavoidable density, not god-class. Split `bootstrap.py` into
-`bootstrap/{adapters,services}.py` only past ~700 LOC.
-
-**Reference shape for new service-level work**: a Protocol (in `services/protocols/`) + an adapter implementing it + a
-`FakeXxxAdapter` in `conftest` + `*ServiceConfig` ctor decomposition. `services/saves/` and `services/library/` are the
-reference decompositions for shared-state sub-services. Sequencing for a new vertical: cross-cutting Protocols first,
-domain extraction next, the biggest service last.
-
-If a refactor breaks a `[CP]` rule, that's an architectural regression — call it out and fix it in the same PR or open a
-follow-up. `[ours]` deviations should be flagged in review but can be debated.
-
-## Protocol naming — suffix by shape `[ours]`
-
-- `…Reader` — object-shaped Protocols with multiple methods (`RetroArchConfigReader`).
-- `…Provider` / `…Fn` — call-shaped (`__call__`-only) Protocols (`RetroArchSaveSortingProvider`, `CoreNameProviderFn`).
-- `…Store` — file-store Protocols (`CoverArtFileStore`).
-- `…Cache` — cache Protocols (`SgdbArtworkCache`).
-- `…Persister` — persistence Protocols (`SettingsPersister`).
-- Bare names — pervasive cross-cutting primitives (`Clock`, `Sleeper`, `UuidGen`, `DebugLogger`).
-
-A sibling set that mixes suffixes reflects a shape difference, not an inconsistency.
-
-## Async/sync method naming `[ours]`
-
-- Async methods carry the bare domain-verb name — no `_async` / `Async` suffix.
-- A **synchronous twin** (typically a lock-free worker run via `run_in_executor` that a peer calls directly to avoid
-  re-entering a lock) is named `do_<verb>` if public/peer-called, `_<verb>_io` if private/internal-only. The async
-  public method keeps the bare verb.
-
-The two idioms coexist by access level; unification is tracked in #813.
-
-## Callable response shapes `[ours]`
-
-Callables returning a plain `dict` that can fail use `{success: False, reason: ErrorCode | str, message: str}`. Both
-`reason` and `message` are **required**. Reuse `lib.list_result.ErrorCode` for coarse categories; bespoke guards
-(`config_error`, `sync_disabled`, `not_installed`, …) stay plain-string reasons. Transport failures collapse onto
-`SERVER_UNREACHABLE`; 401 and 403 collapse onto `AUTH_FAILED` (same slug, distinct `message`). The legacy `error_code`
-key and a second `error` key are **forbidden**. Enforced by `scripts/check_failure_shape.py --check`.
-
-Two carve-outs (pattern-exempt in the gate):
-
-- **Discriminated-status unions** (`status: "ok" | "server_unreachable" | …`, used by the saves version-history
-  callables) keep the `status` discriminant instead of `success` — more than two outcomes. Failure branches still carry
-  `message: str`.
-- **Partial-success responses** returning a full payload alongside a failure flag (`get_save_status`'s
-  `server_query_failed: bool`, `get_save_setup_info`'s `recommended_action`) keep the additive flag.
-
-Full convention paragraph: the `lib/list_result.py` module docstring.
-
-## Subfolder layout `[ours]`
-
-Layer top-level folders are flat by default — one file per concept. A subfolder is justified **only when the modules
-within share an internal type, helper, or state**, not when they share a brand-name prefix. `adapters/romm/` qualifies
-(`http.py` is the internal transport for the public `romm_api.py`); `adapters/retroarch/` would not (a config reader and
-a core lookup share only a brand name). Service decompositions with shared state qualify — `services/saves/`,
-`services/library/`.
-
-## Sub-package `__init__.py` `[ours]`
-
-- **Top-level layer namespace** (`adapters/`, `services/`, `domain/`, `lib/`, `models/`): empty (docstring optional).
-  Consumers deep-import.
-- **Consumed via package import** (`from package import X`): contract-style module docstring, re-exports of the public
-  class(es), optional `__all__`. Examples: `services/saves/`, `services/saves/sync_engine/`.
-- **Consumed only via deep-import**: empty or docstring, no re-exports. Example: `adapters/romm/`.
-
-Implementation never lives in `__init__.py` — it is a namespace marker plus re-exports.
-
-## Docstrings — intent over behavior
-
-**Module and class docstrings** describe **what belongs here** (the contract), not what is currently in the file
-(behavior). Behavior listings rot when methods change; contracts don't.
-
-- Bad (class): `"""Owns save_sync_state.json — persistence, migrations, default construction."""` (rots when a 4th
-  responsibility lands)
-- Good (class): `"""Owns save_sync_state.json — single source of truth for on-disk save-sync state."""`
-
-**Method docstrings are different** — one method's contract is naturally scoped, so describing behavior, parameters, and
-return value is fine and stays in sync with the signature.
-
-Avoid: "mechanical extraction from X", "during the transition", "moved from Y", "added for the Z flow", "see PR #123" —
-commit-message content that rots in source.
-
-## Testing
-
-Every backend feature or callable where testing makes sense MUST have unit tests: **happy path**, **bad path** (invalid
-input, missing data, API errors, network failures), and **edge cases** (empty strings, None, masked values `"••••"`,
-boundaries). Tests mirror the source structure (`tests/services/`, `tests/adapters/`, …), one test file per source
-module. Shared mocks live in `tests/conftest.py`.
-
-### Property-based tests — pure decision kernels (hypothesis)
-
-The pure save-sync decision kernels (`domain/sync_action.py`, `domain/save_path.py`, `domain/iso_time.py`) carry a
-property tier on top of hand-enumerated cases, in `tests/domain/test_*_property.py`. Properties state the safety
-invariant directly (no destructive action without a recovery source; decisions stable under timestamp-format variation;
-replay determinism). `hypothesis` is dev-only and never ships.
-
-**A property states the TRUE invariant, never a watered-down one.** If the invariant's fix is still open, the property
-FAILS today — pin it `@pytest.mark.xfail(strict=True, reason="#<issue>: <one-line>")`. When the fix lands the property
-passes → XPASS → CI fails → the marker must be removed. A property is never weakened to go green.
-
-### Contract tests — real `Plugin` over real `bootstrap`
-
-`tests/contract/` crosses the frontend↔backend wire: it builds the **real** `Plugin` through the **real** `bootstrap()`
-and `wire_services()` (real settings dict, real SQLite + migrations, real file-store adapters, all under `tmp_path`) and
-drives the actual `main.py` callables. Only the outermost edges are faked (`romm_api`, `sgdb_adapter`,
-Clock/UuidGen/Sleeper, `emit`, and `http_adapter.with_retry` as a single-attempt pass-through). Harness lives in
-`tests/contract/_harness.py`; seeding helpers in `tests/contract/_seed.py`.
-
-- **Call callables exactly as the frontend does** — positional, JSON-shaped arguments with the arg types declared in
-  `src/api/backend.ts` (literal `None` where the TS type says `null`).
-- **Assert the response SHAPE + behavior, not delegation.** Pin the literal dict keys, the canonical failure shape, the
-  discriminated-status union, and the partial-success carve-outs. Where a callable has a server-reachable failure mode,
-  exercise BOTH the happy path AND the failure path.
-- The `harness` fixture is **async** so it binds the test's running event loop. Each test gets a fresh `tmp_path`.
-
-`scripts/check_callable_manifest.py` derives the frontend surface from every `callable<[Args], Return>("name")` in
-`src/**/*.ts` and the backend surface from the public `async def` methods on `Plugin`, failing on any name or arity
-divergence. It runs standalone in CI and inside pytest via `tests/contract/test_callable_manifest.py`.
-
-### Gavel conformance vectors — vendored contract tier
-
-Two [romm-gavel](https://github.com/danielcopper/romm-gavel) vector families run against the production save-sync
-kernels: **ladder** against `domain/sync_action.resolve_upload_conflict`, **decision-table** against
-`compute_sync_action`. The vectors are vendored verbatim under `tests/domain/gavel_vectors/` at a pinned upstream commit
-(no submodule, no network in CI), so a contract change lands as a reviewable diff. **Never edit a vector to make the
-kernel pass** — updating means deliberately re-copying the JSON and bumping the commit reference in that folder's
-`README.md`.
-
-### emu-atlas conformance vectors — vendored contract tier
-
-The same self-conformance pattern proves the plugin's save-path kernel agrees with
-[emu-atlas](https://github.com/danielcopper/emu-atlas), the config-aware emulator-knowledge library extracted from this
-plugin, where the two overlap. Its `machines` vector family (16 fixture machines in, detected installations + save
-placements out) runs against the real adapters (`RetroDeckPathsAdapter` + `RetroArchConfigAdapter`) and domain functions
-(`resolve_save_dir` / `compute_local_save_target`) in `tests/test_atlas_machine_vectors.py`. The overlap is partial by
-design — the plugin has no standalone-RetroArch saves-root concept (its saves base always comes from RetroDECK paths) —
-so every vector carries an explicit `_CHECK_LEVELS` entry: `full` (end-to-end dir + filename), `layout-only` (only the
-`retroarch.cfg` interpretation — sort flags or the `ContentDir` classification), or `n/a` (no overlap). No vector is
-silently skipped: a new upstream vector without an allowlist entry fails at collection. Vectors are vendored verbatim
-under `tests/atlas_vectors/machines/` at a pinned upstream release tag; **never edit a vector to make the kernel pass**
-— updating means re-copying the JSON and bumping the tag in that folder's `README.md`.
-
-### Frontend component tests — `@decky/api` event harness
-
-`src/test-utils/decky-api-mock.ts` exposes an in-memory event bus that `addEventListener` / `removeEventListener` route
-through. Tests dispatch backend events via `emitDeckyEvent` instead of mocking `@decky/api` per file;
-`src/components/CustomPlayButton.test.tsx` is the reference shape. The bus resets between tests; use
-`deckyEventListenerCount(name)` to assert `useEffect` cleanup ran. DOM-level `globalThis.dispatchEvent` flows bypass the
-harness — happy-dom handles them natively. Prefer the harness over extracting listener bodies into `src/utils/*.ts`
-purely for testability.
-
-**Catch coverage assertions must be non-vacuous.** A test claiming `.catch` coverage MUST assert the post-catch state —
-the fallback return value, the toast body, the `debugLog` message, the surfaced status. Asserting only that the
-rejecting call was invoked is vacuous: it passes with or without the `.catch`.
 
 ## Security
 

--- a/docs/architecture/database-design.md
+++ b/docs/architecture/database-design.md
@@ -671,7 +671,7 @@ With every consumer moved over, the teardown completed: the dead persisters, the
 (`shortcut_registry`, `metadata_cache`, `installed_roms`, and the catch-all `state` dict) are all deleted.
 
 Chapter 8+ of the Cosmic Python book (domain events + message bus) is explicitly out of scope for this epic; the
-triggers for revisiting that scope are recorded in `CLAUDE.md`.
+triggers for revisiting that scope are recorded in `.claude/rules/adapters-domain.md`.
 
 ## See also
 

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -67,8 +67,8 @@ Tests mirror the source layout (`tests/services/`, `tests/adapters/`, `tests/dom
 with each test file mapping 1:1 to a source module. Shared mocks live in `tests/conftest.py`, which also provides a mock
 `decky` module so tests run without Decky Loader.
 
-Frontend component tests run with `mise run test:frontend` (`pnpm test`); see the CLAUDE.md "Frontend component tests"
-section for the `@decky/api` event harness.
+Frontend component tests run with `mise run test:frontend` (`pnpm test`); see `.claude/rules/testing-frontend.md` for
+the `@decky/api` event harness.
 
 ### Property-based tests
 
@@ -84,7 +84,7 @@ python -m pytest tests/domain/test_sync_action_property.py tests/domain/test_sav
 Hypothesis is a dev-only dependency (pinned in `requirements-dev.txt`, compiled into `requirements-dev.lock` via
 `mise run lock-update` — it never ships in the plugin). A CI-safe profile in `tests/conftest.py` sets `deadline=None`
 (no timing flakes on shared runners) and a fixed example count. The example database is written to `.hypothesis/`, which
-is gitignored. See the CLAUDE.md "Testing" section for the convention on pinning a property that encodes an open bug.
+is gitignored. See `.claude/rules/testing-backend.md` for the convention on pinning a property that encodes an open bug.
 
 ### Contract tests
 
@@ -102,7 +102,7 @@ python -m pytest tests/contract/ -q
 ```
 
 A `backend.ts` manifest gate (Phase 2) that pins the frontend and backend to one parsed artifact is a forthcoming
-separate change. See the CLAUDE.md "Testing" section for the full contract-tier rules.
+separate change. See `.claude/rules/testing-backend.md` for the full contract-tier rules.
 
 ### Gavel conformance vectors
 
@@ -249,6 +249,14 @@ event channel. The same parity assertion is surfaced inside the pytest run by `t
 literal appears anywhere except its owning adapter (`adapters/persistence.py`); confining the literal to one module
 keeps all settings writes in the single crash-safe owner.
 
+`mise run lint` (and CI) also runs `scripts/check_module_size.py`, the decomposition-threshold ratchet: no module in
+`services/` or `bootstrap.py` may cross the ~700-line threshold, and the modules that were already over it when the gate
+landed are pinned at their exact size, so they cannot grow. The pin list lives in the script and only ever gets shorter
+— a module that drops back under the threshold has to leave it, and a module that banks 50+ lines of slack gets a
+non-fatal note asking for its ceiling to be lowered. `main.py` is deliberately out of scope: it grows with the callable
+surface by design. There is deliberately no `--update` flag — re-baselining should be a reviewable diff, never a command
+someone runs to get back to green.
+
 See [Backend Architecture](../architecture/backend-architecture.md) for details.
 
 ## Full CI gate
@@ -275,6 +283,24 @@ SonarCloud scan and its `sonar-gate` (they need `SONAR_TOKEN` and the CI coverag
 - **basedpyright** — Type checking in CI. Checks all source files including the test suite (tests/ is not excluded).
 - **import-linter** — Layer boundary enforcement in CI (see Linting section above).
 - **pytest-cov** — Branch coverage reported to SonarCloud.
+
+## Where the coding conventions live
+
+Two files, split by how often they apply:
+
+- **`CLAUDE.md`** (repo root) — the traps, the cross-cutting invariant register, and the workflow. Everything here
+  applies no matter which file you touch, so it is read up front.
+- **`.claude/rules/*.md`** — the per-area conventions (services, adapters/domain, Python naming and docstrings, callable
+  shapes, bootstrap wiring, vendored assets, backend and frontend testing). Each file carries a `paths:` frontmatter
+  glob and is loaded when a matching file is opened, which keeps the always-on set small.
+
+Most of what lives in `.claude/rules/` has no mechanical check — Protocol suffixes, constructor shape, docstring intent,
+verb-named mutations — so those rules hold only if they are carried while writing. `CLAUDE.md` indexes them with the
+failure mode each one prevents.
+
+Note that `.gitignore` ignores `.claude/*` (worktrees, local agents, `settings.local.json`) and re-includes
+`.claude/rules/` explicitly. Adding a rule file works; adding anything else under `.claude/` will silently not be
+tracked.
 
 ## Project Structure
 

--- a/mise.toml
+++ b/mise.toml
@@ -52,6 +52,7 @@ run = [
     "python scripts/check_service_independence_contract.py",
     "python scripts/check_callable_manifest.py",
     "bash scripts/check_cosmic_call_bans.sh",
+    "python scripts/check_module_size.py",
     "python scripts/check_aggregate_field_assignment.py",
     "python scripts/check_uow_seam_nesting.py",
     "python scripts/check_failure_shape.py --check",

--- a/scripts/check_module_size.py
+++ b/scripts/check_module_size.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Hold the line on module size: no new god classes, no growth in the old ones.
+
+CLAUDE.md sets a ~700-LOC decomposition threshold for ``services/`` and an
+explicit split trigger for ``bootstrap.py``. Both lived in prose, and prose
+drifted: ``sync_orchestrator.py`` was 901 lines when #999 wrote it down and is
+past 2000 today. Nothing failed in between, because nothing was watching.
+
+This gate watches. Every in-scope module above the threshold carries a ceiling
+in ``ALLOWLIST`` — the size it had when it was recorded. That buys the property
+the prose rule never had:
+
+* a **new** module cannot cross the threshold at all, because it is not listed;
+* a **listed** module cannot grow past its recorded ceiling;
+* a module that shrinks back under the threshold must leave the list, so the
+  list only ever gets shorter.
+
+Shrinking below the ceiling without reaching the threshold passes. Demanding an
+exact match would fail CI on any refactor that nets a single line; the gate
+prints an advisory instead, once the banked slack is worth writing down.
+
+Ceilings are physical line counts, so ``wc -l`` reproduces them exactly. There
+is deliberately no ``--update`` flag: re-baselining is the one edit that has to
+be a conscious, reviewable diff — never a command run to get back to green.
+
+Usage:
+    python scripts/check_module_size.py
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+THRESHOLD = 700
+SLACK_ADVISORY = 50
+
+# Trees and files the threshold governs. ``main.py`` is deliberately absent: it
+# owns the Decky lifecycle plus one ``async def`` per callable, so it grows with
+# the callable surface by design (CLAUDE.md, "Process boundaries").
+SCOPE_DIRS = ("py_modules/services",)
+SCOPE_FILES = ("py_modules/bootstrap.py",)
+
+# Modules that were already over the threshold when this gate landed, each
+# pinned at the size it had that day. Entries come out when the module drops
+# back under the threshold; numbers go down when a refactor banks real slack.
+# A number is never raised — that is the whole point of the gate.
+ALLOWLIST = {
+    "py_modules/bootstrap.py": 844,
+    "py_modules/services/artwork.py": 1063,
+    "py_modules/services/connection.py": 844,
+    "py_modules/services/downloads.py": 1501,
+    "py_modules/services/firmware.py": 879,
+    "py_modules/services/library/fetcher.py": 1406,
+    "py_modules/services/library/reporter.py": 920,
+    "py_modules/services/library/sync_orchestrator.py": 2019,
+    "py_modules/services/migration.py": 1093,
+    "py_modules/services/playtime.py": 878,
+    "py_modules/services/saves/sync_engine/engine.py": 1170,
+    "py_modules/services/saves/sync_engine/matrix.py": 1063,
+    "py_modules/services/version_switch.py": 917,
+}
+
+
+def in_scope() -> list[pathlib.Path]:
+    """Every Python module the threshold applies to, in stable order."""
+    paths: set[pathlib.Path] = set()
+    for directory in SCOPE_DIRS:
+        paths.update((ROOT / directory).rglob("*.py"))
+    for filename in SCOPE_FILES:
+        path = ROOT / filename
+        if path.is_file():
+            paths.add(path)
+    return sorted(paths)
+
+
+def line_count(path: pathlib.Path) -> int:
+    """Physical lines, matching ``wc -l``."""
+    return len(path.read_text(encoding="utf-8").splitlines())
+
+
+def main() -> int:
+    sizes = {p.relative_to(ROOT).as_posix(): line_count(p) for p in in_scope()}
+
+    failures: list[str] = []
+    advisories: list[str] = []
+
+    for name, size in sorted(sizes.items()):
+        ceiling = ALLOWLIST.get(name)
+        if ceiling is None:
+            if size > THRESHOLD:
+                failures.append(
+                    f"{name}: {size} lines exceeds the {THRESHOLD}-line threshold.\n"
+                    f"      Decompose it into sub-services (services/saves/ is the reference).\n"
+                    f"      Adding it to ALLOWLIST is not the fix — that list is for modules\n"
+                    f"      that predate this gate."
+                )
+            continue
+        if size > ceiling:
+            failures.append(
+                f"{name}: {size} lines, up from its {ceiling}-line ceiling.\n"
+                f"      This module is already over the threshold; it may not grow.\n"
+                f"      Move the {size - ceiling} added line(s) into a new module."
+            )
+        elif size <= THRESHOLD:
+            failures.append(
+                f"{name}: {size} lines is back under the {THRESHOLD}-line threshold.\n"
+                f"      Drop its ALLOWLIST entry — the list only ever gets shorter."
+            )
+        elif ceiling - size >= SLACK_ADVISORY:
+            advisories.append(f"{name}: {size} lines vs. a {ceiling}-line ceiling — lower it to {size}.")
+
+    failures.extend(
+        f"{name}: listed in ALLOWLIST but not found. Drop the stale entry."
+        for name in sorted(set(ALLOWLIST) - set(sizes))
+    )
+
+    for line in advisories:
+        print(f"note: {line}")
+
+    if failures:
+        print(
+            f"ERROR: module-size gate failed ({len(failures)} module(s)) — see scripts/check_module_size.py:",
+            file=sys.stderr,
+        )
+        for line in failures:
+            print(f"  {line}", file=sys.stderr)
+        return 1
+
+    over = len(ALLOWLIST)
+    print(f"OK: no module over {THRESHOLD} lines outside the allowlist ({over} grandfathered, none grew)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/contract/test_callable_manifest.py
+++ b/tests/contract/test_callable_manifest.py
@@ -28,7 +28,8 @@ _MAIN_PY = _REPO_ROOT / "main.py"
 
 def _load_gate():
     spec = importlib.util.spec_from_file_location("check_callable_manifest", _SCRIPT_PATH)
-    assert spec is not None and spec.loader is not None
+    assert spec is not None
+    assert spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)

--- a/tests/contract/test_event_parity.py
+++ b/tests/contract/test_event_parity.py
@@ -26,7 +26,8 @@ _SRC_DIR = _REPO_ROOT / "src"
 
 def _load_gate():
     spec = importlib.util.spec_from_file_location("check_event_parity", _SCRIPT_PATH)
-    assert spec is not None and spec.loader is not None
+    assert spec is not None
+    assert spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)

--- a/tests/scripts/test_check_404_not_unreachable.py
+++ b/tests/scripts/test_check_404_not_unreachable.py
@@ -28,7 +28,8 @@ _SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "check_404_not_
 
 def _load_check_module() -> ModuleType:
     spec = importlib.util.spec_from_file_location("check_404_not_unreachable", _SCRIPT_PATH)
-    assert spec is not None and spec.loader is not None
+    assert spec is not None
+    assert spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)

--- a/tests/scripts/test_check_aggregate_field_assignment.py
+++ b/tests/scripts/test_check_aggregate_field_assignment.py
@@ -24,7 +24,8 @@ _SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "check_aggregat
 
 def _load_check_module() -> ModuleType:
     spec = importlib.util.spec_from_file_location("check_aggregate_field_assignment", _SCRIPT_PATH)
-    assert spec is not None and spec.loader is not None
+    assert spec is not None
+    assert spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)

--- a/tests/scripts/test_check_callable_manifest.py
+++ b/tests/scripts/test_check_callable_manifest.py
@@ -24,7 +24,8 @@ _SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "check_callable
 
 def _load_check_module() -> ModuleType:
     spec = importlib.util.spec_from_file_location("check_callable_manifest", _SCRIPT_PATH)
-    assert spec is not None and spec.loader is not None
+    assert spec is not None
+    assert spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)

--- a/tests/scripts/test_check_failure_shape.py
+++ b/tests/scripts/test_check_failure_shape.py
@@ -30,7 +30,8 @@ _SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "check_failure_
 
 def _load_check_module() -> ModuleType:
     spec = importlib.util.spec_from_file_location("check_failure_shape", _SCRIPT_PATH)
-    assert spec is not None and spec.loader is not None
+    assert spec is not None
+    assert spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)

--- a/tests/scripts/test_check_markdown_links.py
+++ b/tests/scripts/test_check_markdown_links.py
@@ -34,7 +34,8 @@ _SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "check_markdown
 
 def _load_check_module() -> ModuleType:
     spec = importlib.util.spec_from_file_location("check_markdown_links", _SCRIPT_PATH)
-    assert spec is not None and spec.loader is not None
+    assert spec is not None
+    assert spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)

--- a/tests/scripts/test_check_module_size.py
+++ b/tests/scripts/test_check_module_size.py
@@ -1,0 +1,176 @@
+"""Tests for ``scripts/check_module_size.py``.
+
+The check is loaded via ``importlib`` because ``scripts/`` is not on
+``sys.path`` (and is excluded from ruff/basedpyright). Each test retargets the
+module's ``ROOT`` / scope / allowlist constants at a ``tmp_path`` tree, so the
+real walk and the real comparison logic run against a controlled layout.
+
+Coverage centres on the ratchet's four failure modes — an unlisted module over
+the threshold, a listed module that grew, a listed module that graduated, and a
+stale entry — plus the boundary conditions, where an off-by-one would silently
+widen or narrow the gate.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+_SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "check_module_size.py"
+
+
+def _load_check_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("check_module_size", _SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+check = _load_check_module()
+
+
+def _write_module(root: Path, relative: str, lines: int) -> None:
+    """Create ``relative`` under ``root`` with exactly ``lines`` physical lines."""
+    path = root / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(f"x = {n}" for n in range(lines)) + "\n", encoding="utf-8")
+
+
+@pytest.fixture
+def run_check(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """Yield a helper that lays out modules, retargets the check, and runs it."""
+
+    def _run(modules: dict[str, int], allowlist: dict[str, int]) -> int:
+        (tmp_path / "py_modules" / "services").mkdir(parents=True, exist_ok=True)
+        for relative, lines in modules.items():
+            _write_module(tmp_path, relative, lines)
+        monkeypatch.setattr(check, "ROOT", tmp_path)
+        monkeypatch.setattr(check, "ALLOWLIST", allowlist)
+        return check.main()
+
+    return _run
+
+
+class TestLineCount:
+    """``wc -l`` parity — the ceiling is meaningless if counting disagrees."""
+
+    def test_counts_physical_lines(self, tmp_path: Path) -> None:
+        _write_module(tmp_path, "m.py", 12)
+        assert check.line_count(tmp_path / "m.py") == 12
+
+    def test_final_line_without_trailing_newline_still_counts(self, tmp_path: Path) -> None:
+        (tmp_path / "m.py").write_text("a = 1\nb = 2", encoding="utf-8")
+        assert check.line_count(tmp_path / "m.py") == 2
+
+    def test_empty_file_is_zero(self, tmp_path: Path) -> None:
+        (tmp_path / "m.py").write_text("", encoding="utf-8")
+        assert check.line_count(tmp_path / "m.py") == 0
+
+
+class TestHappyPath:
+    def test_passes_when_everything_is_small(self, run_check, capsys: pytest.CaptureFixture[str]) -> None:
+        assert run_check({"py_modules/services/small.py": 120}, {}) == 0
+        assert "OK: no module over 700 lines" in capsys.readouterr().out
+
+    def test_listed_module_at_its_ceiling_passes(self, run_check) -> None:
+        modules = {"py_modules/services/big.py": 900}
+        assert run_check(modules, {"py_modules/services/big.py": 900}) == 0
+
+    def test_bootstrap_is_in_scope_via_scope_files(self, run_check, capsys: pytest.CaptureFixture[str]) -> None:
+        assert run_check({"py_modules/bootstrap.py": 900}, {}) == 1
+        assert "py_modules/bootstrap.py: 900 lines exceeds" in capsys.readouterr().err
+
+    def test_main_py_is_out_of_scope(self, run_check) -> None:
+        """``main.py`` grows with the callable surface by design — never flagged."""
+        assert run_check({"main.py": 5000}, {}) == 0
+
+
+class TestFailureModes:
+    def test_unlisted_module_over_threshold_fails(self, run_check, capsys: pytest.CaptureFixture[str]) -> None:
+        assert run_check({"py_modules/services/new.py": 701}, {}) == 1
+        err = capsys.readouterr().err
+        assert "py_modules/services/new.py: 701 lines exceeds the 700-line threshold" in err
+        assert "Adding it to ALLOWLIST is not the fix" in err
+
+    def test_listed_module_that_grew_fails_with_the_delta(self, run_check, capsys: pytest.CaptureFixture[str]) -> None:
+        modules = {"py_modules/services/big.py": 910}
+        assert run_check(modules, {"py_modules/services/big.py": 900}) == 1
+        err = capsys.readouterr().err
+        assert "910 lines, up from its 900-line ceiling" in err
+        assert "Move the 10 added line(s)" in err
+
+    def test_graduated_module_must_leave_the_allowlist(self, run_check, capsys: pytest.CaptureFixture[str]) -> None:
+        modules = {"py_modules/services/shrunk.py": 650}
+        assert run_check(modules, {"py_modules/services/shrunk.py": 900}) == 1
+        assert "back under the 700-line threshold" in capsys.readouterr().err
+
+    def test_stale_allowlist_entry_fails(self, run_check, capsys: pytest.CaptureFixture[str]) -> None:
+        assert run_check({}, {"py_modules/services/deleted.py": 900}) == 1
+        assert "listed in ALLOWLIST but not found" in capsys.readouterr().err
+
+    def test_every_failing_module_is_reported_not_just_the_first(
+        self, run_check, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        modules = {"py_modules/services/a.py": 800, "py_modules/services/b.py": 900}
+        assert run_check(modules, {}) == 1
+        err = capsys.readouterr().err
+        assert "2 module(s)" in err
+        assert "services/a.py" in err
+        assert "services/b.py" in err
+
+
+class TestBoundaries:
+    """An off-by-one here silently widens or narrows the gate."""
+
+    def test_exactly_at_threshold_is_allowed(self, run_check) -> None:
+        assert run_check({"py_modules/services/edge.py": 700}, {}) == 0
+
+    def test_one_over_threshold_is_not(self, run_check) -> None:
+        assert run_check({"py_modules/services/edge.py": 701}, {}) == 1
+
+    def test_one_over_ceiling_is_not(self, run_check) -> None:
+        modules = {"py_modules/services/big.py": 901}
+        assert run_check(modules, {"py_modules/services/big.py": 900}) == 1
+
+    def test_threshold_plus_one_stays_listed_rather_than_graduating(self, run_check) -> None:
+        """701 is still over the threshold, so the entry is still required."""
+        modules = {"py_modules/services/big.py": 701}
+        assert run_check(modules, {"py_modules/services/big.py": 900}) == 0
+
+
+class TestSlackAdvisory:
+    """The advisory nudges the ratchet down without failing an honest refactor."""
+
+    def test_banked_slack_prints_a_note_and_still_passes(self, run_check, capsys: pytest.CaptureFixture[str]) -> None:
+        modules = {"py_modules/services/big.py": 850}
+        assert run_check(modules, {"py_modules/services/big.py": 900}) == 0
+        out = capsys.readouterr().out
+        assert "note: py_modules/services/big.py: 850 lines vs. a 900-line ceiling — lower it to 850." in out
+
+    def test_slack_below_the_advisory_threshold_stays_quiet(
+        self, run_check, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        modules = {"py_modules/services/big.py": 899}
+        assert run_check(modules, {"py_modules/services/big.py": 900}) == 0
+        assert "note:" not in capsys.readouterr().out
+
+
+class TestRealRepository:
+    """The shipped allowlist must describe the repository as it actually is."""
+
+    def test_gate_passes_on_the_real_tree(self, capsys: pytest.CaptureFixture[str]) -> None:
+        assert check.main() == 0
+        capsys.readouterr()
+
+    def test_allowlist_has_no_entry_at_or_below_the_threshold(self) -> None:
+        too_small = {name: n for name, n in check.ALLOWLIST.items() if n <= check.THRESHOLD}
+        assert not too_small, f"these entries belong in no allowlist: {too_small}"

--- a/tests/scripts/test_check_module_size.py
+++ b/tests/scripts/test_check_module_size.py
@@ -28,7 +28,8 @@ _SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "check_module_s
 
 def _load_check_module() -> ModuleType:
     spec = importlib.util.spec_from_file_location("check_module_size", _SCRIPT_PATH)
-    assert spec is not None and spec.loader is not None
+    assert spec is not None
+    assert spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)

--- a/tests/scripts/test_check_service_independence_contract.py
+++ b/tests/scripts/test_check_service_independence_contract.py
@@ -24,7 +24,8 @@ _SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "check_service_
 
 def _load_check_module() -> ModuleType:
     spec = importlib.util.spec_from_file_location("check_service_independence_contract", _SCRIPT_PATH)
-    assert spec is not None and spec.loader is not None
+    assert spec is not None
+    assert spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)

--- a/tests/scripts/test_check_sync_lifecycle_owner.py
+++ b/tests/scripts/test_check_sync_lifecycle_owner.py
@@ -27,7 +27,8 @@ _SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "check_sync_lif
 
 def _load_check_module() -> ModuleType:
     spec = importlib.util.spec_from_file_location("check_sync_lifecycle_owner", _SCRIPT_PATH)
-    assert spec is not None and spec.loader is not None
+    assert spec is not None
+    assert spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)

--- a/tests/scripts/test_check_uow_seam_nesting.py
+++ b/tests/scripts/test_check_uow_seam_nesting.py
@@ -24,7 +24,8 @@ _SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "check_uow_seam
 
 def _load_check_module() -> ModuleType:
     spec = importlib.util.spec_from_file_location("check_uow_seam_nesting", _SCRIPT_PATH)
-    assert spec is not None and spec.loader is not None
+    assert spec is not None
+    assert spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)


### PR DESCRIPTION
## Summary

- CLAUDE.md carried 437 lines, ~230 of which were per-area convention depth that only matters when touching a specific tree. That depth moves into `.claude/rules/*.md`, each scoped by a `paths:` glob so it loads when a matching file is opened. The traps, the invariant register, and the workflow stay always-on, because no diff-scoped view ever shows those rules whole. CLAUDE.md is now 238 lines.
- The ~700-LOC decomposition threshold was one of the prose-only rules, and it had drifted: `sync_orchestrator.py` was 901 lines when it was last written down and is 2019 today, with eleven further services and `bootstrap.py` also over the line. `scripts/check_module_size.py` turns the threshold into a ratchet — a new module may not cross it at all, and the thirteen modules that predate the gate are pinned at their exact size and cannot grow.
- Path-scoped rules load when a file is read, which arrives a beat late for code being created rather than edited, and other agents do not load them at all. CLAUDE.md therefore keeps an index that leads with the failure mode each rule prevents, weighted toward the conventions that have no mechanical check — constructor shape, Protocol suffixes, docstring intent, verb-named mutations.

## Test plan

- [x] `pnpm build` clean
- [x] `basedpyright` zero errors
- [x] `python -m pytest tests/ -q` — 6416 passed
- [x] `mise run gate` fully green (adds ruff, import-linter, every `check_*`, frontend eslint/typecheck/size/2270 vitest tests, `deno fmt --check`)
- [x] New gate covered by `tests/scripts/test_check_module_size.py` (20 tests: four failure modes, boundaries, slack advisory, `wc -l` parity)
- [ ] Manual QA on Steam Deck — n/a, no runtime code touched

## Docs

- [x] `docs/` updated in this PR

`docs/contributing/development.md` documents the ratchet and where the conventions now live; three pointers there and one in `docs/architecture/database-design.md` were repointed at the moved sections.

## Notes

`.gitignore` ignored `.claude/` wholesale, which would have kept the rules untracked — git does not descend into an ignored directory, so a negation after it is unreachable. It now ignores `.claude/*` and re-includes `.claude/rules/`; verified that `memory/`, `agents/`, `settings.local.json` and `worktrees/` stay ignored.

The pin list only ever gets shorter, and there is deliberately no `--update` flag, so re-baselining stays a reviewable diff rather than a command someone runs to get back to green. #999 has been rescoped to the `migration.py` split itself now that the gate owns the threshold.

The old `main.py` carve-out is preserved: it grows with the callable surface by design and is out of scope for the gate. `bootstrap.py` is not — it is already past the split trigger and is pinned.