### PR TITLE
fix(launch): read running apps only from SteamUIStore

### DIFF
--- a/docs/adr/0015-single-launch-gate-cancel-then-relaunch.md
+++ b/docs/adr/0015-single-launch-gate-cancel-then-relaunch.md
@@ -8,6 +8,13 @@ portion of [#1144](https://github.com/danielcopper/decky-romm-sync/issues/1144) 
 path in gaming mode — `steam://rungameid` deep links — now funnels through the gate); **desktop-mode** coverage remains
 open there and under [#831](https://github.com/danielcopper/decky-romm-sync/issues/831).
 
+> **Errata (2026-08).** "any Steam running-app source" below overstates what `utils/runningApps` consulted. Two of its
+> three sources — `Router.MainRunningApp` and `Router.RunningApps` — were read as page globals that no SteamUI build
+> defines, so they never reported anything and were removed in
+> [#1588](https://github.com/danielcopper/decky-romm-sync/issues/1588). The already-running guard was decided by
+> `SteamUIStore.RunningApps` alone from the start; the decision and the guard's behaviour are unchanged. Corrected
+> model: [Running-app detection](../architecture/save-file-sync-architecture.md#running-app-detection-utilsrunningapps).
+
 ## Context
 
 A RomM ROM can be launched two ways in Steam gaming mode, and today they behave inconsistently:

--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -1533,14 +1533,14 @@ only on `error` (ADR-0018).
 the next game-stop with nothing to finalize — the pre-reload playtime is lost and the post-exit sync never runs. Two
 signals let the re-initialized `sessionManager` recover it:
 
-- **Steam running-state (liveness).** A defensive multi-source reader (`utils/runningApps`) is the authority for
-  _whether_ the game is still running at re-init — the durable marker (`last_session_start`) is written by
-  `recordSessionStart` precisely so it survives the reload, but only Steam can attest the session has not already ended.
-  No single Steam surface is trusted: `Router.MainRunningApp` never repopulates after a full `plugin_loader` restart
-  without a fresh lifecycle event the reloaded context missed (#1054 / #1148 round 2), so the reader also consults the
-  running-apps lists (`Router.RunningApps`, `SteamUIStore.RunningApps`), each through a guard, merged + de-duped. This
-  read is **polled** (every 500ms for up to 15s), not one-shot, and a timed-out round logs the per-source `diagnostics`
-  so the on-device log names the surface that actually works on a given build.
+- **Steam running-state (liveness).** A guarded reader (`utils/runningApps`) is the authority for _whether_ the game is
+  still running at re-init — the durable marker (`last_session_start`) is written by `recordSessionStart` precisely so
+  it survives the reload, but only Steam can attest the session has not already ended. Its one surface is
+  `SteamUIStore.RunningApps`, read through a guard (an absent store, a `null` store or a throwing getter degrades to
+  "nothing running", never a throw). A single read is not trusted: after a full `plugin_loader` restart the store
+  reports an **empty** list for several seconds with the game still running (#1054 / #1148 round 2), so the read is
+  **polled** (every 500ms for up to 15s), not one-shot, and a timed-out round logs the `diagnostics` note that tells an
+  absent store, an empty list and a throwing getter apart.
 - **A localStorage breadcrumb (attestation).** A single versioned row (`decky-romm-sync:active-session` →
   `{v, appId, romId, startMs}`) is written at start and removed at stop. It is **not** cleared by
   `destroySessionManager`, so it outlives the reload. Every localStorage access is wrapped — a storage failure degrades
@@ -1710,15 +1710,18 @@ The callback receives:
 ### Running-app detection (`utils/runningApps`)
 
 After a game starts, there is a brief window where the app ID may not be fully resolved. The session manager waits 500ms
-and then reads the defensive running-app reader for a reliable `appid` and `display_name`, falling back to `unAppID`
-from the notification if nothing is reported. The reader consults MULTIPLE Steam surfaces — `Router.MainRunningApp` plus
-the `Router.RunningApps` / `SteamUIStore.RunningApps` lists — each through a guard (an absent, `null`, or
-throwing-getter surface degrades to "reported nothing", never a throw), merges them into one de-duped list, and returns
-a per-source `diagnostics` string. No single surface is reliable across builds/timing: after a `plugin_loader` restart
-`Router.MainRunningApp` stays null for several seconds and never repopulates without a fresh lifecycle event (#1054 /
-\#1148 round 2), so the adoption path **polls** the reader (every 500ms up to 15s) instead of reading one surface once,
-and a failed round logs what every candidate reported. The same reader backs the already-running skip on both launch
-surfaces — the interceptor and the Play button ([ADR-0015](../adr/0015-single-launch-gate-cancel-then-relaunch.md)).
+and then reads the guarded running-app reader for a reliable `appid` and `display_name`, falling back to `unAppID` from
+the notification if nothing is reported. The reader has one surface, `SteamUIStore.RunningApps` — the only running-app
+page global Steam actually exposes, and there is no second one to add: `Router` is not a page global on any SteamUI
+build, and `@decky/ui`'s `Router` export resolves to the same `SteamUIStore` singleton (#1588). It is read through a
+guard (an absent, `null`, or throwing-getter store degrades to "reported nothing", never a throw) and returns a
+`diagnostics` string distinguishing absent / empty / threw / the appids found. The list's head is the foreground app —
+Steam derives `RunningApps` and its own `MainRunningApp` from one private array, with `MainRunningApp` defined as
+`RunningApps[0]` — so no second surface is needed to identify it. The store is not reliable across timing, though: after
+a `plugin_loader` restart it reports an empty list for several seconds while the game runs (#1054 / #1148 round 2), so
+the adoption path **polls** the reader (every 500ms up to 15s) instead of reading once, and a failed round logs what the
+store reported. The same reader backs the already-running skip on both launch surfaces — the interceptor and the Play
+button ([ADR-0015](../adr/0015-single-launch-gate-cancel-then-relaunch.md)).
 
 ### State-aware Resume button (#1313)
 

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -177,7 +177,6 @@ vi.mock("@decky/ui", () => {
     // against behavior the real UI does not have.
     MenuItem: ({ children, onClick, disabled }: AnyProps) =>
       createElement("button", { type: "button", onClick, disabled }, children as never),
-    Router: { CloseSideMenus: vi.fn(), Navigate: vi.fn() },
     Navigation: { NavigateToExternalWeb: vi.fn(), Navigate: vi.fn() },
     // findSP locates Steam's <SteamRoot> iframe document for stylesheet
     // injection. Tests run in happy-dom — no Steam, no iframe — so the

--- a/src/types/steam.d.ts
+++ b/src/types/steam.d.ts
@@ -121,18 +121,10 @@ declare var appStore: {
   allApps: SteamAppOverview[];
 };
 
-// Running-app surfaces read by the defensive `utils/runningApps` reader. Steam SP
-// globals — genuinely absent (hence `undefined`) or `null` on some builds/timing,
-// so every read guards. `RunningApps` is optional: present only on builds that
-// expose it (Router.MainRunningApp stays authoritative for the foreground app).
-declare var Router:
-  | {
-      MainRunningApp: SteamAppOverview | null;
-      RunningApps?: SteamAppOverview[];
-    }
-  | null
-  | undefined;
-
+// `SteamUIStore` — a Steam SP global, genuinely absent (hence `undefined`) or
+// `null` on some builds/timing, so every read guards. `RunningApps` is optional
+// for the same reason; it is the running-app surface behind `utils/runningApps`,
+// and its head is the foreground app (Steam's `MainRunningApp` is `RunningApps[0]`).
 declare var SteamUIStore:
   | {
       RunningApps?: SteamAppOverview[];

--- a/src/utils/runningApps.test.ts
+++ b/src/utils/runningApps.test.ts
@@ -1,107 +1,111 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { readRunningApps, readPrimaryRunningApp, isAppRunning } from "./runningApps";
+import { readRunningApps, readPrimaryRunningApp, isAppRunning, isAnyAppRunning } from "./runningApps";
 
-// The util reads bare Steam SP globals (`Router`, `SteamUIStore`). Each test
-// stubs only the surfaces it exercises; the global afterEach in test-setup.ts
-// runs vi.unstubAllGlobals(), so an unstubbed global reads as truly absent
+// The util reads the bare Steam SP global `SteamUIStore`. Each test stubs only
+// what it exercises; the global afterEach in test-setup.ts runs
+// vi.unstubAllGlobals(), so an unstubbed global reads as truly absent
 // (`typeof X === "undefined"`) rather than leaking across tests.
 
-describe("runningApps — defensive multi-source detection", () => {
+describe("runningApps — guarded SteamUIStore reader", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   describe("readRunningApps", () => {
-    it("reads Router.MainRunningApp as the primary source", () => {
-      vi.stubGlobal("Router", { MainRunningApp: { appid: 100, display_name: "Game" } });
+    it("reads the running apps the store reports", () => {
+      vi.stubGlobal("SteamUIStore", { RunningApps: [{ appid: 42, display_name: "Zelda" }] });
 
       const { apps, diagnostics } = readRunningApps();
-      expect(apps).toEqual([{ appid: 100, display_name: "Game" }]);
-      expect(diagnostics).toContain("Router.MainRunningApp=appid=100");
+      expect(apps).toEqual([{ appid: 42, display_name: "Zelda" }]);
+      expect(diagnostics).toBe("SteamUIStore.RunningApps=[42]");
     });
 
-    it("reports null when Router.MainRunningApp is null and finds nothing", () => {
-      vi.stubGlobal("Router", { MainRunningApp: null });
-
-      const { apps, diagnostics } = readRunningApps();
-      expect(apps).toEqual([]);
-      expect(diagnostics).toContain("Router.MainRunningApp=null");
-    });
-
-    it("reports no-Router when the global is absent, without throwing", () => {
-      // Router intentionally not stubbed — a bare `=== undefined` would throw
-      // ReferenceError; the util's typeof guard degrades to a note instead.
-      const { apps, diagnostics } = readRunningApps();
-      expect(apps).toEqual([]);
-      expect(diagnostics).toContain("Router.MainRunningApp=no-Router");
-      expect(diagnostics).toContain("SteamUIStore.RunningApps=no-store");
-    });
-
-    it("reads Router.RunningApps as a list source", () => {
-      vi.stubGlobal("Router", {
-        MainRunningApp: null,
+    it("preserves store order, so the foreground app stays first", () => {
+      // Steam derives RunningApps from one m_runningAppIDs array whose head is
+      // MainRunningApp — the reader must not reorder it.
+      vi.stubGlobal("SteamUIStore", {
         RunningApps: [
-          { appid: 5, display_name: "A" },
-          { appid: 6, strDisplayName: "B" },
+          { appid: 100, display_name: "Foreground" },
+          { appid: 200, display_name: "Background" },
         ],
       });
 
       const { apps, diagnostics } = readRunningApps();
       expect(apps).toEqual([
-        { appid: 5, display_name: "A" },
-        { appid: 6, display_name: "B" },
+        { appid: 100, display_name: "Foreground" },
+        { appid: 200, display_name: "Background" },
       ]);
-      expect(diagnostics).toContain("Router.RunningApps=[5,6]");
+      expect(diagnostics).toBe("SteamUIStore.RunningApps=[100,200]");
     });
 
-    it("reads SteamUIStore.RunningApps as a list source", () => {
-      vi.stubGlobal("SteamUIStore", { RunningApps: [{ appid: 42, display_name: "Zelda" }] });
+    it("falls back to strDisplayName when display_name is absent", () => {
+      vi.stubGlobal("SteamUIStore", { RunningApps: [{ appid: 6, strDisplayName: "B" }] });
+
+      expect(readRunningApps().apps).toEqual([{ appid: 6, display_name: "B" }]);
+    });
+
+    it("keeps a nameless entry with an empty display_name rather than dropping it", () => {
+      // The appid is what every consumer matches on; a missing name must not
+      // make a genuinely running app invisible.
+      vi.stubGlobal("SteamUIStore", { RunningApps: [{ appid: 8 }] });
+
+      expect(readRunningApps().apps).toEqual([{ appid: 8, display_name: "" }]);
+    });
+
+    it("reports an empty list as empty — a running game may still be up (post-restart window)", () => {
+      vi.stubGlobal("SteamUIStore", { RunningApps: [] });
 
       const { apps, diagnostics } = readRunningApps();
-      expect(apps).toEqual([{ appid: 42, display_name: "Zelda" }]);
-      expect(diagnostics).toContain("SteamUIStore.RunningApps=[42]");
+      expect(apps).toEqual([]);
+      expect(diagnostics).toBe("SteamUIStore.RunningApps=empty");
     });
 
-    it("merges + de-dupes across sources, MainRunningApp first", () => {
-      vi.stubGlobal("Router", {
-        MainRunningApp: { appid: 100, display_name: "Main" },
-        RunningApps: [{ appid: 100, display_name: "dup" }],
-      });
-      vi.stubGlobal("SteamUIStore", { RunningApps: [{ appid: 200, display_name: "Second" }] });
+    it("reports absent when the store exposes no RunningApps property", () => {
+      vi.stubGlobal("SteamUIStore", { SetRunningApp: vi.fn() });
 
-      const { apps } = readRunningApps();
-      // 100 de-duped (MainRunningApp wins first-writer), 200 appended.
-      expect(apps).toEqual([
-        { appid: 100, display_name: "Main" },
-        { appid: 200, display_name: "Second" },
-      ]);
+      const { apps, diagnostics } = readRunningApps();
+      expect(apps).toEqual([]);
+      expect(diagnostics).toBe("SteamUIStore.RunningApps=absent");
     });
 
-    it("tolerates a throwing MainRunningApp getter and still reads other sources", () => {
-      vi.stubGlobal("Router", {
-        get MainRunningApp() {
+    it("reports no-store when the global is absent, without throwing", () => {
+      // SteamUIStore intentionally not stubbed — a bare `=== undefined` would
+      // throw ReferenceError; the util's typeof guard degrades to a note instead.
+      const { apps, diagnostics } = readRunningApps();
+      expect(apps).toEqual([]);
+      expect(diagnostics).toBe("SteamUIStore.RunningApps=no-store");
+    });
+
+    it("reports no-store when the global is null", () => {
+      vi.stubGlobal("SteamUIStore", null);
+
+      const { apps, diagnostics } = readRunningApps();
+      expect(apps).toEqual([]);
+      expect(diagnostics).toBe("SteamUIStore.RunningApps=no-store");
+    });
+
+    it("tolerates a throwing RunningApps getter and names it in the diagnostics", () => {
+      vi.stubGlobal("SteamUIStore", {
+        get RunningApps(): unknown {
           throw new Error("bridge fault");
         },
-        RunningApps: [{ appid: 7, display_name: "Survivor" }],
-      });
-
-      const { apps, diagnostics } = readRunningApps();
-      expect(apps).toEqual([{ appid: 7, display_name: "Survivor" }]);
-      expect(diagnostics).toContain("Router.MainRunningApp=threw:");
-    });
-
-    it("drops entries without a numeric appid and reports an empty list", () => {
-      vi.stubGlobal("Router", {
-        MainRunningApp: null,
-        RunningApps: [{ display_name: "no id" }, 42, null],
       });
 
       const { apps, diagnostics } = readRunningApps();
       expect(apps).toEqual([]);
-      expect(diagnostics).toContain("Router.RunningApps=empty");
+      expect(diagnostics).toContain("SteamUIStore.RunningApps=threw:");
+      expect(diagnostics).toContain("bridge fault");
     });
 
-    it("coerces a non-array iterable (MobX-style observable) source", () => {
+    it("drops entries without a numeric appid and reports an empty list", () => {
+      vi.stubGlobal("SteamUIStore", { RunningApps: [{ display_name: "no id" }, 42, null] });
+
+      const { apps, diagnostics } = readRunningApps();
+      expect(apps).toEqual([]);
+      expect(diagnostics).toBe("SteamUIStore.RunningApps=empty");
+    });
+
+    it("coerces a non-array iterable (MobX-style observable)", () => {
       const observable = {
         *[Symbol.iterator]() {
           yield { appid: 11, display_name: "Obs" };
@@ -109,50 +113,89 @@ describe("runningApps — defensive multi-source detection", () => {
       };
       vi.stubGlobal("SteamUIStore", { RunningApps: observable });
 
-      const { apps } = readRunningApps();
+      const { apps, diagnostics } = readRunningApps();
       expect(apps).toEqual([{ appid: 11, display_name: "Obs" }]);
+      expect(diagnostics).toBe("SteamUIStore.RunningApps=[11]");
     });
 
-    it("reports absent for a missing list property", () => {
-      vi.stubGlobal("Router", { MainRunningApp: null });
+    it("reports empty for a present but non-list value", () => {
+      vi.stubGlobal("SteamUIStore", { RunningApps: 7 as unknown as SteamAppOverview[] });
 
-      const { diagnostics } = readRunningApps();
-      expect(diagnostics).toContain("Router.RunningApps=absent");
+      const { apps, diagnostics } = readRunningApps();
+      expect(apps).toEqual([]);
+      expect(diagnostics).toBe("SteamUIStore.RunningApps=empty");
     });
   });
 
   describe("readPrimaryRunningApp", () => {
-    it("returns the first running app and the round diagnostics", () => {
-      vi.stubGlobal("Router", { MainRunningApp: { appid: 100, display_name: "Game" } });
+    it("returns the head of the store's list — the foreground app — plus the diagnostics", () => {
+      vi.stubGlobal("SteamUIStore", {
+        RunningApps: [
+          { appid: 100, display_name: "Foreground" },
+          { appid: 200, display_name: "Background" },
+        ],
+      });
 
       const { app, diagnostics } = readPrimaryRunningApp();
-      expect(app).toEqual({ appid: 100, display_name: "Game" });
-      expect(diagnostics).toContain("Router.MainRunningApp=appid=100");
+      expect(app).toEqual({ appid: 100, display_name: "Foreground" });
+      expect(diagnostics).toBe("SteamUIStore.RunningApps=[100,200]");
     });
 
-    it("returns null when no source reports a running app", () => {
-      vi.stubGlobal("Router", { MainRunningApp: null });
+    it("returns null when the store reports nothing running", () => {
+      vi.stubGlobal("SteamUIStore", { RunningApps: [] });
 
       expect(readPrimaryRunningApp().app).toBeNull();
+    });
+
+    it("returns null and does not throw when the store is absent", () => {
+      expect(readPrimaryRunningApp()).toEqual({ app: null, diagnostics: "SteamUIStore.RunningApps=no-store" });
     });
   });
 
   describe("isAppRunning", () => {
-    it("is true when the appId is reported by any source", () => {
-      vi.stubGlobal("Router", { MainRunningApp: null });
+    it("is true when the appId is reported by the store", () => {
       vi.stubGlobal("SteamUIStore", { RunningApps: [{ appid: 100, display_name: "Game" }] });
 
       expect(isAppRunning(100)).toBe(true);
     });
 
-    it("is false when no source reports the appId", () => {
-      vi.stubGlobal("Router", { MainRunningApp: { appid: 999, display_name: "Other" } });
+    it("is true for a background entry, not just the foreground one", () => {
+      vi.stubGlobal("SteamUIStore", {
+        RunningApps: [
+          { appid: 999, display_name: "Foreground" },
+          { appid: 100, display_name: "Background" },
+        ],
+      });
+
+      expect(isAppRunning(100)).toBe(true);
+    });
+
+    it("is false when the store reports a different appId", () => {
+      vi.stubGlobal("SteamUIStore", { RunningApps: [{ appid: 999, display_name: "Other" }] });
 
       expect(isAppRunning(100)).toBe(false);
     });
 
-    it("is false and does not throw when every source is absent", () => {
+    it("is false and does not throw when the store is absent", () => {
       expect(isAppRunning(100)).toBe(false);
+    });
+  });
+
+  describe("isAnyAppRunning", () => {
+    it("is true when the store reports any running app", () => {
+      vi.stubGlobal("SteamUIStore", { RunningApps: [{ appid: 100, display_name: "Game" }] });
+
+      expect(isAnyAppRunning()).toBe(true);
+    });
+
+    it("is false when the store reports an empty list", () => {
+      vi.stubGlobal("SteamUIStore", { RunningApps: [] });
+
+      expect(isAnyAppRunning()).toBe(false);
+    });
+
+    it("is false and does not throw when the store is absent", () => {
+      expect(isAnyAppRunning()).toBe(false);
     });
   });
 });

--- a/src/utils/runningApps.ts
+++ b/src/utils/runningApps.ts
@@ -1,25 +1,25 @@
 /**
  * Defensive running-app detection.
  *
- * Steam surfaces a game's running state through several page globals, and which
- * one is populated depends on the SteamOS build and on timing. After a
- * `plugin_loader` restart `Router.MainRunningApp` stays `null` for the whole
- * adoption window even though a game is running (#1054 / #1148 round 2 device
- * evidence) — it only (re)populates on a fresh lifecycle event, and our reloaded
- * JS context missed the one that started the game. So no single source is
- * trusted: every known surface is read through a guard, the readings merge into
- * one de-duped list, and a round that finds nothing still reports what EVERY
- * candidate returned (`diagnostics`) so the on-device log names the surface that
- * actually works on a given build.
+ * `SteamUIStore.RunningApps` is the running-app surface — a genuine ambient
+ * Steam SP global (declared in `types/steam.d.ts`), and the only one there is.
+ * Do not add a second: `Router` is not a page global on any SteamUI build (this
+ * reader probed it until #1588 and every logged round said `no-Router`), and
+ * `@decky/ui`'s `Router` export resolves to this very `SteamUIStore` singleton,
+ * whose `MainRunningApp` is defined as `RunningApps[0]`.
  *
- * Every read is guarded. The globals are undeclared Steam SP values — a bare
- * reference to a truly-absent one throws `ReferenceError`, so presence is
- * probed with `typeof`; a present one may be `null`, a throwing getter, a plain
- * array, or a MobX observable (array-like/iterable). Any of those degrades to
- * "this source reported nothing", never a throw out of the reader.
+ * The read is still guarded. A bare reference to a truly-absent SP global
+ * throws `ReferenceError`, so presence is probed with `typeof`; a present store
+ * may be `null`, expose a throwing getter, or hand back a plain array or a MobX
+ * observable (array-like/iterable). Any of those degrades to "nothing running",
+ * never a throw out of the reader.
  *
- * `Router` and `SteamUIStore` are the ambient Steam SP globals declared in
- * `types/steam.d.ts`.
+ * The store can also legitimately report EMPTY while a game is running: after a
+ * `plugin_loader` restart the reloaded JS context sees `RunningApps` empty for
+ * several seconds with the game still up (#1054 / #1148 round 2 device
+ * evidence). So a single empty round proves nothing — the adoption path polls,
+ * and every round reports what the store said (`diagnostics`: absent / empty /
+ * threw / the appids found) so the on-device log can tell those cases apart.
  */
 
 export interface RunningApp {
@@ -28,17 +28,13 @@ export interface RunningApp {
 }
 
 export interface RunningAppsReading {
-  /** Running apps merged + de-duped (by `appid`) across every list-shaped source. */
+  /** The running apps the store reported this round, in store order. */
   apps: RunningApp[];
-  /** Per-source diagnostic — what each candidate reported this round. */
+  /** Diagnostic — what the store reported this round. */
   diagnostics: string;
 }
 
-interface SourceReading {
-  label: string;
-  note: string;
-  apps: RunningApp[];
-}
+const SOURCE_LABEL = "SteamUIStore.RunningApps";
 
 /** Coerce one candidate into a {@link RunningApp}, or `null` if it isn't one. */
 function coerceRunningApp(value: unknown): RunningApp | null {
@@ -78,47 +74,7 @@ function coerceRunningAppList(value: unknown): RunningApp[] {
   return apps;
 }
 
-/** `Router.MainRunningApp` — the single foreground app (unreliable post-restart). */
-function readRouterMainRunningApp(): SourceReading {
-  const label = "Router.MainRunningApp";
-  // NOSONAR(typescript:S7741) — Router is an undeclared Steam SP global; a direct
-  // `=== undefined` would throw ReferenceError when it is genuinely absent.
-  if (typeof Router === "undefined" || Router === null) return { label, note: "no-Router", apps: [] };
-  try {
-    const app = coerceRunningApp(Router.MainRunningApp);
-    return { label, note: app ? `appid=${app.appid}` : "null", apps: app ? [app] : [] };
-  } catch (e) {
-    return { label, note: `threw:${e}`, apps: [] };
-  }
-}
-
-/** `Router.RunningApps` — a running-apps array on some Steam builds. */
-function readRouterRunningApps(): SourceReading {
-  const label = "Router.RunningApps";
-  // NOSONAR(typescript:S7741) — see readRouterMainRunningApp.
-  if (typeof Router === "undefined" || Router === null) return { label, note: "no-Router", apps: [] };
-  try {
-    const apps = coerceRunningAppList(Router.RunningApps);
-    return { label, note: describeList(apps, Router.RunningApps), apps };
-  } catch (e) {
-    return { label, note: `threw:${e}`, apps: [] };
-  }
-}
-
-/** `SteamUIStore.RunningApps` — Steam's own UI store of running games. */
-function readSteamUIStoreRunningApps(): SourceReading {
-  const label = "SteamUIStore.RunningApps";
-  // NOSONAR(typescript:S7741) — SteamUIStore is an undeclared Steam SP global.
-  if (typeof SteamUIStore === "undefined" || SteamUIStore === null) return { label, note: "no-store", apps: [] };
-  try {
-    const apps = coerceRunningAppList(SteamUIStore.RunningApps);
-    return { label, note: describeList(apps, SteamUIStore.RunningApps), apps };
-  } catch (e) {
-    return { label, note: `threw:${e}`, apps: [] };
-  }
-}
-
-/** Diagnostic note for a list source — the appids found, or why nothing was. */
+/** Diagnostic note for the list — the appids found, or why none were. */
 function describeList(apps: RunningApp[], raw: unknown): string {
   if (apps.length > 0) return `[${apps.map((a) => a.appid).join(",")}]`;
   if (raw === null || raw === undefined) return "absent";
@@ -126,40 +82,46 @@ function describeList(apps: RunningApp[], raw: unknown): string {
 }
 
 /**
- * Read every running-app source once, merging into a de-duped list plus a
- * per-source diagnostic string. `Router.MainRunningApp` is read first so, when
- * present, it heads the list (the foreground app), but its absence no longer
- * blinds detection — the list sources fill in after a loader restart.
+ * Read `SteamUIStore.RunningApps` once, as a list plus a diagnostic naming what
+ * the store reported. Never throws: an absent store, a `null` store, a throwing
+ * getter and a non-list value all read as "nothing running" with a note saying
+ * which.
  */
 export function readRunningApps(): RunningAppsReading {
-  const sources = [readRouterMainRunningApp(), readRouterRunningApps(), readSteamUIStoreRunningApps()];
-  const merged = new Map<number, RunningApp>();
-  for (const source of sources) {
-    for (const app of source.apps) {
-      if (!merged.has(app.appid)) merged.set(app.appid, app);
-    }
+  // NOSONAR(typescript:S7741) — SteamUIStore is an undeclared Steam SP global; a
+  // direct `=== undefined` would throw ReferenceError when it is genuinely absent.
+  if (typeof SteamUIStore === "undefined" || SteamUIStore === null) {
+    return { apps: [], diagnostics: `${SOURCE_LABEL}=no-store` };
   }
-  return {
-    apps: Array.from(merged.values()),
-    diagnostics: sources.map((s) => `${s.label}=${s.note}`).join(" | "),
-  };
+  try {
+    // One getter read — re-reading for the diagnostic could observe a different
+    // value, or throw outside the coercion it describes.
+    const raw: unknown = SteamUIStore.RunningApps;
+    const apps = coerceRunningAppList(raw);
+    return { apps, diagnostics: `${SOURCE_LABEL}=${describeList(apps, raw)}` };
+  } catch (e) {
+    return { apps: [], diagnostics: `${SOURCE_LABEL}=threw:${e}` };
+  }
 }
 
 /**
- * The primary running app (first source to report one) plus the round's
- * diagnostics. `null` app means no source saw a running app this round.
+ * The foreground running app plus the round's diagnostics. `apps[0]` IS the
+ * foreground app: the store derives both `RunningApps` and `MainRunningApp`
+ * from one private `m_runningAppIDs` array, with `MainRunningApp` defined as
+ * `RunningApps[0]` — so reading the head of the list needs no second Steam
+ * surface. `null` means the store reported no running app this round.
  */
 export function readPrimaryRunningApp(): { app: RunningApp | null; diagnostics: string } {
   const reading = readRunningApps();
   return { app: reading.apps[0] ?? null, diagnostics: reading.diagnostics };
 }
 
-/** Is a specific `appId` currently running per ANY source? Never throws. */
+/** Is a specific `appId` currently running per the store? Never throws. */
 export function isAppRunning(appId: number): boolean {
   return readRunningApps().apps.some((app) => app.appid === appId);
 }
 
-/** Is ANY app currently running per ANY source? Never throws. */
+/** Is ANY app currently running per the store? Never throws. */
 export function isAnyAppRunning(): boolean {
   return readRunningApps().apps.length > 0;
 }

--- a/src/utils/sessionManager.test.ts
+++ b/src/utils/sessionManager.test.ts
@@ -74,6 +74,18 @@ async function initDrainingAdoptionPoll(): Promise<void> {
   await init;
 }
 
+// Liveness comes from `SteamUIStore.RunningApps` — the one running-app surface
+// (#1588). Its head is the foreground app, so a single-entry list seeds a
+// running game and an empty list seeds "the store reports nothing", which is
+// exactly what the post-loader-restart adoption window looks like on-device.
+function stubRunningApp(appid: number, displayName = "Game"): void {
+  vi.stubGlobal("SteamUIStore", { RunningApps: [{ appid, display_name: displayName }] });
+}
+
+function stubNothingRunning(): void {
+  vi.stubGlobal("SteamUIStore", { RunningApps: [] });
+}
+
 // The session manager registers only the lifecycle hook — suspend/resume
 // tracking was removed (#1148: the Steam hooks never fired on-device; playtime
 // now excludes suspend via the backend monotonic clock). Re-stub after the
@@ -290,7 +302,7 @@ describe("sessionManager reload adoption", () => {
 
   it("adopts a matching breadcrumb without re-stamping the marker, then finalizes on stop", async () => {
     seedBreadcrumb({ v: 1, appId: APP_ID, romId: ROM_ID, startMs: 5_000 });
-    vi.stubGlobal("Router", { MainRunningApp: { appid: APP_ID, display_name: "Game" } });
+    stubRunningApp(APP_ID);
 
     await initSessionManager();
 
@@ -306,7 +318,7 @@ describe("sessionManager reload adoption", () => {
   });
 
   it("adopts a running game with no breadcrumb and re-stamps the marker", async () => {
-    vi.stubGlobal("Router", { MainRunningApp: { appid: APP_ID, display_name: "Game" } });
+    stubRunningApp(APP_ID);
 
     await initSessionManager();
 
@@ -320,7 +332,7 @@ describe("sessionManager reload adoption", () => {
   it("adopts and re-stamps when the breadcrumb names a different app than the running game", async () => {
     // Stale breadcrumb for a different app; the running game is authoritative.
     seedBreadcrumb({ v: 1, appId: 555, romId: 99, startMs: 5_000 });
-    vi.stubGlobal("Router", { MainRunningApp: { appid: APP_ID, display_name: "Game" } });
+    stubRunningApp(APP_ID);
 
     await initSessionManager();
 
@@ -332,7 +344,7 @@ describe("sessionManager reload adoption", () => {
 
   it("clears the breadcrumb and does not adopt when nothing is running", async () => {
     seedBreadcrumb({ v: 1, appId: APP_ID, romId: ROM_ID, startMs: 5_000 });
-    vi.stubGlobal("Router", { MainRunningApp: null });
+    stubNothingRunning();
 
     // Nothing ever runs → the poll times out and the breadcrumb is orphan-cleared.
     await initDrainingAdoptionPoll();
@@ -354,7 +366,7 @@ describe("sessionManager reload adoption", () => {
   });
 
   it("does not adopt when a non-RomM app is running", async () => {
-    vi.stubGlobal("Router", { MainRunningApp: { appid: 999, display_name: "Other" } });
+    stubRunningApp(999, "Other");
 
     await initSessionManager();
 
@@ -366,7 +378,7 @@ describe("sessionManager reload adoption", () => {
   });
 
   it("leaves no breadcrumb after a normal start then stop", async () => {
-    vi.stubGlobal("Router", { MainRunningApp: null });
+    stubNothingRunning();
     await initDrainingAdoptionPoll();
     const lifetime = captureLifetimeCb();
 
@@ -381,7 +393,7 @@ describe("sessionManager reload adoption", () => {
   });
 
   it("degrades to re-stamping when localStorage throws", async () => {
-    vi.stubGlobal("Router", { MainRunningApp: { appid: APP_ID, display_name: "Game" } });
+    stubRunningApp(APP_ID);
     // happy-dom's localStorage is a Proxy — swap the whole global (restored by
     // the global afterEach's vi.unstubAllGlobals) rather than spying a method.
     vi.stubGlobal("localStorage", {
@@ -404,7 +416,7 @@ describe("sessionManager reload adoption", () => {
   });
 
   it("survives a full reload: start, destroy, re-init, stop finalizes the original rom", async () => {
-    vi.stubGlobal("Router", { MainRunningApp: null });
+    stubNothingRunning();
     // No game at first load → the adoption poll times out before init settles.
     await initDrainingAdoptionPoll();
     const lifetime1 = captureLifetimeCb();
@@ -419,9 +431,9 @@ describe("sessionManager reload adoption", () => {
     destroySessionManager();
     expect(readCrumb()).not.toBeNull();
 
-    // Re-init while the game is still running — the poll sees MainRunningApp
-    // immediately and adopts via the surviving breadcrumb.
-    vi.stubGlobal("Router", { MainRunningApp: { appid: APP_ID, display_name: "Game" } });
+    // Re-init while the game is still running — the poll sees the running app
+    // on its first round and adopts via the surviving breadcrumb.
+    stubRunningApp(APP_ID);
     await initSessionManager();
     // Case (a): durable marker preserved — no second record_session_start.
     expect(backend.recordSessionStart).toHaveBeenCalledTimes(1);
@@ -436,7 +448,7 @@ describe("sessionManager reload adoption", () => {
   it("treats a wrong-version breadcrumb as unusable and re-stamps (a′)", async () => {
     // A breadcrumb from a future schema (v2) fails isSessionBreadcrumb.
     seedBreadcrumb({ v: 2, appId: APP_ID, romId: ROM_ID, startMs: 5_000 });
-    vi.stubGlobal("Router", { MainRunningApp: { appid: APP_ID, display_name: "Game" } });
+    stubRunningApp(APP_ID);
 
     await initSessionManager();
 
@@ -449,7 +461,7 @@ describe("sessionManager reload adoption", () => {
   it("treats a non-object breadcrumb JSON as unusable and re-stamps (a′)", async () => {
     // Valid JSON but not an object — isSessionBreadcrumb rejects it.
     localStorage.setItem(BREADCRUMB_KEY, JSON.stringify(42));
-    vi.stubGlobal("Router", { MainRunningApp: { appid: APP_ID, display_name: "Game" } });
+    stubRunningApp(APP_ID);
 
     await initSessionManager();
 
@@ -459,7 +471,7 @@ describe("sessionManager reload adoption", () => {
 
   it("survives a rejected recordSessionStart during adoption", async () => {
     vi.mocked(backend.recordSessionStart).mockRejectedValueOnce(new Error("network down"));
-    vi.stubGlobal("Router", { MainRunningApp: { appid: APP_ID, display_name: "Game" } });
+    stubRunningApp(APP_ID);
 
     // (a′) awaits recordSessionStart; its rejection is caught, not surfaced.
     await expect(initSessionManager()).resolves.toBeUndefined();
@@ -475,7 +487,7 @@ describe("sessionManager reload adoption", () => {
 
   it("clears a live breadcrumb when a non-RomM app is in the foreground", async () => {
     seedBreadcrumb({ v: 1, appId: APP_ID, romId: ROM_ID, startMs: 5_000 });
-    vi.stubGlobal("Router", { MainRunningApp: { appid: 999, display_name: "Other" } });
+    stubRunningApp(999, "Other");
 
     await initSessionManager();
 
@@ -499,7 +511,7 @@ describe("sessionManager reload adoption", () => {
       },
       clear: vi.fn(),
     });
-    vi.stubGlobal("Router", { MainRunningApp: null });
+    stubNothingRunning();
 
     // Nothing running → the poll times out, then the orphaned-breadcrumb clear
     // hits the throwing removeItem, which must be swallowed.
@@ -512,41 +524,58 @@ describe("sessionManager reload adoption", () => {
   });
 
   it("tolerates a throwing running-app getter without erroring adoption", async () => {
-    // Steam's running-app accessor faulting must not crash init. The defensive
-    // reader catches the throw PER-SOURCE (noting it in diagnostics) so adoption
-    // proceeds against the other sources instead of erroring out (#1148 round 2) —
-    // the pre-fix single-source read let the throw escape to the adoption .catch.
-    vi.stubGlobal("Router", {
-      get MainRunningApp(): unknown {
+    // Steam's running-app accessor faulting must not crash init. The reader
+    // catches the throw and notes it in the diagnostics, so adoption reaches its
+    // normal timeout verdict instead of erroring out (#1148 round 2) — the
+    // pre-fix unguarded read let the throw escape to the adoption .catch.
+    vi.stubGlobal("SteamUIStore", {
+      get RunningApps(): unknown {
         throw new Error("running-app read failed");
       },
     });
 
-    // Nothing else running → the poll times out and init resolves cleanly.
+    // Nothing readable → the poll times out and init resolves cleanly.
     const init = initSessionManager();
     await vi.advanceTimersByTimeAsync(ADOPTION_POLL_MAX_MS);
     await expect(init).resolves.toBeUndefined();
 
-    // No adoption error surfaced; the timed-out round logged what every candidate
-    // reported, including the throwing source.
+    // No adoption error surfaced; the timed-out round logged what the store
+    // reported, i.e. that it threw.
     expect(backend.logError).not.toHaveBeenCalledWith(expect.stringContaining("Session adoption error"));
     expect(backend.logInfo).toHaveBeenCalledWith(expect.stringContaining("threw:"));
     expect(backend.logInfo).toHaveBeenCalledWith(expect.stringContaining("no running app"));
   });
 
-  // #1054 follow-up: after a full plugin_loader restart Router.MainRunningApp is
-  // null for several seconds while the game is still running, so a one-shot read
-  // wrongly orphaned a live session. Adoption now polls MainRunningApp.
-  it("adopts a matching breadcrumb once MainRunningApp appears mid-poll, no orphan log", async () => {
+  it("tolerates an entirely absent running-app store without erroring adoption", async () => {
+    // SteamUIStore intentionally not stubbed — on a build/timing where the
+    // global is genuinely absent, a bare read would throw ReferenceError out of
+    // the poll. Adoption must still reach its ordinary timeout verdict.
     seedBreadcrumb({ v: 1, appId: APP_ID, romId: ROM_ID, startMs: 5_000 });
-    vi.stubGlobal("Router", { MainRunningApp: null });
 
     const init = initSessionManager();
-    // Four polls into the loader-restart window, MainRunningApp is still null.
+    await vi.advanceTimersByTimeAsync(ADOPTION_POLL_MAX_MS);
+    await expect(init).resolves.toBeUndefined();
+
+    expect(backend.logError).not.toHaveBeenCalledWith(expect.stringContaining("Session adoption error"));
+    expect(backend.logInfo).toHaveBeenCalledWith(expect.stringContaining("no-store"));
+    // Case (b): nothing attested as running → the breadcrumb is orphan-cleared.
+    expect(readCrumb()).toBeNull();
+    expect(backend.recordSessionStart).not.toHaveBeenCalled();
+  });
+
+  // #1054 follow-up: after a full plugin_loader restart the store reports an
+  // EMPTY running-app list for several seconds while the game is still running,
+  // so a one-shot read wrongly orphaned a live session. Adoption now polls.
+  it("adopts a matching breadcrumb once the store reports the app mid-poll, no orphan log", async () => {
+    seedBreadcrumb({ v: 1, appId: APP_ID, romId: ROM_ID, startMs: 5_000 });
+    stubNothingRunning();
+
+    const init = initSessionManager();
+    // Four polls into the loader-restart window, the store is still empty.
     await vi.advanceTimersByTimeAsync(2_000);
     expect(backend.recordSessionStart).not.toHaveBeenCalled();
     // Steam finally populates the running app; the next poll sees it.
-    vi.stubGlobal("Router", { MainRunningApp: { appid: APP_ID, display_name: "Game" } });
+    stubRunningApp(APP_ID);
     await vi.advanceTimersByTimeAsync(500);
     await init;
 
@@ -564,7 +593,7 @@ describe("sessionManager reload adoption", () => {
 
   it("orphan-clears the breadcrumb after the poll times out with nothing running", async () => {
     seedBreadcrumb({ v: 1, appId: APP_ID, romId: ROM_ID, startMs: 5_000 });
-    vi.stubGlobal("Router", { MainRunningApp: null });
+    stubNothingRunning();
 
     await initDrainingAdoptionPoll();
 
@@ -575,7 +604,7 @@ describe("sessionManager reload adoption", () => {
   });
 
   it("stays silent when the poll times out with no breadcrumb", async () => {
-    vi.stubGlobal("Router", { MainRunningApp: null });
+    stubNothingRunning();
 
     await initDrainingAdoptionPoll();
 
@@ -588,7 +617,7 @@ describe("sessionManager reload adoption", () => {
 
   it("queues a racing stop behind the poll so it finalizes after adoption", async () => {
     seedBreadcrumb({ v: 1, appId: APP_ID, romId: ROM_ID, startMs: 1_000 });
-    vi.stubGlobal("Router", { MainRunningApp: null });
+    stubNothingRunning();
 
     const init = initSessionManager();
     // Let init register the lifetime hook and enter the poll.
@@ -600,7 +629,7 @@ describe("sessionManager reload adoption", () => {
     lifetime({ bRunning: false, unAppID: APP_ID });
 
     // The game becomes visible; the poll resolves and adoption (a) runs first.
-    vi.stubGlobal("Router", { MainRunningApp: { appid: APP_ID, display_name: "Game" } });
+    stubRunningApp(APP_ID);
     await vi.advanceTimersByTimeAsync(500);
     await init;
     await vi.advanceTimersByTimeAsync(0); // flush the queued stop task
@@ -616,14 +645,14 @@ describe("sessionManager reload adoption", () => {
     // Nothing running yet → the poll is mid-flight when destroy fires. A game that
     // appears AFTER teardown must not be adopted: the aborted poll writes no
     // breadcrumb, records no session, and takes no adoption action (#1148 LOW-1).
-    vi.stubGlobal("Router", { MainRunningApp: null });
+    stubNothingRunning();
 
     const init = initSessionManager();
     await vi.advanceTimersByTimeAsync(2_000); // poll running, nothing found yet
     destroySessionManager(); // tears down mid-poll → bumps the epoch
     // A running game appears after teardown; the still-pending poll would adopt it
     // (case a′ → recordSessionStart + breadcrumb) if it did not check the epoch.
-    vi.stubGlobal("Router", { MainRunningApp: { appid: APP_ID, display_name: "Game" } });
+    stubRunningApp(APP_ID);
     await vi.advanceTimersByTimeAsync(500);
     await init;
 
@@ -685,7 +714,7 @@ describe("sessionManager session-changed dispatch (#1313)", () => {
   });
 
   it("dispatches running:true on game start and running:false on stop", async () => {
-    vi.stubGlobal("Router", { MainRunningApp: null });
+    stubNothingRunning();
     await initDrainingAdoptionPoll();
     const lifetime = captureLifetimeCb();
 
@@ -703,7 +732,7 @@ describe("sessionManager session-changed dispatch (#1313)", () => {
       BREADCRUMB_KEY,
       JSON.stringify({ v: 1, appId: APP_ID, romId: ROM_ID, startMs: 5_000, pausedMs: 0 }),
     );
-    vi.stubGlobal("Router", { MainRunningApp: { appid: APP_ID, display_name: "Game" } });
+    stubRunningApp(APP_ID);
 
     await initSessionManager();
 
@@ -711,7 +740,7 @@ describe("sessionManager session-changed dispatch (#1313)", () => {
   });
 
   it("dispatches running:true when adopting a running session with no breadcrumb", async () => {
-    vi.stubGlobal("Router", { MainRunningApp: { appid: APP_ID, display_name: "Game" } });
+    stubRunningApp(APP_ID);
 
     await initSessionManager();
 
@@ -719,7 +748,7 @@ describe("sessionManager session-changed dispatch (#1313)", () => {
   });
 
   it("does not dispatch a session event when nothing is running at init", async () => {
-    vi.stubGlobal("Router", { MainRunningApp: null });
+    stubNothingRunning();
     await initDrainingAdoptionPoll();
     expect(sessionEvents).toEqual([]);
   });

--- a/src/utils/sessionManager.ts
+++ b/src/utils/sessionManager.ts
@@ -3,8 +3,8 @@
  * save sync + playtime tracking via backend callables.
  *
  * Uses SteamClient.GameSessions.RegisterForAppLifetimeNotifications to detect
- * game lifecycle events and the defensive `runningApps` reader (multiple Steam
- * surfaces, not just `Router.MainRunningApp`) for reliable app-ID resolution.
+ * game lifecycle events and the guarded `runningApps` reader
+ * (`SteamUIStore.RunningApps`) for reliable app-ID resolution.
  */
 
 import { toaster } from "@decky/api";
@@ -231,20 +231,20 @@ async function handleGameStop(): Promise<void> {
 }
 
 // Adoption polls Steam's running-app before deciding a session's fate: after a
-// full `plugin_loader` restart the running-app surfaces are not populated for
+// full `plugin_loader` restart `SteamUIStore.RunningApps` reads empty for
 // several seconds even though the game is still running (#1054 / #1148 round 2
 // device evidence), so a single early read wrongly orphaned a live session. Poll
-// the defensive multi-source reader until a running app appears or the window
-// elapses.
+// the reader until a running app appears or the window elapses.
 const ADOPTION_POLL_INTERVAL_MS = 500;
 export const ADOPTION_POLL_MAX_MS = 15_000;
 
 /**
- * Poll every running-app source until one reports a running app or the window
- * elapses. Returns the primary app (any app, RomM or not — the caller applies
+ * Poll the running-app reader until it reports a running app or the window
+ * elapses. Returns the foreground app (any app, RomM or not — the caller applies
  * the adoption matrix) or `null` on timeout, alongside the last round's
- * per-source `diagnostics` so a timed-out adoption logs what EVERY candidate
- * reported. Each round's diagnostics are also emitted at debug level.
+ * `diagnostics` so a timed-out adoption logs what the store actually reported
+ * (absent / empty / threw). Each round's diagnostics are also emitted at debug
+ * level.
  */
 async function pollForRunningApp(): Promise<{ app: RunningApp | null; diagnostics: string }> {
   const started = Date.now();
@@ -263,15 +263,14 @@ async function pollForRunningApp(): Promise<{ app: RunningApp | null; diagnostic
  * `destroySessionManager` wipes the in-memory session on unload, so the
  * game-stop after a reload would otherwise never finalize — the pre-reload
  * playtime is lost and the post-exit sync never runs. Steam's running-state
- * (`Router.MainRunningApp`) is the liveness authority; the localStorage
+ * (`SteamUIStore.RunningApps`) is the liveness authority; the localStorage
  * breadcrumb is the attestation of a start we actually observed. Every finalize
  * fold thus stays anchored to a marker stamped by an observed start.
  *
- * The liveness read is POLLED (not a single read) and consults MULTIPLE Steam
- * surfaces: after a loader restart `Router.MainRunningApp` stays null for seconds
- * and never repopulates without a fresh lifecycle event our reloaded context
- * missed (#1054 / #1148 round 2), so a one-shot single-source read raced the
- * restart and wrongly orphaned a still-running session.
+ * The liveness read is POLLED, not a single read: after a loader restart the
+ * store reports an EMPTY running-app list for seconds while the game is still
+ * up (#1054 / #1148 round 2), so a one-shot read raced the restart and wrongly
+ * orphaned a still-running session.
  */
 async function adoptOrphanedSession(): Promise<void> {
   const epoch = sessionEpoch;


### PR DESCRIPTION
`utils/runningApps` merged three running-app sources defensively, but two of them had never reported anything. `Router.MainRunningApp` and `Router.RunningApps` were read as ambient page globals, and no SteamUI build defines `window.Router`: a scan of every `window.<name> =` assignment across all 206 files of the installed bundle finds `SteamUIStore`, `appStore`, `collectionStore` and others, and no `Router`. The shipped plugin bundle carries the identifier unrenamed, so bundler shadowing was not the explanation, and all 183 diagnostics lines in the retained logs read `no-Router`. The reader has been single-source since it was written; it just did not say so.

Importing `Router` from `@decky/ui` would not have changed that. It is built with `findModuleExport((e) => e.Navigate && e.NavigationManager)`, and this bundle contains exactly one `NavigationManager` — on the singleton exported as `window.SteamUIStore`, the object already being read. Its `MainRunningApp` is literally `RunningApps[0]` off a single private array, so the import would have added no signal while costing a test rewrite, a wrong `appid: string` typing, and a new failure mode: on builds where a second, window-scoped class also exposes `MainRunningApp`, a filter mismatch would report the wrong context as running, and both `launchInterceptor` and `CustomPlayButton` treat "running" as permission to skip the pre-launch save-sync gate.

So the dead branches and the `declare var Router` block are gone, and `SteamUIStore.RunningApps` is named as the single source. No new Steam API reads: `readPrimaryRunningApp` returns `apps[0]`, which already carries foreground-app semantics precisely because `MainRunningApp` is that same head element.

The comments went with them. `runningApps`, `steam.d.ts` and `sessionManager` all described `Router.MainRunningApp` as authoritative for the foreground app and claimed it stayed null for the whole adoption window after a loader restart. That was never observed — the branch never ran. What the logs actually show in those windows is `RunningApps` reading empty, which is why the adoption machinery exists and still does; only the attribution was fiction.

The tests needed the same correction. `sessionManager.test.ts` seeded running state through `vi.stubGlobal("Router", …)` at seventeen sites and `runningApps.test.ts` at eleven, so the suite was exercising a path that never runs in production while the real one went comparatively untested. Both now seed through `SteamUIStore`, with added coverage for an absent store during adoption, store ordering, a nameless entry, a non-list value, and `isAnyAppRunning`. The `Router` entry in the `@decky/ui` test mock was vestigial — nothing imports it — and is removed.

Closes #1588
