### PR TITLE
refactor(bootstrap): split the composition root into adapters and services

### DIFF
--- a/.claude/rules/bootstrap-wiring.md
+++ b/.claude/rules/bootstrap-wiring.md
@@ -1,22 +1,25 @@
 ---
 paths:
-  - "py_modules/bootstrap.py"
+  - "py_modules/bootstrap/*.py"
   - "main.py"
 ---
 
 # Composition root and process boundaries
 
-**Bootstrap (`bootstrap.py`)**: `[CP]` The composition root — the only place concrete adapters meet services. `[ours]`
-`WiringConfig` holds the wiring; protocols in, services out. Adapter instantiation never happens in `main.py` — a
-Protocol-wrapped persister is built in `bootstrap()` and passed through `CallbackBundle`.
+**Bootstrap (`bootstrap/`)**: `[CP]` The composition root — the only place concrete adapters meet services. `[ours]`
+`adapters.py` instantiates every adapter and returns the typed bundles; `services.py` holds `WiringConfig` and turns
+those bundles into service instances — protocols in, services out. `__init__.py` is namespace plus re-exports only, so
+consumers write `from bootstrap import …` and never deep-import a submodule. Adapter instantiation never happens in
+`main.py` — a Protocol-wrapped persister is built in `bootstrap()` and passed through `CallbackBundle`.
 
-**Process boundaries — `main.py` vs `bootstrap.py`**: `[ours]` `main.py` owns the Decky lifecycle (`_main`, `_unload`)
-and the callable surface (one `async def` per `@callable`). `bootstrap.py` owns adapter instantiation and service
-wiring. The split is binding — no callables in `bootstrap.py`, no service wiring in `main.py`.
+**Process boundaries — `main.py` vs `bootstrap/`**: `[ours]` `main.py` owns the Decky lifecycle (`_main`, `_unload`) and
+the callable surface (one `async def` per `@callable`). `bootstrap/` owns adapter instantiation and service wiring. The
+split is binding — no callables in `bootstrap/`, no service wiring in `main.py`.
 
 `main.py` grows with the callable surface it describes; that is unavoidable density, not god-class, and it is
 deliberately out of scope for the module-size gate.
 
-`bootstrap.py` is **not** exempt. It is already past the ~700-LOC split trigger and is pinned at its current size by
-`scripts/check_module_size.py`, so it cannot grow further: new wiring means splitting it into
-`bootstrap/{adapters,services}.py` first.
+`bootstrap/` is **not** exempt. Both modules are governed by the ~700-LOC threshold in `scripts/check_module_size.py`
+and neither is grandfathered, so each has real headroom and a hard stop. A new adapter goes into `adapters.py`, new
+wiring into `services.py`; when either reaches the threshold the answer is the next split along the same seam (a wiring
+module per service cluster), never an allowlist entry.

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -71,7 +71,7 @@ area:playtime:
 area:architecture:
   - changed-files:
       - any-glob-to-any-file:
-          - 'py_modules/bootstrap.py'
+          - 'py_modules/bootstrap/**'
           - 'py_modules/services/protocols/**'
           - 'py_modules/domain/**'
           - 'py_modules/lib/**'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,7 +109,11 @@ jobs:
           # py_modules/native/libgavel-x86_64-linux.so is the compiled save-sync 409 kernel;
           # bootstrap RAISES (no Python fallback) if it's missing, so a Decky CLI
           # packaging change that drops it must fail the release here.
-          for required in main.py plugin.json package.json dist/index.js py_modules/bootstrap.py bin/rom-launcher \
+          # All three bootstrap modules are listed, not just the package marker:
+          # __init__.py is a re-export shim, so asserting it alone would pass a
+          # packaging regression that dropped the composition root's actual code.
+          for required in main.py plugin.json package.json dist/index.js bin/rom-launcher \
+              py_modules/bootstrap/__init__.py py_modules/bootstrap/adapters.py py_modules/bootstrap/services.py \
               py_modules/db/migrations/001_initial.sql py_modules/db/migrations/002_add_emulator_override.sql \
               bios_registry.json py_modules/native/libgavel-x86_64-linux.so; do
             if ! unzip -l "$BUILT_ZIP" | grep -qE "/$required\b"; then

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ new code in it.
   rather than the behavior, and when a subfolder is justified. **No mechanical check exists for any of it.**
 - `adapters-domain.md` — adapters own I/O, domain is pure, aggregate mutations are verb-named after the event
   (`adopt_baseline`, not `update_baseline`). The field-assignment ban is checked; the naming is not.
-- `bootstrap-wiring.md` — the `main.py` / `bootstrap.py` split, and why `bootstrap.py` may no longer grow.
+- `bootstrap-wiring.md` — the `main.py` / `bootstrap/` split, and which half of `bootstrap/` new wiring belongs in.
 - `callables.md` — the `{success, reason, message}` failure shape and its two carve-outs. Checked.
 - `vendored-assets.md` — `_vendor/`, `native/`, `defaults/` are checksum-pinned verbatim copies. The checksums are
   checked; the reflex to fix the upstream artifact instead of the copy is not.
@@ -172,9 +172,9 @@ Format: **invariant** — tier — enforced by.
   same path** — check — `scripts/check_uow_seam_nesting.py`
 - **Services never call clocks / sleep / uuid / random directly (inject the Protocol)** — check —
   `scripts/check_cosmic_call_bans.sh`
-- **No module in `services/` or `bootstrap.py` crosses the ~700-LOC decomposition threshold, and the ones already over
-  it may not grow** — check — `scripts/check_module_size.py` (the modules that predate the gate are grandfathered at
-  their exact size; that list only ever gets shorter)
+- **No module in `services/` or `bootstrap/` crosses the ~700-LOC decomposition threshold, and the ones already over it
+  may not grow** — check — `scripts/check_module_size.py` (the modules that predate the gate are grandfathered at their
+  exact size; that list only ever gets shorter)
 - **Service-independence contract list stays complete** — check — `scripts/check_service_independence_contract.py`
 - **Layer import direction (services ↛ adapters, adapters ↛ services, …)** — check — `.importlinter` (`lint-imports`)
 - **No bare `# type: ignore` / blanket suppressions** — check — `scripts/check_no_bare_ignores.sh`

--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -12,8 +12,8 @@ plugin. Code is split into four layers with a strictly enforced dependency direc
 - **`models/`** — data shapes (TypedDicts, dataclasses) independent of every other layer.
 
 Services depend on **Protocols** (defined in `services/protocols/`), never on concrete adapter classes. Adapters
-implement those Protocols. `bootstrap.py` is the composition root — the only place where concrete adapters meet
-services. `main.py` owns the Decky lifecycle and the callable surface; it holds no business logic.
+implement those Protocols. `bootstrap/` is the composition root — the only place where concrete adapters meet services.
+`main.py` owns the Decky lifecycle and the callable surface; it holds no business logic.
 
 ```python
 class Plugin:
@@ -27,7 +27,7 @@ class Plugin:
 ```text
 main.py (Plugin — Decky lifecycle + callable routing)
     ↓ calls
-bootstrap.py (composition root: bootstrap() builds adapters, wire_services() builds services)
+bootstrap/ (composition root: adapters.bootstrap() builds adapters, services.wire_services() builds services)
     ↓ creates
 ┌─────────────────────────────────────────────────────────┐
 │ Adapters (own all I/O — implement Protocols)            │
@@ -1291,21 +1291,24 @@ nothing from the other layers.
 | File                 | Role                                                                                                          |
 | -------------------- | ------------------------------------------------------------------------------------------------------------- |
 | `main.py`            | Plugin class — Decky lifecycle (`_main`/`_unload`) and the callable surface (one `async def` per `@callable`) |
-| `bootstrap.py`       | Composition root — `bootstrap()` builds adapters, `wire_services()` builds services                           |
+| `bootstrap/`         | Composition root — `adapters.bootstrap()` builds adapters, `services.wire_services()` builds services         |
 | `lib/errors.py`      | Exception hierarchy (`RommApiError`, `classify_error`)                                                        |
 | `lib/list_result.py` | `ErrorCode` and the canonical callable failure shape                                                          |
 
-## Composition Root (`bootstrap.py`)
+## Composition Root (`bootstrap/`)
 
-The composition root has two functions:
+The composition root is a package of two halves, one per phase, plus an `__init__.py` that is namespace and re-exports
+only — consumers write `from bootstrap import …` and never deep-import a submodule:
 
-1. **`bootstrap()`** — builds every adapter, applies the SQLite schema migrations, and loads + migrates `settings.json`
-   (folding in the one-time legacy `save_sync_state.json` settings) so the settings persister binds the live mutable
-   `settings` dict at construction. Returns a typed `BootstrapResult` carrying four bundles (`adapters`, `stores`,
-   `callbacks`, `runtime_adapters`) plus a small `handles` struct for Plugin-only outputs.
+1. **`adapters.py`** — owns `bootstrap()`, which builds every adapter, applies the SQLite schema migrations, and loads +
+   migrates `settings.json` (folding in the one-time legacy `save_sync_state.json` settings) so the settings persister
+   binds the live mutable `settings` dict at construction. Returns a typed `BootstrapResult` carrying four bundles
+   (`adapters`, `stores`, `callbacks`, `runtime_adapters`) plus a small `handles` struct for Plugin-only outputs. The
+   bundle dataclasses are defined here too — they are the vocabulary the second half consumes.
 
-2. **`wire_services()`** — takes a `WiringConfig` (the four bundles plus `min_required_version`) and constructs every
-   service, injecting each one's `*ServiceConfig`. Returns a dict of named service instances.
+2. **`services.py`** — owns `WiringConfig` and `wire_services()`, which takes the four bundles plus
+   `min_required_version` and constructs every service, injecting each one's `*ServiceConfig`. Returns a dict of named
+   service instances.
 
 The two-phase split exists because adapter instantiation and state loading happen first (`bootstrap()`), then `main.py`
 composes the runtime bundle (event loop, `decky.emit`) and calls `wire_services()`. Services receive the `settings` dict
@@ -1315,7 +1318,8 @@ no plural in-memory state dicts remain. Some services are constructed before oth
 peers are threaded via `LateBinding`.
 
 Per the process-boundary rule, adapter instantiation never happens in `main.py`, and no service wiring happens in
-`bootstrap.py`'s caller other than via `wire_services()`.
+`bootstrap/`'s caller other than via `wire_services()`. Both modules are governed by the ~700-line decomposition
+threshold (`scripts/check_module_size.py`), neither is grandfathered.
 
 ## Protocol Interfaces
 

--- a/docs/architecture/config-source-parsers.md
+++ b/docs/architecture/config-source-parsers.md
@@ -194,7 +194,7 @@ import-linter).
 ### 3. Protocol(s) in `py_modules/services/protocols/`
 
 Services never import concrete adapters. They depend on callable protocols defined in the `services/protocols/` package
-(config-source parsers live in `paths.py`), and the concrete adapter method is wired up by `bootstrap.py`.
+(config-source parsers live in `paths.py`), and the concrete adapter method is wired up by `bootstrap/`.
 
 ```python
 class CoreNameProviderFn(Protocol):
@@ -207,9 +207,10 @@ same adapter exposes multiple capabilities (`get_corename`, `get_supported_exten
 each gets its own protocol so services can depend on only what they actually use — and a test double only needs to stub
 the callables a given test exercises.
 
-### 4. Wiring in `py_modules/bootstrap.py`
+### 4. Wiring in `py_modules/bootstrap/`
 
-Adapter instance is created in the composition root, and its method is threaded into services that need it:
+Adapter instance is created in `bootstrap/adapters.py`, and `bootstrap/services.py` threads its method into services
+that need it:
 
 ```python
 retroarch_core_info = RetroArchCoreInfoAdapter(user_home=user_home, logger=logger)
@@ -382,7 +383,7 @@ None of these are in scope for #208. They are listed here so that, when the time
   accessor method on the adapter (e.g. `get_supported_extensions(core_so)`).
 - The underlying `get_core_info` already returns the full dict, so each new accessor is a few lines wrapping
   `info.get(field)`.
-- The new accessor gets wired into bootstrap.py the same way `get_corename` is.
+- The new accessor gets wired into `bootstrap/` the same way `get_corename` is.
 
 ## How to add a new source
 
@@ -396,8 +397,8 @@ When the plugin needs to read a new external config/metadata source, the checkli
    Tests with `tmp_path`.
 4. **Add callback protocol(s)** in `py_modules/services/protocols/`. One protocol per capability, in the existing `*Fn`
    Call-protocol style.
-5. **Wire in `bootstrap.py`.** Instantiate the adapter in the composition root; thread its method(s) into services that
-   need them.
+5. **Wire in `bootstrap/`.** Instantiate the adapter in `adapters.py`; thread its method(s) from `services.py` into the
+   services that need them.
 6. **Consume in services.** Services depend on the protocol, not on the adapter. Handle the `None` / failure case at the
    service layer — no cross-parser fallbacks.
 7. **Add a row to Current parsers** above and update the decisions log below if there's a non-obvious design choice

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -250,7 +250,7 @@ literal appears anywhere except its owning adapter (`adapters/persistence.py`); 
 keeps all settings writes in the single crash-safe owner.
 
 `mise run lint` (and CI) also runs `scripts/check_module_size.py`, the decomposition-threshold ratchet: no module in
-`services/` or `bootstrap.py` may cross the ~700-line threshold, and the modules that were already over it when the gate
+`services/` or `bootstrap/` may cross the ~700-line threshold, and the modules that were already over it when the gate
 landed are pinned at their exact size, so they cannot grow. The pin list lives in the script and only ever gets shorter
 — a module that drops back under the threshold has to leave it, and a module that banks 50+ lines of slack gets a
 non-fatal note asking for its ceiling to be lowered. `main.py` is deliberately out of scope: it grows with the callable
@@ -307,7 +307,9 @@ tracked.
 ```text
 main.py                              # Plugin entry — Decky lifecycle + callable surface
 py_modules/
-  bootstrap.py                       # Composition root — bootstrap() builds adapters, wire_services() builds services
+  bootstrap/                         # Composition root — re-exported through __init__.py
+    adapters.py                      # bootstrap() builds every adapter and the typed bundles
+    services.py                      # wire_services() builds every service from those bundles
   services/                          # Orchestration / business logic (Protocol-typed deps via *ServiceConfig)
     protocols/                       # Protocol interfaces, grouped: transport / determinism /
                                      #   persistence / paths / infra / files / cross_service

--- a/py_modules/bootstrap/__init__.py
+++ b/py_modules/bootstrap/__init__.py
@@ -1,0 +1,33 @@
+"""Composition root — the only place concrete adapters meet services.
+
+``adapters.py`` owns adapter instantiation and the typed bundles it
+hands to ``main.py``; ``services.py`` turns those bundles into the live
+service instances. The names re-exported below are the composition
+root's whole public surface — consumers import them from ``bootstrap``,
+never from a submodule.
+"""
+
+from .adapters import (
+    AdapterBundle,
+    BootstrapHandles,
+    BootstrapResult,
+    CallbackBundle,
+    RuntimeAdaptersBundle,
+    RuntimeBundle,
+    StateBundle,
+    bootstrap,
+)
+from .services import WiringConfig, wire_services
+
+__all__ = [
+    "AdapterBundle",
+    "BootstrapHandles",
+    "BootstrapResult",
+    "CallbackBundle",
+    "RuntimeAdaptersBundle",
+    "RuntimeBundle",
+    "StateBundle",
+    "WiringConfig",
+    "bootstrap",
+    "wire_services",
+]

--- a/py_modules/bootstrap/adapters.py
+++ b/py_modules/bootstrap/adapters.py
@@ -1,0 +1,388 @@
+"""Adapter half of the composition root — the only place adapters are constructed.
+
+Adapter construction lives here so ``main.py`` only deals with the
+Decky lifecycle and the callable surface. ``bootstrap()`` also loads
+and migrates settings as part of adapter wiring so adapters that bind
+a live mutable settings dict (such as ``RommHttpAdapter``) bind the
+migrated dict in a single pass; that same dict is returned for the
+caller to keep as its source of truth.
+
+The bundles defined here are the typed vocabulary the service half
+consumes; nothing outside this module instantiates an adapter.
+"""
+
+from __future__ import annotations
+
+import functools
+import os
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from adapters.asyncio_sleeper import AsyncioSleeper
+from adapters.cover_art_file_store import CoverArtFileStoreAdapter
+from adapters.debug_logger import SettingsAwareDebugLogger
+from adapters.download_file import DownloadFileAdapter
+from adapters.es_de_config import CoreResolver
+from adapters.firmware_file import FirmwareFileAdapter
+from adapters.game_process import GameProcessAdapter
+from adapters.gavel_native import GavelNativeAdapter
+from adapters.hostname import HostnameAdapter
+from adapters.machine_id import MachineIdAdapter
+from adapters.migration_file import MigrationFileAdapter
+from adapters.path_probe import PathProbeAdapter
+from adapters.persistence import (
+    PersistenceAdapter,
+    PlatformCoreReaderAdapter,
+    SettingsPersisterAdapter,
+)
+from adapters.plugin_metadata import PluginMetadataAdapter
+from adapters.renderer_gc import RendererGcAdapter
+from adapters.renderer_rss import RendererRssAdapter
+from adapters.repositories.unit_of_work import SqliteUnitOfWork
+from adapters.retroarch_config import RetroArchConfigAdapter
+from adapters.retroarch_core_info import RetroArchCoreInfoAdapter
+from adapters.retrodeck_paths import RetroDeckPathsAdapter
+from adapters.rom_files import RomFileAdapter
+from adapters.romm.http import RommHttpAdapter
+from adapters.romm.romm_api import RommApiAdapter
+from adapters.save_file import SaveFileAdapter
+from adapters.sgdb_artwork_cache import SgdbArtworkCacheAdapter
+from adapters.sqlite_migrations import MIGRATIONS_DIR, apply_migrations
+from adapters.steam_config import SteamConfigAdapter
+from adapters.steamgriddb import SteamGridDbAdapter
+from adapters.system_clock import SystemClock
+from adapters.system_uuid_gen import SystemUuidGen
+from domain.state_migrations import fold_legacy_save_sync_settings, migrate_settings
+
+if TYPE_CHECKING:
+    import asyncio
+    import logging
+    from typing import Any
+
+    from services.protocols import (
+        Clock,
+        CoreInfoProvider,
+        CoreNameProviderFn,
+        CoverArtFileStore,
+        DebugLogger,
+        DirectoryFileListerFn,
+        DownloadFileStore,
+        EventEmitter,
+        FirmwareFileStore,
+        GameProcessControl,
+        HostnameReader,
+        MachineIdReader,
+        MigrationFileStore,
+        PathExistsReader,
+        PlatformCoreReader,
+        PluginMetadataReader,
+        RendererGcFn,
+        RendererRssFn,
+        ResolveUploadConflictFn,
+        RetroArchSaveLayoutProvider,
+        RetroDeckPaths,
+        RomFileStore,
+        RommApi,
+        SaveFileStore,
+        SettingsPersister,
+        SgdbArtworkCache,
+        Sleeper,
+        SteamConfigStore,
+        SystemM3uSupportFn,
+        SystemSupportedExtensionsFn,
+        UnitOfWorkFactory,
+        UuidGen,
+    )
+
+# Filename of the SQLite database inside the plugin runtime dir. Created by the
+# migration runner at startup; unused until the service cutover (#784).
+_DB_FILENAME = "romm_sync.db"
+
+
+@dataclass(frozen=True)
+class AdapterBundle:
+    """Concrete I/O adapters wired into services."""
+
+    http_adapter: RommHttpAdapter
+    romm_api: RommApi
+    steam_config: SteamConfigStore
+    sgdb_adapter: SteamGridDbAdapter
+    cover_art_file_store: CoverArtFileStore
+    sgdb_artwork_cache: SgdbArtworkCache
+    download_file_store: DownloadFileStore
+    firmware_file_store: FirmwareFileStore
+    migration_file_store: MigrationFileStore
+    rom_file_store: RomFileStore
+    save_file_store: SaveFileStore
+    path_probe: PathExistsReader
+    core_info_provider: CoreInfoProvider
+    renderer_rss: RendererRssFn
+    renderer_gc: RendererGcFn
+    game_process: GameProcessControl
+    resolve_upload_conflict: ResolveUploadConflictFn
+
+
+@dataclass(frozen=True)
+class StateBundle:
+    """Live mutable state shared across services."""
+
+    settings: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class RuntimeBundle:
+    """Process-level runtime infrastructure (event loop, logger, paths, time/UUID/sleep seams)."""
+
+    loop: asyncio.AbstractEventLoop
+    logger: logging.Logger
+    plugin_dir: str
+    runtime_dir: str
+    emit: EventEmitter
+    clock: Clock
+    uuid_gen: UuidGen
+    sleeper: Sleeper
+    hostname_provider: HostnameReader
+    machine_id_provider: MachineIdReader
+
+
+@dataclass(frozen=True)
+class CallbackBundle:
+    """Provider callables and persister Protocols injected into services."""
+
+    retrodeck_paths: RetroDeckPaths
+    get_save_layout: RetroArchSaveLayoutProvider
+    get_core_name: CoreNameProviderFn
+    platform_core_reader: PlatformCoreReader
+    m3u_support: SystemM3uSupportFn
+    system_extensions: SystemSupportedExtensionsFn
+    list_rom_dir_files: DirectoryFileListerFn
+    settings_persister: SettingsPersister
+    log_debug: DebugLogger
+    plugin_metadata: PluginMetadataReader
+    uow_factory: UnitOfWorkFactory
+
+
+@dataclass(frozen=True)
+class RuntimeAdaptersBundle:
+    """Concrete adapters for the Clock/UuidGen/Sleeper/HostnameReader/MachineIdReader seams.
+
+    Bootstrap owns adapter instantiation, but the ``RuntimeBundle``
+    handed to ``wire_services`` also needs runtime-only state ``main.py``
+    introduces (the ``asyncio`` loop, ``decky.emit``). This sub-bundle
+    carries the seams bootstrap builds so ``main.py`` can compose the
+    final ``RuntimeBundle`` without instantiating any adapters itself.
+    """
+
+    clock: Clock
+    uuid_gen: UuidGen
+    sleeper: Sleeper
+    hostname_provider: HostnameReader
+    machine_id_provider: MachineIdReader
+
+
+@dataclass(frozen=True)
+class BootstrapHandles:
+    """Bootstrap outputs ``main.py`` needs that don't fit the wiring bundles.
+
+    Anything ``Plugin`` itself binds (not the services) lives here:
+    the debug logger forwarded by ``Plugin._log_debug`` and the
+    persistence adapter ``Plugin`` holds for disk-touching callable paths
+    that bypass a service. The bundles already cover everything passed to
+    ``wire_services``; this struct keeps those Plugin-only handles typed
+    instead of returning them via the untyped dict shape of yore.
+    """
+
+    debug_logger: DebugLogger
+    persistence: PersistenceAdapter
+
+
+@dataclass(frozen=True)
+class BootstrapResult:
+    """Typed return shape for :func:`bootstrap`.
+
+    The four bundles carry every Protocol-typed seam and live state
+    dict that services need; :attr:`handles` carries the small set of
+    raw outputs only ``main.py`` itself binds (debug logger). Together
+    they replace the historical untyped ``dict`` return so every
+    consumer is caught by basedpyright instead of failing silently at
+    runtime on a typo.
+    """
+
+    adapters: AdapterBundle
+    stores: StateBundle
+    callbacks: CallbackBundle
+    runtime_adapters: RuntimeAdaptersBundle
+    handles: BootstrapHandles
+
+
+def bootstrap(
+    *,
+    settings_dir: str,
+    runtime_dir: str,
+    plugin_dir: str,
+    user_home: str,
+    logger: logging.Logger,
+) -> BootstrapResult:
+    """Build every adapter and bundle the composition root hands to ``main.py``.
+
+    Bootstrap owns adapter instantiation and is the only path that
+    constructs ``PersistenceAdapter``. Settings are loaded + migrated
+    inside here so the ``SettingsPersisterAdapter`` binds the live dict
+    at construction; mutating that dict from the caller side is visible
+    to every adapter/service that holds the same reference.
+
+    Parameters
+    ----------
+    settings_dir:
+        ``decky.DECKY_PLUGIN_SETTINGS_DIR``
+    runtime_dir:
+        ``decky.DECKY_PLUGIN_RUNTIME_DIR``
+    plugin_dir:
+        ``decky.DECKY_PLUGIN_DIR``
+    user_home:
+        ``decky.DECKY_USER_HOME`` — base for RetroDECK and Steam path lookups.
+    logger:
+        ``decky.logger``
+
+    Returns
+    -------
+    :class:`BootstrapResult`
+        Typed bundles consumed by ``wire_services`` (``adapters``,
+        ``stores``, ``callbacks``) plus the small set of Plugin-only
+        handles ``main.py`` itself binds (``handles.debug_logger``).
+    """
+    # Bring the on-disk SQLite schema up to date before any service is wired —
+    # the composition root owns startup infra. Post-cutover (#784) SQLite is the
+    # sole persistence backend: there is no JSON fallback, so a failed or
+    # unopenable database is fatal. Log the cause, then re-raise so bootstrap
+    # aborts and the plugin stays inert — matching the RomM-minimum-version
+    # gate's "inert until the environment is fixed" posture.
+    db_path = os.path.join(runtime_dir, _DB_FILENAME)
+    try:
+        apply_migrations(db_path, MIGRATIONS_DIR, logger=logger)
+    except Exception:
+        logger.exception("SQLite schema migration failed; plugin cannot start")
+        raise
+
+    # The runtime Unit-of-Work factory: each call opens a fresh sync sqlite3
+    # connection on db_path (ADR-0004). Wired here but not yet threaded into any
+    # service config — the service cutover (#784) consumes it.
+    uow_factory: UnitOfWorkFactory = functools.partial(SqliteUnitOfWork, db_path)
+
+    retrodeck_paths = RetroDeckPathsAdapter(user_home=user_home, logger=logger)
+    retroarch_config = RetroArchConfigAdapter(user_home=user_home, logger=logger)
+    retroarch_core_info = RetroArchCoreInfoAdapter(user_home=user_home, logger=logger)
+    core_resolver = CoreResolver(
+        plugin_dir=plugin_dir,
+        logger=logger,
+        user_home=user_home,
+    )
+
+    # SystemClock is dependency-free; construct it here so the single shared
+    # instance threads into PersistenceAdapter (corrupt-settings backup stamp)
+    # and every later seam (uuid_gen/sleeper neighbours, runtime bundle).
+    clock = SystemClock()
+    persistence = PersistenceAdapter(settings_dir, runtime_dir, logger, clock=clock)
+    settings = persistence.load_settings()
+    # One-time JSON→JSON lift (ADR-0003): fold the legacy save-sync knobs +
+    # device_name out of save_sync_state.json before the schema bump stamps
+    # version 4. Idempotent — after the first run save_settings stamps the
+    # new version and this branch is skipped.
+    if settings.get("version", 0) < 4:
+        settings = fold_legacy_save_sync_settings(settings, persistence.load_save_sync_state())
+    settings = migrate_settings(settings)
+    # If load_settings quarantined a corrupt file this boot, fold the reset into
+    # the settings dict as a persistent marker. Set AFTER migration and BEFORE
+    # the save so it lands in the fresh settings.json and survives a plugin
+    # reload — the frontend surfaces it as a banner (QAM + game detail) until the
+    # next successful sign-in clears it (ConnectionService pops it on persist).
+    if persistence.corrupt_reset is not None:
+        settings["_settings_reset_notice"] = {"backed_up_to": persistence.corrupt_reset["backed_up_to"]}
+    persistence.save_settings(settings)
+    settings_persister = SettingsPersisterAdapter(persistence, settings)
+    # Binds the same live settings dict so the per-platform-core fan-out resolves
+    # the freshly-written value, not a snapshot.
+    platform_core_reader = PlatformCoreReaderAdapter(settings)
+    plugin_metadata = PluginMetadataAdapter()
+    # Single source of truth for outgoing User-Agent — read package.json
+    # version once at boot and thread the string to every HTTP-talking
+    # adapter. Bot Fight Mode on Cloudflare blocks the default
+    # ``Python-urllib`` UA before requests reach self-hosted RomM (#249).
+    user_agent = f"decky-romm-sync/{plugin_metadata.read_version(plugin_dir)}"
+    http_adapter = RommHttpAdapter(settings, plugin_dir, logger, user_agent)
+    romm_api = RommApiAdapter(http_adapter)
+    steam_config = SteamConfigAdapter(user_home=user_home, logger=logger)
+    sgdb_adapter = SteamGridDbAdapter(settings=settings, logger=logger, user_agent=user_agent)
+    cover_art_file_store = CoverArtFileStoreAdapter()
+    sgdb_artwork_cache = SgdbArtworkCacheAdapter(runtime_dir=runtime_dir)
+    download_file_store = DownloadFileAdapter()
+    firmware_file_store = FirmwareFileAdapter()
+    migration_file_store = MigrationFileAdapter()
+    rom_file_store = RomFileAdapter()
+    save_file_store = SaveFileAdapter(logger=logger)
+    path_probe = PathProbeAdapter()
+    renderer_rss = RendererRssAdapter()
+    renderer_gc = RendererGcAdapter(logger=logger)
+    game_process = GameProcessAdapter()
+    # The compiled gavel core owns the save-sync upload-409 resolution. Loaded
+    # eagerly so a missing / wrong-architecture artifact is fatal here (like the
+    # SQLite migration gate above) rather than surfacing mid-sync — there is no
+    # Python fallback (GavelNativeLoadError propagates, plugin stays inert).
+    resolve_upload_conflict = GavelNativeAdapter()
+    uuid_gen = SystemUuidGen()
+    sleeper = AsyncioSleeper()
+    hostname_provider = HostnameAdapter()
+    machine_id_provider = MachineIdAdapter()
+    debug_logger = SettingsAwareDebugLogger(settings=settings, logger=logger)
+
+    adapters = AdapterBundle(
+        http_adapter=http_adapter,
+        romm_api=romm_api,
+        steam_config=steam_config,
+        sgdb_adapter=sgdb_adapter,
+        cover_art_file_store=cover_art_file_store,
+        sgdb_artwork_cache=sgdb_artwork_cache,
+        download_file_store=download_file_store,
+        firmware_file_store=firmware_file_store,
+        migration_file_store=migration_file_store,
+        rom_file_store=rom_file_store,
+        save_file_store=save_file_store,
+        path_probe=path_probe,
+        core_info_provider=core_resolver,
+        renderer_rss=renderer_rss,
+        renderer_gc=renderer_gc,
+        game_process=game_process,
+        resolve_upload_conflict=resolve_upload_conflict,
+    )
+    stores = StateBundle(
+        settings=settings,
+    )
+    callbacks = CallbackBundle(
+        retrodeck_paths=retrodeck_paths,
+        get_save_layout=retroarch_config.get_save_layout,
+        get_core_name=retroarch_core_info.get_corename,
+        platform_core_reader=platform_core_reader,
+        m3u_support=core_resolver.system_supports_m3u,
+        system_extensions=core_resolver.get_supported_extensions,
+        list_rom_dir_files=download_file_store.list_files,
+        settings_persister=settings_persister,
+        log_debug=debug_logger,
+        plugin_metadata=plugin_metadata,
+        uow_factory=uow_factory,
+    )
+    runtime_adapters = RuntimeAdaptersBundle(
+        clock=clock,
+        uuid_gen=uuid_gen,
+        sleeper=sleeper,
+        hostname_provider=hostname_provider,
+        machine_id_provider=machine_id_provider,
+    )
+    handles = BootstrapHandles(debug_logger=debug_logger, persistence=persistence)
+
+    return BootstrapResult(
+        adapters=adapters,
+        stores=stores,
+        callbacks=callbacks,
+        runtime_adapters=runtime_adapters,
+        handles=handles,
+    )

--- a/py_modules/bootstrap/services.py
+++ b/py_modules/bootstrap/services.py
@@ -1,56 +1,20 @@
-"""Composition root — instantiates adapters and wires services.
+"""Service half of the composition root — bundles in, live services out.
 
-Adapter construction lives here so ``main.py`` only deals with the
-Decky lifecycle and the callable surface. ``bootstrap()`` also loads
-and migrates settings as part of adapter wiring so adapters that bind
-a live mutable settings dict (such as ``RommHttpAdapter``) bind the
-migrated dict in a single pass; that same dict is returned for the
-caller to keep as its source of truth.
+Service construction is separated from adapter construction because it
+needs runtime state only ``main.py`` can supply (the event loop,
+``decky.emit``) plus plugin state that exists once ``bootstrap()`` has
+run. Services never reach each other by import: every cross-service
+reference is threaded through a ``*ServiceConfig`` here, or deferred
+through a ``LateBinding`` when the two constructors form a cycle.
 """
 
 from __future__ import annotations
 
-import functools
 import os
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from adapters.asyncio_sleeper import AsyncioSleeper
-from adapters.cover_art_file_store import CoverArtFileStoreAdapter
-from adapters.debug_logger import SettingsAwareDebugLogger
-from adapters.download_file import DownloadFileAdapter
-from adapters.es_de_config import CoreResolver
-from adapters.firmware_file import FirmwareFileAdapter
-from adapters.game_process import GameProcessAdapter
-from adapters.gavel_native import GavelNativeAdapter
-from adapters.hostname import HostnameAdapter
-from adapters.machine_id import MachineIdAdapter
-from adapters.migration_file import MigrationFileAdapter
-from adapters.path_probe import PathProbeAdapter
-from adapters.persistence import (
-    PersistenceAdapter,
-    PlatformCoreReaderAdapter,
-    SettingsPersisterAdapter,
-)
-from adapters.plugin_metadata import PluginMetadataAdapter
-from adapters.renderer_gc import RendererGcAdapter
-from adapters.renderer_rss import RendererRssAdapter
-from adapters.repositories.unit_of_work import SqliteUnitOfWork
-from adapters.retroarch_config import RetroArchConfigAdapter
-from adapters.retroarch_core_info import RetroArchCoreInfoAdapter
-from adapters.retrodeck_paths import RetroDeckPathsAdapter
-from adapters.rom_files import RomFileAdapter
-from adapters.romm.http import RommHttpAdapter
-from adapters.romm.romm_api import RommApiAdapter
-from adapters.save_file import SaveFileAdapter
-from adapters.sgdb_artwork_cache import SgdbArtworkCacheAdapter
-from adapters.sqlite_migrations import MIGRATIONS_DIR, apply_migrations
-from adapters.steam_config import SteamConfigAdapter
-from adapters.steamgriddb import SteamGridDbAdapter
-from adapters.system_clock import SystemClock
-from adapters.system_uuid_gen import SystemUuidGen
 from domain.shortcut_data import RETRODECK_APP_ID
-from domain.state_migrations import fold_legacy_save_sync_settings, migrate_settings
 from lib.late_binding import LateBinding
 from services.achievements import AchievementsService, AchievementsServiceConfig
 from services.active_core_resolver import ActiveCoreResolver, ActiveCoreResolverConfig
@@ -79,165 +43,11 @@ from services.steamgrid import SteamGridService, SteamGridServiceConfig
 from services.version_switch import VersionSwitchService, VersionSwitchServiceConfig
 
 if TYPE_CHECKING:
-    import asyncio
-    import logging
     from typing import Any
 
-    from services.protocols import (
-        Clock,
-        CoreInfoProvider,
-        CoreNameProviderFn,
-        CoverArtFileStore,
-        DebugLogger,
-        DirectoryFileListerFn,
-        DownloadFileStore,
-        EventEmitter,
-        FirmwareFileStore,
-        GameProcessControl,
-        HostnameReader,
-        InstalledRomRemoverFn,
-        MachineIdReader,
-        MigrationFileStore,
-        PathExistsReader,
-        PlatformCoreReader,
-        PluginMetadataReader,
-        RendererGcFn,
-        RendererRssFn,
-        ResolveUploadConflictFn,
-        RetroArchSaveLayoutProvider,
-        RetroDeckPaths,
-        RomFileStore,
-        RommApi,
-        SaveFileStore,
-        SettingsPersister,
-        SgdbArtworkCache,
-        Sleeper,
-        SteamConfigStore,
-        SystemM3uSupportFn,
-        SystemSupportedExtensionsFn,
-        UnitOfWorkFactory,
-        UuidGen,
-    )
+    from services.protocols import InstalledRomRemoverFn
 
-# Filename of the SQLite database inside the plugin runtime dir. Created by the
-# migration runner at startup; unused until the service cutover (#784).
-_DB_FILENAME = "romm_sync.db"
-
-
-@dataclass(frozen=True)
-class AdapterBundle:
-    """Concrete I/O adapters wired into services."""
-
-    http_adapter: RommHttpAdapter
-    romm_api: RommApi
-    steam_config: SteamConfigStore
-    sgdb_adapter: SteamGridDbAdapter
-    cover_art_file_store: CoverArtFileStore
-    sgdb_artwork_cache: SgdbArtworkCache
-    download_file_store: DownloadFileStore
-    firmware_file_store: FirmwareFileStore
-    migration_file_store: MigrationFileStore
-    rom_file_store: RomFileStore
-    save_file_store: SaveFileStore
-    path_probe: PathExistsReader
-    core_info_provider: CoreInfoProvider
-    renderer_rss: RendererRssFn
-    renderer_gc: RendererGcFn
-    game_process: GameProcessControl
-    resolve_upload_conflict: ResolveUploadConflictFn
-
-
-@dataclass(frozen=True)
-class StateBundle:
-    """Live mutable state shared across services."""
-
-    settings: dict[str, Any]
-
-
-@dataclass(frozen=True)
-class RuntimeBundle:
-    """Process-level runtime infrastructure (event loop, logger, paths, time/UUID/sleep seams)."""
-
-    loop: asyncio.AbstractEventLoop
-    logger: logging.Logger
-    plugin_dir: str
-    runtime_dir: str
-    emit: EventEmitter
-    clock: Clock
-    uuid_gen: UuidGen
-    sleeper: Sleeper
-    hostname_provider: HostnameReader
-    machine_id_provider: MachineIdReader
-
-
-@dataclass(frozen=True)
-class CallbackBundle:
-    """Provider callables and persister Protocols injected into services."""
-
-    retrodeck_paths: RetroDeckPaths
-    get_save_layout: RetroArchSaveLayoutProvider
-    get_core_name: CoreNameProviderFn
-    platform_core_reader: PlatformCoreReader
-    m3u_support: SystemM3uSupportFn
-    system_extensions: SystemSupportedExtensionsFn
-    list_rom_dir_files: DirectoryFileListerFn
-    settings_persister: SettingsPersister
-    log_debug: DebugLogger
-    plugin_metadata: PluginMetadataReader
-    uow_factory: UnitOfWorkFactory
-
-
-@dataclass(frozen=True)
-class RuntimeAdaptersBundle:
-    """Concrete adapters for the Clock/UuidGen/Sleeper/HostnameReader/MachineIdReader seams.
-
-    Bootstrap owns adapter instantiation, but the ``RuntimeBundle``
-    handed to ``wire_services`` also needs runtime-only state ``main.py``
-    introduces (the ``asyncio`` loop, ``decky.emit``). This sub-bundle
-    carries the seams bootstrap builds so ``main.py`` can compose the
-    final ``RuntimeBundle`` without instantiating any adapters itself.
-    """
-
-    clock: Clock
-    uuid_gen: UuidGen
-    sleeper: Sleeper
-    hostname_provider: HostnameReader
-    machine_id_provider: MachineIdReader
-
-
-@dataclass(frozen=True)
-class BootstrapHandles:
-    """Bootstrap outputs ``main.py`` needs that don't fit the wiring bundles.
-
-    Anything ``Plugin`` itself binds (not the services) lives here:
-    the debug logger forwarded by ``Plugin._log_debug`` and the
-    persistence adapter ``Plugin`` holds for disk-touching callable paths
-    that bypass a service. The bundles already cover everything passed to
-    ``wire_services``; this struct keeps those Plugin-only handles typed
-    instead of returning them via the untyped dict shape of yore.
-    """
-
-    debug_logger: DebugLogger
-    persistence: PersistenceAdapter
-
-
-@dataclass(frozen=True)
-class BootstrapResult:
-    """Typed return shape for :func:`bootstrap`.
-
-    The four bundles carry every Protocol-typed seam and live state
-    dict that services need; :attr:`handles` carries the small set of
-    raw outputs only ``main.py`` itself binds (debug logger). Together
-    they replace the historical untyped ``dict`` return so every
-    consumer is caught by basedpyright instead of failing silently at
-    runtime on a typo.
-    """
-
-    adapters: AdapterBundle
-    stores: StateBundle
-    callbacks: CallbackBundle
-    runtime_adapters: RuntimeAdaptersBundle
-    handles: BootstrapHandles
+    from .adapters import AdapterBundle, CallbackBundle, RuntimeBundle, StateBundle
 
 
 @dataclass(frozen=True)
@@ -256,179 +66,6 @@ class WiringConfig:
     min_required_version: tuple[int, ...]
 
 
-def bootstrap(
-    *,
-    settings_dir: str,
-    runtime_dir: str,
-    plugin_dir: str,
-    user_home: str,
-    logger: logging.Logger,
-) -> BootstrapResult:
-    """Build every adapter and bundle the composition root hands to ``main.py``.
-
-    Bootstrap owns adapter instantiation and is the only path that
-    constructs ``PersistenceAdapter``. Settings are loaded + migrated
-    inside here so the ``SettingsPersisterAdapter`` binds the live dict
-    at construction; mutating that dict from the caller side is visible
-    to every adapter/service that holds the same reference.
-
-    Parameters
-    ----------
-    settings_dir:
-        ``decky.DECKY_PLUGIN_SETTINGS_DIR``
-    runtime_dir:
-        ``decky.DECKY_PLUGIN_RUNTIME_DIR``
-    plugin_dir:
-        ``decky.DECKY_PLUGIN_DIR``
-    user_home:
-        ``decky.DECKY_USER_HOME`` — base for RetroDECK and Steam path lookups.
-    logger:
-        ``decky.logger``
-
-    Returns
-    -------
-    :class:`BootstrapResult`
-        Typed bundles consumed by ``wire_services`` (``adapters``,
-        ``stores``, ``callbacks``) plus the small set of Plugin-only
-        handles ``main.py`` itself binds (``handles.debug_logger``).
-    """
-    # Bring the on-disk SQLite schema up to date before any service is wired —
-    # the composition root owns startup infra. Post-cutover (#784) SQLite is the
-    # sole persistence backend: there is no JSON fallback, so a failed or
-    # unopenable database is fatal. Log the cause, then re-raise so bootstrap
-    # aborts and the plugin stays inert — matching the RomM-minimum-version
-    # gate's "inert until the environment is fixed" posture.
-    db_path = os.path.join(runtime_dir, _DB_FILENAME)
-    try:
-        apply_migrations(db_path, MIGRATIONS_DIR, logger=logger)
-    except Exception:
-        logger.exception("SQLite schema migration failed; plugin cannot start")
-        raise
-
-    # The runtime Unit-of-Work factory: each call opens a fresh sync sqlite3
-    # connection on db_path (ADR-0004). Wired here but not yet threaded into any
-    # service config — the service cutover (#784) consumes it.
-    uow_factory: UnitOfWorkFactory = functools.partial(SqliteUnitOfWork, db_path)
-
-    retrodeck_paths = RetroDeckPathsAdapter(user_home=user_home, logger=logger)
-    retroarch_config = RetroArchConfigAdapter(user_home=user_home, logger=logger)
-    retroarch_core_info = RetroArchCoreInfoAdapter(user_home=user_home, logger=logger)
-    core_resolver = CoreResolver(
-        plugin_dir=plugin_dir,
-        logger=logger,
-        user_home=user_home,
-    )
-
-    # SystemClock is dependency-free; construct it here so the single shared
-    # instance threads into PersistenceAdapter (corrupt-settings backup stamp)
-    # and every later seam (uuid_gen/sleeper neighbours, runtime bundle).
-    clock = SystemClock()
-    persistence = PersistenceAdapter(settings_dir, runtime_dir, logger, clock=clock)
-    settings = persistence.load_settings()
-    # One-time JSON→JSON lift (ADR-0003): fold the legacy save-sync knobs +
-    # device_name out of save_sync_state.json before the schema bump stamps
-    # version 4. Idempotent — after the first run save_settings stamps the
-    # new version and this branch is skipped.
-    if settings.get("version", 0) < 4:
-        settings = fold_legacy_save_sync_settings(settings, persistence.load_save_sync_state())
-    settings = migrate_settings(settings)
-    # If load_settings quarantined a corrupt file this boot, fold the reset into
-    # the settings dict as a persistent marker. Set AFTER migration and BEFORE
-    # the save so it lands in the fresh settings.json and survives a plugin
-    # reload — the frontend surfaces it as a banner (QAM + game detail) until the
-    # next successful sign-in clears it (ConnectionService pops it on persist).
-    if persistence.corrupt_reset is not None:
-        settings["_settings_reset_notice"] = {"backed_up_to": persistence.corrupt_reset["backed_up_to"]}
-    persistence.save_settings(settings)
-    settings_persister = SettingsPersisterAdapter(persistence, settings)
-    # Binds the same live settings dict so the per-platform-core fan-out resolves
-    # the freshly-written value, not a snapshot.
-    platform_core_reader = PlatformCoreReaderAdapter(settings)
-    plugin_metadata = PluginMetadataAdapter()
-    # Single source of truth for outgoing User-Agent — read package.json
-    # version once at boot and thread the string to every HTTP-talking
-    # adapter. Bot Fight Mode on Cloudflare blocks the default
-    # ``Python-urllib`` UA before requests reach self-hosted RomM (#249).
-    user_agent = f"decky-romm-sync/{plugin_metadata.read_version(plugin_dir)}"
-    http_adapter = RommHttpAdapter(settings, plugin_dir, logger, user_agent)
-    romm_api = RommApiAdapter(http_adapter)
-    steam_config = SteamConfigAdapter(user_home=user_home, logger=logger)
-    sgdb_adapter = SteamGridDbAdapter(settings=settings, logger=logger, user_agent=user_agent)
-    cover_art_file_store = CoverArtFileStoreAdapter()
-    sgdb_artwork_cache = SgdbArtworkCacheAdapter(runtime_dir=runtime_dir)
-    download_file_store = DownloadFileAdapter()
-    firmware_file_store = FirmwareFileAdapter()
-    migration_file_store = MigrationFileAdapter()
-    rom_file_store = RomFileAdapter()
-    save_file_store = SaveFileAdapter(logger=logger)
-    path_probe = PathProbeAdapter()
-    renderer_rss = RendererRssAdapter()
-    renderer_gc = RendererGcAdapter(logger=logger)
-    game_process = GameProcessAdapter()
-    # The compiled gavel core owns the save-sync upload-409 resolution. Loaded
-    # eagerly so a missing / wrong-architecture artifact is fatal here (like the
-    # SQLite migration gate above) rather than surfacing mid-sync — there is no
-    # Python fallback (GavelNativeLoadError propagates, plugin stays inert).
-    resolve_upload_conflict = GavelNativeAdapter()
-    uuid_gen = SystemUuidGen()
-    sleeper = AsyncioSleeper()
-    hostname_provider = HostnameAdapter()
-    machine_id_provider = MachineIdAdapter()
-    debug_logger = SettingsAwareDebugLogger(settings=settings, logger=logger)
-
-    adapters = AdapterBundle(
-        http_adapter=http_adapter,
-        romm_api=romm_api,
-        steam_config=steam_config,
-        sgdb_adapter=sgdb_adapter,
-        cover_art_file_store=cover_art_file_store,
-        sgdb_artwork_cache=sgdb_artwork_cache,
-        download_file_store=download_file_store,
-        firmware_file_store=firmware_file_store,
-        migration_file_store=migration_file_store,
-        rom_file_store=rom_file_store,
-        save_file_store=save_file_store,
-        path_probe=path_probe,
-        core_info_provider=core_resolver,
-        renderer_rss=renderer_rss,
-        renderer_gc=renderer_gc,
-        game_process=game_process,
-        resolve_upload_conflict=resolve_upload_conflict,
-    )
-    stores = StateBundle(
-        settings=settings,
-    )
-    callbacks = CallbackBundle(
-        retrodeck_paths=retrodeck_paths,
-        get_save_layout=retroarch_config.get_save_layout,
-        get_core_name=retroarch_core_info.get_corename,
-        platform_core_reader=platform_core_reader,
-        m3u_support=core_resolver.system_supports_m3u,
-        system_extensions=core_resolver.get_supported_extensions,
-        list_rom_dir_files=download_file_store.list_files,
-        settings_persister=settings_persister,
-        log_debug=debug_logger,
-        plugin_metadata=plugin_metadata,
-        uow_factory=uow_factory,
-    )
-    runtime_adapters = RuntimeAdaptersBundle(
-        clock=clock,
-        uuid_gen=uuid_gen,
-        sleeper=sleeper,
-        hostname_provider=hostname_provider,
-        machine_id_provider=machine_id_provider,
-    )
-    handles = BootstrapHandles(debug_logger=debug_logger, persistence=persistence)
-
-    return BootstrapResult(
-        adapters=adapters,
-        stores=stores,
-        callbacks=callbacks,
-        runtime_adapters=runtime_adapters,
-        handles=handles,
-    )
-
-
 def wire_services(cfg: WiringConfig) -> dict[str, Any]:
     """Create service instances after plugin state is initialised.
 
@@ -438,8 +75,9 @@ def wire_services(cfg: WiringConfig) -> dict[str, Any]:
 
     Returns
     -------
-    dict with keys ``save_sync_service``, ``playtime_service``,
-    ``sync_service``, ``download_service``, and ``firmware_service``.
+    Every wired service, keyed by the attribute name ``Plugin._main()``
+    binds it to. Callers index the keys they need; the mapping is not
+    enumerated here because it grows with the service surface.
     """
 
     # Retry-progress surface (#1345): the RommHttpAdapter runs its retry+backoff

--- a/scripts/check_module_size.py
+++ b/scripts/check_module_size.py
@@ -2,7 +2,7 @@
 """Hold the line on module size: no new god classes, no growth in the old ones.
 
 CLAUDE.md sets a ~700-LOC decomposition threshold for ``services/`` and an
-explicit split trigger for ``bootstrap.py``. Both lived in prose, and prose
+explicit split trigger for ``bootstrap/``. Both lived in prose, and prose
 drifted: ``sync_orchestrator.py`` was 901 lines when #999 wrote it down and is
 past 2000 today. Nothing failed in between, because nothing was watching.
 
@@ -36,18 +36,16 @@ ROOT = pathlib.Path(__file__).resolve().parent.parent
 THRESHOLD = 700
 SLACK_ADVISORY = 50
 
-# Trees and files the threshold governs. ``main.py`` is deliberately absent: it
-# owns the Decky lifecycle plus one ``async def`` per callable, so it grows with
-# the callable surface by design (CLAUDE.md, "Process boundaries").
-SCOPE_DIRS = ("py_modules/services",)
-SCOPE_FILES = ("py_modules/bootstrap.py",)
+# Trees the threshold governs. ``main.py`` is deliberately absent: it owns the
+# Decky lifecycle plus one ``async def`` per callable, so it grows with the
+# callable surface by design (CLAUDE.md, "Process boundaries").
+SCOPE_DIRS = ("py_modules/bootstrap", "py_modules/services")
 
 # Modules that were already over the threshold when this gate landed, each
 # pinned at the size it had that day. Entries come out when the module drops
 # back under the threshold; numbers go down when a refactor banks real slack.
 # A number is never raised — that is the whole point of the gate.
 ALLOWLIST = {
-    "py_modules/bootstrap.py": 844,
     "py_modules/services/artwork.py": 1063,
     "py_modules/services/connection.py": 844,
     "py_modules/services/downloads.py": 1501,
@@ -68,10 +66,6 @@ def in_scope() -> list[pathlib.Path]:
     paths: set[pathlib.Path] = set()
     for directory in SCOPE_DIRS:
         paths.update((ROOT / directory).rglob("*.py"))
-    for filename in SCOPE_FILES:
-        path = ROOT / filename
-        if path.is_file():
-            paths.add(path)
     return sorted(paths)
 
 

--- a/tests/scripts/test_check_module_size.py
+++ b/tests/scripts/test_check_module_size.py
@@ -86,9 +86,9 @@ class TestHappyPath:
         modules = {"py_modules/services/big.py": 900}
         assert run_check(modules, {"py_modules/services/big.py": 900}) == 0
 
-    def test_bootstrap_is_in_scope_via_scope_files(self, run_check, capsys: pytest.CaptureFixture[str]) -> None:
-        assert run_check({"py_modules/bootstrap.py": 900}, {}) == 1
-        assert "py_modules/bootstrap.py: 900 lines exceeds" in capsys.readouterr().err
+    def test_bootstrap_package_is_in_scope_via_scope_dirs(self, run_check, capsys: pytest.CaptureFixture[str]) -> None:
+        assert run_check({"py_modules/bootstrap/services.py": 900}, {}) == 1
+        assert "py_modules/bootstrap/services.py: 900 lines exceeds" in capsys.readouterr().err
 
     def test_main_py_is_out_of_scope(self, run_check) -> None:
         """``main.py`` grows with the callable surface by design — never flagged."""


### PR DESCRIPTION
refactor(bootstrap): split the composition root into adapters and services

`main` went red the moment two PRs landed 16 seconds apart. #1612 added 22
lines of service wiring to `py_modules/bootstrap.py`; #1611 landed the
module-size ratchet with bootstrap's ceiling measured on a branch that
predated it. The two touched different files, so git merged them without a
text conflict and the gate failed on its first run against `main`: 866 lines
against a 844-line ceiling.

Raising the ceiling was never an option — the allowlist only ever gets
shorter, and that property is the whole value of the gate. The rule the module
already carried prescribed the remedy: bootstrap is past the ~700-line split
trigger, so new wiring means splitting it first.

`py_modules/bootstrap.py` is now a package:

- `adapters.py` (388 lines) — the bundle dataclasses and `bootstrap()`, which
  builds every adapter and returns the typed bundles.
- `services.py` (503 lines) — `WiringConfig` and `wire_services()`, which
  turns those bundles into the live service instances.
- `__init__.py` — namespace and re-exports only, so `from bootstrap import …`
  keeps working verbatim for `main.py`, the unit tests, and the contract
  harness. No importer changed.

The move is mechanical: no wiring was added, removed, or reordered, and both
modules land under the 700-line threshold with real headroom.

The gate now governs `py_modules/bootstrap/` as a tree instead of a single
file, and the bootstrap allowlist entry is deleted rather than rewritten —
13 grandfathered modules, now 12. `SCOPE_FILES` goes with it: bootstrap was
its only user, and an extension point kept alive by nothing but its own test
is the kind of unexercised mechanism this gate exists to catch.

The release-zip smoke test lists all three bootstrap modules rather than
following the old single path to `__init__.py`. The package marker is a
re-export shim, so asserting it alone would let a packaging regression that
dropped the composition root's actual code reach a release.

`wire_services()`'s docstring promised five keys and returned twenty-three.
It now states the contract — every wired service, keyed by the attribute
`Plugin._main()` binds it to — rather than an enumeration that rots on the
next service.

