### PR TITLE
chore(saves): pin gavel at v1.0.1

### DIFF
--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -1384,10 +1384,10 @@ backstop in `_handle_upload_409` (`services/saves/sync_engine/matrix.py`).
   measured is a real case, distinct from a missing one. The core answers with the chosen `server_save_id`, which the
   adapter resolves back to the caller's own save dict so `Download` / `Conflict` carry the full record their consumers
   read.
-- **What ships**: `py_modules/native/libgavel-x86_64-linux.so` (romm-gavel `v1.0.0`, a freestanding build with zero
+- **What ships**: `py_modules/native/libgavel-x86_64-linux.so` (romm-gavel `v1.0.1`, a freestanding build with zero
   library dependencies — it loads on any x86_64 Linux), vendored verbatim from the upstream release with a pinned
-  SHA-256 checksum. `v1.0.0` is the first release whose C ABI is part of upstream's promise: struct layouts, signatures
-  and enumerator values now cost a major bump to change, which is what makes pinning a compiled artifact meaningful.
+  SHA-256 checksum. The C ABI has been part of upstream's promise since `v1.0.0`: struct layouts, signatures and
+  enumerator values now cost a major bump to change, which is what makes pinning a compiled artifact meaningful.
   Provenance and the update procedure live in
   [`native/README.md`](https://github.com/danielcopper/decky-romm-sync/blob/main/py_modules/native/README.md). The
   checksum is re-verified by CI and the release smoke test asserts the `.so` is present in the plugin zip, so both a

--- a/py_modules/native/README.md
+++ b/py_modules/native/README.md
@@ -15,7 +15,7 @@ per-`(rom, filename, slot)` sync action (`gavel_compute_sync_action`) and the up
 (`gavel_resolve_upload_conflict`).
 
 - **Upstream:** <https://github.com/danielcopper/romm-gavel>
-- **Release:** `v1.0.0` — the first release whose **C ABI is part of the promise**. Struct layouts, signatures and
+- **Release:** `v1.0.1` — the C ABI has been part of upstream's promise since `v1.0.0`. Struct layouts, signatures and
   enumerator values cannot change now without a major bump, which is what makes pinning a compiled artifact meaningful
   rather than hopeful. The binary is byte-identical to `v0.4.0`; only the guarantee attached to it changed.
 - **Architecture:** `x86_64` Linux — freestanding (zero library dependencies: no NEEDED entries, no global undefined

--- a/tests/domain/gavel_vectors/README.md
+++ b/tests/domain/gavel_vectors/README.md
@@ -1,7 +1,7 @@
 # Gavel conformance vectors — vendored
 
 These JSON files are vendored verbatim from [danielcopper/romm-gavel](https://github.com/danielcopper/romm-gavel)
-`vectors/`, at release tag `v1.0.0`. The layout mirrors upstream — one subdirectory per vector family:
+`vectors/`, at release tag `v1.0.1`. The layout mirrors upstream — one subdirectory per vector family:
 
 - `ladder/` — the 409 resolution ladder (`resolve_upload_conflict`), run against the in-tree kernel by
   `tests/domain/test_sync_action_gavel_vectors.py` and against the compiled core by


### PR DESCRIPTION
The v1.0.1 artifact is **byte-identical** to v1.0.0 and v0.4.0 — the same SHA-256 `a9095f78…e1986` — and the vectors are unchanged, verified against `git archive v1.0.1 vectors`. Nothing was re-downloaded, no checksum moved, no test outcome shifted. Only the three pins.

Worth recording *why* the binary did not move: v1.0.1 contains a refactor of `gavel.c` that narrowed two loop variables into the `for` statements owning them. Identical machine code out of changed source is a stronger statement than the review could make — that change provably altered nothing.