### PR TITLE
fix(saves): report a busy save-sync gate as busy, not as an offline server

### DIFF
--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -843,12 +843,13 @@ run-lifecycle state, no run ids, no cancellation — those are out of scope here
 The wait is **bounded** so a stuck run never traps the launch path. Each of the four trigger methods on `SyncEngine`
 wraps its run body in `bounded_run(timeout=…)` with a per-trigger budget — `pre_launch_sync` (30 s), `post_exit_sync`
 (60 s), `sync_rom_saves` (15 s), `sync_all_saves` (60 s). If the gate can't be acquired within the budget the call
-returns its own fallthrough instead of blocking. All four carry the same `reason: "sync_busy"` — a busy gate is a local
-wait, so it never borrows a server-reachability slug (#1625). What differs is the additive `offline: True` flag:
-`pre_launch_sync` keeps it as the launch path's fail-safe steer (the launch proceeds on unverified local saves, so the
-drift warning must still fire), while `post_exit_sync` drops it, since nothing on that path observed the server and the
-session-end toast would otherwise announce "Server offline" about a reachable one. The lock is never leaked on timeout —
-a timed-out acquire releases any photo-finish hold before raising.
+returns its own fallthrough instead of blocking, and all four fallthroughs carry the **same** busy shape:
+`reason: "sync_busy"`, no additive `offline` flag. A busy gate is a local wait — nothing on that path observed the
+server — so it never borrows a server-reachability slug and never sets the offline flag (#1625); the session-end toast
+would otherwise announce "Server offline" about a reachable server. Each caller routes the skip on `success: False`
+alone: the launch gate maps it to `sync_failed` (fallback-launch confirm, so Play is never trapped), the session-end
+toast keys on the reason. The lock is never leaked on timeout — a timed-out acquire releases any photo-finish hold
+before raising.
 
 The gate sits **outside** the per-ROM lock (`SyncEngine.rom_lock(rom_id)`): the device gate admits one run at a time
 across the whole device, then each ROM still takes its own `rom_lock` for the read-mutate-write of its

--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -843,10 +843,12 @@ run-lifecycle state, no run ids, no cancellation — those are out of scope here
 The wait is **bounded** so a stuck run never traps the launch path. Each of the four trigger methods on `SyncEngine`
 wraps its run body in `bounded_run(timeout=…)` with a per-trigger budget — `pre_launch_sync` (30 s), `post_exit_sync`
 (60 s), `sync_rom_saves` (15 s), `sync_all_saves` (60 s). If the gate can't be acquired within the budget the call
-returns its own fallthrough instead of blocking: the launch-path triggers (`pre_launch_sync` / `post_exit_sync`) return
-the `offline` shape (`reason: SERVER_UNREACHABLE`, additive `offline: True`) so the launch flow treats a busy gate like
-an unreachable server; the manual triggers (`sync_rom_saves` / `sync_all_saves`) return `reason: "sync_busy"`. The lock
-is never leaked on timeout — a timed-out acquire releases any photo-finish hold before raising.
+returns its own fallthrough instead of blocking. All four carry the same `reason: "sync_busy"` — a busy gate is a local
+wait, so it never borrows a server-reachability slug (#1625). What differs is the additive `offline: True` flag:
+`pre_launch_sync` keeps it as the launch path's fail-safe steer (the launch proceeds on unverified local saves, so the
+drift warning must still fire), while `post_exit_sync` drops it, since nothing on that path observed the server and the
+session-end toast would otherwise announce "Server offline" about a reachable one. The lock is never leaked on timeout —
+a timed-out acquire releases any photo-finish hold before raising.
 
 The gate sits **outside** the per-ROM lock (`SyncEngine.rom_lock(rom_id)`): the device gate admits one run at a time
 across the whole device, then each ROM still takes its own `rom_lock` for the read-mutate-write of its

--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -1566,12 +1566,14 @@ are not safe. Two games exiting close together therefore sync one after the othe
 second is skipped and retried at its next sync. Playtime is unaffected either way — it is recorded before the sync runs.
 Per-app sync chains are a non-goal, not an oversight.
 
-The skip says what it is (#1625). A gate timeout carries `reason: "sync_busy"` — never `server_unreachable` — and the
-post-exit skip drops the additive `offline` flag entirely, because nothing on that path ever contacted the server. The
-session-end toast keys on the reason and reads "Another save sync was still running — saves will sync next time" instead
-of the old "Server offline", which sent the user debugging a network that was fine. The pre-launch skip keeps its
-`offline: True` flag: there it is the launch path's fail-safe steer ("this launch runs on unverified local saves"), so a
-busy gate still warns on local drift rather than trapping the Play button — only its reason and copy changed.
+The skip says what it is (#1625). A gate timeout carries `reason: "sync_busy"` — never `server_unreachable` — and no
+additive `offline` flag, on the pre-launch side as much as the post-exit one: nothing on either path ever contacted the
+server, so neither may claim it is down. The session-end toast keys on the reason and reads "Another save sync was still
+running — saves will sync next time" instead of the old "Server offline", which sent the user debugging a network that
+was fine. Pre-launch, the launch gate routes the skip on `success: False` alone (verdict `sync_failed` → the
+fallback-launch confirm), so a busy gate still never traps the Play button. The gate's offline drift warning is not
+involved on that path and never was: it is reachable only when the gate's own reachability probe says the server is
+down, and a busy gate means that probe already succeeded.
 
 A skipped run is **not** re-queued on a delay. It is picked up by the next pre-launch or manual sync, which is why the
 copy promises exactly that. Retry-on-a-timer would need scheduling and backoff machinery around a gate that must not be

--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -1566,10 +1566,16 @@ are not safe. Two games exiting close together therefore sync one after the othe
 second is skipped and retried at its next sync. Playtime is unaffected either way — it is recorded before the sync runs.
 Per-app sync chains are a non-goal, not an oversight.
 
-Known rough edge in that skip: a gate timeout is currently classified as `server_unreachable`, so the skipped sync
-surfaces the "Server offline — saves will sync next time" toast even though the server is fine. The wait was local. No
-data is at risk (the sync is simply retried), but the copy is misleading, and concurrent exits are the first thing that
-makes the path reachable.
+The skip says what it is (#1625). A gate timeout carries `reason: "sync_busy"` — never `server_unreachable` — and the
+post-exit skip drops the additive `offline` flag entirely, because nothing on that path ever contacted the server. The
+session-end toast keys on the reason and reads "Another save sync was still running — saves will sync next time" instead
+of the old "Server offline", which sent the user debugging a network that was fine. The pre-launch skip keeps its
+`offline: True` flag: there it is the launch path's fail-safe steer ("this launch runs on unverified local saves"), so a
+busy gate still warns on local drift rather than trapping the Play button — only its reason and copy changed.
+
+A skipped run is **not** re-queued on a delay. It is picked up by the next pre-launch or manual sync, which is why the
+copy promises exactly that. Retry-on-a-timer would need scheduling and backoff machinery around a gate that must not be
+parallelised, for an outcome that costs one deferred sync — deliberately deferred, not overlooked.
 
 ### Surviving a plugin reload mid-session
 

--- a/docs/user-guide/save-sync.md
+++ b/docs/user-guide/save-sync.md
@@ -196,6 +196,11 @@ sync" message. When more than one save file fails in the same sync, the toast sh
 a "(+N more)" count so the message stays short. If you see an authentication message, re-enter your server URL and sign
 in again in the plugin settings.
 
+One more thing "Server offline" is never used for: syncs run one at a time on your Deck, so if you exit two games within
+moments of each other, the second one's sync waits for the first. If that wait runs long the second sync is skipped, and
+it says so — "Another save sync was still running — saves will sync next time". Your local save is untouched and is
+picked up by the next launch or by a manual **Sync All Saves Now**; nothing about your server is wrong.
+
 After a failed sync the game-detail save panel reflects the honest state right away: a file whose upload failed shows a
 yellow **Local changes** badge (not a green "synced"), and its "Last synced" line keeps the time of the last
 _successful_ sync — a green checkmark appears only once a sync actually succeeds. A separate "Checked" line shows when

--- a/py_modules/services/saves/_messages.py
+++ b/py_modules/services/saves/_messages.py
@@ -25,6 +25,12 @@ MIGRATION_DEVICE_NOT_REGISTERED = (
 # policy stop, #1489). Distinct from ``sync_disabled``, which is the LOCAL toggle.
 DEVICE_SYNC_DISABLED_REASON = "device_sync_disabled"
 DEVICE_SYNC_DISABLED = "Save sync is disabled for this device on the RomM server"
+# The device-wide save-sync gate was still held by another run when the bounded
+# wait expired, so this run was skipped. A LOCAL scheduling outcome — it says
+# nothing about the server, which the skipped run may never have contacted
+# (#1625). Never collapse it onto ``server_unreachable``.
+SAVE_SYNC_BUSY_REASON = "sync_busy"
+SAVE_SYNC_BUSY = "Another save sync is still running"
 # RetroArch ``savefiles_in_content_dir=true``: saves are written next to the
 # ROM, outside the saves tree the plugin syncs, so save sync is unavailable.
 # Neutral phrasing — the frontend treats this as a benign skip, not an error.

--- a/py_modules/services/saves/sync_engine/_gate.py
+++ b/py_modules/services/saves/sync_engine/_gate.py
@@ -3,7 +3,7 @@
 One in-flight save-sync run per device: a second trigger waits (queue
 semantics) for the in-flight run to finish rather than running alongside
 it, and the wait is bounded so a stuck run never traps the launch path —
-on expiry the caller gets a timeout it can turn into an offline/busy
+on expiry the caller gets a timeout it can turn into its busy
 fallthrough. The :class:`asyncio.Lock` IS the serializer/queue; this
 module owns only the bounded-acquire discipline around it.
 
@@ -44,7 +44,8 @@ class SaveSyncTimeoutError(Exception):
     """Raised when a save-sync run cannot acquire the device gate in time.
 
     Signals that another run is in flight and the bounded wait elapsed — the
-    caller turns this into its trigger-specific offline/busy fallthrough.
+    caller turns this into its trigger-specific busy fallthrough. It is a
+    LOCAL scheduling outcome: no caller may report it as a server verdict.
     """
 
 

--- a/py_modules/services/saves/sync_engine/engine.py
+++ b/py_modules/services/saves/sync_engine/engine.py
@@ -42,6 +42,8 @@ from services.saves._messages import (
     DEVICE_NOT_REGISTERED_REASON,
     DEVICE_SYNC_DISABLED,
     DEVICE_SYNC_DISABLED_REASON,
+    SAVE_SYNC_BUSY,
+    SAVE_SYNC_BUSY_REASON,
     SAVE_SYNC_DISABLED,
     SAVE_SYNC_DISABLED_REASON,
     SAVE_SYNC_IN_CONTENT_DIR,
@@ -776,13 +778,12 @@ class SyncEngine:
                     "conflicts": list(conflicts),
                 }
         except SaveSyncTimeoutError:
-            # Another save-sync run held the device gate past the bounded wait —
-            # treat as offline so the launch path warns on local drift instead
-            # of trapping the Play button. Mirrors _heartbeat_failure_result.
+            # Device gate held past the bounded wait. The reason names that LOCAL wait (#1625); the additive
+            # ``offline`` flag stays as the launch path's drift-warning steer, so Play is never trapped.
             return {
                 "success": False,
-                "reason": ErrorCode.SERVER_UNREACHABLE.value,
-                "message": "Save-sync busy — treating as offline",
+                "reason": SAVE_SYNC_BUSY_REASON,
+                "message": SAVE_SYNC_BUSY,
                 "synced": 0,
                 "offline": True,
             }
@@ -865,15 +866,14 @@ class SyncEngine:
                     "conflicts": list(conflicts),
                 }
         except SaveSyncTimeoutError:
-            # Another save-sync run held the device gate past the bounded wait —
-            # skip the post-exit upload rather than block on a stuck run.
+            # Device gate held past the bounded wait — skip rather than block on a stuck run. No ``offline``
+            # flag and no reachability reason (#1625): nothing observed the server. Next sync picks it up.
             self._logger.info("post_exit_sync skipped: save-sync busy")
             return {
                 "success": False,
-                "reason": ErrorCode.SERVER_UNREACHABLE.value,
-                "message": "Save-sync busy — skipping post-exit sync",
+                "reason": SAVE_SYNC_BUSY_REASON,
+                "message": SAVE_SYNC_BUSY,
                 "synced": 0,
-                "offline": True,
             }
         except RommSyncDisabledError:
             # RomM has save sync disabled for this device server-side — stop with
@@ -937,8 +937,8 @@ class SyncEngine:
             # Another save-sync run held the device gate past the bounded wait.
             return {
                 "success": False,
-                "reason": "sync_busy",
-                "message": "Another save-sync run is in progress",
+                "reason": SAVE_SYNC_BUSY_REASON,
+                "message": SAVE_SYNC_BUSY,
                 "synced": 0,
                 "errors": [],
                 "conflicts": [],
@@ -1098,8 +1098,8 @@ class SyncEngine:
             # Another save-sync run held the device gate past the bounded wait.
             return {
                 "success": False,
-                "reason": "sync_busy",
-                "message": "Another save-sync run is in progress",
+                "reason": SAVE_SYNC_BUSY_REASON,
+                "message": SAVE_SYNC_BUSY,
                 "synced": 0,
                 "conflicts": 0,
                 "conflicts_list": [],

--- a/py_modules/services/saves/sync_engine/engine.py
+++ b/py_modules/services/saves/sync_engine/engine.py
@@ -778,14 +778,14 @@ class SyncEngine:
                     "conflicts": list(conflicts),
                 }
         except SaveSyncTimeoutError:
-            # Device gate held past the bounded wait. The reason names that LOCAL wait (#1625); the additive
-            # ``offline`` flag stays as the launch path's drift-warning steer, so Play is never trapped.
+            # Device gate held past the bounded wait — the same LOCAL outcome the other three triggers
+            # report, so it carries the identical busy shape: no reachability reason, no ``offline`` (#1625).
+            # The launch path routes on ``success: False`` alone (→ ``sync_failed``), so Play is not trapped.
             return {
                 "success": False,
                 "reason": SAVE_SYNC_BUSY_REASON,
                 "message": SAVE_SYNC_BUSY,
                 "synced": 0,
-                "offline": True,
             }
         except RommSyncDisabledError:
             # RomM has save sync disabled for this device server-side. Mirror the

--- a/py_modules/services/session_lifecycle.py
+++ b/py_modules/services/session_lifecycle.py
@@ -39,12 +39,19 @@ if TYPE_CHECKING:
 _TOAST_BODY_OFFLINE = "Server offline — saves will sync next time"
 _TOAST_BODY_FAILED = "Failed to sync saves after exit"
 _TOAST_BODY_SYNC_DISABLED = "Save sync is disabled for this device on the RomM server"
+_TOAST_BODY_SYNC_BUSY = "Another save sync was still running — saves will sync next time"
 
 # Reason slug the saves engine returns when RomM's per-device sync-disabled switch
 # stops the post-exit run (#1489). Mirrored here as a literal — a service must not
 # import another service's module — kept in step with the saves engine's
 # ``DEVICE_SYNC_DISABLED_REASON``.
 _DEVICE_SYNC_DISABLED_REASON = "device_sync_disabled"
+
+# Reason slug the saves engine returns when the device-wide save-sync gate was
+# still held by another run at the end of the bounded wait, so this post-exit run
+# was skipped (#1625). Mirrored as a literal for the same reason as above; kept in
+# step with the saves engine's ``SAVE_SYNC_BUSY_REASON``.
+_SAVE_SYNC_BUSY_REASON = "sync_busy"
 
 
 @dataclass(frozen=True)
@@ -136,11 +143,15 @@ def _render_failure_toast(
     The directional success toast is presentation the frontend renders from the
     transfer counts (``saveSyncToastBody``), so a successful run returns ``None``
     here. Offline wins over the generic failure body; the per-device
-    sync-disabled policy stop (#1489) gets its own dedicated copy; a classified
-    ``message`` (e.g. "Authentication failed — sign in again", #971) names the
-    cause instead of the generic fallback, keeping the post-exit toast consistent
-    with the pre-launch fallback modal. The #239 content-dir benign skip is
-    suppressed by its caller before this is reached.
+    sync-disabled policy stop (#1489) and the busy-gate skip (#1625) each get
+    their own dedicated copy, keyed on the reason; a classified ``message``
+    (e.g. "Authentication failed — sign in again", #971) names the cause instead
+    of the generic fallback, keeping the post-exit toast consistent with the
+    pre-launch fallback modal. The #239 content-dir benign skip is suppressed by
+    its caller before this is reached.
+
+    A busy gate is a LOCAL wait, never a server verdict — it must not reach the
+    offline body, which would send the user debugging a reachable server.
     """
     if offline:
         return _TOAST_BODY_OFFLINE
@@ -148,6 +159,8 @@ def _render_failure_toast(
         return None
     if reason == _DEVICE_SYNC_DISABLED_REASON:
         return _TOAST_BODY_SYNC_DISABLED
+    if reason == _SAVE_SYNC_BUSY_REASON:
+        return _TOAST_BODY_SYNC_BUSY
     return message or _TOAST_BODY_FAILED
 
 

--- a/tests/services/saves/sync_engine/test_engine.py
+++ b/tests/services/saves/sync_engine/test_engine.py
@@ -1553,7 +1553,8 @@ class TestSaveSyncDeviceGate:
     Only one save-sync run is in flight at a time per device. A second
     trigger queues behind the in-flight one; the wait is bounded, so a stuck
     run never traps the launch path — on expiry each trigger returns its
-    own offline/busy fallthrough. The gate sits OUTSIDE the per-ROM lock.
+    own busy fallthrough, never a server verdict (#1625). The gate sits
+    OUTSIDE the per-ROM lock.
     """
 
     async def _assert_timeout_fallthrough(self, svc, monkeypatch, const_name, trigger, expected):
@@ -1575,7 +1576,10 @@ class TestSaveSyncDeviceGate:
         assert engine._device_gate.is_in_flight() is False
 
     @pytest.mark.asyncio
-    async def test_pre_launch_sync_times_out_to_offline(self, tmp_path, monkeypatch):
+    async def test_pre_launch_sync_times_out_to_busy_keeping_the_offline_steer(self, tmp_path, monkeypatch):
+        """#1625: the reason names the local wait; the launch path's ``offline``
+        steer is kept, so a busy gate still routes the launch to its drift
+        warning instead of trapping the Play button."""
         svc, fake = make_service(tmp_path)
         svc._config.settings["save_sync_enabled"] = True
         _set_device_id(svc, "test-device")
@@ -1589,8 +1593,8 @@ class TestSaveSyncDeviceGate:
             lambda: svc.pre_launch_sync(42),
             {
                 "success": False,
-                "reason": ErrorCode.SERVER_UNREACHABLE.value,
-                "message": "Save-sync busy — treating as offline",
+                "reason": "sync_busy",
+                "message": "Another save sync is still running",
                 "synced": 0,
                 "offline": True,
             },
@@ -1599,7 +1603,10 @@ class TestSaveSyncDeviceGate:
         assert not any(c[0] in ("download_save", "list_saves", "heartbeat") for c in fake.call_log)
 
     @pytest.mark.asyncio
-    async def test_post_exit_sync_times_out_to_offline(self, tmp_path, monkeypatch):
+    async def test_post_exit_sync_times_out_to_busy_not_offline(self, tmp_path, monkeypatch):
+        """#1625: a busy gate is a local wait — no ``offline`` flag and no
+        reachability reason, so the session-end toast stops claiming the server
+        is down while it is plainly reachable."""
         svc, fake = make_service(tmp_path)
         svc._config.settings["save_sync_enabled"] = True
         _set_device_id(svc, "test-device")
@@ -1613,13 +1620,45 @@ class TestSaveSyncDeviceGate:
             lambda: svc.post_exit_sync(42),
             {
                 "success": False,
-                "reason": ErrorCode.SERVER_UNREACHABLE.value,
-                "message": "Save-sync busy — skipping post-exit sync",
+                "reason": "sync_busy",
+                "message": "Another save sync is still running",
                 "synced": 0,
-                "offline": True,
             },
         )
         assert not any(c[0] in ("upload_save", "heartbeat") for c in fake.call_log)
+
+    @pytest.mark.asyncio
+    async def test_busy_gate_and_unreachable_server_stay_distinguishable(self, tmp_path, monkeypatch):
+        """#1625 regression guard: the two post-exit skips must not re-collapse.
+
+        A busy gate and an unreachable server are different events with
+        different user remedies, so their reason slugs and their ``offline``
+        flags must differ. Collapsing the busy reason back onto
+        ``SERVER_UNREACHABLE`` fails here.
+        """
+        busy_svc, _ = make_service(tmp_path / "busy")
+        busy_svc._config.settings["save_sync_enabled"] = True
+        _set_device_id(busy_svc, "test-device")
+        monkeypatch.setattr("services.saves.sync_engine.engine.POST_EXIT_GATE_TIMEOUT", 0.01)
+        gate = busy_svc._sync_engine._device_gate
+        await gate._lock.acquire()
+        try:
+            busy = await busy_svc.post_exit_sync(42)
+        finally:
+            gate._lock.release()
+
+        offline_svc, offline_fake = make_service(tmp_path / "offline")
+        offline_svc._config.settings["save_sync_enabled"] = True
+        _set_device_id(offline_svc, "test-device")
+        _install_rom(offline_svc, tmp_path / "offline")
+        offline_fake.heartbeat_raises = RommConnectionError("Connection refused")
+        offline = await offline_svc.post_exit_sync(42)
+
+        assert busy["reason"] != offline["reason"]
+        assert busy["reason"] != ErrorCode.SERVER_UNREACHABLE.value
+        assert "offline" not in busy
+        assert offline["reason"] == ErrorCode.SERVER_UNREACHABLE.value
+        assert offline["offline"] is True
 
     @pytest.mark.asyncio
     async def test_sync_rom_saves_times_out_to_busy(self, tmp_path, monkeypatch):
@@ -1637,7 +1676,7 @@ class TestSaveSyncDeviceGate:
             {
                 "success": False,
                 "reason": "sync_busy",
-                "message": "Another save-sync run is in progress",
+                "message": "Another save sync is still running",
                 "synced": 0,
                 "errors": [],
                 "conflicts": [],
@@ -1662,7 +1701,7 @@ class TestSaveSyncDeviceGate:
             {
                 "success": False,
                 "reason": "sync_busy",
-                "message": "Another save-sync run is in progress",
+                "message": "Another save sync is still running",
                 "synced": 0,
                 "conflicts": 0,
                 "conflicts_list": [],

--- a/tests/services/saves/sync_engine/test_engine.py
+++ b/tests/services/saves/sync_engine/test_engine.py
@@ -1552,8 +1552,8 @@ class TestSaveSyncDeviceGate:
 
     Only one save-sync run is in flight at a time per device. A second
     trigger queues behind the in-flight one; the wait is bounded, so a stuck
-    run never traps the launch path — on expiry each trigger returns its
-    own busy fallthrough, never a server verdict (#1625). The gate sits
+    run never traps the launch path — on expiry every trigger returns the
+    same busy fallthrough, never a server verdict (#1625). The gate sits
     OUTSIDE the per-ROM lock.
     """
 
@@ -1576,10 +1576,10 @@ class TestSaveSyncDeviceGate:
         assert engine._device_gate.is_in_flight() is False
 
     @pytest.mark.asyncio
-    async def test_pre_launch_sync_times_out_to_busy_keeping_the_offline_steer(self, tmp_path, monkeypatch):
-        """#1625: the reason names the local wait; the launch path's ``offline``
-        steer is kept, so a busy gate still routes the launch to its drift
-        warning instead of trapping the Play button."""
+    async def test_pre_launch_sync_times_out_to_busy_not_offline(self, tmp_path, monkeypatch):
+        """#1625: the busy shape is identical on every trigger — the reason names
+        the local wait and no ``offline`` flag rides along. The launch gate routes
+        this on ``success: False`` alone, so the Play button is still not trapped."""
         svc, fake = make_service(tmp_path)
         svc._config.settings["save_sync_enabled"] = True
         _set_device_id(svc, "test-device")
@@ -1596,7 +1596,6 @@ class TestSaveSyncDeviceGate:
                 "reason": "sync_busy",
                 "message": "Another save sync is still running",
                 "synced": 0,
-                "offline": True,
             },
         )
         # The gate fired before any sync work — no transfer was attempted.

--- a/tests/services/test_session_lifecycle.py
+++ b/tests/services/test_session_lifecycle.py
@@ -437,6 +437,68 @@ class TestFinalizeSyncToasts:
         assert result.sync.offline is False
         assert result.sync.failure_toast != "Failed to sync saves after exit"
 
+    def test_save_sync_busy_renders_the_busy_toast_not_the_offline_one(self, event_loop, logger):
+        """#1625: a skipped run behind a busy device gate says so, never "Server offline".
+
+        The gate wait is local — the post-exit run never contacted the server —
+        so the body names the real cause and the offline flag stays down.
+        """
+        post = FakePostExitSync(
+            payload={
+                "success": False,
+                "reason": "sync_busy",
+                "message": "Another save sync is still running",
+                "synced": 0,
+            }
+        )
+        service = _make_service(
+            playtime_recorder=FakePlaytimeRecorder(),
+            post_exit_sync=post,
+            achievement_sync=FakeAchievementSync(),
+            migration_reader=FakeMigrationReader(),
+            logger=logger,
+        )
+
+        result = event_loop.run_until_complete(service.finalize(99))
+        event_loop.run_until_complete(_drain_background_tasks(service))
+
+        assert result.sync.failure_toast == "Another save sync was still running — saves will sync next time"
+        assert result.sync.offline is False
+        # Neither the offline copy nor the generic fallback.
+        assert result.sync.failure_toast != "Server offline — saves will sync next time"
+        assert result.sync.failure_toast != "Failed to sync saves after exit"
+
+    def test_unreachable_server_still_renders_the_offline_toast(self, event_loop, logger):
+        """#1625 regression guard: the busy and offline bodies must not re-collapse.
+
+        A genuinely unreachable server (``offline=True`` +
+        ``reason=server_unreachable``) keeps the offline copy — the honest
+        busy copy is reserved for the local gate wait.
+        """
+        post = FakePostExitSync(
+            payload={
+                "success": False,
+                "offline": True,
+                "reason": "server_unreachable",
+                "message": "Server offline",
+                "synced": 0,
+            }
+        )
+        service = _make_service(
+            playtime_recorder=FakePlaytimeRecorder(),
+            post_exit_sync=post,
+            achievement_sync=FakeAchievementSync(),
+            migration_reader=FakeMigrationReader(),
+            logger=logger,
+        )
+
+        result = event_loop.run_until_complete(service.finalize(99))
+        event_loop.run_until_complete(_drain_background_tasks(service))
+
+        assert result.sync.offline is True
+        assert result.sync.failure_toast == "Server offline — saves will sync next time"
+        assert result.sync.failure_toast != "Another save sync was still running — saves will sync next time"
+
     def test_failure_without_message_falls_back_to_generic_body(self, event_loop, logger):
         """A failure with no ``message`` key falls back to the generic failure body."""
         post = FakePostExitSync(payload={"success": False, "synced": 0})


### PR DESCRIPTION
A save sync that was skipped because the device-wide sync gate was busy reported itself as a server problem. `SaveSyncTimeoutError` was mapped onto `ErrorCode.SERVER_UNREACHABLE` with `offline: true`, which the session-lifecycle toast renderer turned into "Server offline — saves will sync next time" while the server was perfectly reachable and the only thing that had happened was another game's sync holding the gate.

Concurrent play sessions made this reachable for the first time: before #1624 a second session could not exist, so two post-exit syncs could never queue behind one another.

All four gate-timeout sites now carry the bespoke reason `sync_busy` — the slug two of them already emitted, so one condition ends up with one slug rather than a new coinage. The post-exit path drops `offline` and renders "Another save sync was still running — saves will sync next time"; the branch is keyed on the reason literal mirrored in `session_lifecycle`, following the precedent set for the device-sync-disabled slug, since a service must not import a peer service's module.

The pre-launch path drops the flag too. Keeping it was considered and rejected: nothing reads it — `preLaunchSync` does not even declare it on its TypeScript return type — and the drift warning it was supposed to steer is unreachable from a busy gate by construction, because `checkLocalDrift` only runs when the reachability probe returned false while a busy gate implies it returned true. What actually keeps Play from being trapped is `success: false` routing to the fallback-launch confirm. An unread field justified by a mechanism that does not exist is the same shape this change exists to remove, and it would have left one reason carrying contradictory `offline` values on two paths.

The gate itself is untouched and must stay that way: RomM's `negotiate` session is device-scoped and the sync engine's layout cache is shared mutable state, so two overlapping runs would cancel each other's session. Serialising is correct; only the reporting was wrong.

Retrying a skipped sync on a delay was raised in the issue and is deliberately not implemented here. It needs scheduling and backoff around a gate that must not be parallelised, whereas the defect was that we said something untrue. The deferral is recorded in the architecture page.

Busy and unreachable are now pinned apart by tests that build the unreachable case from a real connection error rather than a hand-written payload, so collapsing the two back together fails three tests across both layers.

Closes #1625
