### PR TITLE
test(prune): pin installed-selection paging without a 257-row render

### DIFF
--- a/src/components/RemovedGamesCleanup.test.tsx
+++ b/src/components/RemovedGamesCleanup.test.tsx
@@ -12,7 +12,12 @@ import {
   setPruneComplete,
   setPruneProgress,
 } from "../utils/pruneStore";
-import { openRemovedGamesCleanupModal, RemovedGamesCleanupSection, STAGE_LABELS } from "./RemovedGamesCleanup";
+import {
+  openRemovedGamesCleanupModal,
+  RemovedGamesCleanupSection,
+  stageInstalledSelections,
+  STAGE_LABELS,
+} from "./RemovedGamesCleanup";
 
 const preview: backend.PrunePreviewResult = {
   success: true,
@@ -347,36 +352,116 @@ describe("RemovedGamesCleanup", () => {
     });
   });
 
-  it("stages every installed selection above 256 in bounded pages", async () => {
-    const items = Array.from({ length: 257 }, (_, index) => ({
-      ...preview.items![0]!,
-      rom_id: index + 1,
-      installed_bytes: 0,
-      name: `Game ${index + 1}`,
-    }));
-    vi.mocked(backend.getPrunePreview).mockResolvedValue({ ...preview, items, total: items.length, free_bytes: 1 });
-    vi.mocked(backend.stagePruneInstalledSelection).mockImplementation(async (request) => ({
+  it("stages the checked installed content and carries its selection id into the run", async () => {
+    vi.mocked(backend.getPrunePreview).mockResolvedValue({
+      ...preview,
+      total: 2,
+      free_bytes: 1,
+      items: [
+        { ...preview.items![0]!, rom_id: 11, installed_bytes: 0, name: "Game 11" },
+        { ...preview.items![0]!, rom_id: 12, installed_bytes: 0, name: "Game 12" },
+      ],
+    });
+    vi.mocked(backend.stagePruneInstalledSelection).mockResolvedValue({
       success: true,
-      selection_id: "selection-many",
-      selected_count: request.rom_ids[request.rom_ids.length - 1] ?? 0,
-      finalized: request.final,
-    }));
+      selection_id: "selection-final",
+      selected_count: 2,
+      finalized: true,
+    });
     await openRemovedGamesCleanupModal();
     const modal = render(shownModal());
+    // The four option toggles come first, then one content toggle per installed row.
     const toggles = modal.getAllByTestId("toggle-input") as HTMLInputElement[];
-    act(() => {
-      for (const toggle of toggles.slice(4)) toggle.click();
-    });
+    fireEvent.click(toggles[4]!);
+    fireEvent.click(toggles[5]!);
 
     fireEvent.click(modal.getByRole("button", { name: "Confirm Cleanup" }));
     await waitFor(() => expect(backend.startPrune).toHaveBeenCalled());
 
-    const pages = vi.mocked(backend.stagePruneInstalledSelection).mock.calls.map(([request]) => request);
-    expect(pages.map((page) => page.rom_ids.length)).toEqual([100, 100, 57]);
-    expect(pages.map((page) => page.selection_id)).toEqual([null, "selection-many", "selection-many"]);
-    expect(pages.map((page) => page.final)).toEqual([false, false, true]);
-    expect(vi.mocked(backend.startPrune).mock.calls[0]?.[0].installed_selection_id).toBe("selection-many");
-  }, 30_000);
+    expect(vi.mocked(backend.stagePruneInstalledSelection)).toHaveBeenCalledExactlyOnceWith({
+      preview_id: "preview-1",
+      selection_id: null,
+      rom_ids: [11, 12],
+      final: true,
+    });
+    expect(vi.mocked(backend.startPrune).mock.calls[0]?.[0].installed_selection_id).toBe("selection-final");
+  });
+
+  it("does not start the run when the staged selection is refused", async () => {
+    vi.mocked(backend.getPrunePreview).mockResolvedValue({
+      ...preview,
+      free_bytes: 1,
+      items: [{ ...preview.items![0]!, installed_bytes: 0 }],
+    });
+    vi.mocked(backend.stagePruneInstalledSelection).mockResolvedValue({
+      success: false,
+      reason: "stale_preview",
+      message: "That cleanup preview is no longer current.",
+    });
+    await openRemovedGamesCleanupModal();
+    const modal = render(shownModal());
+    fireEvent.click((modal.getAllByTestId("toggle-input") as HTMLInputElement[])[4]!);
+
+    fireEvent.click(modal.getByRole("button", { name: "Confirm Cleanup" }));
+    await waitFor(() => {
+      expect(modal.container.textContent).toContain("That cleanup preview is no longer current.");
+      // Back at its resting label, so the whole Confirm path has run and the
+      // control is usable for a retry.
+      expect((modal.getByRole("button", { name: "Confirm Cleanup" }) as HTMLButtonElement).disabled).toBe(false);
+    });
+
+    // The run would otherwise execute against a selection the backend never accepted.
+    expect(backend.startPrune).not.toHaveBeenCalled();
+  });
+
+  describe("stageInstalledSelections", () => {
+    // Enough to cross the page boundary twice and leave a short final page. The
+    // dialog would need one rendered row and one click per id to reach it.
+    const romIds = Array.from({ length: 257 }, (_, index) => index + 1);
+
+    it("splits a selection into bounded pages, each chained onto the one before", async () => {
+      let page = 0;
+      vi.mocked(backend.stagePruneInstalledSelection).mockImplementation(async (request) => ({
+        success: true,
+        selection_id: `selection-${++page}`,
+        selected_count: request.rom_ids.length,
+        finalized: request.final,
+      }));
+
+      await expect(stageInstalledSelections("preview-1", romIds, vi.fn())).resolves.toEqual({
+        ok: true,
+        selectionId: "selection-3",
+      });
+
+      const pages = vi.mocked(backend.stagePruneInstalledSelection).mock.calls.map(([request]) => request);
+      expect(pages.map((request) => request.rom_ids.length)).toEqual([100, 100, 57]);
+      expect(pages.map((request) => request.selection_id)).toEqual([null, "selection-1", "selection-2"]);
+      // Only the last page finalizes — an early close would drop the rest.
+      expect(pages.map((request) => request.final)).toEqual([false, false, true]);
+      expect(pages.flatMap((request) => request.rom_ids)).toEqual(romIds);
+    });
+
+    it("stops at a refused page and reports the backend's message", async () => {
+      const setStatus = vi.fn();
+      vi.mocked(backend.stagePruneInstalledSelection)
+        .mockResolvedValueOnce({ success: true, selection_id: "selection-1", selected_count: 100, finalized: false })
+        .mockResolvedValueOnce({
+          success: false,
+          reason: "stale_preview",
+          message: "That cleanup preview is no longer current.",
+        });
+
+      await expect(stageInstalledSelections("preview-1", romIds, setStatus)).resolves.toEqual({ ok: false });
+
+      // The third page is never sent: a partially staged selection must not be
+      // extended past the point the backend stopped accepting it.
+      expect(backend.stagePruneInstalledSelection).toHaveBeenCalledTimes(2);
+      expect(setStatus).toHaveBeenCalledExactlyOnceWith("That cleanup preview is no longer current.");
+      expect(logs.warn).toHaveBeenCalledWith(
+        expect.stringContaining("Confirm aborted while staging installed content"),
+      );
+    });
+  });
 
   it("surfaces bounded save warnings in terminal details", async () => {
     await openRemovedGamesCleanupModal();

--- a/src/components/RemovedGamesCleanup.test.tsx
+++ b/src/components/RemovedGamesCleanup.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, waitFor, type RenderResult } from "@testing-library/react";
 import { createElement, type ReactElement } from "react";
 import { toaster } from "@decky/api";
 import { showModal } from "@decky/ui";
@@ -54,6 +54,24 @@ function shownModal(): ReactElement {
   const element = calls[calls.length - 1]?.[0] as ReactElement | undefined;
   if (!element) throw new Error("Expected cleanup modal");
   return element;
+}
+
+/**
+ * The "include installed ROM content" checkbox belonging to `gameName`'s row.
+ *
+ * The dialog's option toggles and its per-row content toggles share one flat
+ * `toggle-input` list, so indexing it ties every row assertion to the number of
+ * options rendered above the list. Throws rather than returning nothing: a row
+ * that has lost its content toggle is the failure, not a silently skipped click.
+ */
+function contentToggleFor(modal: RenderResult, gameName: string): HTMLInputElement {
+  const row = modal.getByText(gameName).parentElement;
+  const toggle = [...(row?.querySelectorAll<HTMLElement>('[data-testid="toggle"]') ?? [])].find((el) =>
+    el.textContent.includes("Include installed ROM content"),
+  );
+  const input = toggle?.querySelector<HTMLInputElement>('[data-testid="toggle-input"]');
+  if (!input) throw new Error(`No installed-content toggle in the row for ${gameName}`);
+  return input;
 }
 
 describe("RemovedGamesCleanup", () => {
@@ -370,10 +388,8 @@ describe("RemovedGamesCleanup", () => {
     });
     await openRemovedGamesCleanupModal();
     const modal = render(shownModal());
-    // The four option toggles come first, then one content toggle per installed row.
-    const toggles = modal.getAllByTestId("toggle-input") as HTMLInputElement[];
-    fireEvent.click(toggles[4]!);
-    fireEvent.click(toggles[5]!);
+    fireEvent.click(contentToggleFor(modal, "Game 11"));
+    fireEvent.click(contentToggleFor(modal, "Game 12"));
 
     fireEvent.click(modal.getByRole("button", { name: "Confirm Cleanup" }));
     await waitFor(() => expect(backend.startPrune).toHaveBeenCalled());
@@ -400,7 +416,7 @@ describe("RemovedGamesCleanup", () => {
     });
     await openRemovedGamesCleanupModal();
     const modal = render(shownModal());
-    fireEvent.click((modal.getAllByTestId("toggle-input") as HTMLInputElement[])[4]!);
+    fireEvent.click(contentToggleFor(modal, "Removed Game"));
 
     fireEvent.click(modal.getByRole("button", { name: "Confirm Cleanup" }));
     await waitFor(() => {
@@ -460,6 +476,35 @@ describe("RemovedGamesCleanup", () => {
       expect(logs.warn).toHaveBeenCalledWith(
         expect.stringContaining("Confirm aborted while staging installed content"),
       );
+    });
+
+    it("treats a page that reports success without a selection id as refused", async () => {
+      const setStatus = vi.fn();
+      vi.mocked(backend.stagePruneInstalledSelection).mockResolvedValue({
+        success: true,
+        selected_count: 100,
+        message: "The selection was accepted but not stored.",
+      });
+
+      await expect(stageInstalledSelections("preview-1", romIds, setStatus)).resolves.toEqual({ ok: false });
+
+      // There is nothing to chain the next page onto. Carrying on would open a
+      // second, unrelated selection and stage the remaining ids into it, and the
+      // run would then be started against whichever one Confirm happened to hold.
+      expect(backend.stagePruneInstalledSelection).toHaveBeenCalledTimes(1);
+      expect(setStatus).toHaveBeenCalledExactlyOnceWith("The selection was accepted but not stored.");
+    });
+
+    it("says something of its own when a refusal carries no message", async () => {
+      const setStatus = vi.fn();
+      vi.mocked(backend.stagePruneInstalledSelection).mockResolvedValue({ success: false, reason: "stale_preview" });
+
+      await expect(stageInstalledSelections("preview-1", romIds, setStatus)).resolves.toEqual({ ok: false });
+
+      // Confirm reports through this string alone, so an unexplained refusal
+      // must not surface as a blank line in the dialog.
+      expect(setStatus).toHaveBeenCalledExactlyOnceWith("Installed-content selections could not be staged.");
+      expect(logs.warn).toHaveBeenCalledWith(expect.stringContaining("installed content: no message"));
     });
   });
 

--- a/src/components/RemovedGamesCleanup.tsx
+++ b/src/components/RemovedGamesCleanup.tsx
@@ -194,8 +194,12 @@ function confirmBlockedReason(state: {
  * Stage the installed-content opt-ins page by page, chaining each page onto the
  * selection the previous one opened. A refused page reports itself and stops the
  * whole Confirm — a partially staged selection must never reach the run.
+ *
+ * Exported so a test can pin the page boundary directly: reaching it through the
+ * dialog needs one rendered row and one click per selected id, which makes the
+ * cost of proving it grow with the boundary it is proving.
  */
-async function stageInstalledSelections(
+export async function stageInstalledSelections(
   previewId: string,
   selected: number[],
   setStatus: (message: string) => void,

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -62,9 +62,16 @@ vi.mock("@decky/api", async () => {
 vi.mock("@decky/ui", () => {
   type AnyProps = Record<string, unknown> & { children?: unknown };
   const passthrough = (tag: string) => (props: AnyProps) => createElement(tag, props, props.children as never);
+  // The modal shells take Steam's own prop vocabulary — closeModal, onOK,
+  // strTitle, bAlertDialog. React puts none of it on a host element: it drops
+  // each one and logs a warning, and a warning on every modal render buries the
+  // next real one. Forwarding only the children leaves the rendered tree
+  // identical, since React was already dropping the rest. Neither shell is ever
+  // handed className or style — every caller wraps its own body in a div.
+  const modalShell = (props: AnyProps) => createElement("div", null, props.children as never);
   return {
-    ConfirmModal: passthrough("div"),
-    ModalRoot: passthrough("div"),
+    ConfirmModal: modalShell,
+    ModalRoot: modalShell,
     DialogButton: ({
       children,
       onClick,


### PR DESCRIPTION
The `stages every installed selection above 256 in bounded pages` test rendered a 257-item preview and clicked every content toggle inside one `act()`. Each click re-rendered the whole list, so the cost grew with the square of the item count and the wall time depended on what else the runner was doing — about 6.6 s for that single test locally, against the 30-second per-test timeout it carried, the only one in the file. Under CI load it went red on its own and green on a re-run with nothing changed.

What it has to prove is the paging arithmetic, and none of that needs 257 DOM clicks. `stageInstalledSelections` is exported so a test can call it directly with a 257-id selection: the page split `[100, 100, 57]`, the `selection_id` chain — `null`, then the id the previous page returned — `final` on the last page only, and that no id is dropped at a page boundary. The mocked pages hand back distinct ids per page, so an implementation that echoed a fixed id instead of chaining now fails where the old test passed.

The component-level wiring keeps a DOM test, shrunk to two rows: the checked content reaches the backend as `rom_ids`, and the id staging returns reaches `startPrune` as `installed_selection_id`. Three refusal branches gain coverage they did not have — a refused page, a page that reports success without a selection id, and a refusal carrying no message.

Two test-quality fixes ride along. The new tests reach a row's content toggle through the row's game name and the toggle's own label rather than a position in the toggle list, and throw when the row has none. And the shared `ConfirmModal` / `ModalRoot` test stubs render their children instead of spreading every prop onto a `div`, which removes nine React unknown-prop warnings across five test files.

No behavioural change: the production diff is the `export` keyword and the comment saying why it is there. The file runs in 2.1 s instead of 8.8 s, with the slowest test at 23 ms and no per-test timeout.

docs: N/A — test-only change; no user-visible behaviour, architecture, or data flow is affected.

Closes #1639
