### PR TITLE
chore(ci): extend the module-size gate to adapters, domain, lib and models

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,9 +184,10 @@ Format: **invariant** — tier — enforced by.
   same path** — check — `scripts/check_uow_seam_nesting.py`
 - **Services never call clocks / sleep / uuid / random directly (inject the Protocol)** — check —
   `scripts/check_cosmic_call_bans.sh`
-- **No module in `services/` or `bootstrap/` crosses the ~1000-LOC decomposition threshold, and the ones already over it
-  may not grow** — check — `scripts/check_module_size.py` (the modules that predate the gate are grandfathered at their
-  exact size; that list only ever gets shorter)
+- **No module in `services/`, `bootstrap/`, `adapters/`, `domain/`, `lib/` or `models/` crosses the ~1000-LOC
+  decomposition threshold, and the ones already over it may not grow** — check — `scripts/check_module_size.py` (the
+  modules that predate the gate are grandfathered at their exact size; that list only ever gets shorter. `main.py`,
+  `_vendor/`, `tests/`, `scripts/` and `src/` are out of scope, each for a reason recorded at `SCOPE_DIRS`)
 - **Service-independence contract list stays complete** — check — `scripts/check_service_independence_contract.py`
 - **Layer import direction (services ↛ adapters, adapters ↛ services, …)** — check — `.importlinter` (`lint-imports`)
 - **No bare `# type: ignore` / blanket suppressions** — check — `scripts/check_no_bare_ignores.sh`

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -250,12 +250,14 @@ literal appears anywhere except its owning adapter (`adapters/persistence.py`); 
 keeps all settings writes in the single crash-safe owner.
 
 `mise run lint` (and CI) also runs `scripts/check_module_size.py`, the decomposition-threshold ratchet: no module in
-`services/` or `bootstrap/` may cross the ~1000-LOC threshold, and the modules that were already over it when the gate
-landed are pinned at their exact size, so they cannot grow. The pin list lives in the script and only ever gets shorter
-— a module that drops back under the threshold has to leave it, and a module that banks 50+ lines of slack gets a
-non-fatal note asking for its ceiling to be lowered. `main.py` is deliberately out of scope: it grows with the callable
-surface by design. There is deliberately no `--update` flag — re-baselining should be a reviewable diff, never a command
-someone runs to get back to green.
+`services/`, `bootstrap/`, `adapters/`, `domain/`, `lib/` or `models/` may cross the ~1000-LOC threshold, and the
+modules that were already over it when the gate landed are pinned at their exact size, so they cannot grow. The pin list
+lives in the script and only ever gets shorter — a module that drops back under the threshold has to leave it, and a
+module that banks 50+ lines of slack gets a non-fatal note asking for its ceiling to be lowered. What the gate does not
+walk is listed at `SCOPE_DIRS` with the reason for each: `main.py` grows with the callable surface by design, `_vendor/`
+is a checksum-pinned copy, a large file under `tests/` is the one-file-per-source-module rule working, `scripts/` never
+ships, and `src/` needs a per-scope glob before it can be added. There is deliberately no `--update` flag —
+re-baselining should be a reviewable diff, never a command someone runs to get back to green.
 
 See [Backend Architecture](../architecture/backend-architecture.md) for details.
 

--- a/scripts/check_module_size.py
+++ b/scripts/check_module_size.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 """Hold the line on module size: no new god classes, no growth in the old ones.
 
-CLAUDE.md sets a decomposition threshold for ``services/`` and an explicit
-split trigger for ``bootstrap/``. Both lived in prose, and prose drifted:
-``sync_orchestrator.py`` was 901 lines when #999 wrote it down and kept
-growing. Nothing failed in between, because nothing was watching.
+CLAUDE.md sets a decomposition threshold for every first-party backend tree —
+``services/``, ``bootstrap/``, ``adapters/``, ``domain/``, ``lib/`` and
+``models/``. It lived in prose, and prose drifted: ``sync_orchestrator.py`` was
+901 lines when #999 wrote it down and kept growing. Nothing failed in between,
+because nothing was watching.
 
 This gate watches. Every in-scope module above the threshold carries a ceiling
 in ``ALLOWLIST`` — the size it had when it was recorded. That buys the property
@@ -44,10 +45,27 @@ ROOT = pathlib.Path(__file__).resolve().parent.parent
 THRESHOLD = 1000
 SLACK_ADVISORY = 50
 
-# Trees the threshold governs. ``main.py`` is deliberately absent: it owns the
-# Decky lifecycle plus one ``async def`` per callable, so it grows with the
-# callable surface by design (CLAUDE.md, "Process boundaries").
-SCOPE_DIRS = ("py_modules/bootstrap", "py_modules/services")
+# Trees the threshold governs — every first-party backend tree. What is absent
+# is absent on purpose, not by oversight:
+#   ``main.py`` owns the Decky lifecycle plus one ``async def`` per callable,
+#     so it grows with the callable surface by design (CLAUDE.md, "Process
+#     boundaries").
+#   ``py_modules/_vendor`` is a checksum-pinned verbatim copy; its size is
+#     upstream's decision (.claude/rules/vendored-assets.md).
+#   ``tests/`` is one file per source module by rule
+#     (.claude/rules/testing-backend.md), so a large test file is that rule
+#     working — gating it here would put two of our own rules in conflict.
+#   ``scripts/`` is developer tooling that never ships.
+#   ``src/`` has the same god-class problem and no enforcement, but needs a
+#     per-scope glob first: ``in_scope`` hardcodes ``*.py``.
+SCOPE_DIRS = (
+    "py_modules/adapters",
+    "py_modules/bootstrap",
+    "py_modules/domain",
+    "py_modules/lib",
+    "py_modules/models",
+    "py_modules/services",
+)
 
 # Modules that were already over the threshold when this gate landed, each
 # pinned at the size it had that day. Entries come out when the module drops

--- a/tests/scripts/test_check_module_size.py
+++ b/tests/scripts/test_check_module_size.py
@@ -8,8 +8,9 @@ real walk and the real comparison logic run against a controlled layout.
 Coverage centres on the ratchet's four failure modes — an unlisted module over
 the threshold, a listed module that grew, a listed module that graduated, and a
 stale entry — plus the boundary conditions, where an off-by-one would silently
-widen or narrow the gate, and the code-line counting itself, where counting
-comments would quietly turn every ceiling into a budget shared with prose.
+widen or narrow the gate, the code-line counting itself, where counting
+comments would quietly turn every ceiling into a budget shared with prose, and
+the walked scope, where a tree left out fails nothing at all.
 """
 
 from __future__ import annotations
@@ -122,13 +123,37 @@ class TestHappyPath:
         modules = {"py_modules/services/big.py": 1200}
         assert run_check(modules, {"py_modules/services/big.py": 1200}) == 0
 
-    def test_bootstrap_package_is_in_scope_via_scope_dirs(self, run_check, capsys: pytest.CaptureFixture[str]) -> None:
-        assert run_check({"py_modules/bootstrap/services.py": 1200}, {}) == 1
-        assert "py_modules/bootstrap/services.py: 1200 lines exceeds" in capsys.readouterr().err
+
+class TestScope:
+    """Which trees the walk reaches. A tree left out of ``SCOPE_DIRS`` fails nothing, silently."""
+
+    @pytest.mark.parametrize(
+        "tree",
+        [
+            "py_modules/adapters",
+            "py_modules/bootstrap",
+            "py_modules/domain",
+            "py_modules/lib",
+            "py_modules/models",
+            "py_modules/services",
+        ],
+    )
+    def test_governed_tree_is_walked(self, tree: str, run_check, capsys: pytest.CaptureFixture[str]) -> None:
+        assert run_check({f"{tree}/big.py": 1200}, {}) == 1
+        assert f"{tree}/big.py: 1200 lines exceeds" in capsys.readouterr().err
+
+    def test_subpackages_are_walked(self, run_check, capsys: pytest.CaptureFixture[str]) -> None:
+        """The walk recurses — the largest modules in scope live in subpackages."""
+        assert run_check({"py_modules/adapters/romm/big.py": 1200}, {}) == 1
+        assert "py_modules/adapters/romm/big.py: 1200 lines exceeds" in capsys.readouterr().err
 
     def test_main_py_is_out_of_scope(self, run_check) -> None:
         """``main.py`` grows with the callable surface by design — never flagged."""
         assert run_check({"main.py": 5000}, {}) == 0
+
+    def test_vendored_code_is_out_of_scope(self, run_check) -> None:
+        """``_vendor/`` sits beside the governed trees but its size is upstream's decision."""
+        assert run_check({"py_modules/_vendor/big.py": 5000}, {}) == 0
 
 
 class TestCodeLinesNotPhysicalLines:
@@ -226,6 +251,26 @@ class TestRealRepository:
     def test_gate_passes_on_the_real_tree(self, capsys: pytest.CaptureFixture[str]) -> None:
         assert check.main() == 0
         capsys.readouterr()
+
+    def test_every_scope_dir_exists(self) -> None:
+        """A misspelled scope entry governs nothing: ``rglob`` on a missing directory just yields nothing."""
+        missing = [d for d in check.SCOPE_DIRS if not (check.ROOT / d).is_dir()]
+        assert not missing, f"SCOPE_DIRS entries that do not exist: {missing}"
+
+    def test_every_backend_package_with_python_is_governed(self) -> None:
+        """The mirror of the entry-exists check: a new package under ``py_modules/`` must not escape the gate.
+
+        ``_vendor/`` is the one deliberate exemption — a checksum-pinned verbatim copy whose size is upstream's
+        decision, not ours (the reasoning is recorded beside ``SCOPE_DIRS``). Every other package holding Python
+        belongs in scope, so do not widen this exemption to silence a failure.
+        """
+        governed = {d.split("/", 1)[1] for d in check.SCOPE_DIRS if d.startswith("py_modules/")}
+        ungoverned = sorted(
+            d.name
+            for d in (check.ROOT / "py_modules").iterdir()
+            if d.is_dir() and d.name not in governed and d.name != "_vendor" and any(d.rglob("*.py"))
+        )
+        assert not ungoverned, f"py_modules packages holding Python but outside SCOPE_DIRS: {ungoverned}"
 
     def test_allowlist_has_no_entry_at_or_below_the_threshold(self) -> None:
         too_small = {name: n for name, n in check.ALLOWLIST.items() if n <= check.THRESHOLD}


### PR DESCRIPTION
chore(ci): extend the module-size gate to adapters, domain, lib and models

`scripts/check_module_size.py` governed `py_modules/services/` and `py_modules/bootstrap/` only. Every other
backend tree could grow a god class with nothing failing — the exact condition the gate exists to end.
`adapters/`, `domain/`, `lib/` and `models/` join the scope, which brings every first-party backend tree under it.

Extending now costs zero allowlist entries. Measured under the current counting (code lines, 1000-line
threshold), the largest module in each new tree is `adapters/recovery_bundle.py` at 842, `domain/sync_action.py`
at 291, `lib/prune_gate.py` at 248, and `models/sync.py` at 68. Before a tree has anything to grandfather is the
cheapest moment to start watching it: an allowlist entry added on a scope extension would bless a god class that
extension had just discovered, which is not what that list is for.

Worth knowing going in: `adapters/recovery_bundle.py` has 158 lines of headroom and
`adapters/descriptor_paths.py` 169. Ungated that was nobody's problem; they are now the first two modules that
will reach the ceiling.

What stays out, and why, is recorded at `SCOPE_DIRS`. `main.py` grows with the callable surface by design.
`py_modules/_vendor/` is a checksum-pinned verbatim copy whose size is upstream's decision. A large file under
`tests/` is the one-file-per-source-module rule working, so gating it at the production threshold would put two
of our own rules in direct conflict. `scripts/` is developer tooling that never ships. `src/` has the same
god-class problem and no enforcement, but needs per-scope globs before it can be added at all, since
`in_scope()` hardcodes `rglob("*.py")`.

Gate tests pin each governed tree as walked, subpackage recursion, `_vendor/` and `main.py` as out of scope, and
the scope list against the repository in both directions: every entry names a directory that exists, since a
misspelled entry would govern nothing and fail nothing, and every package under `py_modules/` holding Python is
listed, so a seventh backend package cannot land outside the gate unnoticed.

Refs #1618

