### PR TITLE
chore(rules): make an inline comment the exception, not the default

### DIFF
--- a/.claude/rules/comments.md
+++ b/.claude/rules/comments.md
@@ -1,0 +1,34 @@
+---
+paths:
+  - "py_modules/**/*.py"
+  - "main.py"
+  - "src/**/*.ts"
+  - "src/**/*.tsx"
+---
+
+# Inline comments — the exception, never the default
+
+No mechanical check exists for any of this. It holds only if it is carried at the point of writing.
+
+Code names the **what**. A comment that restates the code is deleted on sight, not improved. If a comment is needed to
+explain what the code does, the code is the problem — fix the code and drop the comment.
+
+An inline comment earns its place only by carrying knowledge that **cannot be put into code**:
+
+- **A fact about the outside world** — another program's behavior, a protocol quirk, a kernel or driver constraint. Name
+  the source (file, symbol, version, issue) so a later reader can re-verify it rather than trust it.
+- **A road not taken** — the obvious alternative and why it is wrong. Without it the next person builds it.
+- **A constraint the code cannot express** — an ordering that must hold, a call that must never happen twice.
+
+A comment that would be equally true on a `docs/` page belongs on that page, under the heading that owns the topic.
+Inline is the last resort, not the first.
+
+**When you touch a line, re-read the comment above it.** If it no longer matches, correct or delete it in the same
+change. A stale comment is worse than none, because it is believed: it is read as current truth by everyone who arrives
+later, and nothing in the toolchain will ever contradict it.
+
+Avoid entirely: "mechanical extraction from X", "during the transition", "moved from Y", "added for the Z flow", "see PR
+#123" — commit-message content that rots in source.
+
+Docstrings are governed separately (`python-conventions.md`): module and class docstrings state the contract, method
+docstrings may describe behavior, parameters and return value.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,9 @@ new code in it.
   checked; the reflex to fix the upstream artifact instead of the copy is not.
 - `testing-backend.md` — test tiers, gate tests, vendored conformance vectors.
 - `testing-frontend.md` — the `@decky/api` event harness, non-vacuous catch assertions.
+- `comments.md` — an inline comment is the exception: only an outside-world fact, a road not taken, or a constraint the
+  code cannot express. Re-read the comment on the line you touch — a stale one is worse than none, because it is
+  believed and nothing in the toolchain contradicts it. **No mechanical check exists.**
 
 ## Documentation
 


### PR DESCRIPTION
Code names the *what*. A comment that restates it carries no information and rots on its own schedule, so the default for an inline comment is: don't. If one is needed to explain what the code does, the code is the problem.

Three cases earn one, and they share a property — each carries knowledge that no amount of simplification can put into the code itself:

- a fact about the outside world (another program's behaviour, a protocol quirk, a driver constraint), named with its source so a later reader can re-verify it rather than trust it;
- a road not taken, so the next person doesn't build the obvious wrong thing;
- a constraint the code cannot express, such as an ordering that must hold or a call that must never happen twice.

Anything equally true on a `docs/` page belongs on that page. Inline is the last resort.

The rule that will matter most in practice is the last one: **re-read the comment on the line you touch, and correct or delete it in the same change.** A stale comment is worse than none, because it is believed — it reads as current truth to everyone who arrives later, and nothing in the toolchain will ever contradict it. Recent work turned up four separate comments asserting behaviour that was never true or had stopped being true, including one on the page that owns its topic; none of them was caught by reading, only by checking.

The rule is path-scoped to both trees, since the frontend has the same problem as the backend. Docstrings stay governed by `python-conventions.md` — module and class docstrings state the contract, method docstrings may describe behaviour, parameters and return value.

docs: N/A — a convention rule for contributors and agents, with no user-facing or architectural surface.
