### PR TITLE
docs(rules): own the 404 entity-proof rule in a path-scoped rule file

### DIFF
--- a/.claude/rules/romm-http.md
+++ b/.claude/rules/romm-http.md
@@ -1,0 +1,50 @@
+---
+paths:
+  - "py_modules/adapters/romm/**"
+---
+
+# RomM HTTP error translation `[ours]`
+
+No mechanical check exists for any of this — only the tests named at the bottom, and they pin the call sites that exist
+today, not the one you are about to add.
+
+`RommNotFoundError` does not mean "the server said 404". It means **RomM's entity layer said this entity does not
+exist**, and downstream that reading is authority: the removed-game cleanup deletes on it, the version picker marks a
+version vanished on it, save-sync drops a stale device registration on it.
+
+A bare 404 does not carry that meaning on its own. FastAPI answers a misconfigured path prefix with the same status and
+a generic `{"detail": "Not Found"}` body, and a reverse proxy in front of RomM (Cloudflare Tunnel, Traefik) answers a
+misroute with an HTML or empty one. So on the **API routes** `translate_http_error` raises `RommNotFoundError` only for
+a response that proves RomM answered: a JSON content type whose body parses to an object carrying a `detail` string that
+is neither blank nor FastAPI's stock `Not Found`, matched case-insensitively. The requested id is deliberately **not**
+parsed back out of that detail — its wording moves between RomM releases while the generic default stays put, so
+blocklisting the default is the robust test.
+
+Every other 404 shape — proxy HTML, an empty or unparseable body, a non-object body, an absent or non-string `detail`,
+FastAPI's generic route-404 — degrades to a plain `RommApiError`, the transport class `classify_error` maps to
+`server_unreachable`. Each caller then fails **open**: infrastructure can no longer authorize a deletion.
+
+## The strict proof is the default; the exemption is opt-in
+
+This polarity is the part that breaks silently. A new API call inherits the strict proof by doing nothing. Opting out is
+explicit and currently has exactly three call sites, all in `adapters/romm/http.py` — `download`,
+`download_conditional`, `download_external` pass `translate_http_error(..., asset_route=True)` and keep the plain status
+mapping.
+
+Those three are byte-stream fetches: their 404 answers about a **file**, not an entity, so it is never
+deletion-authority grade (`download_external` reaches a third-party CDN, which has no entity layer at all). They also
+have to keep raising `RommNotFoundError`, because RomM serves its cover resources from a static mount where a genuinely
+missing cover answers with exactly the generic route-404 body — and the one consumer that branches on it reacts by
+refetching the cover from the ROM's external `url_cover`, which is non-destructive and self-correcting.
+
+**Never unify the two directions.** Demanding the entity proof on the asset routes disarms the cover fallback; dropping
+it from the API routes hands deletion authority back to any proxy that answers a 404.
+
+Adding a fourth byte-stream fetch is a deliberate decision, not a copy-paste: it opts out only if its 404 can never
+authorize a destructive action, and each existing call site carries that constraint as a comment.
+
+Both directions are pinned in `tests/adapters/romm/test_http.py`: `TestNotFoundDiscrimination` for the translation
+itself, and a `test_generic_route_404_still_raises_not_found` in `TestRommDownloadErrors`, `TestDownloadConditional` and
+`TestDownloadExternal` for each opt-out call site. Full detail, including the RomM-version caveat on the entity-answer
+shape:
+[what makes a 404 an entity verdict](../../docs/architecture/backend-architecture.md#rommhttpadapter-notes-what-makes-a-404-an-entity-verdict).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,9 @@ new code in it.
   rather than the behavior, and when a subfolder is justified. **No mechanical check exists for any of it.**
 - `adapters-domain.md` — adapters own I/O, domain is pure, aggregate mutations are verb-named after the event
   (`adopt_baseline`, not `update_baseline`). The field-assignment ban is checked; the naming is not.
+- `romm-http.md` — an unproven 404 must never become `RommNotFoundError`, which is deletion authority downstream: the
+  entity proof is the default and only the three byte-stream fetches opt out. Tests pin both directions; nothing else
+  does.
 - `bootstrap-wiring.md` — the `main.py` / `bootstrap/` split, and which half of `bootstrap/` new wiring belongs in.
 - `callables.md` — the `{success, reason, message}` failure shape and its two carve-outs. Checked.
 - `vendored-assets.md` — `_vendor/`, `native/`, `defaults/` are checksum-pinned verbatim copies. The checksums are
@@ -165,6 +168,10 @@ Format: **invariant** — tier — enforced by.
   bind a verdict key (`reason` / `status` / `recommended_action`) to a hardcoded `SERVER_UNREACHABLE`; route the
   exception through `classify_error`, or peel the 404 off with a sibling `except RommNotFoundError` where the verdict is
   a partial-success flag** — check — `scripts/check_404_not_unreachable.py --check`
+- **A 404 becomes `RommNotFoundError` only when RomM's entity layer is proven to have answered it; only the three
+  byte-stream fetches opt out** — test + prompt-only — `TestNotFoundDiscrimination` plus the per-call-site
+  `test_generic_route_404_still_raises_not_found` trio in `tests/adapters/romm/test_http.py`; a fourth byte-stream
+  fetch's opt-out is prompt-only — `.claude/rules/romm-http.md`
 - **Frontend↔backend callable parity (names + arity)** — check — `scripts/check_callable_manifest.py`
 - **Every backend `emit` event name has a frontend listener, and vice versa** — check — `scripts/check_event_parity.py`
 - **`settings.json` is written only by its owner (`adapters/persistence.py`)** — check —


### PR DESCRIPTION
docs(rules): own the 404 entity-proof rule in a path-scoped rule file

A 404 becomes `RommNotFoundError` — deletion authority downstream — only when the response
proves RomM's entity layer answered it: a JSON content type whose body is an object with a
`detail` string that is neither blank nor FastAPI's stock `Not Found`. Every other shape degrades
to `RommApiError` and classifies as unreachable, so the caller fails open instead of letting a
proxy authorize a deletion.

The rule now lives in `.claude/rules/romm-http.md`, scoped to `py_modules/adapters/romm/**`. Its
breakable surface is a single file — whoever edits the translation or adds a fourth byte-stream
fetch — and a path-scoped rule reaches exactly them. Consumers in `services/` need nothing: they
catch `RommNotFoundError` and the adapter's proof already protects them.

The property most at risk is the polarity: the strict proof is the default and the byte-stream
exemption is opt-in, because a cover miss off RomM's static mount is indistinguishable from a
route-404 and its one consumer answers with a non-destructive refetch. Unifying the two
directions disarms one of them, and only tests stand behind that.

The invariant register keeps a one-line entry naming the test class and the rule file, the way
the mechanically-checked entries name their script. The register is the inventory of the
enforcement surface, not a second copy of a rule its owning file already states in full.

