### PR TITLE
chore(memory): commit the repo agent-memory tier

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -1,0 +1,124 @@
+# Memory Index
+
+Last consolidated: 2026-05-26.
+
+## [appid-launchoptions-reliability.md](appid-launchoptions-reliability.md)
+
+_Updated: 2026-06-03_ · type: project
+
+Hardware-validated (#827, closed): `SetAppLaunchOptions` on an **existing** Steam shortcut IS reliable — in-session
+(~150 ms read-back), across a full Steam restart, and over 30 add/set/remove churn cycles. appId = CRC32(exe + appname),
+so `launch_options` / `startDir` mutations are appId-safe while `exe` / `name` are appId-destructive (orphan artwork /
+playtime / collections). Narrows the overstated "shortcut property re-sync unreliable" framing in CLAUDE.md +
+`steam-non-steam-shortcuts.md` (real hazard is a removal-churn corruption mode, not launch_options writes). Unblocks the
+ADR-0005 reliable branch → #785 full refactor. Robust write pattern: fire `SetAppLaunchOptions` then poll `AppDetails`
+to confirm. See also [[desktop-mode-test-constraints]], [[dev-deploy-loop]].
+
+## [romm-injects-m3u-keep-es-de-gate.md](romm-injects-m3u-keep-es-de-gate.md)
+
+_Updated: 2026-07-28_ · type: project
+
+We are NOT the only producer of `.m3u` in a freshly extracted ROM dir — treat any playlist found there as foreign input.
+The ES-DE `es_systems.xml` gate (`system_supports_m3u`, `adapters/es_de_config.py:259`) is load-bearing and must not be
+narrowed to "only gate what we generate", even though `_maybe_generate_m3u_io` almost never fires against a real server.
+Removing or narrowing it regresses #1111. Version-stamped upstream half (RomM 5.0.0, 2026-07-28): the server injects
+`{fs_name}.m3u` into every multi-file download zip, ungated by platform — the original cause of #1111 — with three grep
+paths to re-verify. See also [[romm-siblings-cannot-identify-discs]].
+
+## [romm-siblings-cannot-identify-discs.md](romm-siblings-cannot-identify-discs.md)
+
+_Updated: 2026-07-28_ · type: project
+
+RomM has exactly ONE relation between related roms and it cannot tell "Disc 2 of the same release" from "the European
+release". Never implement multi-disc grouping (#1554) on `sibling_group_key` alone — it silently merges regional
+variants into one game with one save, and that mistake looks correct from inside our code because we already store the
+key (#1295/#1297). Any grouping needs a disc discriminator the server does not supply; the fallback (declare the
+per-disc library shape unsupported) is legitimate. Version-stamped upstream half (RomM 5.0.0, 2026-07-28) with
+re-verification paths.
+
+## [sync-ui-trigger-surfaces.md](sync-ui-trigger-surfaces.md)
+
+_Updated: 2026-05-26_ · type: project
+
+Which UI surface triggers which save-sync backend call, and which one actually surfaces `SyncConflictModal`. Three
+surfaces: per-ROM Sync button (`sync_rom_saves` — toasts only), game-detail page open (`get_save_status` — refreshes
+SAVES tab), Play button / `CustomPlayButton` (`pre_launch_sync` — opens the conflict modal in its "Resolve conflict"
+state). Smoke-testing the conflict modal requires the Play button — the Sync button looks like the obvious entry point
+but isn't.
+
+## [save-conflict-test-path.md](save-conflict-test-path.md)
+
+_Updated: 2026-05-26_ · type: project
+
+How to produce a save conflict for testing. The newest-wins matrix in `domain/sync_action.py` has exactly one Conflict
+path: `_decide_when_not_current`. Needs both sides diverged AND our device holding a (now-stale) sync entry on the
+newest server save. Covers the `device_syncs` empty-without-`device_id` gotcha (re-verified 2026-05-20 on RomM 4.8.1,
+NOT a regression), how a device gets its sync row (POST/download/confirm_download upsert; PUT does NOT on 4.8.1 →
+confirm_download workaround, drop once min RomM ≥ 4.9.x per #748), and the no-device-authorship-column constraint
+(`own_upload_ids` local-only; #276 records PUT uploads too). Related: #276 same area.
+
+## [desktop-mode-test-constraints.md](desktop-mode-test-constraints.md)
+
+_Updated: 2026-05-26_ · type: project
+
+Steam Deck Game Mode vs Desktop Mode constraints. The Decky plugin toggle UI lives in Game Mode only; from Desktop the
+user can stop/start `plugin_loader` via systemctl or switch sessions (the swap reloads the plugin). Game Mode and
+Desktop Mode are temporally mutually exclusive — Claude runs in Desktop terminal, user exercises UI in Game Mode. No
+live mid-UI injection — TOCTOU-style tests (inject server state while a modal is open) aren't doable; static setup →
+switch → observe is the only viable shape. The `stale_conflict` / TOCTOU guard #384 is covered by service-layer unit
+tests; on-device it's untestable here.
+
+## [sonarcloud-findings-inline.md](sonarcloud-findings-inline.md)
+
+_Updated: 2026-05-26_ · type: project
+
+SonarCloud findings get surfaced inline in chat by the user, not via PR comments. SonarCloud runs on every PR + push to
+main; Quality Gate enforces 80% coverage on new code, 0 bugs, 0 vulnerabilities (per CLAUDE.md). Expect findings
+mid-session — address in the current commit when reasonable, otherwise note for a follow-up before the PR merges.
+
+## [dev-deploy-loop.md](dev-deploy-loop.md)
+
+_Updated: 2026-05-26_ · type: project
+
+Standard tight dev loop on the Steam Deck: Claude edits in Desktop Mode (repo at `/home/deck/Repos/decky-romm-sync`) →
+user runs `mise run dev` (builds via Rollup → `dist/index.js` and restarts `plugin_loader`, deploying locally) → user
+switches to Game Mode (session swap reloads the plugin) → exercises UI on real hardware → reports observed behavior.
+Real-hardware testing is fast and cheap — prefer asking the user to deploy and try a candidate fix over over-engineering
+theoretical solutions. `mise run dev` is the canonical command; don't invent alternatives. See also
+[[desktop-mode-test-constraints]].
+
+## [release-build-sourcemap.md](release-build-sourcemap.md)
+
+_Updated: 2026-05-26_ · type: project
+
+Release build must strip source maps in `rollup.config.js`, NOT in a workflow step. `decky plugin build` rebuilds the
+frontend itself (runs `rollup -c` in its build container) before zipping — workflow-level `rm -f dist/*.map` is dead
+weight (this is how 0.18.0 shipped no asset, #763/#764). `@decky/rollup` hardcodes `output.sourcemap: true` and the
+preset's options arg is silently reverted (`mergeAndConcat(options,
+defaultOptions)` lets defaults win) — mutate the
+returned object instead. Default `rollup.config.js` must be the map-free one; dev opts in via `rollup.dev.config.js`
+(`pnpm build:dev` + mise `build` task). CI uses raw `pnpm build` → map-free.
+
+## [release-zip-defaults.md](release-zip-defaults.md)
+
+_Updated: 2026-05-26_ · type: project
+
+What ships in the release zip vs the repo layout. `config.json` / `bios_registry.json` / `core_defaults.json` appear at
+the ROOT of the release zip even though they live under `defaults/` in the repo — that's decky's `defaults/` convention:
+contents are copied to the plugin root on install. Backend reads via dual path: root first (release), then `defaults/`
+(dev, where `mise run deploy` rsyncs into a `defaults/` subdir). See `firmware.py`, `es_de_config.py`,
+`adapters/romm/http.py`. Vendored `vdf` lib ships `vdf/__init__.py` + `vdf/vdict.py` only — `*.dist-info` removed (#764)
+as unused pip metadata (`vdf` hardcodes `__version__`).
+
+## [domain/cosmic-python.md](domain/cosmic-python.md)
+
+_Updated: 2026-05-26_ · type: domain
+
+Cosmic Python architecture rules for the backend (services / adapters / domain / lib / models). Forbidden in services:
+concrete adapter imports (use Protocols from `services/protocols.py`), raw I/O (`os.*` beyond pure path algebra, `open`,
+`pathlib` read/write, `fcntl`, `urllib`, `shutil`, `subprocess`), hidden I/O (`time.time`, `datetime.now`, `uuid.uuid4`,
+`asyncio.sleep`, `random` — inject `Clock` / `UuidGen` / `Sleeper` Protocols per #294), service-to-service concrete
+imports, module-function imports from `domain/`. God-class signal: services > 600 LOC or `__init__`
+
+> 6 params (S107). Smell → fix mapping table. Refactor wave plan link (#277): Wave 1 (#256) → Wave 2 (#295) → Wave 3
+> (#297–#302) → Wave 4 (#274 + #277 verify), with saves vertical (#254) in parallel.

--- a/.claude/memory/appid-launchoptions-reliability.md
+++ b/.claude/memory/appid-launchoptions-reliability.md
@@ -1,0 +1,41 @@
+---
+name: appid-launchoptions-reliability
+description: Hardware-validated (#827, 2026-06-03) — SetAppLaunchOptions on an EXISTING Steam shortcut IS reliable (in-session + across restart + 30-churn). appId=CRC32(exe+appname), so launch_options/startDir mutations are appId-safe, exe/name are appId-destructive. Narrows the old "shortcut property re-sync unreliable" framing in CLAUDE.md + steam-non-steam-shortcuts.md. Unblocks #785.
+type: project
+---
+
+# Updating existing Steam shortcuts — what's actually reliable
+
+Hardware-validated on a Steam Deck on **2026-06-03** (#827, now closed), run from the **desktop-mode** browser CEF
+inspector (`localhost:8080` → SharedJSContext — same `SteamClient.Apps` API / `shortcuts.vdf` as Game Mode):
+
+- **`SetAppLaunchOptions` on an existing shortcut is reliable.** In-session change reads back the new value via
+  `RegisterForAppDetails` in ~150 ms; the change **persists across a full Steam restart** (rules out in-memory-only);
+  30× add → set → read-back → remove churn cycles ran with zero failures.
+- **appId = CRC32(exe + appname).** Therefore `launch_options` and `startDir` mutations are **appId-safe** (artwork /
+  playtime / collections preserved); changing **exe** or **name** is **appId-destructive** (orphans all of those).
+  `SetShortcutExe` on an existing shortcut _does_ read back the new exe in-session, but that doesn't make it safe — the
+  appId desyncs. Never `SetShortcutExe` on a live RomM shortcut; the launcher exe path must stay constant.
+
+**Why:** the old framing in CLAUDE.md ("Shortcut property re-sync … Full delete + recreate required") and
+`docs/architecture/steam-non-steam-shortcuts.md` ("Set* … may not take effect reliably") was **documented but never
+empirically validated** — and it's overstated for `launch_options` specifically. The real, narrower hazard is a
+Steam-client **corruption state triggered by removal churn** at higher/random volume, after which _all_ property sets
+silently fail until `SteamClient.User.StartRestart(true)`. That's a removal-volume lifecycle hazard, not a property of
+`SetAppLaunchOptions`.
+
+**How to apply:**
+
+- This is the ADR-0005 "reliable" branch → **#785 proceeds as the full refactor**: bake the resolved ROM path into
+  `launch_options` at download-complete (an update-to-existing, now proven safe), make `bin/rom-launcher` a pure exec
+  wrapper, drop the interim DB-read launcher.
+- **Robust write pattern:** fire `SetAppLaunchOptions`, then poll `AppDetails` (`RegisterForAppDetails`) until the value
+  lands — not fire-and-forget. The ~150 ms read-back makes the confirm cheap. The current `syncManager.ts` update path
+  (existing-shortcut branch) is fire-and-forget and should adopt this.
+- **Shortcut enumeration:** `collectionStore.deckDesktopApps.apps` gives the appId set, but the overview object lacks
+  `display_name` for freshly-created shortcuts (name lives in `AppDetails.strDisplayName`). Matters for #785's ownership
+  detection, which moves off the `romm:<id>` launch_options marker onto the launcher **exe path**.
+- **Doc debt to settle in the #785 PR:** update CLAUDE.md's "Shortcut property re-sync" note +
+  `steam-non-steam-shortcuts.md` to the narrowed reality, and flip ADR-0005's status to the reliable branch.
+
+Related: [[desktop-mode-test-constraints]], [[dev-deploy-loop]].

--- a/.claude/memory/desktop-mode-test-constraints.md
+++ b/.claude/memory/desktop-mode-test-constraints.md
@@ -1,0 +1,28 @@
+---
+name: desktop-mode-test-constraints
+description: Steam Deck Game Mode vs Desktop Mode constraints for smoke-testing the Decky plugin. The plugin toggle UI is only accessible in Game Mode — from Desktop Mode the user can only stop/start plugin_loader via systemctl or switch to Game Mode (which restarts the loader as part of the session swap). Game Mode and Desktop Mode are temporally mutually exclusive — no live mid-UI injection (Claude runs in Desktop terminal, user exercises UI in Game Mode). TOCTOU-style tests (inject server state mid-modal) are not doable; static setup → switch → observe is the only viable shape. The stale_conflict / TOCTOU guard #384 is covered by service-layer unit tests; on-device it's untestable here.
+type: project
+---
+
+# Smoke testing on the Steam Deck — desktop mode constraints
+
+The Decky plugin toggle UI is only accessible in **Game Mode**. When the user is in Desktop Mode:
+
+- They cannot toggle the plugin off/on through the Decky UI.
+- The available controls are stopping/starting the plugin loader from the terminal (e.g.
+  `systemctl --user stop plugin_loader`) or switching to Game Mode (which restarts the plugin loader as part of the
+  session swap).
+- "Toggle plugin off in Decky" instructions only work when the user is testing in Game Mode.
+
+When prepping a test that needs the plugin restarted: ask whether they're on desktop or game mode and tailor the prep
+step accordingly. A switch to Game Mode is itself a plugin reload, so a typical desktop-mode test flow is: I prep state
+file edits with the loader stopped, user switches to Game Mode (which loads the plugin), they exercise the UI, I verify
+state on disk afterwards.
+
+**Game Mode and Desktop Mode are temporally mutually exclusive — no live mid-UI injection.** I (Claude) run in the
+Desktop-Mode terminal session; the user exercises the plugin UI in Game Mode. They cannot be in both at once, so they
+can't relay live UI state (e.g. "the modal shows server_save_id=48") back to me while I simultaneously write to the
+server/files. Any test that needs a server/file change injected _while a UI element is open_ (TOCTOU-style: open
+conflict modal → inject newer server save mid-modal → resolve → expect `stale_conflict`) is **not doable** in this setup
+— skip those. Static setup → switch to Game Mode → observe is the only viable shape. (The `stale_conflict` / TOCTOU
+guard #384 is covered by unit tests at the service layer; on-device it's untestable here.)

--- a/.claude/memory/dev-deploy-loop.md
+++ b/.claude/memory/dev-deploy-loop.md
@@ -1,0 +1,22 @@
+---
+name: dev-deploy-loop
+description: Standard tight dev loop on the Steam Deck. Claude edits in Desktop Mode (repo at /home/deck/Repos/decky-romm-sync) → user runs `mise run dev` (builds via Rollup → dist/index.js and restarts plugin_loader, deploying locally) → user switches to Game Mode (session swap reloads the plugin) → user exercises UI on real hardware → reports observed behavior. Real-hardware testing is fast and cheap — prefer asking the user to deploy and try a candidate fix over over-engineering theoretical solutions. `mise run dev` is the canonical command; don't invent alternatives.
+type: project
+---
+
+# Dev deploy loop on the Steam Deck
+
+The user often works **on the Steam Deck itself** in Desktop Mode while iterating on the plugin. The standard tight loop
+is:
+
+1. I make code changes in Desktop Mode (repo at `/home/deck/Repos/decky-romm-sync`).
+2. User runs `mise run dev` — builds (Rollup → `dist/index.js`) and restarts `plugin_loader`, deploying locally.
+3. User switches to Game Mode (the session swap reloads the plugin) and exercises the UI on the actual hardware.
+4. User reports observed behaviour; we iterate.
+
+So when investigating QAM/UI issues, assume real-hardware testing is fast and cheap — I can ask the user to deploy and
+try a candidate fix rather than over-engineering theoretical solutions. `mise run dev` is the canonical deploy command;
+do not invent alternatives.
+
+See also [[desktop-mode-test-constraints]] for the Game-Mode-vs-Desktop-Mode temporal exclusion that shapes what kinds
+of tests are possible.

--- a/.claude/memory/domain/cosmic-python.md
+++ b/.claude/memory/domain/cosmic-python.md
@@ -1,0 +1,65 @@
+---
+name: cosmic-python
+description: Architecture rules enforced for backend (services / adapters / domain / lib / models). What's forbidden in services, what belongs in domain, how to spot regressions. Source of truth is CLAUDE.md "Architecture — Cosmic Python rules" section; this memory exists so the rules auto-inject when CLAUDE.md isn't loaded.
+type: domain
+---
+
+# Cosmic Python rules — decky-romm-sync backend
+
+Backend layout: `services/` (orchestration) / `adapters/` (I/O) / `domain/` (pure compute) / `lib/` (cross-cutting
+utilities) / `models/` (data shapes). `import-linter` enforces direction.
+
+## Services — what's forbidden
+
+- Concrete adapter imports. Services depend on Protocols defined in `services/protocols.py`, never on adapter classes
+  directly.
+- Raw I/O: `os.*` (except pure path algebra: `realpath`, `relpath`, `join`, `splitext`, `basename`, `dirname`),
+  `open(...)`, `pathlib.Path(...).read_*` / `write_*`, `fcntl.*`, `urllib.*`, `shutil.*`, `subprocess.*`,
+  `hashlib.<x>(open(...))`.
+- Hidden I/O: `time.time()`, `time.monotonic()`, `datetime.now()`, `uuid.uuid4()`, `asyncio.sleep()`, `random.*`
+  directly. Inject `Clock` / `UuidGen` / `Sleeper` Protocols (see #294).
+- Service-to-service concrete imports. Services are independent. Cross-service dependencies are Protocol-typed.
+- Module-function imports from `domain/`. If tests need `patch("services.X.module_name.fn")`, that's the smell — wrap
+  the module behind a Protocol and inject it (see #296 for `CoreInfoProvider` precedent).
+
+## God-class signal
+
+Services > ~600 LOC or `__init__` > 6 params (S107) — decompose into sub-services with constructor injection. Reference
+pattern: `services/saves/` (`SaveService` façade + `StateService` + `SyncEngine` + `StatusService` + `SlotsService`).
+
+## Adapters
+
+Own all I/O. Never import from `services/`. Implement Protocols defined in `services/protocols.py`.
+
+## Domain
+
+Pure compute only. No I/O, no state mutation, no service or adapter imports. Functions take inputs, return outputs.
+
+If a function in a service has no `self._<adapter>.*` calls and no state mutation, it belongs in `domain/`.
+
+## Bootstrap
+
+`bootstrap.py` is the only place where concrete adapters meet services. `WiringConfig` holds the wiring; protocols come
+in, services come out.
+
+## Smell → fix mapping (quick reference)
+
+| Smell                                                                      | Fix                                                                                                                                                   |
+| -------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `import os` + `open(...)` in `services/X.py`                               | Extract to adapter, inject Protocol                                                                                                                   |
+| `time.time()` / `datetime.now()` in service                                | Inject `Clock` (#294)                                                                                                                                 |
+| `uuid.uuid4()` in service                                                  | Inject `UuidGen` (#294)                                                                                                                               |
+| `asyncio.sleep(...)` in service                                            | Inject `Sleeper` (#294)                                                                                                                               |
+| `Callable[..., None]` ctor param                                           | Replace with named Protocol (precedent: `StatePersister` at `services/protocols.py:288`)                                                              |
+| `from domain import es_de_config` then calling its functions               | Wrap behind `CoreInfoProvider` Protocol (#296)                                                                                                        |
+| Pure helper inside a service (no `self.*` access)                          | Move to `domain/` (#295 lists candidates)                                                                                                             |
+| `tests/services/test_X.py` does `patch("services.X.os.path...")`           | Service has un-injected I/O; extract to adapter                                                                                                       |
+| `ignore_imports = …` carve-out in `.importlinter` to allow a banned module | Redesign the Protocol so the import isn't needed (e.g. `UuidGen.uuid4() -> str`, not `-> uuid.UUID` — #294). Suppressions are the smell, not the fix. |
+
+## Refactor wave plan
+
+Tracked under #277. Wave 1 (#256 cross-cutting infrastructure) → Wave 2 (#295 domain promotions) → Wave 3 (#297-#302
+per-service verticals, smallest-to-largest, LibraryService #300 last) → Wave 4 (#274 main.py + #277 final verification).
+Saves vertical (#254) runs in parallel.
+
+Full sequencing rationale lives in `CLAUDE.md` "Refactor wave plan" section.

--- a/.claude/memory/release-build-sourcemap.md
+++ b/.claude/memory/release-build-sourcemap.md
@@ -1,0 +1,27 @@
+---
+name: release-build-sourcemap
+description: Release build must strip source maps in rollup.config.js, NOT in a workflow step. `decky plugin build` rebuilds the frontend itself (runs `rollup -c` in its build container) before zipping — it does not package whatever dist/ you handed it. So any workflow-level `rm -f dist/*.map` before packaging is dead weight (this is exactly how 0.18.0 shipped no asset — #763/#764). @decky/rollup hardcodes `output.sourcemap: true` and the preset's options arg is silently reverted (`mergeAndConcat(options, defaultOptions)` lets defaults win) — mutate the returned object instead. Default rollup.config.js must be the map-free one; dev opts in via rollup.dev.config.js (`pnpm build:dev` + mise build task). CI uses raw `pnpm build` → map-free.
+type: project
+---
+
+# Release build — strip source maps in the rollup config, never in a workflow step
+
+`decky plugin build` **rebuilds the frontend itself** (runs `rollup -c` in its build container) before zipping — it does
+not package whatever `dist/` you handed it. So any "build then `rm -f dist/*.map` before packaging" step in
+`release.yml` is dead weight: decky regenerates `dist/index.js.map` and zips it anyway. This is exactly how the 0.18.0
+release shipped no asset (#763/#764): the map slipped back in and the source-map smoke-test guard failed the
+`build-plugin` job.
+
+Consequences that constrain any future change here:
+
+- **The map must be stripped in `rollup.config.js`, not the workflow.** `@decky/rollup` hardcodes
+  `output.sourcemap: true` and you **cannot** override it via the preset's options arg
+  (`deckyPlugin({ output: { sourcemap: false } })` is silently reverted — `mergeAndConcat(options, defaultOptions)` lets
+  the defaults win). Mutate the returned object instead:
+  `const config = deckyPlugin({}); config.output.sourcemap = false;`.
+- **The DEFAULT `rollup.config.js` must be the map-free one.** `decky plugin build` always runs the default `rollup -c`
+  and can't be pointed at another config file — there is no CLI flag for that, and `-b` is `--build-as-root`, unrelated.
+  So the map-free config is the default; dev opts _into_ maps via `rollup.dev.config.js` (inherits the default, flips
+  `sourcemap` back on), wired through `pnpm build:dev` and the mise `build` task. CI uses raw `pnpm build` → map-free.
+- Community plugins mostly just ship the map (e.g. MoonDeck); there is no blessed decky flag or env-var pattern for
+  this. The two-config split is our own.

--- a/.claude/memory/release-zip-defaults.md
+++ b/.claude/memory/release-zip-defaults.md
@@ -1,0 +1,14 @@
+---
+name: release-zip-defaults
+description: What ships in the release zip vs the repo layout. `config.json` / `bios_registry.json` / `core_defaults.json` appear at the ROOT of the release zip even though they live under `defaults/` in the repo — that's decky's `defaults/` convention: its contents are copied to the plugin root on install. Backend reads them with a dual path: root first (release), then `defaults/` (dev, where `mise run deploy` rsyncs them into a `defaults/` subdir). See firmware.py, es_de_config.py, adapters/romm/http.py. Vendored vdf lib ships `vdf/__init__.py` + `vdf/vdict.py` only — `*.dist-info` was removed (#764) as unused pip metadata (vdf hardcodes `__version__`; nothing reads `importlib.metadata`).
+    type: project
+---
+
+# What ships in the release zip — `defaults/` flattens to plugin root
+
+`config.json` / `bios_registry.json` / `core_defaults.json` appear at the **root** of the release zip even though they
+live under `defaults/` in the repo. That is decky's `defaults/` convention: its contents are copied to the plugin root
+on install. The backend reads them with a dual path — root first (release), then `defaults/` (dev, where
+`mise run deploy` rsyncs them into a `defaults/` subdir). See `firmware.py`, `es_de_config.py`, `adapters/romm/http.py`.
+These are required, not cruft. The vendored `vdf` lib ships `vdf/__init__.py` + `vdf/vdict.py` only — its `*.dist-info`
+was removed (#764) as unused pip metadata (`vdf` hardcodes `__version__`; nothing reads `importlib.metadata`).

--- a/.claude/memory/romm-injects-m3u-keep-es-de-gate.md
+++ b/.claude/memory/romm-injects-m3u-keep-es-de-gate.md
@@ -1,0 +1,47 @@
+---
+name: romm-injects-m3u-keep-es-de-gate
+description: We are NOT the only producer of .m3u in our extract dir — the RomM server injects one into multi-file download zips, ungated by platform. The ES-DE es_systems gate in the download path is what stops that reaching systems whose emulator breaks on a playlist (#1111), so it is load-bearing even though our own `_maybe_generate_m3u_io` almost never fires in practice. Upstream half is version-stamped and must be re-verified.
+type: project
+---
+
+# `.m3u` in the extract dir can come from the server — keep the ES-DE gate
+
+**Durable rule (holds regardless of what upstream does):** the plugin is **not** the only producer of `.m3u` files
+landing in a freshly extracted ROM directory. Treat any playlist found there as **foreign input**, and keep the
+per-system gate that decides whether a playlist is allowed to be the launch target at all.
+
+**Why:** `_maybe_generate_m3u_io` (`services/downloads.py`) reads like the only m3u source in the system, and it skips
+whenever a playlist already exists — so against a real server it almost never fires. That makes it look like dead code
+worth simplifying away, and makes the ES-DE gate look redundant ("we're the only producer, why gate our own output?").
+Both readings are wrong and both regress [#1111](https://github.com/danielcopper/decky-romm-sync/issues/1111), where
+cartridge/disc-less systems got a stray `.m3u` and a `.m3u`-suffixed folder. The gate — `system_supports_m3u` in
+`adapters/es_de_config.py:259`, reading ES-DE's own `es_systems.xml` — is the thing that actually holds the line. It
+gates both playlist generation and launch-file selection, which is why a foreign playlist is ignored on a system that
+cannot launch one.
+
+**How to apply:** before touching m3u generation, the launch-file detector, or the ES-DE collapse rename, assume a
+playlist may already be present and may not be ours. Never narrow the gate to "only gate what we generate". If the
+generator ever looks removable, the question to answer first is who else is writing the file.
+
+## Upstream half — VERIFY BEFORE RELYING ON THIS
+
+Observed on **RomM 5.0.0, 2026-07-28**. This is upstream implementation detail and can change in any release — it is
+recorded because re-deriving it cost a full source investigation, not because it is stable.
+
+RomM injects `f"{rom.fs_name}.m3u"` into every multi-file download zip that does not already contain one, **ungated by
+platform** — so a Switch or Xbox 360 multi-file game gets a playlist too. That, not anything on our side, is the
+original cause of #1111.
+
+Re-verify with three greps against a RomM checkout:
+
+- `backend/endpoints/roms/__init__.py:1374-1384` — the injection into the zip (and `:1436-1445` for the same on the
+  zip-content-line path)
+- `backend/utils/m3u.py` — `generate_m3u_content`: `.cue` files only when any exist, otherwise all files; bare relative
+  filenames, `\n`-joined
+- `backend/models/rom.py:588-593` — `has_m3u_file()`, the only gate: a bundled playlist is shipped verbatim and never
+  regenerated
+
+If a future check shows RomM has stopped injecting, the durable rule above still stands — a user's own library can
+contain a hand-made or tool-made playlist, and other clients write them too.
+
+Related: [[romm-siblings-cannot-identify-discs]].

--- a/.claude/memory/romm-siblings-cannot-identify-discs.md
+++ b/.claude/memory/romm-siblings-cannot-identify-discs.md
@@ -1,0 +1,51 @@
+---
+name: romm-siblings-cannot-identify-discs
+description: RomM has ONE relation between related roms (`sibling_roms`) and it cannot distinguish "Disc 2 of the same release" from "the European release". Never implement multi-disc grouping (#1554) on `sibling_group_key` alone — that silently merges regional variants into one game. Any grouping needs a disc discriminator the server does not provide. Upstream half is version-stamped and must be re-verified.
+type: project
+---
+
+# Sibling ≠ disc — never group multi-disc on `sibling_group_key` alone
+
+**Durable rule:** before building any multi-disc grouping feature, first establish whether the server can distinguish a
+**disc** sibling from a **regional/revision** sibling. If it cannot, grouping requires a discriminator the client has to
+invent, and that decision needs to be made deliberately — not assumed.
+
+**Why:** we already store `sibling_group_key` and `is_main_sibling` on `roms` (from the version-picker work,
+#1295/#1297). So the obvious implementation of [#1554](https://github.com/danielcopper/decky-romm-sync/issues/1554) —
+"group the siblings, download them into one folder, one save" — is a two-line reach from code we already have, and it is
+**wrong**: the same relation that links `Game (Disc 1)` / `Game (Disc 2)` also links `Game (USA)` / `Game (Europe)`.
+Grouping on it merges separate regional releases into a single game with a single save. That is a data-losing mistake
+that looks entirely reasonable from inside our codebase, because nothing on our side reveals that the relation is
+overloaded.
+
+The only signal that separates the two cases is the `(Disc N)` text in the filename. That is a filename heuristic, not
+server data, and it is not sufficient on its own — `Game (USA) (Disc 1)` and `Game (Europe) (Disc 1)` are siblings too,
+so a correct grouping has to reconstruct release identity (region, revision, version) from flattened tags before
+deciding which siblings belong to the same release. Argosy does the regex grouping and then needs a fuzzy substring
+match in its save layer to cope with the fallout; Grout does not attempt it at all.
+
+**How to apply:** treat "which roms are discs of one game" as an **open design question**, not a lookup. If #1554 or a
+successor is picked up, the shape of the discriminator is the first thing to settle, and the fallback position (declare
+the per-disc library shape unsupported, point at the folder-per-game shape that RomM's docs recommend and that every
+client handles correctly) is legitimate.
+
+## Upstream half — VERIFY BEFORE RELYING ON THIS
+
+Observed on **RomM 5.0.0, 2026-07-28**. Upstream implementation detail; re-check before acting on it. Recorded because
+establishing it took a full source sweep.
+
+RomM has **no multi-disc concept anywhere** — no disc-number column, no disc relation, no grouping logic. Every `disc`
+occurrence in the backend is either disc-_image_ hashing (PSP/RVZ) or audio track metadata. There is exactly one
+relation, and disc siblings and regional siblings are indistinguishable within it.
+
+Re-verify against a RomM checkout:
+
+- `backend/alembic/versions/0069_sibling_roms_fs_name.py:53-72` — the `sibling_roms` **view**: same `platform_id`, and
+  either a shared metadata id (igdb/moby/ss/launchbox/ra/hasheous/tgdb) **or** equal `fs_name_no_tags`
+- `backend/handler/filesystem/roms_handler.py:181` — `parse_tags`: every parenthesised/bracketed chunk becomes a tag;
+  anything not recognised as region/language/version/revision lands in `other_tags`, and is stripped from
+  `fs_name_no_tags`. `(Disc 1)` and `(USA)` go through the identical path.
+- Empirically confirmable against a live server: a rom with `fs_name` `"<Game> (USA)"` reports `fs_name_no_tags`
+  `"<Game>"`.
+
+Related: [[romm-injects-m3u-keep-es-de-gate]].

--- a/.claude/memory/save-conflict-test-path.md
+++ b/.claude/memory/save-conflict-test-path.md
@@ -1,0 +1,46 @@
+---
+name: save-conflict-test-path
+description: How to produce a save conflict for testing. The newest-wins matrix in domain/sync_action.py has exactly one path that yields Conflict — _decide_when_not_current. Conflict needs both sides diverged AND our device holding a (now-stale) sync entry on the newest server save. Also covers the device_syncs-empty gotcha (RomM 4.8.1 requires device_id query param), how a device gets its sync row (POST upload / download / confirm_download upsert; PUT does NOT on 4.8.1 — confirm_download fires after PUT as workaround, tracked in #748), and the no-device-authorship-column constraint (#276 records PUT uploads to own_upload_ids; display-only, doesn't affect matrix).
+type: project
+---
+
+# Producing a save conflict for testing — the one conflict path
+
+The newest-wins matrix (`domain/sync_action.py`) has exactly **one** path that yields a `Conflict`:
+`_decide_when_not_current`. Every other branch is download/upload/skip ("newer wins"). Conflict fires iff ALL of:
+
+1. The **newest** server save in the slot has OUR device's `device_syncs` entry with `is_current=False` (server moved
+   past us).
+2. `local_file` exists.
+3. `last_sync_hash` exists (we have a baseline).
+4. `local_hash != last_sync_hash` (local also diverged).
+
+So a conflict needs **both sides diverged** AND our device to already hold a (now-stale) sync entry on the newest save.
+
+**`device_syncs` requires the `device_id` query param — NOT a regression (re-verified 2026-05-20, RomM 4.8.1):** RomM
+only computes `device_syncs` _relative to a queried device_. `GET /api/saves?rom_id=` WITHOUT `device_id` returns
+`device_syncs=[]` for every save; WITH `&device_id=<our id>` it returns our device's single sync row (`is_current`,
+`last_synced_at`). The server returns ONLY the queried device's row, never other devices' — same in 4.8.1 and master. So
+the earlier "device_syncs always empty / conflict path dead" reading was an inspection artifact (the probe omitted
+`device_id`), not a regression. All 11 `list_saves` call sites in the plugin pass `device_id`, so the matrix receives
+populated rows and branches 4/5 ARE reachable. Conflict detection is functional.
+
+How a save gets our sync row (so `is_current` can be true): POST upload with `device_id` upserts it;
+`download_save_content(..., optimistic=True)` upserts it (merely downloading marks us current — `optimistic` defaults
+true); `confirm_download` (POST `/saves/{id}/downloaded`) upserts it. On 4.8.1 **PUT does NOT upsert** — so
+`do_upload_save` calls `confirm_download` after every upload to mark us current (load-bearing for the PUT path on 4.8.1;
+redundant-but-harmless on master, where PUT upserts). Tracking issue to drop the confirm once min RomM ≥ 4.9.x: #748.
+
+The RomM `Save` model has NO device-authorship column (only `user_id`) — neither 4.8.1 nor master records who _uploaded_
+a save, and a sync row can't distinguish upload from download. So "did THIS device upload this version" is local-only:
+`own_upload_ids`. #276 fixes it to record PUT uploads too (was POST-only) — display attribution only, does NOT affect
+the matrix.
+
+Device registration verified working: `steamdeck` (our `server_device_id`) is registered, `sync_enabled`, `last_seen`
+current; the `ensure_device_registered` → `update_device` heartbeat bumps `last_seen` on each sync.
+
+Transport note: RomM auth is Basic (`auth_header()` in `adapters/romm/http.py`); a save update is a multipart
+`PUT /api/saves/{id}` with form field `saveFile`. Never log secret values.
+
+Related: #276 (PUT uploads don't update `own_upload_ids` → wrong "(this device)" attribution) is in the same save-sync
+device-tracking area.

--- a/.claude/memory/sonarcloud-findings-inline.md
+++ b/.claude/memory/sonarcloud-findings-inline.md
@@ -1,0 +1,12 @@
+---
+name: sonarcloud-findings-inline
+description: SonarCloud findings get surfaced inline in chat by the user rather than waiting for me to read PR comments. SonarCloud runs on every PR + push to main; Quality Gate enforces 80% coverage on new code, 0 bugs, 0 vulnerabilities (per CLAUDE.md). Expect findings to arrive mid-session — address in the current commit when reasonable, otherwise note for a follow-up before the PR merges.
+type: project
+---
+
+# SonarCloud findings — inline channel during refactor sessions
+
+When the user spots SonarCloud findings on a PR or while iterating, they will surface them inline in chat rather than
+waiting for me to read the PR comments. SonarCloud runs on every PR + push to main and the Quality Gate enforces 80%
+coverage on new code, 0 bugs, 0 vulnerabilities (per `CLAUDE.md`). So expect findings to come in mid-session — address
+them in the current commit when reasonable, otherwise note for a follow-up commit before the PR merges.

--- a/.claude/memory/sync-ui-trigger-surfaces.md
+++ b/.claude/memory/sync-ui-trigger-surfaces.md
@@ -1,0 +1,21 @@
+---
+name: sync-ui-trigger-surfaces
+description: Which UI surface triggers which save-sync backend call, and which one actually surfaces the SyncConflictModal. Three surfaces exist (per-ROM Sync button, game-detail page open, Play button) — only the Play button (CustomPlayButton) opens the conflict modal; the others just toast or refresh. When smoke-testing the conflict modal, use the Play button in its conflict state — the Sync button looks like the obvious entry point but isn't.
+type: project
+---
+
+# Sync UI triggers — which surface does what
+
+Three user-facing surfaces can trigger save sync. They are NOT interchangeable for testing the conflict modal:
+
+| Surface                                     | Backend call              | Surfaces conflict modal?                                                                                               |
+| ------------------------------------------- | ------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| Per-ROM **Sync** button on game-detail page | `sync_rom_saves(rom_id)`  | **No.** Just toasts the result.                                                                                        |
+| Game-detail page **open** (component mount) | `get_save_status(rom_id)` | **No.** Just refreshes the SAVES tab.                                                                                  |
+| **Play** button (`CustomPlayButton`)        | `pre_launch_sync(rom_id)` | **Yes.** Button switches to "Resolve conflict" state when a conflict is pending; tapping it opens `SyncConflictModal`. |
+
+So: when smoke-testing or debugging the conflict modal, the only way to surface it is via the Play button (in its
+conflict-state form). The Sync button and page-open run sync but never open the modal.
+
+This is non-obvious — the Sync button looks like it might surface conflicts because it's the explicit "sync now" action.
+It doesn't.

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ log.txt
 # not descend into an ignored directory.
 .claude/*
 !.claude/rules/
+!.claude/memory/
 .venv/
 
 # Git worktrees

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -298,9 +298,10 @@ Most of what lives in `.claude/rules/` has no mechanical check — Protocol suff
 verb-named mutations — so those rules hold only if they are carried while writing. `CLAUDE.md` indexes them with the
 failure mode each one prevents.
 
-Note that `.gitignore` ignores `.claude/*` (worktrees, local agents, `settings.local.json`) and re-includes
-`.claude/rules/` explicitly. Adding a rule file works; adding anything else under `.claude/` will silently not be
-tracked.
+Note that `.gitignore` ignores `.claude/*` (worktrees, local agents, `settings.local.json`) and re-includes exactly two
+directories: `.claude/rules/` and `.claude/memory/` (the per-repo agent-memory tier — durable, reviewable repo
+knowledge; public-safe content only). Adding a file in those two works; adding anything else under `.claude/` will
+silently not be tracked.
 
 ## Project Structure
 


### PR DESCRIPTION
## Summary

- Track `.claude/memory/` — the per-repo agent-knowledge tier (deploy loop, release packaging traps, save-conflict test recipe, RomM upstream constraints). It existed only as an untracked directory on one machine; tracking makes it durable, available in every worktree, and reviewable like code.
- `.gitignore` gains the `!.claude/memory/` re-include next to `!.claude/rules/`.
- Content was redacted for a public repository before the initial commit: the credentials note in `save-conflict-test-path.md` now records only the transport shape, not where credentials live.

## Test plan

- [x] `markdownlint` + `deno fmt --check` + `scripts/check_markdown_links.py` green over the new files
- [x] `git check-ignore` verified: `worktrees/`, `agents/`, `settings.local.json` stay ignored
- [ ] Manual QA on Steam Deck — n/a, no runtime code

## Docs

- [x] `docs/` updated in this PR (`development.md`: the `.claude/` ignore note now names both re-included directories)

## Notes

One known content conflict ships as-is and is queued for the memory consolidation pass rather than silently edited here: `appid-launchoptions-reliability.md` still claims the CRC32 appId formula that CLAUDE.md marks disproven.