### PR TITLE
docs(adr): correct ADR-0007's re-link premise and the per-ROM cascade count

### DIFF
--- a/docs/adr/0002-per-rom-table-per-aggregate-split.md
+++ b/docs/adr/0002-per-rom-table-per-aggregate-split.md
@@ -62,12 +62,19 @@ a deliberate full prune does, and cascading per-ROM state when the ROM is genuin
   multi-table cleanup, no orphan risk.
 - Foreign-key count goes 1 → 5. `PRAGMA foreign_keys=ON` (already locked by the epic, set per-connection by the adapter)
   is required for the cascades to fire.
+
 - This **deviates from the epic's literal wording** ("one `roms` mega-table", "no other FKs"). Both were explicit
   starting points written before the split; #780 is the sanctioned place to finalize the layout, so this is a
   resolution, not a relitigation. ADR-0001's "`platform_slug` as an FK" wording is clarified there to mean a logical
   reference, not a DB constraint.
 - It is **not a one-way door.** Merging back to a mega-table (or splitting a table further) later is an internal
   numbered migration plus a repository SQL rewrite — not a user-facing breaking change.
+
+> **Correction (#1570).** The per-ROM cascade count is **six**, not five. `rom_playtime_sessions` — the outbox of play
+> sessions not yet ingested by RomM, added in migration `006` as the `Playtime` aggregate's second table
+> ([ADR-0018](0018-native-play-session-tracking-additive-ingest.md)) — carries the same `ON DELETE CASCADE` onto `roms`
+> and is missing from the enumeration above. The decision is unaffected: it landed after this ADR and followed its rule
+> rather than deviating from it.
 
 ## Alternatives considered
 

--- a/docs/adr/0007-rom-retention-identity-anchor.md
+++ b/docs/adr/0007-rom-retention-identity-anchor.md
@@ -27,6 +27,23 @@ and save history **survive a ROM leaving RomM**.
 - **No time-based GC.** `roms` grows with every ROM ever seen; rows are tiny (single-digit MB over years even for a
   heavy curator), and the stable `rom_id` re-links cleanly on re-add. This is accepted over mirroring RomM exactly.
 
+> **Correction (#1570).** The Decision stands — retention is what made the deliberate purge cheap to add — but two of
+> the statements above are wrong as written and a third has been overtaken:
+>
+> - **`rom_id` does not re-link on re-add.** RomM issues a _new_ id when a ROM is deleted and rescanned, so a re-add
+>   produces a **second row in the same sibling group** ([ADR-0022](0022-component-based-sibling-group-key.md)) rather
+>   than reattaching to the retained one. The retained row keeps the local playtime and saves recorded under the old id,
+>   and nothing carries them across on its own. Retention is still right — losing that history to a transient absence
+>   would be worse — but "it re-links" was never the reason.
+> - **There are six per-ROM cascade children, not five.** The Context above lists `rom_installs`, `rom_metadata`,
+>   `rom_playtime`, `rom_save_sync_states` and `rom_save_files`. `rom_playtime_sessions` — the outbox of play sessions
+>   not yet ingested by RomM, added in migration `006` — carries the same `ON DELETE CASCADE` and is missing from the
+>   list. A purge therefore also discards queued sessions that exist nowhere else, which is part of why it captures
+>   playtime before deleting.
+> - **The deliberate purge now exists.** "That action does not exist today" was true when this was written. Removed-game
+>   cleanup ([removed-game-cleanup.md](../architecture/removed-game-cleanup.md)) is that action: explicit, opt-in, and
+>   authorized only by a fresh exact-id 404 from RomM. The cascade FKs are no longer dormant.
+
 ## Consequences
 
 - The cascade FKs are real and correct but **never auto-fire** — a future reader seeing `ON DELETE CASCADE` with no


### PR DESCRIPTION
Two records in the ADR trail state things that are not true. Both are corrected in place with a dated correction block, leaving the original text and decisions intact.

**ADR-0007's retention rationale is falsified.** It argues that `roms` may grow forever partly because "the stable `rom_id` re-links cleanly on re-add". RomM issues a new id when a ROM is deleted and rescanned, so a re-add produces a second row in the same sibling group rather than reattaching to the retained one — the retained row keeps the playtime and saves recorded under the old id, and nothing carries them across. The Decision is unaffected and is what made the deliberate purge cheap to add; only the reasoning was wrong.

Two further statements in the same record are corrected alongside it: the deliberate purge it describes as not existing now exists, so the cascade FKs are no longer dormant; and the per-ROM cascade children are miscounted.

**Both ADR-0007 and ADR-0002 enumerate five per-ROM cascade children. There are six.** `rom_playtime_sessions` — the outbox of play sessions not yet ingested by RomM, added in migration `006` as the `Playtime` aggregate's second table — carries the same `ON DELETE CASCADE` onto `roms` and appears in neither list. It is the one child whose rows exist nowhere else, which is why a purge captures playtime before deleting.

The remaining PR 6 items from #1570 — recording the per-call liveness rule in the shortcuts page and the purge in the user guide — already landed with the earlier PRs in that issue.

docs: N/A — this PR is documentation.

Closes #1570.
