### PR TITLE
fix(session): scope the lifecycle stop to the session's own app

### DIFF
--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -1408,7 +1408,10 @@ Triggered from the game detail page when the user clicks the Play button (if `sy
 
 Triggered automatically when a game stops (if `sync_after_exit` is enabled).
 
-1. `RegisterForAppLifetimeNotifications` fires with `bRunning: false`.
+1. `RegisterForAppLifetimeNotifications` fires with `bRunning: false`. The notification arrives for **every** app Steam
+   tracks, so `handleGameStop(unAppID)` finalizes only when the stopping app is the one that opened the active session —
+   see [Session scoping](#session-scoping-one-slot-keyed-by-its-app). A stop for any other app returns before the
+   `finalizeGameSession` call, so the post-exit sync never runs against a game that is still holding its save file open.
 2. `sessionManager.handleGameStop` makes a single `finalizeGameSession(romId)` call; the backend
    `SessionLifecycleService.finalize` orchestrates playtime record → post-exit save sync → migration refresh and returns
    one typed payload (the old `recordSessionEnd` / `postExitSync` frontend callables were collapsed into it). If the
@@ -1526,6 +1529,29 @@ Playtime is **additive, not a conflict** — the union of per-device session str
 newest-wins / conflict / `.romm-backup` machinery. The server dedupes on `(user_id, device_id, rom_id, start_time)`, so
 a re-POST of a queued session is idempotent; the outbox dequeues on a `created` or `duplicate` result and stays queued
 only on `error` (ADR-0018).
+
+### Session scoping: one slot, keyed by its app
+
+`sessionManager` tracks **one** active session: `{appId, romId, startMs}`, opened on a game start and on either
+reload-adoption branch, and always with the appId set alongside the rom.
+
+The appId is what a stop is matched against. `RegisterForAppLifetimeNotifications` fires for every app Steam tracks —
+another non-Steam shortcut, a regular Steam game, a second RomM game — so the stop path checks the stopping app against
+the **appId recorded with the session**, never a fresh `appId → romId` map lookup (the cached map can be stale at stop
+time, and a stale miss would drop a real session instead of an unrelated one). A stop for any other app is a debug-level
+no-op: no playtime write, no post-exit sync, and the session stays open until its own app exits. Before #1621 the stop
+path took no appId at all and finalized whatever was in the slot, which recorded a wrong (early) duration and — the part
+that mattered — ran the post-exit save sync against a game whose emulator still held the save file open, capturing a
+half-written file that the real exit then diverged from.
+
+Two RomM games at once still exceed the single slot: the second start displaces the first, and the displaced session is
+**dropped**, logged at warning with both rom ids. Its stop was never observed, so it gets no fabricated end — the same
+rule an orphaned breadcrumb follows (see below).
+
+Keeping the slot single is a deliberate decision, not an oversight. A per-rom map would ripple into the breadcrumb, both
+adoption branches, and every `getActiveSessionRomId()` consumer — including the launch gate's already-running guard,
+which is save-safety machinery. Concurrent RomM games are rare, and scoping the stop to its own app removes the
+dangerous behaviour without touching that surface. Revisit only if concurrent play stops being an edge case.
 
 ### Surviving a plugin reload mid-session
 

--- a/src/utils/sessionManager.test.ts
+++ b/src/utils/sessionManager.test.ts
@@ -27,6 +27,11 @@ type LifetimeCb = (update: LifetimeUpdate) => void;
 // The map binds Steam app id 100 → RomM rom id 7.
 const APP_ID = 100;
 const ROM_ID = 7;
+// A second RomM shortcut — the concurrent-games case from #1621.
+const OTHER_APP_ID = 200;
+const OTHER_ROM_ID = 9;
+// An app the plugin does not own: a regular Steam game or a foreign shortcut.
+const UNRELATED_APP_ID = 4242;
 
 const IDLE_FINALIZE = {
   total_seconds: null,
@@ -50,17 +55,27 @@ function captureLifetimeCb(): LifetimeCb {
   return cb as LifetimeCb;
 }
 
-/** Drive a game-start notification through the serialized lifecycle chain. */
-async function startGame(cb: LifetimeCb): Promise<void> {
-  cb({ bRunning: true, unAppID: APP_ID });
+/** Drive a start notification for a specific app through the lifecycle chain. */
+async function startApp(cb: LifetimeCb, appId: number): Promise<void> {
+  cb({ bRunning: true, unAppID: appId });
   // handleGameStart is gated behind a delay(500) inside the lifecycle chain.
   await vi.advanceTimersByTimeAsync(500);
 }
 
+/** Drive a stop notification for a specific app and flush the chain. */
+async function stopApp(cb: LifetimeCb, appId: number): Promise<void> {
+  cb({ bRunning: false, unAppID: appId });
+  await vi.advanceTimersByTimeAsync(0);
+}
+
+/** Drive a game-start notification through the serialized lifecycle chain. */
+async function startGame(cb: LifetimeCb): Promise<void> {
+  await startApp(cb, APP_ID);
+}
+
 /** Drive a game-stop notification and flush the chain. */
 async function stopGame(cb: LifetimeCb): Promise<void> {
-  cb({ bRunning: false, unAppID: APP_ID });
-  await vi.advanceTimersByTimeAsync(0);
+  await stopApp(cb, APP_ID);
 }
 
 // #1148: adoptOrphanedSession now polls the running-app surfaces for up to 15s
@@ -751,5 +766,164 @@ describe("sessionManager session-changed dispatch (#1313)", () => {
     stubNothingRunning();
     await initDrainingAdoptionPoll();
     expect(sessionEvents).toEqual([]);
+  });
+});
+
+// #1621: RegisterForAppLifetimeNotifications fires for EVERY app Steam tracks,
+// so the stop path must finalize only the app that opened the active session.
+// Finalizing on a foreign app's exit recorded the wrong playtime AND ran the
+// post-exit save sync against a game still holding its save file open.
+describe("sessionManager stop scoping (#1621)", () => {
+  const BREADCRUMB_KEY = "decky-romm-sync:active-session";
+  const readCrumb = (): unknown => {
+    const raw = localStorage.getItem(BREADCRUMB_KEY);
+    return raw === null ? null : JSON.parse(raw);
+  };
+
+  // finalizeGameSession is the single callable behind BOTH the playtime write and
+  // the post-exit save sync, so "not called" is the direct assertion that neither
+  // ran. total_seconds makes the playtime display write observable too.
+  const FINALIZE_WITH_PLAYTIME = { ...IDLE_FINALIZE, total_seconds: 99 };
+
+  let dataChanged: unknown[];
+  let dataListener: (e: Event) => void;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    localStorage.clear();
+    stubLifecycleSteamClient();
+    // Two RomM shortcuts in the map; the unrelated app is deliberately absent.
+    vi.mocked(backend.getAppIdRomIdMap).mockResolvedValue({
+      [String(APP_ID)]: ROM_ID,
+      [String(OTHER_APP_ID)]: OTHER_ROM_ID,
+    });
+    vi.mocked(backend.recordSessionStart).mockResolvedValue({ success: true });
+    vi.mocked(backend.finalizeGameSession).mockResolvedValue({ ...FINALIZE_WITH_PLAYTIME });
+    // Nothing in the running-app store → handleGameStart resolves the app from
+    // the notification's unAppID, so each start is addressable per app.
+    stubNothingRunning();
+    dataChanged = [];
+    dataListener = (e: Event) => dataChanged.push((e as CustomEvent).detail);
+    globalThis.addEventListener("romm_data_changed", dataListener);
+  });
+
+  afterEach(() => {
+    globalThis.removeEventListener("romm_data_changed", dataListener);
+    destroySessionManager();
+    vi.useRealTimers();
+  });
+
+  it("finalizes when the active session's own app stops", async () => {
+    await initDrainingAdoptionPoll();
+    const lifetime = captureLifetimeCb();
+
+    await startGame(lifetime);
+    vi.setSystemTime(60_000);
+    await stopApp(lifetime, APP_ID);
+
+    expect(backend.finalizeGameSession).toHaveBeenCalledWith(ROM_ID);
+    expect(updatePlaytimeDisplay).toHaveBeenCalledWith(APP_ID, 99);
+    expect(dataChanged).toContainEqual({ type: "save_sync", rom_id: ROM_ID });
+  });
+
+  it("ignores a stop for an unrelated app and leaves the session open", async () => {
+    await initDrainingAdoptionPoll();
+    const lifetime = captureLifetimeCb();
+
+    await startGame(lifetime);
+    vi.setSystemTime(30_000);
+    await stopApp(lifetime, UNRELATED_APP_ID);
+
+    // No playtime write and no post-exit sync — finalizeGameSession performs both.
+    expect(backend.finalizeGameSession).not.toHaveBeenCalled();
+    expect(updatePlaytimeDisplay).not.toHaveBeenCalled();
+    expect(dataChanged).toEqual([]);
+    expect(backend.debugLog).toHaveBeenCalledWith(expect.stringContaining("Session stop ignored"));
+
+    // The session is still open: its breadcrumb survives and its own app's stop
+    // still finalizes it, at the real end time.
+    expect(readCrumb()).toMatchObject({ v: 1, appId: APP_ID, romId: ROM_ID });
+    vi.setSystemTime(60_000);
+    await stopApp(lifetime, APP_ID);
+    expect(backend.finalizeGameSession).toHaveBeenCalledWith(ROM_ID);
+    expect(updatePlaytimeDisplay).toHaveBeenCalledWith(APP_ID, 99);
+  });
+
+  it("ignores a stop for a second RomM game that is not the active session", async () => {
+    // The stopping app maps to a real rom, so a fresh map lookup would happily
+    // resolve one — only the appId RECORDED with the session rejects it.
+    await initDrainingAdoptionPoll();
+    const lifetime = captureLifetimeCb();
+
+    await startGame(lifetime);
+    await stopApp(lifetime, OTHER_APP_ID);
+
+    expect(backend.finalizeGameSession).not.toHaveBeenCalled();
+    expect(dataChanged).toEqual([]);
+  });
+
+  it("warns and drops the displaced session when a second game takes the slot", async () => {
+    await initDrainingAdoptionPoll();
+    const lifetime = captureLifetimeCb();
+
+    await startGame(lifetime);
+    vi.setSystemTime(30_000);
+    await startApp(lifetime, OTHER_APP_ID);
+
+    // The displaced session leaves a trace and is dropped, not finalized with a
+    // fabricated end — its stop was never observed.
+    const warning = vi.mocked(backend.logWarn).mock.calls.map((c) => c[0]);
+    expect(warning).toContainEqual(expect.stringContaining(`romId=${OTHER_ROM_ID}`));
+    expect(warning).toContainEqual(expect.stringContaining(`romId=${ROM_ID}`));
+    expect(backend.finalizeGameSession).not.toHaveBeenCalled();
+    expect(backend.recordSessionStart).toHaveBeenCalledWith(OTHER_ROM_ID);
+
+    // The displaced app's exit is now a no-op; the live session finalizes on its
+    // own app's exit — the exact ordering from the device log in #1621.
+    await stopApp(lifetime, APP_ID);
+    expect(backend.finalizeGameSession).not.toHaveBeenCalled();
+    await stopApp(lifetime, OTHER_APP_ID);
+    expect(backend.finalizeGameSession).toHaveBeenCalledTimes(1);
+    expect(backend.finalizeGameSession).toHaveBeenCalledWith(OTHER_ROM_ID);
+  });
+
+  it("does not warn when the same game re-opens its own session", async () => {
+    await initDrainingAdoptionPoll();
+    const lifetime = captureLifetimeCb();
+
+    await startGame(lifetime);
+    await startGame(lifetime);
+
+    expect(backend.logWarn).not.toHaveBeenCalled();
+  });
+
+  it("scopes the stop after adopting a session from a matching breadcrumb", async () => {
+    localStorage.setItem(BREADCRUMB_KEY, JSON.stringify({ v: 1, appId: APP_ID, romId: ROM_ID, startMs: 5_000 }));
+    stubRunningApp(APP_ID);
+
+    await initSessionManager();
+    const lifetime = captureLifetimeCb();
+
+    // The adopted session carries its appId, so a foreign stop is still ignored.
+    await stopApp(lifetime, UNRELATED_APP_ID);
+    expect(backend.finalizeGameSession).not.toHaveBeenCalled();
+
+    await stopApp(lifetime, APP_ID);
+    expect(backend.finalizeGameSession).toHaveBeenCalledWith(ROM_ID);
+  });
+
+  it("scopes the stop after adopting a running game with no breadcrumb", async () => {
+    stubRunningApp(APP_ID);
+
+    await initSessionManager();
+    const lifetime = captureLifetimeCb();
+
+    await stopApp(lifetime, UNRELATED_APP_ID);
+    expect(backend.finalizeGameSession).not.toHaveBeenCalled();
+
+    await stopApp(lifetime, APP_ID);
+    expect(backend.finalizeGameSession).toHaveBeenCalledWith(ROM_ID);
   });
 });

--- a/src/utils/sessionManager.test.ts
+++ b/src/utils/sessionManager.test.ts
@@ -889,6 +889,37 @@ describe("sessionManager stop scoping (#1621)", () => {
     expect(backend.finalizeGameSession).toHaveBeenCalledWith(OTHER_ROM_ID);
   });
 
+  it("finalizes the live session even when the app map went stale mid-session", async () => {
+    // The reason the stop compares the RECORDED appId instead of re-resolving the
+    // stopping app through the cached map: the map can go stale while a game runs
+    // (a sync that drops or re-keys the shortcut). A fresh lookup would then
+    // resolve nothing for the very app that opened the session and drop it —
+    // losing its playtime AND skipping its post-exit sync, which turns a
+    // mis-attribution bug into a data-loss one. The recorded appId cannot go
+    // stale, so the live session still finalizes.
+    await initDrainingAdoptionPoll();
+    const lifetime = captureLifetimeCb();
+
+    await startGame(lifetime);
+
+    // The map empties, and an unrelated app's start refreshes the cache to it —
+    // that start is a no-op for the session (nothing maps to the app).
+    vi.mocked(backend.getAppIdRomIdMap).mockResolvedValue({});
+    await startApp(lifetime, UNRELATED_APP_ID);
+    expect(backend.recordSessionStart).toHaveBeenCalledTimes(1);
+    expect(backend.recordSessionStart).toHaveBeenCalledWith(ROM_ID);
+
+    vi.setSystemTime(60_000);
+    await stopApp(lifetime, APP_ID);
+
+    // The session finalizes on the stale map: playtime folded, display updated,
+    // post-exit sync run, breadcrumb cleared.
+    expect(backend.finalizeGameSession).toHaveBeenCalledWith(ROM_ID);
+    expect(updatePlaytimeDisplay).toHaveBeenCalledWith(APP_ID, 99);
+    expect(dataChanged).toContainEqual({ type: "save_sync", rom_id: ROM_ID });
+    expect(readCrumb()).toBeNull();
+  });
+
   it("does not warn when the same game re-opens its own session", async () => {
     await initDrainingAdoptionPoll();
     const lifetime = captureLifetimeCb();

--- a/src/utils/sessionManager.ts
+++ b/src/utils/sessionManager.ts
@@ -8,7 +8,15 @@
  */
 
 import { toaster } from "@decky/api";
-import { recordSessionStart, getAppIdRomIdMap, finalizeGameSession, logInfo, logError, debugLog } from "../api/backend";
+import {
+  recordSessionStart,
+  getAppIdRomIdMap,
+  finalizeGameSession,
+  logInfo,
+  logWarn,
+  logError,
+  debugLog,
+} from "../api/backend";
 import { saveSyncToastBody } from "./saveSyncToast";
 import { setMigrationStatus } from "./migrationStore";
 import { setSaveSortMigrationStatus } from "./saveSortMigrationStore";
@@ -17,9 +25,24 @@ import { detach } from "./detach";
 import { readPrimaryRunningApp, readRunningApps, type RunningApp } from "./runningApps";
 import { delay } from "./pacedOps";
 
-// Active session tracking
-let activeRomId: number | null = null;
-let sessionStartTime: number | null = null;
+// Active session tracking — ONE slot, deliberately (#1621). The slot records the
+// Steam app that opened the session alongside the rom, so a lifecycle stop can be
+// matched against it; a second RomM game starting displaces the first. Turning
+// the slot into a per-rom map is a deliberate non-goal, not an oversight: it
+// would ripple into the breadcrumb, both adoption branches, and every
+// `getActiveSessionRomId()` consumer — including the launch gate's already-running
+// guard, which is save-safety machinery. Concurrent RomM games are rare, and
+// scoping the stop to its own app already removes the dangerous behaviour
+// (finalizing the wrong session, post-exit save sync against a running game).
+interface ActiveSession {
+  /** The Steam app that opened the session — what a lifecycle stop is matched against. */
+  appId: number;
+  romId: number;
+  /** Wall-clock start, mirrored into the durable breadcrumb. */
+  startMs: number;
+}
+
+let activeSession: ActiveSession | null = null;
 
 // Serialization chain — ensures lifecycle events don't interleave
 let lifecycleChain: Promise<void> = Promise.resolve();
@@ -60,14 +83,7 @@ export function getAppIdRomIdMapSnapshot(): Record<string, number> {
  * holds the file open, and Steam blocks the relaunch as "already running" anyway.
  */
 export function getActiveSessionRomId(): number | null {
-  return activeRomId;
-}
-
-function getAppIdForRom(romId: number): number | null {
-  for (const [appIdStr, rid] of Object.entries(appIdToRomId)) {
-    if (rid === romId) return Number(appIdStr);
-  }
-  return null;
+  return activeSession?.romId ?? null;
 }
 
 async function refreshAppIdMap(): Promise<void> {
@@ -145,12 +161,21 @@ async function handleGameStart(appId: number): Promise<void> {
   if (!romId) return; // Not a RomM shortcut
 
   logInfo(`Session start: romId=${romId}, appId=${appId}`);
-  activeRomId = romId;
-  sessionStartTime = Date.now();
+  if (activeSession && activeSession.romId !== romId) {
+    // Two RomM games at once, and the single slot holds one. The displaced session
+    // is dropped rather than given a fabricated end — its stop was never observed,
+    // the same rule an orphaned breadcrumb follows. Rare enough to keep the slot
+    // single (see the state block), loud enough to leave a trace when it happens.
+    logWarn(
+      `Session start for romId=${romId} displaces still-active romId=${activeSession.romId} — its playtime is dropped`,
+    );
+  }
+  const session: ActiveSession = { appId, romId, startMs: Date.now() };
+  activeSession = session;
   dispatchSessionChanged(true, appId, romId);
 
   // Attest the open session so a reload mid-game can adopt and finalize it.
-  writeSessionBreadcrumb({ v: SESSION_BREADCRUMB_VERSION, appId, romId, startMs: sessionStartTime });
+  writeSessionBreadcrumb({ v: SESSION_BREADCRUMB_VERSION, appId, romId, startMs: session.startMs });
 
   // Record session start for playtime tracking
   try {
@@ -161,22 +186,42 @@ async function handleGameStart(appId: number): Promise<void> {
   // Pre-launch sync moved to CustomPlayButton.handlePlay
 }
 
-async function handleGameStop(): Promise<void> {
-  if (!activeRomId) return;
+/**
+ * Finalize the active session, but only when `stoppedAppId` is the app that
+ * opened it.
+ *
+ * `RegisterForAppLifetimeNotifications` fires for EVERY app Steam tracks, so an
+ * unrelated app's exit reaches here too (#1621). The comparison is against the
+ * appId RECORDED WITH THE SESSION, never a fresh `getRomIdForApp` lookup: the
+ * cached map can be stale at stop time, and a stale miss would drop a real
+ * session — recording no playtime and skipping the post-exit sync entirely.
+ */
+async function handleGameStop(stoppedAppId: number): Promise<void> {
+  const session = activeSession;
+  if (!session) return;
 
-  const romId = activeRomId;
+  if (session.appId !== stoppedAppId) {
+    // Some other app stopped. The live session stays open — finalizing here would
+    // record its playtime early AND run the post-exit save sync while the emulator
+    // still holds the save file open, capturing a half-written file.
+    detach(
+      debugLog(
+        `Session stop ignored: appId=${stoppedAppId} is not the active session (appId=${session.appId}, romId=${session.romId})`,
+      ),
+    );
+    return;
+  }
+
+  const { appId, romId } = session;
   logInfo(`Session end: romId=${romId}`);
 
-  // Flip any open Resume button back to Play before we lose the appId mapping
-  // (#1313). Best-effort — a missing reverse-map entry leaves the button to
-  // self-heal on remount; the button keys on romId regardless.
-  const stoppedAppId = getAppIdForRom(romId);
-  if (stoppedAppId !== null) dispatchSessionChanged(false, stoppedAppId, romId);
+  // Flip any open Resume button back to Play (#1313). The appId comes from the
+  // session itself, so this needs no reverse-map lookup.
+  dispatchSessionChanged(false, appId, romId);
 
   // Clear active session immediately to avoid double-processing. The breadcrumb
   // goes with it — the stop is observed, so there is nothing left to adopt.
-  activeRomId = null;
-  sessionStartTime = null;
+  activeSession = null;
   clearSessionBreadcrumb();
 
   try {
@@ -184,10 +229,7 @@ async function handleGameStop(): Promise<void> {
 
     // Playtime display update — appStore mutation must stay frontend.
     if (result.total_seconds != null) {
-      const appId = getAppIdForRom(romId);
-      if (appId) {
-        updatePlaytimeDisplay(appId, result.total_seconds);
-      }
+      updatePlaytimeDisplay(appId, result.total_seconds);
     }
 
     // Post-exit save-sync toast. The directional success toast is rendered
@@ -297,8 +339,7 @@ async function adoptOrphanedSession(): Promise<void> {
       // (a) The breadcrumb attests this exact running session. Restore the
       // in-memory state and leave the durable marker untouched — re-stamping it
       // would discard the pre-reload playtime the backend already holds.
-      activeRomId = runningRomId;
-      sessionStartTime = crumb.startMs;
+      activeSession = { appId, romId: runningRomId, startMs: crumb.startMs };
       dispatchSessionChanged(true, appId, runningRomId);
       logInfo(`Adopted running session from breadcrumb: romId=${runningRomId}, appId=${appId}`);
     } else {
@@ -306,13 +347,13 @@ async function adoptOrphanedSession(): Promise<void> {
       // corrupt). Adopt it and re-stamp the marker to a truthful lower bound
       // from now, then attest with a fresh breadcrumb so a later reload adopts
       // via (a) rather than re-stamping again.
-      activeRomId = runningRomId;
-      sessionStartTime = Date.now();
+      const adopted: ActiveSession = { appId, romId: runningRomId, startMs: Date.now() };
+      activeSession = adopted;
       writeSessionBreadcrumb({
         v: SESSION_BREADCRUMB_VERSION,
         appId,
         romId: runningRomId,
-        startMs: sessionStartTime,
+        startMs: adopted.startMs,
       });
       dispatchSessionChanged(true, appId, runningRomId);
       try {
@@ -357,8 +398,8 @@ export async function initSessionManager(): Promise<void> {
             await handleGameStart(appId);
           }
         } else {
-          // Game stopped
-          await handleGameStop();
+          // An app stopped — `handleGameStop` decides whether it is ours.
+          await handleGameStop(update.unAppID);
         }
       })
       .catch((e) => {
@@ -390,8 +431,7 @@ export function destroySessionManager(): void {
     lifetimeHook = null;
   }
 
-  activeRomId = null;
-  sessionStartTime = null;
+  activeSession = null;
   lifecycleChain = Promise.resolve();
   // Signal any in-flight adoption poll to abort instead of mutating torn-down state.
   sessionEpoch++;


### PR DESCRIPTION
The session manager was asymmetric: the start path filtered by app, the stop path did not. `handleGameStart` resolved the notification's app to a ROM and returned early for anything unrecognised, but `handleGameStop()` took no argument at all and finalized whatever session was active. `RegisterForAppLifetimeNotifications` fires for every app Steam tracks, so any app exiting ended the live RomM session — a second RomM game was only the easiest reproduction, and a regular Steam game or another non-Steam shortcut did the same thing.

The counting damage was the smaller half. The real problem was that `post_exit_sync` then ran for a game that was still playing, uploading from a save file the emulator still held open — the same hazard the already-running guard prevents on the launch surfaces, where a mid-session upload captures a half-written file and the true exit diverges from it into a conflict. That was observed on device: one game's exit finalized the other's session and ran its post-exit sync six seconds before that game actually stopped.

The active session now carries the app it belongs to — `{appId, romId, startMs}` — recorded on the normal start and on both adoption branches, and `handleGameStop(stoppedAppId)` finalizes only when the stopping app is that app. Anything else is a logged no-op that leaves the session open, so no playtime is written and no post-exit sync runs for a game that has not exited.

The comparison deliberately uses the appId **recorded with the session** rather than resolving the stopping app through the id map at stop time. A stale map would then fail to resolve a live session's own app and drop it — turning a mis-attribution bug into a data-loss one, losing the playtime and skipping the post-exit sync that was the whole point. A test pins that choice: it lets the map go stale mid-session and asserts the session's own stop still finalizes.

A second RomM game displacing an active session still drops the displaced one, now with a warning naming both ROMs instead of vanishing silently. No end is fabricated for it — a session whose stop was never observed is dropped rather than given an invented duration, which is the rule the orphaned-breadcrumb path already follows.

Keeping the single slot instead of a map keyed by ROM is deliberate. A map would reach into the session breadcrumb, the adoption paths and every `getActiveSessionRomId()` consumer, including the launch gate's already-running guard, which is save-safety machinery. Concurrent RomM games are rare, and scoping alone removes the dangerous behaviour without touching that surface. The reasoning is recorded in the code and the architecture page so a later reader sees a decision rather than an oversight.

Closes #1621
