### PR TITLE
fix(session): track one play session per running app

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -265,6 +265,15 @@ counts, and the lists of platforms/collections actually completed. Replaces the 
 at the end). The "how many ROMs" figure is **not** stored on it — that is a live `len(registry)` count computed at read
 time.
 
+### Active session
+
+One play session the frontend is currently tracking: `{appId, romId, startMs}` in `sessionManager`'s map, keyed by the
+Steam app that opened it. There is one entry **per running app**, not one overall — two RomM games at once are two
+active sessions, each finalizing on its own app's exit. An active session is opened by a game-start notification or by
+reload-adoption, and its durable counterpart is the `last_session_start` marker on the ROM's `rom_playtime` row plus the
+`decky-romm-sync:active-session` breadcrumb that lets a reload adopt it. "Active" is about the frontend's tracking, not
+about foreground/focus — a backgrounded game's session is still active.
+
 ### Unbind / stale / prune
 
 Three deliberately-distinct ROM-removal notions (see [ADR-0007](docs/adr/0007-rom-retention-identity-anchor.md)):

--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -1410,7 +1410,7 @@ Triggered automatically when a game stops (if `sync_after_exit` is enabled).
 
 1. `RegisterForAppLifetimeNotifications` fires with `bRunning: false`. The notification arrives for **every** app Steam
    tracks, so `handleGameStop(unAppID)` finalizes only when the stopping app is the one that opened the active session —
-   see [Session scoping](#session-scoping-one-slot-keyed-by-its-app). A stop for any other app returns before the
+   see [Session scoping](#session-scoping-one-entry-per-running-app). A stop for any other app returns before the
    `finalizeGameSession` call, so the post-exit sync never runs against a game that is still holding its save file open.
 2. `sessionManager.handleGameStop` makes a single `finalizeGameSession(romId)` call; the backend
    `SessionLifecycleService.finalize` orchestrates playtime record → post-exit save sync → migration refresh and returns
@@ -1530,60 +1530,99 @@ newest-wins / conflict / `.romm-backup` machinery. The server dedupes on `(user_
 a re-POST of a queued session is idempotent; the outbox dequeues on a `created` or `duplicate` result and stays queued
 only on `error` (ADR-0018).
 
-### Session scoping: one slot, keyed by its app
+### Session scoping: one entry per running app
 
-`sessionManager` tracks **one** active session: `{appId, romId, startMs}`, opened on a game start and on either
-reload-adoption branch, and always with the appId set alongside the rom.
+`sessionManager` tracks active sessions in a map keyed by Steam appId, each entry `{appId, romId, startMs}`, opened on a
+game start and on adoption. Two RomM games at once hold two entries and each records its own playtime and runs its own
+post-exit sync (#1624). Before that the manager held a single slot, and the second game to start displaced the first —
+the displaced session was dropped outright: no playtime for the span already played, and no post-exit save sync when
+that game eventually exited, because its stop found a slot that no longer held it.
 
-The appId is what a stop is matched against. `RegisterForAppLifetimeNotifications` fires for every app Steam tracks —
-another non-Steam shortcut, a regular Steam game, a second RomM game — so the stop path checks the stopping app against
-the **appId recorded with the session**, never a fresh `appId → romId` map lookup (the cached map can be stale at stop
-time, and a stale miss would drop a real session instead of an unrelated one). A stop for any other app is a debug-level
-no-op: no playtime write, no post-exit sync, and the session stays open until its own app exits. Before #1621 the stop
-path took no appId at all and finalized whatever was in the slot, which recorded a wrong (early) duration and — the part
-that mattered — ran the post-exit save sync against a game whose emulator still held the save file open, capturing a
+The key is the appId, not the romId, for two reasons. Every write path is handed an appId — the lifetime notification's
+`unAppID` on both edges, and the running-app reading at adoption. And the stop path must match against the **appId
+recorded with the session**, never a fresh `appId → romId` map lookup: `RegisterForAppLifetimeNotifications` fires for
+every app Steam tracks (another non-Steam shortcut, a regular Steam game, a second RomM game), and the cached map can be
+stale at stop time, so a stale miss would drop a real session instead of an unrelated one. A romId key would force
+exactly that reverse lookup back into the path. A stop for an app with no entry is a debug-level no-op: no playtime
+write, no post-exit sync, and every open session stays open until its own app exits. Before #1621 the stop path took no
+appId at all and finalized whatever was in the slot, which recorded a wrong (early) duration and — the part that
+mattered — ran the post-exit save sync against a game whose emulator still held the save file open, capturing a
 half-written file that the real exit then diverged from.
 
-Two RomM games at once still exceed the single slot: the second start displaces the first, and the displaced session is
-**dropped**, logged at warning with both rom ids. Its stop was never observed, so it gets no fabricated end — the same
-rule an orphaned breadcrumb follows (see below).
+**A start for an app that already has an entry is ignored** (#1589) — the entry keeps its earlier `startMs` and
+`record_session_start` is **not** called again. The backend RE-OPENS the marker rather than extending it, so a second
+call silently discards the span already played; the re-open is deliberate (adoption depends on it), so the guard belongs
+frontend-side. The duplicate start still re-dispatches `romm_session_changed` with `running: true`, so a surface that
+missed the first event self-heals. The guard is checked before the rom lookup, so a map that emptied mid-session cannot
+drop a live entry.
 
-Keeping the slot single is a deliberate decision, not an oversight. A per-rom map would ripple into the breadcrumb, both
-adoption branches, and every `getActiveSessionRomId()` consumer — including the launch gate's already-running guard,
-which is save-safety machinery. Concurrent RomM games are rare, and scoping the stop to its own app removes the
-dangerous behaviour without touching that surface. Revisit only if concurrent play stops being an edge case.
+Liveness is exposed to the launch surfaces as `isSessionActive(romId)` — a predicate over the map, which is what all
+five call sites were asking anyway.
+
+**Concurrency of the post-exit work is deliberately not per-app.** Lifecycle events run on one serialized chain, and the
+post-exit save syncs behind them serialize further on a **device-wide** gate (`services/saves/sync_engine/_gate.py`, 60s
+budget) — RomM's `negotiate` is device-scoped and the engine's layout state is shared mutable state, so parallel syncs
+are not safe. Two games exiting close together therefore sync one after the other; if the first overruns the budget the
+second is skipped and retried at its next sync. Playtime is unaffected either way — it is recorded before the sync runs.
+Per-app sync chains are a non-goal, not an oversight.
+
+Known rough edge in that skip: a gate timeout is currently classified as `server_unreachable`, so the skipped sync
+surfaces the "Server offline — saves will sync next time" toast even though the server is fine. The wait was local. No
+data is at risk (the sync is simply retried), but the copy is misleading, and concurrent exits are the first thing that
+makes the path reachable.
 
 ### Surviving a plugin reload mid-session
 
-`destroySessionManager` wipes the in-memory session on unload, so a plugin reload while a game is running would leave
+`destroySessionManager` wipes the in-memory sessions on unload, so a plugin reload while a game is running would leave
 the next game-stop with nothing to finalize — the pre-reload playtime is lost and the post-exit sync never runs. Two
-signals let the re-initialized `sessionManager` recover it:
+signals let the re-initialized `sessionManager` recover them:
 
-- **Steam running-state (liveness).** A guarded reader (`utils/runningApps`) is the authority for _whether_ the game is
-  still running at re-init — the durable marker (`last_session_start`) is written by `recordSessionStart` precisely so
-  it survives the reload, but only Steam can attest the session has not already ended. Its one surface is
+- **Steam running-state (liveness).** A guarded reader (`utils/runningApps`) is the authority for _whether_ the games
+  are still running at re-init — the durable marker (`last_session_start`) is written by `recordSessionStart` precisely
+  so it survives the reload, but only Steam can attest a session has not already ended. Its one surface is
   `SteamUIStore.RunningApps`, read through a guard (an absent store, a `null` store or a throwing getter degrades to
   "nothing running", never a throw). A single read is not trusted: after a full `plugin_loader` restart the store
   reports an **empty** list for several seconds with the game still running (#1054 / #1148 round 2), so the read is
   **polled** (every 500ms for up to 15s), not one-shot, and a timed-out round logs the `diagnostics` note that tells an
-  absent store, an empty list and a throwing getter apart.
-- **A localStorage breadcrumb (attestation).** A single versioned row (`decky-romm-sync:active-session` →
-  `{v, appId, romId, startMs}`) is written at start and removed at stop. It is **not** cleared by
+  absent store, an empty list and a throwing getter apart. The poll settles once something is running **and every
+  attested app has surfaced**: the store omits apps whose overview has not loaded, so a reading listing one concurrent
+  game can still be missing its sibling, and stopping at the first non-empty round would orphan it.
+- **A localStorage breadcrumb (attestation).** One versioned row (`decky-romm-sync:active-session` →
+  `{v: 2, sessions: [{appId, romId, startMs}, …]}`) holds **every** open session. It is **not** cleared by
   `destroySessionManager`, so it outlives the reload. Every localStorage access is wrapped — a storage failure degrades
   to the no-attestation path, never throws.
 
-At `initSessionManager` the recovery runs on the lifecycle chain (so a stop event racing the liveness poll serializes
-after adoption — adopt first, then finalize):
+  Writes are a **projection**: the map is the source of truth and the whole row is rewritten after each mutation, before
+  any await, never read-modify-written. `setItem` is atomic per key, so a failed write leaves the previous row intact
+  and self-heals at the next mutation. An empty map removes the row, so "no live session" stays the absent state.
 
-- **Game running + breadcrumb matches** → adopt in-memory state from the breadcrumb (`sessionStartTime`) and leave the
-  durable marker untouched. Re-stamping would discard the pre-reload span the backend already holds.
-- **Game running, no / mismatched / corrupt breadcrumb** → adopt and re-stamp the marker to a truthful lower bound
-  (`recordSessionStart`), then write a fresh breadcrumb so a subsequent reload adopts via the matching case instead of
-  re-stamping again.
-- **Breadcrumb present but nothing running once the liveness poll times out** (or a non-RomM app is foreground) → the
-  session ended while the plugin was down; a truthful finalize is impossible without an observed end, so the breadcrumb
-  is dropped and the session is logged as orphaned — never a fabricated end time. A stale breadcrumb left by a reboot
-  resolves the same way at the next init; no expiry timers.
+  The reader branches on the stored **version first, before any field**, and each version a released build could have
+  written gets its own lift into the current shape — a v1 row (one session inline) becomes a one-entry list and is
+  rewritten as v2 at the next persist. Validating version and fields in one expression would fail every v1 row, and a
+  failed validation is indistinguishable from no attestation, so a running session's pre-upgrade span would be silently
+  discarded on the first reload after an update. Entries are read individually: one corrupt entry never voids its
+  siblings. An unknown (future) version is unusable — same standing as no row at all.
+
+At `initSessionManager` the recovery runs on the lifecycle chain (so a stop event racing the liveness poll serializes
+after adoption — adopt first, then finalize). The attested set and the running set are then reconciled **per app**, so
+any number of concurrent games recovers together:
+
+- **Attested + running** → adopted as attested, durable marker untouched. Re-stamping would discard the pre-reload span
+  the backend already holds. The **breadcrumb's own romId** is adopted, never the one the `appId → romId` map resolves
+  now: the binding is 1:1 at any instant but not stable over time (a version switch moves a shortcut to a different rom
+  row), and the open marker belongs to the rom the start opened — re-stamping the current one would open a second marker
+  and leave the original dangling.
+- **Running + ours + unattested** → adopted with the marker re-stamped to a truthful lower bound (`recordSessionStart`),
+  then attested so a subsequent reload adopts it as attested instead of re-stamping again.
+- **Attested but not running** once the poll settles → the session ended while the plugin was down; a truthful finalize
+  is impossible without an observed end, so the entry is dropped and logged as orphaned — never a fabricated end time. A
+  stale breadcrumb left by a reboot resolves the same way at the next init; no expiry timers.
+- **Running but not ours** → ignored entirely. A foreign app is never adopted, and never a reason to orphan anything
+  else. Before #1624 adoption read only the head of the running list, so a foreign app in the foreground orphaned a RomM
+  game still running behind it.
+
+An app whose session a start notification already opened is skipped by both passes, so adoption never re-opens a live
+session (#1589).
 
 **Attestation invariant:** every finalize fold uses a marker stamped by a start we actually observed (either the
 original `recordSessionStart` or an adoption re-stamp) — the client never invents an end time for a session whose stop
@@ -1765,12 +1804,12 @@ shows no Steam "already running" dialog, which dissolves the mid-session-sync pr
 defending against it. (`SteamClient.Apps.RaiseWindowForGame` — the earlier approach — is a **desktop-overlay** call:
 native only acts on it when `SteamUIStore.GetOverlayInstances(appId)` is non-empty, which it never is in gamescope Game
 Mode, so it reports `Success` but silently does nothing. Hence the switch to the store-navigation path.) A click first
-runs a **liveness gate**: if nothing is actually running (`isAppRunning(appId)` / `getActiveSessionRomId()` both say no
-— a stale overlay from a session that ended without a stop event reaching the button), it clears the overlay and falls
+runs a **liveness gate**: if nothing is actually running (`isAppRunning(appId)` / `isSessionActive(romId)` both say no —
+a stale overlay from a session that ended without a stop event reaching the button), it clears the overlay and falls
 through to the normal launch funnel (self-heal). If `NavigateToRunningApp` is absent on an older SteamUI build, the
 foreground falls back to `Navigation.Navigate("/apprunning")` after the `SetRunningApp` selection (same visible effect).
 
-Detection is **reactive, not polled**: the overlay is seeded synchronously at mount from `getActiveSessionRomId()` /
+Detection is **reactive, not polled**: the overlay is seeded synchronously at mount from `isSessionActive(romId)` /
 `isAppRunning(appId)` (so a page opened mid-session — or after a reload-adoption — shows Resume immediately) and flipped
 live by the `romm_session_changed` DOM event, which `sessionManager` dispatches on game start (`running: true`), game
 stop (`running: false`), and both reload-adoption branches (`running: true`). The already-running guards from #1148 /

--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -1735,19 +1735,25 @@ The callback receives:
 
 ### Running-app detection (`utils/runningApps`)
 
-After a game starts, there is a brief window where the app ID may not be fully resolved. The session manager waits 500ms
-and then reads the guarded running-app reader for a reliable `appid` and `display_name`, falling back to `unAppID` from
-the notification if nothing is reported. The reader has one surface, `SteamUIStore.RunningApps` — the only running-app
-page global Steam actually exposes, and there is no second one to add: `Router` is not a page global on any SteamUI
-build, and `@decky/ui`'s `Router` export resolves to the same `SteamUIStore` singleton (#1588). It is read through a
-guard (an absent, `null`, or throwing-getter store degrades to "reported nothing", never a throw) and returns a
-`diagnostics` string distinguishing absent / empty / threw / the appids found. The list's head is the foreground app —
-Steam derives `RunningApps` and its own `MainRunningApp` from one private array, with `MainRunningApp` defined as
-`RunningApps[0]` — so no second surface is needed to identify it. The store is not reliable across timing, though: after
-a `plugin_loader` restart it reports an empty list for several seconds while the game runs (#1054 / #1148 round 2), so
-the adoption path **polls** the reader (every 500ms up to 15s) instead of reading once, and a failed round logs what the
-store reported. The same reader backs the already-running skip on both launch surfaces — the interceptor and the Play
-button ([ADR-0015](../adr/0015-single-launch-gate-cancel-then-relaunch.md)).
+The reader has one surface, `SteamUIStore.RunningApps` — the only running-app page global Steam actually exposes, and
+there is no second one to add: `Router` is not a page global on any SteamUI build, and `@decky/ui`'s `Router` export
+resolves to the same `SteamUIStore` singleton (#1588). It is read through a guard (an absent, `null`, or throwing-getter
+store degrades to "reported nothing", never a throw) and returns a `diagnostics` string distinguishing absent / empty /
+threw / the appids found.
+
+**It answers membership, never identity.** The list is the store's private running-appid array mapped through the app
+store with unloaded overviews dropped, so its head is not even reliably Steam's own `MainRunningApp` — the two diverge
+during exactly the post-launch window this plugin cares about. The order it does carry is "most recently foregrounded"
+(`SetRunningApp` removes and unshifts), while the reconciler that notices a newly-launched process appends it at the
+tail. So the head is never the app that just started, and nothing reads it to identify one: the session manager takes
+the starting app's id from the lifetime notification's own `unAppID` (#1624 — it previously waited 500ms and read the
+head, which both mis-attributed a start while another game was running and stalled the serialized lifecycle chain).
+
+The store is also not reliable across timing: after a `plugin_loader` restart it reports an empty list for several
+seconds while the game runs (#1054 / #1148 round 2), so the adoption path **polls** the reader (every 500ms up to 15s)
+instead of reading once, and a failed round logs what the store reported. The same reader backs the already-running skip
+on both launch surfaces — the interceptor and the Play button
+([ADR-0015](../adr/0015-single-launch-gate-cancel-then-relaunch.md)).
 
 ### State-aware Resume button (#1313)
 

--- a/src/components/CustomPlayButton.test.tsx
+++ b/src/components/CustomPlayButton.test.tsx
@@ -63,7 +63,7 @@ vi.mock("../utils/migrationStore", () => ({
 // CustomPlayButton is the only in-graph importer of either module, so a full mock
 // exposing just the guard's two functions is safe.
 vi.mock("../utils/sessionManager", () => ({
-  getActiveSessionRomId: vi.fn(() => null),
+  isSessionActive: vi.fn(() => false),
 }));
 vi.mock("../utils/runningApps", () => ({
   isAppRunning: vi.fn(() => false),
@@ -91,7 +91,7 @@ import { setRommConnectionState, reportServerReachable, getRommConnectionState }
 import { setLaunchOptionsConfirmed } from "../utils/steamShortcuts";
 import { markLaunchSkipped, consumeLaunchSkip } from "../utils/launchGate";
 import { getMigrationState } from "../utils/migrationStore";
-import { getActiveSessionRomId } from "../utils/sessionManager";
+import { isSessionActive } from "../utils/sessionManager";
 import { isAppRunning } from "../utils/runningApps";
 import { showOfflineDriftModal } from "../components/OfflineDriftModal";
 import { showFallbackLaunchModal } from "../components/FallbackLaunchModal";
@@ -738,7 +738,7 @@ describe("CustomPlayButton — already-running guard (#1148 round 2)", () => {
     vi.mocked(getCachedGameDetail).mockReset();
     vi.mocked(toaster.toast).mockReset();
     // Guard defaults: no live session, nothing running (overridden per test).
-    vi.mocked(getActiveSessionRomId).mockReturnValue(null);
+    vi.mocked(isSessionActive).mockReturnValue(false);
     vi.mocked(isAppRunning).mockReturnValue(false);
     // Gate predecessors so the NORMAL path can reach preLaunchSync when the guard
     // is inert; the guard tests assert these are never touched.
@@ -771,7 +771,7 @@ describe("CustomPlayButton — already-running guard (#1148 round 2)", () => {
     const playBtn = await findByText("Play");
     // The session starts after render, before the click — the render→click race
     // the handlePlay guard exists to catch.
-    vi.mocked(getActiveSessionRomId).mockReturnValue(42);
+    vi.mocked(isSessionActive).mockReturnValue(true);
     await act(async () => {
       playBtn.click();
     });
@@ -1914,7 +1914,7 @@ describe("CustomPlayButton — pre-launch relaunch re-confirm (#1150)", () => {
 // (SetRunningApp + NavigateToRunningApp) — Steam's own gamescope "Resume Game"
 // path, NOT the pre-launch sync funnel and NOT the desktop-only RaiseWindowForGame
 // (which silently no-ops in Game Mode). Detection is reactive: seeded at mount from
-// getActiveSessionRomId()/isAppRunning and flipped live by the romm_session_changed
+// isSessionActive(romId)/isAppRunning and flipped live by the romm_session_changed
 // DOM event. The #1148/#1308 already-running guards stay intact as backstops.
 // ---------------------------------------------------------------------------
 describe("CustomPlayButton — state-aware Resume (#1313)", () => {
@@ -1926,7 +1926,7 @@ describe("CustomPlayButton — state-aware Resume (#1313)", () => {
     vi.mocked(getCachedGameDetail).mockReset();
     vi.mocked(toaster.toast).mockReset();
     // Detection defaults: not running (overridden per test).
-    vi.mocked(getActiveSessionRomId).mockReturnValue(null);
+    vi.mocked(isSessionActive).mockReturnValue(false);
     vi.mocked(isAppRunning).mockReturnValue(false);
     // Gate predecessors so the self-heal fall-through can reach the full funnel.
     vi.mocked(backend.isSaveTrackingConfigured).mockResolvedValue({ configured: true, active_slot: "default" });
@@ -1962,7 +1962,7 @@ describe("CustomPlayButton — state-aware Resume (#1313)", () => {
   });
 
   it("renders Resume (not Play) and foregrounds via SteamUIStore when this rom is the live session — no gate/sync/RunGame", async () => {
-    vi.mocked(getActiveSessionRomId).mockReturnValue(42);
+    vi.mocked(isSessionActive).mockReturnValue(true);
 
     const { findByText, queryByText } = render(<CustomPlayButton appId={100} />);
 
@@ -1986,7 +1986,7 @@ describe("CustomPlayButton — state-aware Resume (#1313)", () => {
   });
 
   it("renders Resume and foregrounds when a running-app source reports the appId — no gate/sync/RunGame", async () => {
-    vi.mocked(getActiveSessionRomId).mockReturnValue(null);
+    vi.mocked(isSessionActive).mockReturnValue(false);
     vi.mocked(isAppRunning).mockReturnValue(true);
 
     const { findByText, queryByText } = render(<CustomPlayButton appId={100} />);
@@ -2029,7 +2029,7 @@ describe("CustomPlayButton — state-aware Resume (#1313)", () => {
   });
 
   it("flips back to Play when the session-stop event for this rom arrives", async () => {
-    vi.mocked(getActiveSessionRomId).mockReturnValue(42);
+    vi.mocked(isSessionActive).mockReturnValue(true);
 
     const { findByText, queryByText } = render(<CustomPlayButton appId={100} />);
     await findByText("Resume");
@@ -2115,7 +2115,7 @@ describe("CustomPlayButton — state-aware Resume (#1313)", () => {
 
   it("self-heals a stale overlay: falls through to the launch funnel when nothing is actually running", async () => {
     // Seed Resume via the session-start EVENT while the live sources stay false
-    // (getActiveSessionRomId null, isAppRunning false), so the liveness gate in
+    // (isSessionActive false, isAppRunning false), so the liveness gate in
     // handleResumeGame sees nothing running and falls through to handlePlay — the
     // already-running guard there is inert, so the FULL funnel runs (self-heal).
     const { findByText } = render(<CustomPlayButton appId={100} />);
@@ -2141,7 +2141,7 @@ describe("CustomPlayButton — state-aware Resume (#1313)", () => {
   });
 
   it("falls back to Navigation.Navigate('/apprunning') when NavigateToRunningApp is missing (API drift)", async () => {
-    vi.mocked(getActiveSessionRomId).mockReturnValue(42);
+    vi.mocked(isSessionActive).mockReturnValue(true);
     // Older SteamUI: SetRunningApp present, NavigateToRunningApp absent.
     vi.stubGlobal("SteamUIStore", { SetRunningApp: setRunningApp });
 
@@ -2161,7 +2161,7 @@ describe("CustomPlayButton — state-aware Resume (#1313)", () => {
   });
 
   it("falls back to Navigation.Navigate('/apprunning') when SteamUIStore.SetRunningApp throws (present-but-broken store)", async () => {
-    vi.mocked(getActiveSessionRomId).mockReturnValue(42);
+    vi.mocked(isSessionActive).mockReturnValue(true);
     // Present store, but SetRunningApp is a throwing getter/method — the exact
     // present-but-broken failure class this whole PR was born from. Without the
     // guard the async fn rejects, detach() swallows it, and the route fallback is
@@ -2193,7 +2193,7 @@ describe("CustomPlayButton — state-aware Resume (#1313)", () => {
   });
 
   it("navigates directly when SteamUIStore is absent (extreme API drift)", async () => {
-    vi.mocked(getActiveSessionRomId).mockReturnValue(42);
+    vi.mocked(isSessionActive).mockReturnValue(true);
     // No SteamUIStore at all — the last-resort route nav still foregrounds.
     vi.stubGlobal("SteamUIStore", undefined);
 
@@ -2225,7 +2225,7 @@ describe("CustomPlayButton — Stop Game", () => {
     vi.mocked(showContextMenu).mockReset();
     vi.mocked(toaster.toast).mockReset();
     // Live session for appId 100 / rom 42 → the running overlay renders.
-    vi.mocked(getActiveSessionRomId).mockReturnValue(42);
+    vi.mocked(isSessionActive).mockReturnValue(true);
     vi.mocked(isAppRunning).mockReturnValue(true);
     vi.mocked(getCachedGameDetail).mockResolvedValue({
       found: true,
@@ -2379,7 +2379,7 @@ describe("CustomPlayButton — Stop Game", () => {
   it("self-heals a stale overlay without confirming or calling the backend", async () => {
     // Overlay seeded by the session-start EVENT while the live sources say
     // nothing is running — the same stale-overlay case handleResumeGame heals.
-    vi.mocked(getActiveSessionRomId).mockReturnValue(null);
+    vi.mocked(isSessionActive).mockReturnValue(false);
     vi.mocked(isAppRunning).mockReturnValue(false);
 
     const utils = render(<CustomPlayButton appId={100} />);
@@ -2591,7 +2591,7 @@ describe("CustomPlayButton — Stop Game", () => {
   it("resets a stuck Launching state on a successful stop", async () => {
     // The session-start path sets isRunning but leaves state === "launching";
     // clearing only the overlay would expose a stale "Launching..." label.
-    vi.mocked(getActiveSessionRomId).mockReturnValue(null);
+    vi.mocked(isSessionActive).mockReturnValue(false);
     vi.mocked(isAppRunning).mockReturnValue(false);
     vi.mocked(backend.isSaveTrackingConfigured).mockResolvedValue({ configured: true, active_slot: "default" });
     vi.mocked(backend.checkCoreChange).mockResolvedValue({ changed: false });
@@ -2613,7 +2613,7 @@ describe("CustomPlayButton — Stop Game", () => {
     });
     // The launch left the state at "launching"; the session-start event raises
     // the overlay on top of it, and the live sources now report the session.
-    vi.mocked(getActiveSessionRomId).mockReturnValue(42);
+    vi.mocked(isSessionActive).mockReturnValue(true);
     vi.mocked(isAppRunning).mockReturnValue(true);
     act(() => {
       globalThis.dispatchEvent(
@@ -2643,7 +2643,7 @@ describe("CustomPlayButton — version switch (#1298)", () => {
     vi.mocked(getCachedGameDetail).mockReset();
     // Prior describes leave the running-overlay stubs live (Resume button) —
     // reset to "nothing running" so the button lands on Play/Download.
-    vi.mocked(getActiveSessionRomId).mockReturnValue(null);
+    vi.mocked(isSessionActive).mockReturnValue(false);
     vi.mocked(isAppRunning).mockReturnValue(false);
   });
 

--- a/src/components/CustomPlayButton.tsx
+++ b/src/components/CustomPlayButton.tsx
@@ -49,7 +49,7 @@ import { showStopGameModal } from "./StopGameModal";
 import { getMigrationState } from "../utils/migrationStore";
 import { runLaunchGate, markLaunchSkipped } from "../utils/launchGate";
 import type { GateVerdict, LaunchGateOps, PreLaunchSyncOutcome } from "../utils/launchGate";
-import { getActiveSessionRomId } from "../utils/sessionManager";
+import { isSessionActive } from "../utils/sessionManager";
 import { isAppRunning } from "../utils/runningApps";
 import type { DownloadProgressEvent, DownloadCompleteEvent, DownloadFailedEvent } from "../types";
 import { SAVEFILES_IN_CONTENT_DIR_REASON } from "../types";
@@ -201,7 +201,7 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
         // Seed the running overlay from the live session/running-app state so a
         // button mounted mid-session (or after a reload-adoption) shows Resume
         // immediately, without waiting for a session event (#1313).
-        setIsRunning(getActiveSessionRomId() === rid || isAppRunning(appId));
+        setIsRunning(isSessionActive(rid) || isAppRunning(appId));
 
         if (cached.installed) {
           // Check for conflicts from cached save status
@@ -589,7 +589,7 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
     // open and manufacture a conflict at exit. Skip the whole gate/sync funnel and
     // just bring the game to front — `dispatchLaunch` skip-marks the appId so the
     // resulting RunGame doesn't re-enter the interceptor and re-gate either.
-    if (getActiveSessionRomId() === romId || isAppRunning(appId)) {
+    if (isSessionActive(romId) || isAppRunning(appId)) {
       detach(debugLog(`CustomPlayButton: appId=${appId} already running — skipping pre-launch sync`));
       await dispatchLaunch(gameId);
       return;
@@ -686,7 +686,7 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
     // event reaching this button). If nothing is actually running, clear the
     // overlay and fall through to the normal launch funnel — self-heal, so a click
     // never strands the user on a dead Resume.
-    if (!(isAppRunning(appId) || getActiveSessionRomId() === romId)) {
+    if (!(isAppRunning(appId) || (romId !== null && isSessionActive(romId)))) {
       detach(debugLog(`CustomPlayButton: Resume on appId=${appId} but nothing is running — self-healing to launch`));
       setIsRunning(false);
       await handlePlay();
@@ -762,7 +762,7 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
     // Stale-overlay self-heal, mirroring handleResumeGame: if nothing is
     // actually running, the overlay is stale — clear it back to Play without
     // prompting or touching the backend.
-    if (!(isAppRunning(appId) || getActiveSessionRomId() === romId)) {
+    if (!(isAppRunning(appId) || (romId !== null && isSessionActive(romId)))) {
       detach(debugLog(`CustomPlayButton: Stop on appId=${appId} but nothing is running — clearing stale overlay`));
       clearRunningOverlay();
       return;

--- a/src/utils/launchInterceptor.test.ts
+++ b/src/utils/launchInterceptor.test.ts
@@ -56,7 +56,7 @@ vi.mock("./launchGate", async (importActual) => {
 
 vi.mock("./sessionManager", () => ({
   getAppIdRomIdMapSnapshot: vi.fn(() => ({ "1234": 42 })),
-  getActiveSessionRomId: vi.fn(() => null),
+  isSessionActive: vi.fn(() => false),
 }));
 
 vi.mock("./runningApps", () => ({
@@ -156,7 +156,7 @@ describe("launchInterceptor — full funnel watcher", () => {
     vi.mocked(sessionManager.getAppIdRomIdMapSnapshot).mockReturnValue({ "1234": 42 });
     // Default: no live session and nothing running, so the already-running guard
     // is inert and the existing funnel tests run unchanged. Overridden per-test.
-    vi.mocked(sessionManager.getActiveSessionRomId).mockReturnValue(null);
+    vi.mocked(sessionManager.isSessionActive).mockReturnValue(false);
     vi.mocked(runningApps.isAppRunning).mockReturnValue(false);
     vi.mocked(launchGate.runLaunchGate).mockResolvedValue({ decision: "allow" });
     // The shared relaunch re-confirm (#1152) runs on every relaunch; default it
@@ -214,13 +214,16 @@ describe("launchInterceptor — full funnel watcher", () => {
   describe("already-running guard", () => {
     it("skips the funnel (no cancel, no gate, no sync) when the appId is the live session", async () => {
       // Our own session state says rom 42 (appId 1234) is live.
-      vi.mocked(sessionManager.getActiveSessionRomId).mockReturnValue(42);
+      vi.mocked(sessionManager.isSessionActive).mockReturnValue(true);
 
       registerLaunchInterceptor();
       const handler = captureHandler();
       handler(77, "1234", "LaunchApp", 0);
       await flush();
 
+      // The liveness question is asked about the rom the PRESSED app resolves to
+      // through the map snapshot — not about whatever rom happens to be live.
+      expect(sessionManager.isSessionActive).toHaveBeenCalledWith(42);
       expect(SteamClient.Apps.CancelGameAction).not.toHaveBeenCalled();
       expect(launchGate.runLaunchGate).not.toHaveBeenCalled();
       expect(backend.preLaunchSync).not.toHaveBeenCalled();
@@ -232,7 +235,7 @@ describe("launchInterceptor — full funnel watcher", () => {
 
     it("skips the funnel when a running-app source reports the appId running", async () => {
       // No live session in our state, but Steam's running-app surfaces show it.
-      vi.mocked(sessionManager.getActiveSessionRomId).mockReturnValue(null);
+      vi.mocked(sessionManager.isSessionActive).mockReturnValue(false);
       vi.mocked(runningApps.isAppRunning).mockReturnValue(true);
 
       registerLaunchInterceptor();
@@ -250,10 +253,10 @@ describe("launchInterceptor — full funnel watcher", () => {
       );
     });
 
-    it("does NOT skip when a DIFFERENT rom is the live session — normal funnel runs", async () => {
-      // A different game (rom 99) is live; the pressed appId 1234 (rom 42) is not
-      // running → the guard is inert and the normal cancel+gate funnel proceeds.
-      vi.mocked(sessionManager.getActiveSessionRomId).mockReturnValue(99);
+    it("does NOT skip when the pressed rom has no live session — normal funnel runs", async () => {
+      // Another game may well be live; what matters is that the PRESSED rom (42)
+      // is not → the guard is inert and the normal cancel+gate funnel proceeds.
+      vi.mocked(sessionManager.isSessionActive).mockReturnValue(false);
       vi.mocked(runningApps.isAppRunning).mockReturnValue(false);
 
       registerLaunchInterceptor();
@@ -261,6 +264,7 @@ describe("launchInterceptor — full funnel watcher", () => {
       handler(77, "1234", "LaunchApp", 0);
       await flush();
 
+      expect(sessionManager.isSessionActive).toHaveBeenCalledWith(42);
       expect(SteamClient.Apps.CancelGameAction).toHaveBeenCalledWith(77);
       expect(launchGate.runLaunchGate).toHaveBeenCalled();
       expect(runGameMock()).toHaveBeenCalledWith("gid-7", "", -1, 100);

--- a/src/utils/launchInterceptor.ts
+++ b/src/utils/launchInterceptor.ts
@@ -34,7 +34,7 @@ import {
 import { getMigrationState, setMigrationStatus } from "./migrationStore";
 import { reportServerReachable } from "./connectionState";
 import { setSaveSortMigrationStatus } from "./saveSortMigrationStore";
-import { getAppIdRomIdMapSnapshot, getActiveSessionRomId } from "./sessionManager";
+import { getAppIdRomIdMapSnapshot, isSessionActive } from "./sessionManager";
 import { isAppRunning } from "./runningApps";
 import { runLaunchGate, markLaunchSkipped, consumeLaunchSkip } from "./launchGate";
 import type { GateVerdict, LaunchGateOps, PreLaunchSyncOutcome } from "./launchGate";
@@ -303,9 +303,8 @@ export function registerLaunchInterceptor(): void {
       // "already running" anyway, so the cancel+re-sync is pure damage. Skip the
       // whole funnel when this appId is our live session OR any Steam running-app
       // source reports it running; Steam surfaces its own "already running" popup.
-      const activeRomId = getActiveSessionRomId();
-      const activeAppRomId = getAppIdRomIdMapSnapshot()[String(appId)];
-      if ((activeRomId !== null && activeAppRomId === activeRomId) || isAppRunning(appId)) {
+      const pressedRomId = getAppIdRomIdMapSnapshot()[String(appId)];
+      if ((pressedRomId !== undefined && isSessionActive(pressedRomId)) || isAppRunning(appId)) {
         logInfo(`Launch interceptor: appId=${appId} already running — skipping pre-launch sync`);
         return;
       }

--- a/src/utils/runningApps.test.ts
+++ b/src/utils/runningApps.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { readRunningApps, readPrimaryRunningApp, isAppRunning, isAnyAppRunning } from "./runningApps";
+import { readRunningApps, isAppRunning, isAnyAppRunning } from "./runningApps";
 
 // The util reads the bare Steam SP global `SteamUIStore`. Each test stubs only
 // what it exercises; the global afterEach in test-setup.ts runs
@@ -20,9 +20,11 @@ describe("runningApps — guarded SteamUIStore reader", () => {
       expect(diagnostics).toBe("SteamUIStore.RunningApps=[42]");
     });
 
-    it("preserves store order, so the foreground app stays first", () => {
-      // Steam derives RunningApps from one m_runningAppIDs array whose head is
-      // MainRunningApp — the reader must not reorder it.
+    it("reports every running app, in store order, without reordering", () => {
+      // The reader passes the store's order through untouched. That order is
+      // "most recently foregrounded", NOT launch order — no consumer may read
+      // the head as "the app that just started" — but the reader must not
+      // invent an order of its own either.
       vi.stubGlobal("SteamUIStore", {
         RunningApps: [
           { appid: 100, display_name: "Foreground" },
@@ -124,31 +126,6 @@ describe("runningApps — guarded SteamUIStore reader", () => {
       const { apps, diagnostics } = readRunningApps();
       expect(apps).toEqual([]);
       expect(diagnostics).toBe("SteamUIStore.RunningApps=empty");
-    });
-  });
-
-  describe("readPrimaryRunningApp", () => {
-    it("returns the head of the store's list — the foreground app — plus the diagnostics", () => {
-      vi.stubGlobal("SteamUIStore", {
-        RunningApps: [
-          { appid: 100, display_name: "Foreground" },
-          { appid: 200, display_name: "Background" },
-        ],
-      });
-
-      const { app, diagnostics } = readPrimaryRunningApp();
-      expect(app).toEqual({ appid: 100, display_name: "Foreground" });
-      expect(diagnostics).toBe("SteamUIStore.RunningApps=[100,200]");
-    });
-
-    it("returns null when the store reports nothing running", () => {
-      vi.stubGlobal("SteamUIStore", { RunningApps: [] });
-
-      expect(readPrimaryRunningApp().app).toBeNull();
-    });
-
-    it("returns null and does not throw when the store is absent", () => {
-      expect(readPrimaryRunningApp()).toEqual({ app: null, diagnostics: "SteamUIStore.RunningApps=no-store" });
     });
   });
 

--- a/src/utils/runningApps.ts
+++ b/src/utils/runningApps.ts
@@ -5,8 +5,17 @@
  * Steam SP global (declared in `types/steam.d.ts`), and the only one there is.
  * Do not add a second: `Router` is not a page global on any SteamUI build (this
  * reader probed it until #1588 and every logged round said `no-Router`), and
- * `@decky/ui`'s `Router` export resolves to this very `SteamUIStore` singleton,
- * whose `MainRunningApp` is defined as `RunningApps[0]`.
+ * `@decky/ui`'s `Router` export resolves to this very `SteamUIStore` singleton.
+ *
+ * The list is a MEMBERSHIP set, not a launch order. The store maps its private
+ * running-appid array through the app store and DROPS entries whose overview has
+ * not loaded yet, so the head of `RunningApps` is not even reliably Steam's own
+ * `MainRunningApp` — the two diverge exactly during the post-launch window this
+ * plugin cares about. And the ordering it does carry is "most recently
+ * FOREGROUNDED" (`SetRunningApp` removes and unshifts), while the reconciler that
+ * notices a newly-launched process APPENDS it at the tail. The head is therefore
+ * never a way to identify the app that just started — use the appid the lifetime
+ * notification carries. Consumers here ask membership questions only.
  *
  * The read is still guarded. A bare reference to a truly-absent SP global
  * throws `ReferenceError`, so presence is probed with `typeof`; a present store
@@ -102,18 +111,6 @@ export function readRunningApps(): RunningAppsReading {
   } catch (e) {
     return { apps: [], diagnostics: `${SOURCE_LABEL}=threw:${e}` };
   }
-}
-
-/**
- * The foreground running app plus the round's diagnostics. `apps[0]` IS the
- * foreground app: the store derives both `RunningApps` and `MainRunningApp`
- * from one private `m_runningAppIDs` array, with `MainRunningApp` defined as
- * `RunningApps[0]` — so reading the head of the list needs no second Steam
- * surface. `null` means the store reported no running app this round.
- */
-export function readPrimaryRunningApp(): { app: RunningApp | null; diagnostics: string } {
-  const reading = readRunningApps();
-  return { app: reading.apps[0] ?? null, diagnostics: reading.diagnostics };
 }
 
 /** Is a specific `appId` currently running per the store? Never throws. */

--- a/src/utils/sessionManager.test.ts
+++ b/src/utils/sessionManager.test.ts
@@ -98,6 +98,10 @@ function stubRunningApp(appid: number, displayName = "Game"): void {
   vi.stubGlobal("SteamUIStore", { RunningApps: [{ appid, display_name: displayName }] });
 }
 
+function stubRunningApps(apps: { appid: number; display_name: string }[]): void {
+  vi.stubGlobal("SteamUIStore", { RunningApps: apps });
+}
+
 function stubNothingRunning(): void {
   vi.stubGlobal("SteamUIStore", { RunningApps: [] });
 }
@@ -448,18 +452,20 @@ describe("sessionManager reload adoption", () => {
     expect(readSessions()).toEqual([expect.objectContaining({ appId: APP_ID, romId: ROM_ID })]);
   });
 
-  it("adopts and re-stamps when the breadcrumb names a different app than the running game", async () => {
-    // Stale breadcrumb for a different app, in the pre-#1624 shape; the running
-    // game is authoritative.
+  it("adopts and re-stamps the running game while orphaning a breadcrumb for a different app", async () => {
+    // Stale breadcrumb for an app that is not running, in the pre-#1624 shape.
+    // Its app never surfaces, so the poll spends its whole budget waiting for it.
     seedV1Session({ appId: 555, romId: 99, startMs: 5_000 });
     stubRunningApp(APP_ID);
 
-    await initSessionManager();
+    await initDrainingAdoptionPoll();
 
     expect(backend.recordSessionStart).toHaveBeenCalledTimes(1);
     expect(backend.recordSessionStart).toHaveBeenCalledWith(ROM_ID);
-    // The stale breadcrumb is overwritten with a fresh one for the live game.
+    // The running game is adopted on its own terms; the stale attestation is
+    // orphaned rather than transplanted onto it.
     expect(readSessions()).toEqual([expect.objectContaining({ appId: APP_ID, romId: ROM_ID })]);
+    expect(backend.logInfo).toHaveBeenCalledWith(expect.stringContaining("orphaned"));
   });
 
   it("clears the breadcrumb and does not adopt when nothing is running", async () => {
@@ -664,16 +670,187 @@ describe("sessionManager reload adoption", () => {
     expect(backend.finalizeGameSession).toHaveBeenCalledWith(ROM_ID);
   });
 
-  it("clears a live breadcrumb when a non-RomM app is in the foreground", async () => {
+  // #1624: liveness is a MEMBERSHIP question. Adoption used to read only the head
+  // of the running-app list, so a foreign app in the foreground orphaned a RomM
+  // game that was still running right behind it — losing its playtime and its
+  // post-exit save sync.
+  it("adopts a running game listed behind a foreground foreign app", async () => {
     seedSessions([{ appId: APP_ID, romId: ROM_ID, startMs: 5_000 }]);
-    stubRunningApp(999, "Other");
+    stubRunningApps([
+      { appid: 999, display_name: "Other" },
+      { appid: APP_ID, display_name: "Game" },
+    ]);
 
     await initSessionManager();
 
-    // The RomM game is not the foreground app → its session is orphaned, its
-    // breadcrumb dropped, and nothing is adopted or finalized.
+    // Attested and running → adopted as attested, marker untouched, row kept.
+    expect(backend.recordSessionStart).not.toHaveBeenCalled();
+    expect(readSessions()).toEqual([{ appId: APP_ID, romId: ROM_ID, startMs: 5_000 }]);
+    expect(backend.logInfo).not.toHaveBeenCalledWith(expect.stringContaining("orphaned"));
+
+    const lifetime = captureLifetimeCb();
+    await stopGame(lifetime);
+    expect(backend.finalizeGameSession).toHaveBeenCalledWith(ROM_ID);
+  });
+
+  // #1624: adoption reconciles the whole attested SET against the whole running
+  // set, so any number of concurrent games recovers from one reload.
+  it("restores two attested sessions when both games are still running", async () => {
+    vi.mocked(backend.getAppIdRomIdMap).mockResolvedValue({
+      [String(APP_ID)]: ROM_ID,
+      [String(OTHER_APP_ID)]: OTHER_ROM_ID,
+    });
+    seedSessions([
+      { appId: APP_ID, romId: ROM_ID, startMs: 5_000 },
+      { appId: OTHER_APP_ID, romId: OTHER_ROM_ID, startMs: 7_000 },
+    ]);
+    stubRunningApps([
+      { appid: APP_ID, display_name: "Game" },
+      { appid: OTHER_APP_ID, display_name: "Other Game" },
+    ]);
+    const sessionEvents: unknown[] = [];
+    const listener = (e: WindowEventMap["romm_session_changed"]) => sessionEvents.push(e.detail);
+    globalThis.addEventListener("romm_session_changed", listener);
+
+    try {
+      await initSessionManager();
+
+      // Both attested spans survive: neither marker is re-stamped, both rows are
+      // kept verbatim, and both surfaces are told their game is live.
+      expect(backend.recordSessionStart).not.toHaveBeenCalled();
+      expect(readSessions()).toEqual([
+        { appId: APP_ID, romId: ROM_ID, startMs: 5_000 },
+        { appId: OTHER_APP_ID, romId: OTHER_ROM_ID, startMs: 7_000 },
+      ]);
+      expect(sessionEvents).toEqual([
+        { running: true, appId: APP_ID, romId: ROM_ID },
+        { running: true, appId: OTHER_APP_ID, romId: OTHER_ROM_ID },
+      ]);
+
+      // Each adopted session finalizes on its own app's exit.
+      const lifetime = captureLifetimeCb();
+      await stopApp(lifetime, OTHER_APP_ID);
+      expect(backend.finalizeGameSession).toHaveBeenCalledTimes(1);
+      expect(backend.finalizeGameSession).toHaveBeenCalledWith(OTHER_ROM_ID);
+      await stopApp(lifetime, APP_ID);
+      expect(backend.finalizeGameSession).toHaveBeenCalledTimes(2);
+      expect(backend.finalizeGameSession).toHaveBeenLastCalledWith(ROM_ID);
+    } finally {
+      globalThis.removeEventListener("romm_session_changed", listener);
+    }
+  });
+
+  it("waits for a late-surfacing attested app instead of orphaning it", async () => {
+    // The store omits apps whose overview has not loaded yet, so a reading that
+    // already lists one concurrent game can still be missing its sibling.
+    // Settling on the first non-empty reading would orphan the straggler.
+    vi.mocked(backend.getAppIdRomIdMap).mockResolvedValue({
+      [String(APP_ID)]: ROM_ID,
+      [String(OTHER_APP_ID)]: OTHER_ROM_ID,
+    });
+    seedSessions([
+      { appId: APP_ID, romId: ROM_ID, startMs: 5_000 },
+      { appId: OTHER_APP_ID, romId: OTHER_ROM_ID, startMs: 7_000 },
+    ]);
+    stubRunningApp(APP_ID);
+
+    const init = initSessionManager();
+    await vi.advanceTimersByTimeAsync(1_000); // rounds pass with only one app listed
+    stubRunningApps([
+      { appid: APP_ID, display_name: "Game" },
+      { appid: OTHER_APP_ID, display_name: "Other Game" },
+    ]);
+    await vi.advanceTimersByTimeAsync(500);
+    await init;
+
+    expect(backend.recordSessionStart).not.toHaveBeenCalled();
+    expect(backend.logInfo).not.toHaveBeenCalledWith(expect.stringContaining("orphaned"));
+    expect(readSessions()).toEqual([
+      { appId: APP_ID, romId: ROM_ID, startMs: 5_000 },
+      { appId: OTHER_APP_ID, romId: OTHER_ROM_ID, startMs: 7_000 },
+    ]);
+  });
+
+  it("adopts the attested session that is still running and orphans the one that is not", async () => {
+    vi.mocked(backend.getAppIdRomIdMap).mockResolvedValue({
+      [String(APP_ID)]: ROM_ID,
+      [String(OTHER_APP_ID)]: OTHER_ROM_ID,
+    });
+    seedSessions([
+      { appId: APP_ID, romId: ROM_ID, startMs: 5_000 },
+      { appId: OTHER_APP_ID, romId: OTHER_ROM_ID, startMs: 7_000 },
+    ]);
+    stubRunningApp(APP_ID);
+
+    // The second game's app never surfaces — the poll waits out its budget for it.
+    await initDrainingAdoptionPoll();
+
+    expect(backend.recordSessionStart).not.toHaveBeenCalled();
+    expect(readSessions()).toEqual([{ appId: APP_ID, romId: ROM_ID, startMs: 5_000 }]);
+    expect(backend.logInfo).toHaveBeenCalledWith(expect.stringContaining(`orphaned`));
+    expect(backend.logInfo).toHaveBeenCalledWith(expect.stringContaining(`romId=${OTHER_ROM_ID}`));
+
+    // The survivor still finalizes; the orphan's app is no longer tracked.
+    const lifetime = captureLifetimeCb();
+    await stopApp(lifetime, OTHER_APP_ID);
+    expect(backend.finalizeGameSession).not.toHaveBeenCalled();
+    await stopApp(lifetime, APP_ID);
+    expect(backend.finalizeGameSession).toHaveBeenCalledWith(ROM_ID);
+  });
+
+  it("adopts an attested game as-is alongside an unattested one it re-stamps", async () => {
+    vi.mocked(backend.getAppIdRomIdMap).mockResolvedValue({
+      [String(APP_ID)]: ROM_ID,
+      [String(OTHER_APP_ID)]: OTHER_ROM_ID,
+    });
+    seedSessions([{ appId: APP_ID, romId: ROM_ID, startMs: 5_000 }]);
+    vi.setSystemTime(9_000);
+    stubRunningApps([
+      { appid: APP_ID, display_name: "Game" },
+      { appid: OTHER_APP_ID, display_name: "Other Game" },
+    ]);
+
+    await initSessionManager();
+
+    // Exactly one re-stamp — the attested game keeps its span, the unattested one
+    // gets a truthful lower bound from now.
+    expect(backend.recordSessionStart).toHaveBeenCalledTimes(1);
+    expect(backend.recordSessionStart).toHaveBeenCalledWith(OTHER_ROM_ID);
+    expect(readSessions()).toEqual([
+      { appId: APP_ID, romId: ROM_ID, startMs: 5_000 },
+      { appId: OTHER_APP_ID, romId: OTHER_ROM_ID, startMs: 9_000 },
+    ]);
+  });
+
+  it("adopts the romId the breadcrumb attests, not the one the map now resolves", async () => {
+    // The appId → romId binding is 1:1 at any instant but not stable over time —
+    // a version switch moves the shortcut to a different rom row. The durable
+    // marker belongs to the rom the START opened, so re-stamping the map's
+    // CURRENT rom would open a second marker and leave the original dangling.
+    seedSessions([{ appId: APP_ID, romId: OTHER_ROM_ID, startMs: 5_000 }]);
+    stubRunningApp(APP_ID); // the map binds APP_ID to ROM_ID, not OTHER_ROM_ID
+
+    await initSessionManager();
+
+    expect(backend.recordSessionStart).not.toHaveBeenCalled();
+    expect(readSessions()).toEqual([{ appId: APP_ID, romId: OTHER_ROM_ID, startMs: 5_000 }]);
+
+    const lifetime = captureLifetimeCb();
+    await stopGame(lifetime);
+    expect(backend.finalizeGameSession).toHaveBeenCalledWith(OTHER_ROM_ID);
+  });
+
+  it("orphans an attested session when only a foreign app is running", async () => {
+    seedSessions([{ appId: APP_ID, romId: ROM_ID, startMs: 5_000 }]);
+    stubRunningApp(999, "Other");
+
+    // The attested app never surfaces, so the poll waits out its budget before
+    // concluding the session ended while the plugin was down.
+    await initDrainingAdoptionPoll();
+
     expect(readCrumb()).toBeNull();
     expect(backend.recordSessionStart).not.toHaveBeenCalled();
+    expect(backend.logInfo).toHaveBeenCalledWith(expect.stringContaining("orphaned"));
     const lifetime = captureLifetimeCb();
     await stopGame(lifetime);
     expect(backend.finalizeGameSession).not.toHaveBeenCalled();

--- a/src/utils/sessionManager.test.ts
+++ b/src/utils/sessionManager.test.ts
@@ -1162,6 +1162,38 @@ describe("sessionManager stop scoping (#1621)", () => {
     expect(dataChanged).toContainEqual({ type: "save_sync", rom_id: ROM_ID });
   });
 
+  it("drops the session and rewrites the row before awaiting the finalize", async () => {
+    // Ordering invariant: the stop is OBSERVED the moment it arrives, so the
+    // entry and its attestation must be gone before the long finalize await —
+    // not after it. Persisting afterwards would leave the row live for the whole
+    // post-exit sync, and a reload landing in that window would adopt a session
+    // whose stop was already seen, re-opening its marker over a closed span.
+    let releaseFinalize!: (result: typeof FINALIZE_WITH_PLAYTIME) => void;
+    vi.mocked(backend.finalizeGameSession).mockImplementation(
+      () => new Promise((resolve) => (releaseFinalize = resolve)),
+    );
+
+    await initDrainingAdoptionPoll();
+    const lifetime = captureLifetimeCb();
+    vi.setSystemTime(20_000);
+    await startGame(lifetime);
+    expect(readSessions()).not.toBeNull();
+
+    vi.setSystemTime(60_000);
+    await stopApp(lifetime, APP_ID);
+
+    // The finalize is in flight and has NOT resolved yet.
+    expect(backend.finalizeGameSession).toHaveBeenCalledWith(ROM_ID);
+    expect(updatePlaytimeDisplay).not.toHaveBeenCalled();
+    // Already forgotten, both in memory and on disk.
+    expect(isSessionActive(ROM_ID)).toBe(false);
+    expect(readCrumb()).toBeNull();
+
+    releaseFinalize({ ...FINALIZE_WITH_PLAYTIME });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(updatePlaytimeDisplay).toHaveBeenCalledWith(APP_ID, 99);
+  });
+
   it("ignores a stop for an unrelated app and leaves the session open", async () => {
     await initDrainingAdoptionPoll();
     const lifetime = captureLifetimeCb();

--- a/src/utils/sessionManager.test.ts
+++ b/src/utils/sessionManager.test.ts
@@ -12,7 +12,6 @@ vi.mock("../api/backend", () => ({
   getAppIdRomIdMap: vi.fn(),
   finalizeGameSession: vi.fn(),
   logInfo: vi.fn(),
-  logWarn: vi.fn(),
   logError: vi.fn(),
   debugLog: vi.fn(),
 }));
@@ -1272,14 +1271,62 @@ describe("sessionManager stop scoping (#1621)", () => {
     expect(readCrumb()).toBeNull();
   });
 
-  it("does not warn when the same game re-opens its own session", async () => {
+  // #1589: `record_session_start` RE-OPENS the durable marker instead of
+  // extending it, so a second start for a live session discards the span already
+  // played. The observed symptom was a launch inside the plugin's startup window
+  // being stamped twice, ~1.3s apart, and measured short by the gap.
+  it("does not re-open a live session when the same game reports a second start", async () => {
     await initDrainingAdoptionPoll();
     const lifetime = captureLifetimeCb();
 
+    vi.setSystemTime(20_000);
     await startGame(lifetime);
+    vi.setSystemTime(50_000);
     await startGame(lifetime);
 
-    expect(backend.logWarn).not.toHaveBeenCalled();
+    // One marker, still stamped at the FIRST start — the 30s in between survives.
+    expect(backend.recordSessionStart).toHaveBeenCalledTimes(1);
+    expect(readSessions()).toEqual([{ appId: APP_ID, romId: ROM_ID, startMs: 20_000 }]);
+    expect(backend.debugLog).toHaveBeenCalledWith(expect.stringContaining("Session start ignored"));
+  });
+
+  it("re-announces the live session on a duplicate start so a stale surface self-heals", async () => {
+    await initDrainingAdoptionPoll();
+    const lifetime = captureLifetimeCb();
+    await startGame(lifetime);
+
+    const sessionEvents: unknown[] = [];
+    const listener = (e: WindowEventMap["romm_session_changed"]) => sessionEvents.push(e.detail);
+    globalThis.addEventListener("romm_session_changed", listener);
+    try {
+      await startGame(lifetime);
+      expect(sessionEvents).toEqual([{ running: true, appId: APP_ID, romId: ROM_ID }]);
+    } finally {
+      globalThis.removeEventListener("romm_session_changed", listener);
+    }
+  });
+
+  it("does not re-stamp the marker when the real start notification follows an adoption", async () => {
+    // The #1589 device ordering: adoption opens the session at init, then the
+    // launch's own notification arrives a second later.
+    seedSessions([{ appId: APP_ID, romId: ROM_ID, startMs: 5_000 }]);
+    stubRunningApp(APP_ID);
+
+    await initSessionManager();
+    const lifetime = captureLifetimeCb();
+    expect(backend.recordSessionStart).not.toHaveBeenCalled();
+
+    vi.setSystemTime(20_000);
+    await startGame(lifetime);
+
+    // The adopted span is kept and the marker is left alone.
+    expect(backend.recordSessionStart).not.toHaveBeenCalled();
+    expect(readSessions()).toEqual([{ appId: APP_ID, romId: ROM_ID, startMs: 5_000 }]);
+
+    // The session is still the adopted one — its stop finalizes normally.
+    vi.setSystemTime(60_000);
+    await stopGame(lifetime);
+    expect(backend.finalizeGameSession).toHaveBeenCalledWith(ROM_ID);
   });
 
   it("scopes the stop after adopting a session from a matching breadcrumb", async () => {

--- a/src/utils/sessionManager.test.ts
+++ b/src/utils/sessionManager.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { toaster } from "@decky/api";
 import * as backend from "../api/backend";
 import { updatePlaytimeDisplay } from "../patches/metadataPatches";
-import { initSessionManager, destroySessionManager, ADOPTION_POLL_MAX_MS } from "./sessionManager";
+import { initSessionManager, destroySessionManager, isSessionActive, ADOPTION_POLL_MAX_MS } from "./sessionManager";
 
 // sessionManager talks to the backend callable surface and the migration
 // stores. Mock both so the test observes only what `handleGameStop` forwards
@@ -230,6 +230,58 @@ describe("sessionManager lifecycle forwarding", () => {
     } finally {
       globalThis.removeEventListener("romm_data_changed", listener);
     }
+  });
+});
+
+// The liveness predicate both launch surfaces read synchronously — the Play
+// button to seed and self-heal its Resume overlay, the interceptor to skip its
+// cancel-then-gate funnel for an already-running game. It must discriminate by
+// rom: answering "yes" for a rom that is not the live one would skip the
+// pre-launch sync for a game that is not running.
+describe("sessionManager isSessionActive", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    localStorage.clear();
+    stubLifecycleSteamClient();
+    stubNothingRunning();
+    vi.mocked(backend.getAppIdRomIdMap).mockResolvedValue({
+      [String(APP_ID)]: ROM_ID,
+      [String(OTHER_APP_ID)]: OTHER_ROM_ID,
+    });
+    vi.mocked(backend.finalizeGameSession).mockResolvedValue({ ...IDLE_FINALIZE });
+  });
+
+  afterEach(() => {
+    destroySessionManager();
+    vi.useRealTimers();
+  });
+
+  it("is false with no session open", async () => {
+    await initDrainingAdoptionPoll();
+
+    expect(isSessionActive(ROM_ID)).toBe(false);
+  });
+
+  it("is true for the live rom and false for any other", async () => {
+    await initDrainingAdoptionPoll();
+    const lifetime = captureLifetimeCb();
+
+    await startApp(lifetime, APP_ID);
+
+    expect(isSessionActive(ROM_ID)).toBe(true);
+    expect(isSessionActive(OTHER_ROM_ID)).toBe(false);
+  });
+
+  it("goes false again once the session's own app stops", async () => {
+    await initDrainingAdoptionPoll();
+    const lifetime = captureLifetimeCb();
+
+    await startApp(lifetime, APP_ID);
+    await stopApp(lifetime, APP_ID);
+
+    expect(isSessionActive(ROM_ID)).toBe(false);
   });
 });
 

--- a/src/utils/sessionManager.test.ts
+++ b/src/utils/sessionManager.test.ts
@@ -2,7 +2,13 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { toaster } from "@decky/api";
 import * as backend from "../api/backend";
 import { updatePlaytimeDisplay } from "../patches/metadataPatches";
-import { initSessionManager, destroySessionManager, isSessionActive, ADOPTION_POLL_MAX_MS } from "./sessionManager";
+import {
+  initSessionManager,
+  destroySessionManager,
+  isSessionActive,
+  planAdoption,
+  ADOPTION_POLL_MAX_MS,
+} from "./sessionManager";
 
 // sessionManager talks to the backend callable surface and the migration
 // stores. Mock both so the test observes only what `handleGameStop` forwards
@@ -145,6 +151,81 @@ function stubLifecycleSteamClient(): void {
     },
   });
 }
+
+// The reconcile matrix as a pure decision, independent of the poll, the epoch,
+// localStorage and the backend. The behavioural tests below drive the same
+// matrix end-to-end; these pin each cell of it directly, including the
+// combinations that are awkward to stage through the running-app store.
+describe("planAdoption — the reload reconcile matrix", () => {
+  // The map binds APP_ID → ROM_ID and OTHER_APP_ID → OTHER_ROM_ID; anything else
+  // is a foreign app the plugin does not own.
+  const resolveRomId = (appId: number): number | null =>
+    ({ [APP_ID]: ROM_ID, [OTHER_APP_ID]: OTHER_ROM_ID })[appId] ?? null;
+  const NOW = 9_000;
+  const plan = (crumbs: { appId: number; romId: number; startMs: number }[], running: number[], tracked?: number[]) =>
+    planAdoption(crumbs, running, new Set(tracked ?? []), resolveRomId, NOW);
+
+  it("decides nothing from nothing", () => {
+    expect(plan([], [])).toEqual({ adopted: [], restamped: [], orphans: [] });
+  });
+
+  it("adopts an attested session whose app is running, keeping its attested rom and start", () => {
+    // The attested romId is trusted over the resolver: the open marker belongs to
+    // the rom the START opened, and the binding is not stable over time.
+    const crumb = { appId: APP_ID, romId: OTHER_ROM_ID, startMs: 5_000 };
+
+    expect(plan([crumb], [APP_ID])).toEqual({ adopted: [crumb], restamped: [], orphans: [] });
+  });
+
+  it("orphans an attested session whose app is not running", () => {
+    const crumb = { appId: APP_ID, romId: ROM_ID, startMs: 5_000 };
+
+    expect(plan([crumb], [])).toEqual({ adopted: [], restamped: [], orphans: [crumb] });
+  });
+
+  it("re-stamps a running app of ours that nothing attests", () => {
+    expect(plan([], [APP_ID])).toEqual({
+      adopted: [],
+      restamped: [{ appId: APP_ID, romId: ROM_ID, startMs: NOW }],
+      orphans: [],
+    });
+  });
+
+  it("ignores a foreign running app entirely, and never orphans over it", () => {
+    // The foreign app is at the HEAD, ahead of the attested one — the ordering
+    // that used to make adoption drop a live session.
+    const crumb = { appId: APP_ID, romId: ROM_ID, startMs: 5_000 };
+
+    expect(plan([crumb], [UNRELATED_APP_ID, APP_ID])).toEqual({
+      adopted: [crumb],
+      restamped: [],
+      orphans: [],
+    });
+  });
+
+  it("splits a mixed set: one adopted, one orphaned, one re-stamped", () => {
+    const live = { appId: APP_ID, romId: ROM_ID, startMs: 5_000 };
+    const gone = { appId: 555, romId: 99, startMs: 7_000 };
+
+    expect(plan([live, gone], [APP_ID, OTHER_APP_ID])).toEqual({
+      adopted: [live],
+      restamped: [{ appId: OTHER_APP_ID, romId: OTHER_ROM_ID, startMs: NOW }],
+      orphans: [gone],
+    });
+  });
+
+  it("skips an app that already holds an open session, in both passes (#1589)", () => {
+    // Neither re-adopted (which would reset its start) nor orphaned (which would
+    // drop a live attestation) — the running session is simply left alone.
+    const crumb = { appId: APP_ID, romId: ROM_ID, startMs: 5_000 };
+
+    expect(plan([crumb], [APP_ID, OTHER_APP_ID], [APP_ID, OTHER_APP_ID])).toEqual({
+      adopted: [],
+      restamped: [],
+      orphans: [],
+    });
+  });
+});
 
 describe("sessionManager lifecycle forwarding", () => {
   beforeEach(() => {

--- a/src/utils/sessionManager.test.ts
+++ b/src/utils/sessionManager.test.ts
@@ -102,6 +102,35 @@ function stubNothingRunning(): void {
   vi.stubGlobal("SteamUIStore", { RunningApps: [] });
 }
 
+// The durable attestation: one versioned localStorage row holding EVERY open
+// session. `seedSessions` writes the current (v2) shape; a few tests seed a
+// literal v1 row instead, so the in-place upgrade stays covered where it
+// actually happens. `readSessions` is the shape assertion most tests want (the
+// attested list, or null for "no row"); `readCrumb` exposes the raw row for the
+// version itself.
+const BREADCRUMB_KEY = "decky-romm-sync:active-session";
+
+function seedSessions(sessions: { appId: number; romId: number; startMs: number }[]): void {
+  localStorage.setItem(BREADCRUMB_KEY, JSON.stringify({ v: 2, sessions }));
+}
+
+/** A row in the pre-#1624 (v1) shape — one session inline, no `sessions` list. */
+function seedV1Session(session: { appId: number; romId: number; startMs: number }): void {
+  localStorage.setItem(BREADCRUMB_KEY, JSON.stringify({ v: 1, ...session }));
+}
+
+function readCrumb(): unknown {
+  const raw = localStorage.getItem(BREADCRUMB_KEY);
+  return raw === null ? null : JSON.parse(raw);
+}
+
+function readSessions(): unknown[] | null {
+  const crumb = readCrumb();
+  if (crumb === null) return null;
+  const sessions = (crumb as { sessions?: unknown }).sessions;
+  return Array.isArray(sessions) ? sessions : null;
+}
+
 // The session manager registers only the lifecycle hook — suspend/resume
 // tracking was removed (#1148: the Steam hooks never fired on-device; playtime
 // now excludes suspend via the backend monotonic clock). Re-stub after the
@@ -374,16 +403,6 @@ describe("sessionManager post-exit save-sync toast (#1481)", () => {
 });
 
 describe("sessionManager reload adoption", () => {
-  const BREADCRUMB_KEY = "decky-romm-sync:active-session";
-
-  const seedBreadcrumb = (crumb: { v: number; appId: number; romId: number; startMs: number }) =>
-    localStorage.setItem(BREADCRUMB_KEY, JSON.stringify(crumb));
-
-  const readCrumb = (): unknown => {
-    const raw = localStorage.getItem(BREADCRUMB_KEY);
-    return raw === null ? null : JSON.parse(raw);
-  };
-
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useFakeTimers();
@@ -401,7 +420,7 @@ describe("sessionManager reload adoption", () => {
   });
 
   it("adopts a matching breadcrumb without re-stamping the marker, then finalizes on stop", async () => {
-    seedBreadcrumb({ v: 1, appId: APP_ID, romId: ROM_ID, startMs: 5_000 });
+    seedSessions([{ appId: APP_ID, romId: ROM_ID, startMs: 5_000 }]);
     stubRunningApp(APP_ID);
 
     await initSessionManager();
@@ -426,12 +445,13 @@ describe("sessionManager reload adoption", () => {
     // a later reload adopts via case (a) instead of re-stamping again.
     expect(backend.recordSessionStart).toHaveBeenCalledTimes(1);
     expect(backend.recordSessionStart).toHaveBeenCalledWith(ROM_ID);
-    expect(readCrumb()).toMatchObject({ v: 1, appId: APP_ID, romId: ROM_ID });
+    expect(readSessions()).toEqual([expect.objectContaining({ appId: APP_ID, romId: ROM_ID })]);
   });
 
   it("adopts and re-stamps when the breadcrumb names a different app than the running game", async () => {
-    // Stale breadcrumb for a different app; the running game is authoritative.
-    seedBreadcrumb({ v: 1, appId: 555, romId: 99, startMs: 5_000 });
+    // Stale breadcrumb for a different app, in the pre-#1624 shape; the running
+    // game is authoritative.
+    seedV1Session({ appId: 555, romId: 99, startMs: 5_000 });
     stubRunningApp(APP_ID);
 
     await initSessionManager();
@@ -439,11 +459,11 @@ describe("sessionManager reload adoption", () => {
     expect(backend.recordSessionStart).toHaveBeenCalledTimes(1);
     expect(backend.recordSessionStart).toHaveBeenCalledWith(ROM_ID);
     // The stale breadcrumb is overwritten with a fresh one for the live game.
-    expect(readCrumb()).toMatchObject({ v: 1, appId: APP_ID, romId: ROM_ID });
+    expect(readSessions()).toEqual([expect.objectContaining({ appId: APP_ID, romId: ROM_ID })]);
   });
 
   it("clears the breadcrumb and does not adopt when nothing is running", async () => {
-    seedBreadcrumb({ v: 1, appId: APP_ID, romId: ROM_ID, startMs: 5_000 });
+    seedSessions([{ appId: APP_ID, romId: ROM_ID, startMs: 5_000 }]);
     stubNothingRunning();
 
     // Nothing ever runs → the poll times out and the breadcrumb is orphan-cleared.
@@ -545,28 +565,87 @@ describe("sessionManager reload adoption", () => {
     expect(backend.finalizeGameSession).toHaveBeenCalledWith(ROM_ID);
   });
 
-  it("treats a wrong-version breadcrumb as unusable and re-stamps (a′)", async () => {
-    // A breadcrumb from a future schema (v2) fails isSessionBreadcrumb.
-    seedBreadcrumb({ v: 2, appId: APP_ID, romId: ROM_ID, startMs: 5_000 });
+  // #1624: the durable row is versioned, and the version is branched on BEFORE
+  // any field is read. A row written by the PREVIOUS release must upgrade in
+  // place — treating it as unusable would silently discard the pre-upgrade span
+  // of a session that is still running, on the very first reload after an update.
+  it("upgrades a v1 breadcrumb in place: adopted via (a), marker untouched, row rewritten as v2", async () => {
+    seedV1Session({ appId: APP_ID, romId: ROM_ID, startMs: 5_000 });
+    stubRunningApp(APP_ID);
+
+    await initSessionManager();
+
+    // The pre-upgrade start survives: no re-stamp, and the rewritten row carries
+    // the ORIGINAL startMs rather than "now".
+    expect(backend.recordSessionStart).not.toHaveBeenCalled();
+    expect(readCrumb()).toEqual({ v: 2, sessions: [{ appId: APP_ID, romId: ROM_ID, startMs: 5_000 }] });
+
+    const lifetime = captureLifetimeCb();
+    await stopGame(lifetime);
+    expect(backend.finalizeGameSession).toHaveBeenCalledWith(ROM_ID);
+  });
+
+  it("keeps the sound entries of a v2 row when one entry is malformed", async () => {
+    // Per-entry tolerance: a single corrupt entry must not void its siblings.
+    localStorage.setItem(
+      BREADCRUMB_KEY,
+      JSON.stringify({
+        v: 2,
+        sessions: [
+          { appId: "not-a-number", romId: ROM_ID },
+          { appId: APP_ID, romId: ROM_ID, startMs: 5_000 },
+        ],
+      }),
+    );
+    stubRunningApp(APP_ID);
+
+    await initSessionManager();
+
+    // The good entry still attests the running session — adopted via (a).
+    expect(backend.recordSessionStart).not.toHaveBeenCalled();
+    expect(readSessions()).toEqual([{ appId: APP_ID, romId: ROM_ID, startMs: 5_000 }]);
+  });
+
+  it("treats a future-version breadcrumb as unusable and re-stamps (a′)", async () => {
+    // A row from a schema this build knows nothing about: its fields cannot be
+    // trusted even if they happen to look right.
+    localStorage.setItem(BREADCRUMB_KEY, JSON.stringify({ v: 3, sessions: [{ appId: APP_ID, romId: ROM_ID }] }));
     stubRunningApp(APP_ID);
 
     await initSessionManager();
 
     expect(backend.recordSessionStart).toHaveBeenCalledTimes(1);
     expect(backend.recordSessionStart).toHaveBeenCalledWith(ROM_ID);
-    // Overwritten with a fresh v1 breadcrumb.
-    expect(readCrumb()).toMatchObject({ v: 1, appId: APP_ID, romId: ROM_ID });
+    // Overwritten with a fresh row in the current shape.
+    expect(readCrumb()).toEqual({ v: 2, sessions: [{ appId: APP_ID, romId: ROM_ID, startMs: 0 }] });
+  });
+
+  it("treats a v2 row whose sessions are missing or not a list as unusable and re-stamps (a′)", async () => {
+    localStorage.setItem(BREADCRUMB_KEY, JSON.stringify({ v: 2 }));
+    stubRunningApp(APP_ID);
+
+    await initSessionManager();
+
+    expect(backend.recordSessionStart).toHaveBeenCalledTimes(1);
+
+    destroySessionManager();
+    vi.clearAllMocks();
+    localStorage.setItem(BREADCRUMB_KEY, JSON.stringify({ v: 2, sessions: { appId: APP_ID } }));
+
+    await initSessionManager();
+
+    expect(backend.recordSessionStart).toHaveBeenCalledTimes(1);
   });
 
   it("treats a non-object breadcrumb JSON as unusable and re-stamps (a′)", async () => {
-    // Valid JSON but not an object — isSessionBreadcrumb rejects it.
+    // Valid JSON but not an object — no version to branch on.
     localStorage.setItem(BREADCRUMB_KEY, JSON.stringify(42));
     stubRunningApp(APP_ID);
 
     await initSessionManager();
 
     expect(backend.recordSessionStart).toHaveBeenCalledTimes(1);
-    expect(readCrumb()).toMatchObject({ v: 1, appId: APP_ID, romId: ROM_ID });
+    expect(readSessions()).toEqual([expect.objectContaining({ appId: APP_ID, romId: ROM_ID })]);
   });
 
   it("survives a rejected recordSessionStart during adoption", async () => {
@@ -579,14 +658,14 @@ describe("sessionManager reload adoption", () => {
 
     // The breadcrumb is written before the failing call, and the session is
     // still adopted — a subsequent stop finalizes the original rom.
-    expect(readCrumb()).toMatchObject({ v: 1, appId: APP_ID, romId: ROM_ID });
+    expect(readSessions()).toEqual([expect.objectContaining({ appId: APP_ID, romId: ROM_ID })]);
     const lifetime = captureLifetimeCb();
     await stopGame(lifetime);
     expect(backend.finalizeGameSession).toHaveBeenCalledWith(ROM_ID);
   });
 
   it("clears a live breadcrumb when a non-RomM app is in the foreground", async () => {
-    seedBreadcrumb({ v: 1, appId: APP_ID, romId: ROM_ID, startMs: 5_000 });
+    seedSessions([{ appId: APP_ID, romId: ROM_ID, startMs: 5_000 }]);
     stubRunningApp(999, "Other");
 
     await initSessionManager();
@@ -650,7 +729,7 @@ describe("sessionManager reload adoption", () => {
     // SteamUIStore intentionally not stubbed — on a build/timing where the
     // global is genuinely absent, a bare read would throw ReferenceError out of
     // the poll. Adoption must still reach its ordinary timeout verdict.
-    seedBreadcrumb({ v: 1, appId: APP_ID, romId: ROM_ID, startMs: 5_000 });
+    seedSessions([{ appId: APP_ID, romId: ROM_ID, startMs: 5_000 }]);
 
     const init = initSessionManager();
     await vi.advanceTimersByTimeAsync(ADOPTION_POLL_MAX_MS);
@@ -667,7 +746,7 @@ describe("sessionManager reload adoption", () => {
   // EMPTY running-app list for several seconds while the game is still running,
   // so a one-shot read wrongly orphaned a live session. Adoption now polls.
   it("adopts a matching breadcrumb once the store reports the app mid-poll, no orphan log", async () => {
-    seedBreadcrumb({ v: 1, appId: APP_ID, romId: ROM_ID, startMs: 5_000 });
+    seedSessions([{ appId: APP_ID, romId: ROM_ID, startMs: 5_000 }]);
     stubNothingRunning();
 
     const init = initSessionManager();
@@ -692,7 +771,7 @@ describe("sessionManager reload adoption", () => {
   });
 
   it("orphan-clears the breadcrumb after the poll times out with nothing running", async () => {
-    seedBreadcrumb({ v: 1, appId: APP_ID, romId: ROM_ID, startMs: 5_000 });
+    seedSessions([{ appId: APP_ID, romId: ROM_ID, startMs: 5_000 }]);
     stubNothingRunning();
 
     await initDrainingAdoptionPoll();
@@ -716,7 +795,7 @@ describe("sessionManager reload adoption", () => {
   });
 
   it("queues a racing stop behind the poll so it finalizes after adoption", async () => {
-    seedBreadcrumb({ v: 1, appId: APP_ID, romId: ROM_ID, startMs: 1_000 });
+    seedSessions([{ appId: APP_ID, romId: ROM_ID, startMs: 1_000 }]);
     stubNothingRunning();
 
     const init = initSessionManager();
@@ -768,7 +847,6 @@ describe("sessionManager reload adoption", () => {
 // sessionManager dispatches it (running:true on start + reload-adoption,
 // running:false on stop) with the appId+romId the button matches on.
 describe("sessionManager session-changed dispatch (#1313)", () => {
-  const BREADCRUMB_KEY = "decky-romm-sync:active-session";
   let sessionEvents: { running: boolean; appId: number; romId: number }[];
   let sessionListener: (e: WindowEventMap["romm_session_changed"]) => void;
 
@@ -828,6 +906,7 @@ describe("sessionManager session-changed dispatch (#1313)", () => {
   });
 
   it("dispatches running:true when adopting a running session via a matching breadcrumb", async () => {
+    // A v1 row, extra keys and all — the lift ignores what it does not know.
     localStorage.setItem(
       BREADCRUMB_KEY,
       JSON.stringify({ v: 1, appId: APP_ID, romId: ROM_ID, startMs: 5_000, pausedMs: 0 }),
@@ -859,12 +938,6 @@ describe("sessionManager session-changed dispatch (#1313)", () => {
 // Finalizing on a foreign app's exit recorded the wrong playtime AND ran the
 // post-exit save sync against a game still holding its save file open.
 describe("sessionManager stop scoping (#1621)", () => {
-  const BREADCRUMB_KEY = "decky-romm-sync:active-session";
-  const readCrumb = (): unknown => {
-    const raw = localStorage.getItem(BREADCRUMB_KEY);
-    return raw === null ? null : JSON.parse(raw);
-  };
-
   // finalizeGameSession is the single callable behind BOTH the playtime write and
   // the post-exit save sync, so "not called" is the direct assertion that neither
   // ran. total_seconds makes the playtime display write observable too.
@@ -917,6 +990,8 @@ describe("sessionManager stop scoping (#1621)", () => {
     await initDrainingAdoptionPoll();
     const lifetime = captureLifetimeCb();
 
+    // Times are absolute and the adoption poll already drained to 15s.
+    vi.setSystemTime(20_000);
     await startGame(lifetime);
     vi.setSystemTime(30_000);
     await stopApp(lifetime, UNRELATED_APP_ID);
@@ -929,16 +1004,16 @@ describe("sessionManager stop scoping (#1621)", () => {
 
     // The session is still open: its breadcrumb survives and its own app's stop
     // still finalizes it, at the real end time.
-    expect(readCrumb()).toMatchObject({ v: 1, appId: APP_ID, romId: ROM_ID });
+    expect(readSessions()).toEqual([{ appId: APP_ID, romId: ROM_ID, startMs: 20_000 }]);
     vi.setSystemTime(60_000);
     await stopApp(lifetime, APP_ID);
     expect(backend.finalizeGameSession).toHaveBeenCalledWith(ROM_ID);
     expect(updatePlaytimeDisplay).toHaveBeenCalledWith(APP_ID, 99);
   });
 
-  it("ignores a stop for a second RomM game that is not the active session", async () => {
+  it("ignores a stop for a second RomM game that opened no session", async () => {
     // The stopping app maps to a real rom, so a fresh map lookup would happily
-    // resolve one — only the appId RECORDED with the session rejects it.
+    // resolve one — only its absence from the session map rejects it.
     await initDrainingAdoptionPoll();
     const lifetime = captureLifetimeCb();
 
@@ -949,29 +1024,44 @@ describe("sessionManager stop scoping (#1621)", () => {
     expect(dataChanged).toEqual([]);
   });
 
-  it("warns and drops the displaced session when a second game takes the slot", async () => {
+  // #1624: a second RomM game used to displace the first, which then recorded no
+  // playtime and ran no post-exit save sync at all — its stop found a slot that
+  // no longer held it. Both now stand on their own.
+  it("keeps both sessions when a second RomM game starts, finalizing each on its own app's exit", async () => {
     await initDrainingAdoptionPoll();
     const lifetime = captureLifetimeCb();
 
+    // Times are absolute and the adoption poll already drained to 15s.
+    vi.setSystemTime(20_000);
     await startGame(lifetime);
     vi.setSystemTime(30_000);
     await startApp(lifetime, OTHER_APP_ID);
 
-    // The displaced session leaves a trace and is dropped, not finalized with a
-    // fabricated end — its stop was never observed.
-    const warning = vi.mocked(backend.logWarn).mock.calls.map((c) => c[0]);
-    expect(warning).toContainEqual(expect.stringContaining(`romId=${OTHER_ROM_ID}`));
-    expect(warning).toContainEqual(expect.stringContaining(`romId=${ROM_ID}`));
-    expect(backend.finalizeGameSession).not.toHaveBeenCalled();
+    // Two open markers, two attested sessions, nothing finalized yet.
+    expect(backend.recordSessionStart).toHaveBeenCalledWith(ROM_ID);
     expect(backend.recordSessionStart).toHaveBeenCalledWith(OTHER_ROM_ID);
-
-    // The displaced app's exit is now a no-op; the live session finalizes on its
-    // own app's exit — the exact ordering from the device log in #1621.
-    await stopApp(lifetime, APP_ID);
     expect(backend.finalizeGameSession).not.toHaveBeenCalled();
-    await stopApp(lifetime, OTHER_APP_ID);
+    expect(readSessions()).toEqual([
+      { appId: APP_ID, romId: ROM_ID, startMs: 20_000 },
+      { appId: OTHER_APP_ID, romId: OTHER_ROM_ID, startMs: 30_000 },
+    ]);
+
+    // The first game exits: only its rom is finalized, and the sibling session
+    // survives — both in memory and in the rewritten row.
+    vi.setSystemTime(60_000);
+    await stopApp(lifetime, APP_ID);
     expect(backend.finalizeGameSession).toHaveBeenCalledTimes(1);
-    expect(backend.finalizeGameSession).toHaveBeenCalledWith(OTHER_ROM_ID);
+    expect(backend.finalizeGameSession).toHaveBeenCalledWith(ROM_ID);
+    expect(updatePlaytimeDisplay).toHaveBeenCalledWith(APP_ID, 99);
+    expect(readSessions()).toEqual([{ appId: OTHER_APP_ID, romId: OTHER_ROM_ID, startMs: 30_000 }]);
+
+    // The second game exits: its own rom is finalized, at its own end time.
+    vi.setSystemTime(90_000);
+    await stopApp(lifetime, OTHER_APP_ID);
+    expect(backend.finalizeGameSession).toHaveBeenCalledTimes(2);
+    expect(backend.finalizeGameSession).toHaveBeenLastCalledWith(OTHER_ROM_ID);
+    expect(updatePlaytimeDisplay).toHaveBeenCalledWith(OTHER_APP_ID, 99);
+    expect(readCrumb()).toBeNull();
   });
 
   it("finalizes the live session even when the app map went stale mid-session", async () => {
@@ -1016,7 +1106,7 @@ describe("sessionManager stop scoping (#1621)", () => {
   });
 
   it("scopes the stop after adopting a session from a matching breadcrumb", async () => {
-    localStorage.setItem(BREADCRUMB_KEY, JSON.stringify({ v: 1, appId: APP_ID, romId: ROM_ID, startMs: 5_000 }));
+    seedSessions([{ appId: APP_ID, romId: ROM_ID, startMs: 5_000 }]);
     stubRunningApp(APP_ID);
 
     await initSessionManager();

--- a/src/utils/sessionManager.test.ts
+++ b/src/utils/sessionManager.test.ts
@@ -58,8 +58,9 @@ function captureLifetimeCb(): LifetimeCb {
 /** Drive a start notification for a specific app through the lifecycle chain. */
 async function startApp(cb: LifetimeCb, appId: number): Promise<void> {
   cb({ bRunning: true, unAppID: appId });
-  // handleGameStart is gated behind a delay(500) inside the lifecycle chain.
-  await vi.advanceTimersByTimeAsync(500);
+  // The start path runs straight off the notification — no timer to advance past,
+  // only the chain's microtasks to flush.
+  await vi.advanceTimersByTimeAsync(0);
 }
 
 /** Drive a stop notification for a specific app and flush the chain. */
@@ -90,9 +91,9 @@ async function initDrainingAdoptionPoll(): Promise<void> {
 }
 
 // Liveness comes from `SteamUIStore.RunningApps` — the one running-app surface
-// (#1588). Its head is the foreground app, so a single-entry list seeds a
-// running game and an empty list seeds "the store reports nothing", which is
-// exactly what the post-loader-restart adoption window looks like on-device.
+// (#1588). It is a membership set, so a single-entry list seeds a running game
+// and an empty list seeds "the store reports nothing", which is exactly what the
+// post-loader-restart adoption window looks like on-device.
 function stubRunningApp(appid: number, displayName = "Game"): void {
   vi.stubGlobal("SteamUIStore", { RunningApps: [{ appid, display_name: displayName }] });
 }
@@ -164,6 +165,38 @@ describe("sessionManager lifecycle forwarding", () => {
 
     expect(backend.recordSessionStart).not.toHaveBeenCalled();
     expect(backend.finalizeGameSession).not.toHaveBeenCalled();
+  });
+
+  // #1624: the start path takes the app id from the notification itself. The
+  // running-app store must not be consulted — see the reader's docstring.
+  it("opens the session for the app the notification names, not the running-app head", async () => {
+    // A DIFFERENT app sits at the head of the store. `RunningApps` is ordered
+    // most-recently-foregrounded and appends fresh arrivals at the tail, so the
+    // head is never the app that just started; trusting it would open a session
+    // on the wrong app and leave this one's stop finalizing nothing.
+    vi.stubGlobal("SteamUIStore", { RunningApps: [{ appid: OTHER_APP_ID, display_name: "Other" }] });
+    await initSessionManager();
+    const lifetime = captureLifetimeCb();
+
+    await startApp(lifetime, APP_ID);
+    expect(backend.recordSessionStart).toHaveBeenCalledWith(ROM_ID);
+
+    vi.setSystemTime(60_000);
+    await stopApp(lifetime, APP_ID);
+    expect(backend.finalizeGameSession).toHaveBeenCalledWith(ROM_ID);
+  });
+
+  it("records the start without stalling the lifecycle chain on a timer", async () => {
+    // The 500ms wait existed only so the running-app head could populate. With
+    // that read gone it stalls every queued lifecycle event behind it — advancing
+    // no time at all must already have recorded the start.
+    await initDrainingAdoptionPoll();
+    const lifetime = captureLifetimeCb();
+
+    lifetime({ bRunning: true, unAppID: APP_ID });
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(backend.recordSessionStart).toHaveBeenCalledWith(ROM_ID);
   });
 
   it("dispatches romm_data_changed on stop even when the post-exit sync failed (#1334)", async () => {
@@ -801,8 +834,8 @@ describe("sessionManager stop scoping (#1621)", () => {
     });
     vi.mocked(backend.recordSessionStart).mockResolvedValue({ success: true });
     vi.mocked(backend.finalizeGameSession).mockResolvedValue({ ...FINALIZE_WITH_PLAYTIME });
-    // Nothing in the running-app store → handleGameStart resolves the app from
-    // the notification's unAppID, so each start is addressable per app.
+    // Nothing in the running-app store, so reload-adoption is inert here and each
+    // start is addressable per app via its notification's unAppID.
     stubNothingRunning();
     dataChanged = [];
     dataListener = (e: Event) => dataChanged.push((e as CustomEvent).detail);

--- a/src/utils/sessionManager.ts
+++ b/src/utils/sessionManager.ts
@@ -31,7 +31,7 @@ import { delay } from "./pacedOps";
 // matched against it; a second RomM game starting displaces the first. Turning
 // the slot into a per-rom map is a deliberate non-goal, not an oversight: it
 // would ripple into the breadcrumb, both adoption branches, and every
-// `getActiveSessionRomId()` consumer — including the launch gate's already-running
+// `isSessionActive()` consumer — including the launch gate's already-running
 // guard, which is save-safety machinery. Concurrent RomM games are rare, and
 // scoping the stop to its own app already removes the dangerous behaviour
 // (finalizing the wrong session, post-exit save sync against a running game).
@@ -77,14 +77,15 @@ export function getAppIdRomIdMapSnapshot(): Record<string, number> {
 }
 
 /**
- * The romId of the session this manager currently tracks as live, or `null` when
- * none is open. The launch interceptor reads it synchronously to skip its
- * cancel-then-gate funnel for a Play press on an already-running game (#1148
- * round 2) — re-syncing mid-session would upload the save while the emulator
- * holds the file open, and Steam blocks the relaunch as "already running" anyway.
+ * Does this manager currently track a live session for `romId`? Read
+ * synchronously by the launch interceptor, to skip its cancel-then-gate funnel
+ * for a Play press on an already-running game (#1148 round 2) — re-syncing
+ * mid-session would upload the save while the emulator holds the file open, and
+ * Steam blocks the relaunch as "already running" anyway — and by the Play
+ * button, to seed and self-heal its Resume overlay.
  */
-export function getActiveSessionRomId(): number | null {
-  return activeSession?.romId ?? null;
+export function isSessionActive(romId: number): boolean {
+  return activeSession?.romId === romId;
 }
 
 async function refreshAppIdMap(): Promise<void> {

--- a/src/utils/sessionManager.ts
+++ b/src/utils/sessionManager.ts
@@ -185,7 +185,29 @@ function dispatchSessionChanged(running: boolean, appId: number, romId: number):
   globalThis.dispatchEvent(new CustomEvent("romm_session_changed", { detail: { running, appId, romId } }));
 }
 
+/**
+ * Open a session for the app that just started — unless it already has one.
+ *
+ * The idempotency is load-bearing (#1589). `record_session_start` RE-OPENS the
+ * durable marker rather than extending it, so a second call for a live session
+ * silently discards the span already played. Steam can report an app as started
+ * twice (notably when a launch lands inside the plugin's own startup window and
+ * reload-adoption has already opened the session), and the re-open is deliberate
+ * backend behaviour that adoption relies on — so the guard belongs here.
+ *
+ * It is keyed on the appId and checked BEFORE the romId lookup: a map that
+ * emptied mid-session must not be able to drop a live entry.
+ */
 async function handleGameStart(appId: number): Promise<void> {
+  const open = activeSessions.get(appId);
+  if (open) {
+    detach(debugLog(`Session start ignored: appId=${appId} already has an open session (romId=${open.romId})`));
+    // Re-announce it — a surface that missed the first event self-heals, and the
+    // earlier startMs is kept.
+    dispatchSessionChanged(true, open.appId, open.romId);
+    return;
+  }
+
   const romId = getRomIdForApp(appId);
   if (!romId) return; // Not a RomM shortcut
 
@@ -373,11 +395,15 @@ async function adoptOrphanedSessions(): Promise<void> {
   const adopted: ActiveSession[] = [];
   const orphans: ActiveSession[] = [];
   for (const crumb of crumbs) {
+    // A start notification for this app already opened its session — leave it be
+    // rather than re-opening it over the top (#1589).
+    if (activeSessions.has(crumb.appId)) continue;
     (running.has(crumb.appId) ? adopted : orphans).push(crumb);
   }
 
   const restamped: ActiveSession[] = [];
   for (const app of reading.apps) {
+    if (activeSessions.has(app.appid)) continue;
     if (adopted.some((session) => session.appId === app.appid)) continue;
     const romId = getRomIdForApp(app.appid);
     if (romId === null) continue;

--- a/src/utils/sessionManager.ts
+++ b/src/utils/sessionManager.ts
@@ -327,7 +327,7 @@ export const ADOPTION_POLL_MAX_MS = 15_000;
  * surfaced. Stopping at the first non-empty reading is not enough — the store
  * omits apps whose overview has not loaded yet, so a reading that already lists
  * one concurrent game can still be missing its sibling, which would then be
- * orphaned. The wait for a stragglers shares the one existing budget.
+ * orphaned. The wait for stragglers shares the one existing budget.
  */
 async function pollForRunningApps(wanted: Set<number>): Promise<RunningAppsReading> {
   const started = Date.now();
@@ -391,12 +391,21 @@ async function adoptOrphanedSessions(): Promise<void> {
       : `adoption: no running app after ${waitedMs}ms [${reading.diagnostics}]`,
   );
 
+  // Both passes skip an app that already has an open session, so adoption can
+  // never re-open one a start notification opened first (#1589).
+  //
+  // UNREACHABLE as currently wired, deliberately kept: adoption and every
+  // notification handler run on the one serialized `lifecycleChain`, adoption is
+  // enqueued in the same synchronous block that registers the hook, and a
+  // teardown clears the map — so a fresh init always reconciles an empty map. Two
+  // wiring changes would make these live: taking adoption off that chain (giving
+  // a notification a window to complete during the up-to-15s poll), or a handler
+  // that acts directly instead of enqueueing. Do not delete these as dead code
+  // without making one of those orderings impossible instead.
   const running = new Set(reading.apps.map((app) => app.appid));
   const adopted: ActiveSession[] = [];
   const orphans: ActiveSession[] = [];
   for (const crumb of crumbs) {
-    // A start notification for this app already opened its session — leave it be
-    // rather than re-opening it over the top (#1589).
     if (activeSessions.has(crumb.appId)) continue;
     (running.has(crumb.appId) ? adopted : orphans).push(crumb);
   }

--- a/src/utils/sessionManager.ts
+++ b/src/utils/sessionManager.ts
@@ -3,8 +3,9 @@
  * save sync + playtime tracking via backend callables.
  *
  * Uses SteamClient.GameSessions.RegisterForAppLifetimeNotifications to detect
- * game lifecycle events and the guarded `runningApps` reader
- * (`SteamUIStore.RunningApps`) for reliable app-ID resolution.
+ * game lifecycle events — the notification's own `unAppID` identifies the app on
+ * both edges. The guarded `runningApps` reader (`SteamUIStore.RunningApps`) is
+ * used only for LIVENESS at reload-adoption, never to identify a launching app.
  */
 
 import { toaster } from "@decky/api";
@@ -22,7 +23,7 @@ import { setMigrationStatus } from "./migrationStore";
 import { setSaveSortMigrationStatus } from "./saveSortMigrationStore";
 import { updatePlaytimeDisplay } from "../patches/metadataPatches";
 import { detach } from "./detach";
-import { readPrimaryRunningApp, readRunningApps, type RunningApp } from "./runningApps";
+import { readRunningApps, type RunningApp } from "./runningApps";
 import { delay } from "./pacedOps";
 
 // Active session tracking — ONE slot, deliberately (#1621). The slot records the
@@ -388,10 +389,15 @@ export async function initSessionManager(): Promise<void> {
     lifecycleChain = lifecycleChain
       .then(async () => {
         if (update.bRunning) {
-          // Game started — wait for the running-app surfaces to populate
-          await delay(500);
-          const running = readPrimaryRunningApp().app;
-          const appId = running?.appid ?? update.unAppID;
+          // The notification's own appid identifies the app that started. Do NOT
+          // consult `SteamUIStore.RunningApps` here: its head is the most recently
+          // FOREGROUNDED app and a fresh arrival is appended at the tail, so the
+          // head names some other running game — attributing the start to it opens
+          // a session on the wrong rom and never opens one for this app, whose
+          // stop then finalizes nothing. Reading it also cost a 500ms delay that
+          // stalled the whole serialized lifecycle chain (a stop queued behind a
+          // start waited for it too); both are gone.
+          const appId = update.unAppID;
           if (appId) {
             // Refresh map in case a sync happened since init
             await refreshAppIdMap();

--- a/src/utils/sessionManager.ts
+++ b/src/utils/sessionManager.ts
@@ -21,7 +21,7 @@ import { delay } from "./pacedOps";
 // Active session tracking — ONE ENTRY PER RUNNING APP (#1624). Two RomM games at
 // once each hold their own entry, so a second start no longer displaces the
 // first (which dropped its playtime and its post-exit save sync entirely).
-interface ActiveSession {
+export interface ActiveSession {
   /** The Steam app that opened the session — what a lifecycle stop is matched against. */
   appId: number;
   romId: number;
@@ -341,6 +341,77 @@ async function pollForRunningApps(wanted: Set<number>): Promise<RunningAppsReadi
   }
 }
 
+/** What reconciling the attested sessions against the running apps decided. */
+export interface AdoptionPlan {
+  /** Attested and still running — restored exactly as attested. */
+  adopted: ActiveSession[];
+  /** Running and ours but unattested — restored with the marker re-stamped. */
+  restamped: ActiveSession[];
+  /** Attested but no longer running — dropped, never finalized. */
+  orphans: ActiveSession[];
+}
+
+/**
+ * Decide the fate of every attested session and every running app (#1624).
+ *
+ * Pure: reads no module state, performs no I/O, mutates nothing it is handed.
+ * The caller commits the plan — this only says what should happen:
+ *
+ * - attested AND running → adopted as attested. The crumb's own romId is
+ *   trusted, which is why `resolveRomId` is not consulted for it: the durable
+ *   marker belongs to THAT rom, and re-stamping the map's current romId instead
+ *   would open a marker on a different row and leave the original dangling (the
+ *   rule #1621 established for the stop path — an `appId → romId` binding is 1:1
+ *   at any instant but not stable over time).
+ * - running, ours, but unattested → re-stamped: adopted with the marker moved to
+ *   `nowMs`, a truthful lower bound, and attested afterwards so a later reload
+ *   adopts it as attested rather than re-stamping again.
+ * - attested but NOT running → orphaned. Its stop was never observed, and a
+ *   truthful finalize is impossible without an observed end, so the attestation
+ *   is dropped rather than an end time fabricated.
+ * - running but not ours (`resolveRomId` returns `null`) → ignored entirely. A
+ *   foreign app is never adopted and never causes anything else to be orphaned.
+ *
+ * `tracked` names the apps that already hold an open session; both passes skip
+ * them, so adoption can never re-open one a start notification opened first
+ * (#1589).
+ *
+ * That skip is UNREACHABLE as the manager is currently wired, and deliberately
+ * kept: adoption and every notification handler run on the one serialized
+ * `lifecycleChain`, adoption is enqueued in the same synchronous block that
+ * registers the hook, and a teardown clears the session map — so a fresh init
+ * always reconciles against an empty `tracked`. Two wiring changes would make it
+ * live: taking adoption off that chain (giving a notification a window to
+ * complete during the up-to-15s poll), or a handler that acts directly instead
+ * of enqueueing. Do not delete it as dead code without making one of those
+ * orderings impossible instead.
+ */
+export function planAdoption(
+  crumbs: readonly ActiveSession[],
+  runningAppIds: readonly number[],
+  tracked: ReadonlySet<number>,
+  resolveRomId: (appId: number) => number | null,
+  nowMs: number,
+): AdoptionPlan {
+  const running = new Set(runningAppIds);
+  const adopted: ActiveSession[] = [];
+  const orphans: ActiveSession[] = [];
+  for (const crumb of crumbs) {
+    if (tracked.has(crumb.appId)) continue;
+    (running.has(crumb.appId) ? adopted : orphans).push(crumb);
+  }
+
+  const attested = new Set(adopted.map((session) => session.appId));
+  const restamped: ActiveSession[] = [];
+  for (const appId of runningAppIds) {
+    if (tracked.has(appId) || attested.has(appId)) continue;
+    const romId = resolveRomId(appId);
+    if (romId !== null) restamped.push({ appId, romId, startMs: nowMs });
+  }
+
+  return { adopted, restamped, orphans };
+}
+
 /**
  * Adopt the play sessions orphaned by a plugin reload mid-game.
  *
@@ -356,22 +427,9 @@ async function pollForRunningApps(wanted: Set<number>): Promise<RunningAppsReadi
  * up (#1054 / #1148 round 2), so a one-shot read raced the restart and wrongly
  * orphaned a still-running session.
  *
- * The two sets are then reconciled per app, so any number of concurrent games
- * recovers together (#1624):
- *
- * - attested AND running → adopted as attested. The crumb's own romId is
- *   trusted; the durable marker belongs to THAT rom, and re-stamping the map's
- *   current romId instead would open a marker on a different row and leave the
- *   original dangling (the rule #1621 established for the stop path — an
- *   `appId → romId` binding is 1:1 at any instant but not stable over time).
- * - running, ours, but unattested → adopted with the marker re-stamped to a
- *   truthful lower bound from now, then attested so a later reload adopts it
- *   as attested rather than re-stamping again.
- * - attested but NOT running → orphaned. Its stop was never observed, and a
- *   truthful finalize is impossible without an observed end, so the attestation
- *   is dropped rather than an end time fabricated.
- * - running but not ours → ignored entirely. A foreign app is never adopted and
- *   never causes anything else to be orphaned.
+ * This is the orchestration around that: capture the epoch, poll, re-check the
+ * epoch, ask {@link planAdoption} what to do, then commit / dispatch / log /
+ * re-stamp. The reconcile matrix itself lives in that pure function.
  */
 async function adoptOrphanedSessions(): Promise<void> {
   const epoch = sessionEpoch;
@@ -391,33 +449,13 @@ async function adoptOrphanedSessions(): Promise<void> {
       : `adoption: no running app after ${waitedMs}ms [${reading.diagnostics}]`,
   );
 
-  // Both passes skip an app that already has an open session, so adoption can
-  // never re-open one a start notification opened first (#1589).
-  //
-  // UNREACHABLE as currently wired, deliberately kept: adoption and every
-  // notification handler run on the one serialized `lifecycleChain`, adoption is
-  // enqueued in the same synchronous block that registers the hook, and a
-  // teardown clears the map — so a fresh init always reconciles an empty map. Two
-  // wiring changes would make these live: taking adoption off that chain (giving
-  // a notification a window to complete during the up-to-15s poll), or a handler
-  // that acts directly instead of enqueueing. Do not delete these as dead code
-  // without making one of those orderings impossible instead.
-  const running = new Set(reading.apps.map((app) => app.appid));
-  const adopted: ActiveSession[] = [];
-  const orphans: ActiveSession[] = [];
-  for (const crumb of crumbs) {
-    if (activeSessions.has(crumb.appId)) continue;
-    (running.has(crumb.appId) ? adopted : orphans).push(crumb);
-  }
-
-  const restamped: ActiveSession[] = [];
-  for (const app of reading.apps) {
-    if (activeSessions.has(app.appid)) continue;
-    if (adopted.some((session) => session.appId === app.appid)) continue;
-    const romId = getRomIdForApp(app.appid);
-    if (romId === null) continue;
-    restamped.push({ appId: app.appid, romId, startMs: Date.now() });
-  }
+  const { adopted, restamped, orphans } = planAdoption(
+    crumbs,
+    reading.apps.map((app) => app.appid),
+    new Set(activeSessions.keys()),
+    getRomIdForApp,
+    Date.now(),
+  );
 
   const recovered = [...adopted, ...restamped];
   for (const session of recovered) activeSessions.set(session.appId, session);

--- a/src/utils/sessionManager.ts
+++ b/src/utils/sessionManager.ts
@@ -15,7 +15,7 @@ import { setMigrationStatus } from "./migrationStore";
 import { setSaveSortMigrationStatus } from "./saveSortMigrationStore";
 import { updatePlaytimeDisplay } from "../patches/metadataPatches";
 import { detach } from "./detach";
-import { readRunningApps, type RunningApp } from "./runningApps";
+import { readRunningApps, type RunningAppsReading } from "./runningApps";
 import { delay } from "./pacedOps";
 
 // Active session tracking — ONE ENTRY PER RUNNING APP (#1624). Two RomM games at
@@ -296,94 +296,118 @@ const ADOPTION_POLL_INTERVAL_MS = 500;
 export const ADOPTION_POLL_MAX_MS = 15_000;
 
 /**
- * Poll the running-app reader until it reports a running app or the window
- * elapses. Returns the foreground app (any app, RomM or not — the caller applies
- * the adoption matrix) or `null` on timeout, alongside the last round's
- * `diagnostics` so a timed-out adoption logs what the store actually reported
- * (absent / empty / threw). Each round's diagnostics are also emitted at debug
- * level.
+ * Poll the running-app reader until its reading has SETTLED or the window
+ * elapses, and return that last reading (its `diagnostics` say what the store
+ * reported — absent / empty / threw / the appids found; each round's are also
+ * emitted at debug level).
+ *
+ * Settled means: something is running AND every app the breadcrumbs attest has
+ * surfaced. Stopping at the first non-empty reading is not enough — the store
+ * omits apps whose overview has not loaded yet, so a reading that already lists
+ * one concurrent game can still be missing its sibling, which would then be
+ * orphaned. The wait for a stragglers shares the one existing budget.
  */
-async function pollForRunningApp(): Promise<{ app: RunningApp | null; diagnostics: string }> {
+async function pollForRunningApps(wanted: Set<number>): Promise<RunningAppsReading> {
   const started = Date.now();
   for (;;) {
     const reading = readRunningApps();
     detach(debugLog(`adoption poll round: ${reading.diagnostics}`));
-    if (reading.apps.length > 0) return { app: reading.apps[0]!, diagnostics: reading.diagnostics };
-    if (Date.now() - started >= ADOPTION_POLL_MAX_MS) return { app: null, diagnostics: reading.diagnostics };
+    const surfaced = new Set(reading.apps.map((app) => app.appid));
+    if (surfaced.size > 0 && [...wanted].every((appId) => surfaced.has(appId))) return reading;
+    if (Date.now() - started >= ADOPTION_POLL_MAX_MS) return reading;
     await delay(ADOPTION_POLL_INTERVAL_MS);
   }
 }
 
 /**
- * Adopt a play session orphaned by a plugin reload mid-game.
+ * Adopt the play sessions orphaned by a plugin reload mid-game.
  *
- * `destroySessionManager` wipes the in-memory session on unload, so the
- * game-stop after a reload would otherwise never finalize — the pre-reload
+ * `destroySessionManager` wipes the in-memory sessions on unload, so the
+ * game-stops after a reload would otherwise never finalize — the pre-reload
  * playtime is lost and the post-exit sync never runs. Steam's running-state
  * (`SteamUIStore.RunningApps`) is the liveness authority; the localStorage
- * breadcrumb is the attestation of a start we actually observed. Every finalize
- * fold thus stays anchored to a marker stamped by an observed start.
+ * breadcrumbs are the attestations of starts we actually observed. Every
+ * finalize fold thus stays anchored to a marker stamped by an observed start.
  *
  * The liveness read is POLLED, not a single read: after a loader restart the
  * store reports an EMPTY running-app list for seconds while the game is still
  * up (#1054 / #1148 round 2), so a one-shot read raced the restart and wrongly
  * orphaned a still-running session.
+ *
+ * The two sets are then reconciled per app, so any number of concurrent games
+ * recovers together (#1624):
+ *
+ * - attested AND running → adopted as attested. The crumb's own romId is
+ *   trusted; the durable marker belongs to THAT rom, and re-stamping the map's
+ *   current romId instead would open a marker on a different row and leave the
+ *   original dangling (the rule #1621 established for the stop path — an
+ *   `appId → romId` binding is 1:1 at any instant but not stable over time).
+ * - running, ours, but unattested → adopted with the marker re-stamped to a
+ *   truthful lower bound from now, then attested so a later reload adopts it
+ *   as attested rather than re-stamping again.
+ * - attested but NOT running → orphaned. Its stop was never observed, and a
+ *   truthful finalize is impossible without an observed end, so the attestation
+ *   is dropped rather than an end time fabricated.
+ * - running but not ours → ignored entirely. A foreign app is never adopted and
+ *   never causes anything else to be orphaned.
  */
-async function adoptOrphanedSession(): Promise<void> {
+async function adoptOrphanedSessions(): Promise<void> {
   const epoch = sessionEpoch;
   const pollStart = Date.now();
-  const { app: running, diagnostics } = await pollForRunningApp();
+  const crumbs = readSessionBreadcrumbs();
+  const reading = await pollForRunningApps(new Set(crumbs.map((c) => c.appId)));
   if (epoch !== sessionEpoch) {
     // destroySessionManager ran while the poll was in flight — abort before
-    // touching module state, the breadcrumb, or the backend.
+    // touching module state, the breadcrumbs, or the backend.
     detach(debugLog("adoption: cancelled by destroy"));
     return;
   }
   const waitedMs = Date.now() - pollStart;
   logInfo(
-    running
-      ? `adoption: running app appeared after ${waitedMs}ms [${diagnostics}]`
-      : `adoption: no running app after ${waitedMs}ms [${diagnostics}]`,
+    reading.apps.length > 0
+      ? `adoption: running app appeared after ${waitedMs}ms [${reading.diagnostics}]`
+      : `adoption: no running app after ${waitedMs}ms [${reading.diagnostics}]`,
   );
-  const runningRomId = running ? getRomIdForApp(running.appid) : null;
-  const crumbs = readSessionBreadcrumbs();
-  const crumb = crumbs[0] ?? null;
 
-  if (running && runningRomId !== null) {
-    const appId = running.appid;
-    if (crumb && crumb.appId === appId && crumb.romId === runningRomId) {
-      // (a) The breadcrumb attests this exact running session. Restore the
-      // in-memory state, keeping the attested startMs — re-stamping the durable
-      // marker would discard the pre-reload playtime the backend already holds.
-      activeSessions.set(appId, { appId, romId: runningRomId, startMs: crumb.startMs });
-      persistSessions();
-      dispatchSessionChanged(true, appId, runningRomId);
-      logInfo(`Adopted running session from breadcrumb: romId=${runningRomId}, appId=${appId}`);
-    } else {
-      // (a′) A game is running but no usable breadcrumb (missing / mismatched /
-      // corrupt). Adopt it and re-stamp the marker to a truthful lower bound
-      // from now, then attest it so a later reload adopts via (a) rather than
-      // re-stamping again.
-      const adopted: ActiveSession = { appId, romId: runningRomId, startMs: Date.now() };
-      activeSessions.set(appId, adopted);
-      persistSessions();
-      dispatchSessionChanged(true, appId, runningRomId);
-      try {
-        await recordSessionStart(runningRomId);
-      } catch (e) {
-        logError(`Failed to record session start on adoption: ${e}`);
-      }
-      logInfo(`Adopted running session without breadcrumb, re-stamped marker: romId=${runningRomId}, appId=${appId}`);
-    }
-    return;
+  const running = new Set(reading.apps.map((app) => app.appid));
+  const adopted: ActiveSession[] = [];
+  const orphans: ActiveSession[] = [];
+  for (const crumb of crumbs) {
+    (running.has(crumb.appId) ? adopted : orphans).push(crumb);
   }
 
-  // No RomM game is running (nothing running, or a non-RomM app). A breadcrumb
-  // here names a session whose stop we never saw — a truthful finalize is
-  // impossible without an observed end, so drop it rather than fabricate one.
-  if (crumb) {
-    persistSessions();
-    logInfo(`Session orphaned — playtime not recorded (romId=${crumb.romId})`);
+  const restamped: ActiveSession[] = [];
+  for (const app of reading.apps) {
+    if (adopted.some((session) => session.appId === app.appid)) continue;
+    const romId = getRomIdForApp(app.appid);
+    if (romId === null) continue;
+    restamped.push({ appId: app.appid, romId, startMs: Date.now() });
+  }
+
+  const recovered = [...adopted, ...restamped];
+  for (const session of recovered) activeSessions.set(session.appId, session);
+  // One rewrite for the whole reconcile: it drops the orphans and lifts a row
+  // written by an older schema version into the current one.
+  persistSessions();
+
+  for (const session of recovered) dispatchSessionChanged(true, session.appId, session.romId);
+  for (const s of adopted) logInfo(`Adopted running session from breadcrumb: romId=${s.romId}, appId=${s.appId}`);
+  for (const s of orphans) logInfo(`Session orphaned — playtime not recorded (romId=${s.romId})`);
+
+  for (const session of restamped) {
+    if (epoch !== sessionEpoch) {
+      // Each re-stamp is an await, so the teardown check is per iteration.
+      detach(debugLog("adoption: cancelled by destroy"));
+      return;
+    }
+    try {
+      await recordSessionStart(session.romId);
+    } catch (e) {
+      logError(`Failed to record session start on adoption: ${e}`);
+    }
+    logInfo(
+      `Adopted running session without breadcrumb, re-stamped marker: romId=${session.romId}, appId=${session.appId}`,
+    );
   }
 }
 
@@ -428,7 +452,7 @@ export async function initSessionManager(): Promise<void> {
   // lifecycle chain so a stop notification arriving during adoption finalizes
   // after it rather than interleaving with the in-memory state it restores.
   const adoption = lifecycleChain
-    .then(() => adoptOrphanedSession())
+    .then(() => adoptOrphanedSessions())
     .catch((e) => {
       logError(`Session adoption error: ${e}`);
     });

--- a/src/utils/sessionManager.ts
+++ b/src/utils/sessionManager.ts
@@ -9,15 +9,7 @@
  */
 
 import { toaster } from "@decky/api";
-import {
-  recordSessionStart,
-  getAppIdRomIdMap,
-  finalizeGameSession,
-  logInfo,
-  logWarn,
-  logError,
-  debugLog,
-} from "../api/backend";
+import { recordSessionStart, getAppIdRomIdMap, finalizeGameSession, logInfo, logError, debugLog } from "../api/backend";
 import { saveSyncToastBody } from "./saveSyncToast";
 import { setMigrationStatus } from "./migrationStore";
 import { setSaveSortMigrationStatus } from "./saveSortMigrationStore";
@@ -26,15 +18,9 @@ import { detach } from "./detach";
 import { readRunningApps, type RunningApp } from "./runningApps";
 import { delay } from "./pacedOps";
 
-// Active session tracking — ONE slot, deliberately (#1621). The slot records the
-// Steam app that opened the session alongside the rom, so a lifecycle stop can be
-// matched against it; a second RomM game starting displaces the first. Turning
-// the slot into a per-rom map is a deliberate non-goal, not an oversight: it
-// would ripple into the breadcrumb, both adoption branches, and every
-// `isSessionActive()` consumer — including the launch gate's already-running
-// guard, which is save-safety machinery. Concurrent RomM games are rare, and
-// scoping the stop to its own app already removes the dangerous behaviour
-// (finalizing the wrong session, post-exit save sync against a running game).
+// Active session tracking — ONE ENTRY PER RUNNING APP (#1624). Two RomM games at
+// once each hold their own entry, so a second start no longer displaces the
+// first (which dropped its playtime and its post-exit save sync entirely).
 interface ActiveSession {
   /** The Steam app that opened the session — what a lifecycle stop is matched against. */
   appId: number;
@@ -43,7 +29,17 @@ interface ActiveSession {
   startMs: number;
 }
 
-let activeSession: ActiveSession | null = null;
+// Keyed by appId, because that is what every write path is handed: the lifetime
+// notification's `unAppID` on both edges, and the running-app reading at
+// adoption. The stop path in particular must match against the appId RECORDED
+// WITH THE SESSION (#1621) — a romId key would force a reverse lookup through
+// the `appId → romId` map, which can go stale mid-session and would then drop a
+// live session instead of an unrelated one.
+//
+// `const` + `clear()` on teardown: the binding is never reassigned, so a handler
+// already queued on the lifecycle chain cannot end up writing into a map that
+// has been swapped out from under it.
+const activeSessions = new Map<number, ActiveSession>();
 
 // Serialization chain — ensures lifecycle events don't interleave
 let lifecycleChain: Promise<void> = Promise.resolve();
@@ -85,7 +81,10 @@ export function getAppIdRomIdMapSnapshot(): Record<string, number> {
  * button, to seed and self-heal its Resume overlay.
  */
 export function isSessionActive(romId: number): boolean {
-  return activeSession?.romId === romId;
+  for (const session of activeSessions.values()) {
+    if (session.romId === romId) return true;
+  }
+  return false;
 }
 
 async function refreshAppIdMap(): Promise<void> {
@@ -96,56 +95,84 @@ async function refreshAppIdMap(): Promise<void> {
   }
 }
 
-// Durable attestation of the open session — survives a plugin reload so the
-// re-initialized manager can adopt the still-running game and finalize its
-// stop. A single versioned localStorage row; every access is wrapped so a
+// Durable attestation of the open sessions — survives a plugin reload so the
+// re-initialized manager can adopt the still-running games and finalize their
+// stops. A single versioned localStorage row; every access is wrapped so a
 // storage failure degrades to the no-attestation path instead of throwing.
 const SESSION_BREADCRUMB_KEY = "decky-romm-sync:active-session";
-const SESSION_BREADCRUMB_VERSION = 1;
+const SESSION_BREADCRUMB_VERSION = 2;
 
-interface SessionBreadcrumb {
-  v: number;
-  appId: number;
-  romId: number;
-  startMs: number;
+/** Read one stored entry into the current shape, or `null` if it isn't one. */
+function toSessionEntry(value: unknown): ActiveSession | null {
+  if (typeof value !== "object" || value === null) return null;
+  const { appId, romId, startMs } = value as Record<string, unknown>;
+  if (typeof appId !== "number" || typeof romId !== "number" || typeof startMs !== "number") return null;
+  return { appId, romId, startMs };
 }
 
-function isSessionBreadcrumb(value: unknown): value is SessionBreadcrumb {
-  if (typeof value !== "object" || value === null) return false;
-  const c = value as Record<string, unknown>;
-  return (
-    c.v === SESSION_BREADCRUMB_VERSION &&
-    typeof c.appId === "number" &&
-    typeof c.romId === "number" &&
-    typeof c.startMs === "number"
-  );
-}
-
-function readSessionBreadcrumb(): SessionBreadcrumb | null {
+/**
+ * The sessions the durable row attests, or an empty list when it attests none.
+ *
+ * The stored version is branched on FIRST, before any field is looked at, and
+ * every version a released build could have written gets its own lift into the
+ * current shape. Validating version and fields in one expression would make
+ * every row written by the previous version fail — and a failed validation is
+ * indistinguishable from "no attestation", so the live session's pre-upgrade
+ * span would be silently discarded on the first reload after an upgrade.
+ *
+ * Entries are read individually: one malformed entry never voids its siblings.
+ */
+function readSessionBreadcrumbs(): ActiveSession[] {
   try {
     const raw = localStorage.getItem(SESSION_BREADCRUMB_KEY);
-    if (raw === null) return null;
+    if (raw === null) return [];
     const parsed: unknown = JSON.parse(raw);
-    return isSessionBreadcrumb(parsed) ? parsed : null;
+    if (typeof parsed !== "object" || parsed === null) return [];
+    const crumb = parsed as Record<string, unknown>;
+    if (crumb.v === 2) {
+      if (!Array.isArray(crumb.sessions)) return [];
+      return crumb.sessions.map(toSessionEntry).filter((s) => s !== null);
+    }
+    if (crumb.v === 1) {
+      // v1 carried a single session inline — lift it into a one-entry list. No
+      // writer emits v1 any more; the next persist rewrites the row as v2.
+      const lifted = toSessionEntry(crumb);
+      return lifted === null ? [] : [lifted];
+    }
+    // Unknown version: written by a build this one knows nothing about, so its
+    // fields cannot be trusted. Same standing as no attestation at all.
+    return [];
   } catch (e) {
     logError(`Failed to read session breadcrumb: ${e}`);
-    return null;
+    return [];
   }
 }
 
-function writeSessionBreadcrumb(crumb: SessionBreadcrumb): void {
+/**
+ * Rewrite the durable row from the session map.
+ *
+ * A projection, never a read-modify-write: the map is the source of truth and
+ * the whole row is rewritten after every mutation, before any await. A failed
+ * write leaves the previous row intact (`setItem` is atomic per key) and
+ * self-heals at the next mutation.
+ *
+ * An empty map removes the row rather than storing an empty list, so "no live
+ * session" stays the absent state every reader already understands.
+ */
+function persistSessions(): void {
+  if (activeSessions.size === 0) {
+    try {
+      localStorage.removeItem(SESSION_BREADCRUMB_KEY);
+    } catch (e) {
+      logError(`Failed to clear session breadcrumb: ${e}`);
+    }
+    return;
+  }
   try {
-    localStorage.setItem(SESSION_BREADCRUMB_KEY, JSON.stringify(crumb));
+    const row = { v: SESSION_BREADCRUMB_VERSION, sessions: [...activeSessions.values()] };
+    localStorage.setItem(SESSION_BREADCRUMB_KEY, JSON.stringify(row));
   } catch (e) {
     logError(`Failed to write session breadcrumb: ${e}`);
-  }
-}
-
-function clearSessionBreadcrumb(): void {
-  try {
-    localStorage.removeItem(SESSION_BREADCRUMB_KEY);
-  } catch (e) {
-    logError(`Failed to clear session breadcrumb: ${e}`);
   }
 }
 
@@ -163,21 +190,11 @@ async function handleGameStart(appId: number): Promise<void> {
   if (!romId) return; // Not a RomM shortcut
 
   logInfo(`Session start: romId=${romId}, appId=${appId}`);
-  if (activeSession && activeSession.romId !== romId) {
-    // Two RomM games at once, and the single slot holds one. The displaced session
-    // is dropped rather than given a fabricated end — its stop was never observed,
-    // the same rule an orphaned breadcrumb follows. Rare enough to keep the slot
-    // single (see the state block), loud enough to leave a trace when it happens.
-    logWarn(
-      `Session start for romId=${romId} displaces still-active romId=${activeSession.romId} — its playtime is dropped`,
-    );
-  }
-  const session: ActiveSession = { appId, romId, startMs: Date.now() };
-  activeSession = session;
+  activeSessions.set(appId, { appId, romId, startMs: Date.now() });
   dispatchSessionChanged(true, appId, romId);
 
-  // Attest the open session so a reload mid-game can adopt and finalize it.
-  writeSessionBreadcrumb({ v: SESSION_BREADCRUMB_VERSION, appId, romId, startMs: session.startMs });
+  // Attest the open sessions so a reload mid-game can adopt and finalize them.
+  persistSessions();
 
   // Record session start for playtime tracking
   try {
@@ -189,28 +206,23 @@ async function handleGameStart(appId: number): Promise<void> {
 }
 
 /**
- * Finalize the active session, but only when `stoppedAppId` is the app that
- * opened it.
+ * Finalize the session the stopped app opened, if it opened one.
  *
  * `RegisterForAppLifetimeNotifications` fires for EVERY app Steam tracks, so an
- * unrelated app's exit reaches here too (#1621). The comparison is against the
- * appId RECORDED WITH THE SESSION, never a fresh `getRomIdForApp` lookup: the
- * cached map can be stale at stop time, and a stale miss would drop a real
- * session — recording no playtime and skipping the post-exit sync entirely.
+ * unrelated app's exit reaches here too (#1621). The lookup is by the appId
+ * RECORDED WITH THE SESSION, never a fresh `getRomIdForApp` lookup: the cached
+ * map can be stale at stop time, and a stale miss would drop a real session —
+ * recording no playtime and skipping the post-exit sync entirely.
+ *
+ * Any other app's exit — a foreign app, or a concurrent RomM game — leaves every
+ * open session untouched. Finalizing one of those would record its playtime
+ * early AND run the post-exit save sync while its emulator still holds the save
+ * file open, capturing a half-written file.
  */
 async function handleGameStop(stoppedAppId: number): Promise<void> {
-  const session = activeSession;
-  if (!session) return;
-
-  if (session.appId !== stoppedAppId) {
-    // Some other app stopped. The live session stays open — finalizing here would
-    // record its playtime early AND run the post-exit save sync while the emulator
-    // still holds the save file open, capturing a half-written file.
-    detach(
-      debugLog(
-        `Session stop ignored: appId=${stoppedAppId} is not the active session (appId=${session.appId}, romId=${session.romId})`,
-      ),
-    );
+  const session = activeSessions.get(stoppedAppId);
+  if (!session) {
+    detach(debugLog(`Session stop ignored: appId=${stoppedAppId} opened no session`));
     return;
   }
 
@@ -221,10 +233,11 @@ async function handleGameStop(stoppedAppId: number): Promise<void> {
   // session itself, so this needs no reverse-map lookup.
   dispatchSessionChanged(false, appId, romId);
 
-  // Clear active session immediately to avoid double-processing. The breadcrumb
-  // goes with it — the stop is observed, so there is nothing left to adopt.
-  activeSession = null;
-  clearSessionBreadcrumb();
+  // Drop this session immediately to avoid double-processing, and rewrite the
+  // row before the finalize await — the stop is observed, so there is nothing
+  // left to adopt for this app; any concurrent session stays attested.
+  activeSessions.delete(appId);
+  persistSessions();
 
   try {
     const result = await finalizeGameSession(romId);
@@ -333,30 +346,27 @@ async function adoptOrphanedSession(): Promise<void> {
       : `adoption: no running app after ${waitedMs}ms [${diagnostics}]`,
   );
   const runningRomId = running ? getRomIdForApp(running.appid) : null;
-  const crumb = readSessionBreadcrumb();
+  const crumbs = readSessionBreadcrumbs();
+  const crumb = crumbs[0] ?? null;
 
   if (running && runningRomId !== null) {
     const appId = running.appid;
     if (crumb && crumb.appId === appId && crumb.romId === runningRomId) {
       // (a) The breadcrumb attests this exact running session. Restore the
-      // in-memory state and leave the durable marker untouched — re-stamping it
-      // would discard the pre-reload playtime the backend already holds.
-      activeSession = { appId, romId: runningRomId, startMs: crumb.startMs };
+      // in-memory state, keeping the attested startMs — re-stamping the durable
+      // marker would discard the pre-reload playtime the backend already holds.
+      activeSessions.set(appId, { appId, romId: runningRomId, startMs: crumb.startMs });
+      persistSessions();
       dispatchSessionChanged(true, appId, runningRomId);
       logInfo(`Adopted running session from breadcrumb: romId=${runningRomId}, appId=${appId}`);
     } else {
       // (a′) A game is running but no usable breadcrumb (missing / mismatched /
       // corrupt). Adopt it and re-stamp the marker to a truthful lower bound
-      // from now, then attest with a fresh breadcrumb so a later reload adopts
-      // via (a) rather than re-stamping again.
+      // from now, then attest it so a later reload adopts via (a) rather than
+      // re-stamping again.
       const adopted: ActiveSession = { appId, romId: runningRomId, startMs: Date.now() };
-      activeSession = adopted;
-      writeSessionBreadcrumb({
-        v: SESSION_BREADCRUMB_VERSION,
-        appId,
-        romId: runningRomId,
-        startMs: adopted.startMs,
-      });
+      activeSessions.set(appId, adopted);
+      persistSessions();
       dispatchSessionChanged(true, appId, runningRomId);
       try {
         await recordSessionStart(runningRomId);
@@ -372,7 +382,7 @@ async function adoptOrphanedSession(): Promise<void> {
   // here names a session whose stop we never saw — a truthful finalize is
   // impossible without an observed end, so drop it rather than fabricate one.
   if (crumb) {
-    clearSessionBreadcrumb();
+    persistSessions();
     logInfo(`Session orphaned — playtime not recorded (romId=${crumb.romId})`);
   }
 }
@@ -438,7 +448,7 @@ export function destroySessionManager(): void {
     lifetimeHook = null;
   }
 
-  activeSession = null;
+  activeSessions.clear();
   lifecycleChain = Promise.resolve();
   // Signal any in-flight adoption poll to abort instead of mutating torn-down state.
   sessionEpoch++;

--- a/tests/contract/test_session_finalize.py
+++ b/tests/contract/test_session_finalize.py
@@ -58,6 +58,35 @@ async def test_finalize_fully_suspended_session_counts_zero(harness):
     assert result["total_seconds"] == 0
 
 
+async def test_overlapping_sessions_each_fold_their_own_span(harness):
+    """Two ROMs played at once each record their own duration (#1624).
+
+    The open-session marker is a column on the per-ROM ``rom_playtime`` row, so
+    two ROMs hold independent markers and one session cannot displace or
+    truncate the other. The frontend's per-app session map rests entirely on
+    that independence: it opens a second marker while the first is still open,
+    and finalizes them in whichever order the games exit.
+
+    ROM 1 runs 0s→300s, ROM 2 runs 60s→360s. The starts and exits interleave, so
+    a single shared marker would surface as a wrong span on both.
+    """
+    seed_rom(harness, 1)
+    seed_rom(harness, 2)
+    harness.plugin.settings["save_sync_enabled"] = False
+
+    await harness.plugin.record_session_start(1)
+    harness.clock.advance(60)
+    await harness.plugin.record_session_start(2)  # ROM 1 is still open
+    harness.clock.advance(240)
+
+    first = await harness.plugin.finalize_game_session(1)  # ROM 2 is still open
+    harness.clock.advance(60)
+    second = await harness.plugin.finalize_game_session(2)
+
+    assert first["total_seconds"] == 300
+    assert second["total_seconds"] == 300
+
+
 async def test_finalize_no_active_session_leaves_total_none(harness):
     """No open session → playtime record fails → ``total_seconds`` is ``None``."""
     seed_rom(harness, 1)


### PR DESCRIPTION
Two games running at once meant only one of them recorded any playtime. The session manager held a single slot, so the second game to start displaced the first, and the displaced session was dropped: no session end, no playtime, no post-exit save sync. #1621 had already stopped an unrelated app's exit from finalizing the wrong session, but the displacement loss was left standing.

The slot becomes a map keyed by Steam appId, holding `{appId, romId, startMs}` per running game. The key is the appId because all three write paths take one as input — the stop, the start and adoption — and the stop is the correctness-critical one: #1621 established that a stop must match against the appId **recorded with the session**, never a fresh id-map lookup, and a romId key would reintroduce exactly the staleness that rule removed. The five consumers ask by romId, so `getActiveSessionRomId()` becomes `isSessionActive(romId)` — a predicate over a map that holds one or two entries, and a simplification at every call site.

The breadcrumb that survives a plugin reload becomes a list, `{v: 2, sessions: [...]}`. Its validator now branches on the version **before** any field check: the old shape tested the version in the same expression as the fields, so bumping it would have made every live v1 row fail validation, fall into the re-stamp branch, and silently discard the pre-reload span on the first reload after the upgrade. A v1 row is lifted into a one-entry list instead, adopted as recorded.

Adoption stops looking only at the head of the running-app list and reconciles the whole set against every stored entry: each attested app that is running is adopted with its original start time, each whose app is gone is orphaned individually, and each running game with no attestation is re-stamped. Foreign apps are skipped rather than treated as evidence — that closes a live bug where a foreground non-RomM app caused a still-running game's breadcrumb to be cleared, taking its playtime and its post-exit sync with it. A test had been pinning that behaviour as intended.

A launching game is now identified by the notification's own `unAppID` rather than the head of the running-app list. `RunningApps` is ordered most-recently-foregrounded and the store's polling reconciler appends new arrivals at the tail, so the head is not the app that just started; under a map that would have re-stamped the wrong app and never created the new one's entry, making its stop a silent no-op. The 500 ms delay that existed only to let that head read populate goes with it, which also stops stalling the whole notification chain.

Closing #1589 here is not a bundled extra: under a per-app map a duplicate start must either overwrite the entry — which is literally #1589's symptom, since the backend resets the session marker rather than extending it — or short-circuit. The short-circuit is the fix. A start for an app that already has a session keeps the earlier start time and does not re-record.

Verified on device across the full matrix. Two games running concurrently produced a running-app reading holding both app ids, which had never been observed before; a plugin reload mid-session adopted both from their breadcrumbs with no re-stamp and no orphan; the two sessions then ended in the opposite order to their starts and folded 894 s and 921 s independently, each matching wall time to the second **across the reload**. A game started on the previous build and reloaded into this one was adopted from its v1 breadcrumb without re-stamping, so the migration holds on real data.

One known bound: the adoption poll now waits for every attested app to surface before settling, so a breadcrumb left by a session whose end was never observed delays adoption until the 15 s budget expires. Settling earlier would reintroduce orphaning a live concurrent session, which is the larger loss. Init is fire-and-forget and the lifetime hook is registered before the wait, so no notification is dropped.

Concurrent sessions also make an existing rough edge reachable for the first time: two post-exit save syncs now queue on the device-wide sync gate, and one skipped past its budget reports itself as "Server offline" while the server is fine. That is tracked separately in #1625 — the gate itself is load-bearing and must not be parallelised.

Closes #1624
Closes #1589
