### PR TITLE
test(frontend): fail tests that emit console.error

### DIFF
--- a/src/components/DangerZone.test.tsx
+++ b/src/components/DangerZone.test.tsx
@@ -199,7 +199,7 @@ describe("DangerZone", () => {
       expect(container.textContent).toContain("No synced platforms");
     });
 
-    it("shows the loading Spinner before refreshPlatforms resolves", () => {
+    it("shows the loading Spinner before refreshPlatforms resolves", async () => {
       vi.mocked(backend.getRegistryPlatforms).mockImplementation(
         () =>
           new Promise(() => {
@@ -210,6 +210,9 @@ describe("DangerZone", () => {
       // initial render runs before any effect — but useEffect fires before
       // the assert below; loading state is still true while the promise stalls.
       expect(queryAllByTestId("spinner").length).toBeGreaterThan(0);
+      // getRegistryPlatforms stalls by design, but the sibling mount effects do
+      // resolve — their state updates have to land inside act.
+      await flushAsync();
     });
 
     it("logs the failure when getWhitelistSettings rejects on mount", async () => {
@@ -421,7 +424,9 @@ describe("DangerZone", () => {
       const view = render(<DangerZone onBack={vi.fn()} />);
       await flushAsync();
       fireEvent.click(view.getByText("Super Nintendo (1)"));
-      lastShownModalProps<{ onRemoveShortcuts?: () => void }>()?.onRemoveShortcuts?.();
+      act(() => {
+        lastShownModalProps<{ onRemoveShortcuts?: () => void }>()?.onRemoveShortcuts?.();
+      });
       await waitFor(() => expect(clearPlatformCollection).toHaveBeenCalled());
 
       view.unmount();
@@ -453,7 +458,9 @@ describe("DangerZone", () => {
       const view = render(<DangerZone onBack={vi.fn()} />);
       await flushAsync();
       fireEvent.click(view.getByText("Super Nintendo (2)"));
-      lastShownModalProps<{ onRemoveShortcuts?: () => void }>()?.onRemoveShortcuts?.();
+      act(() => {
+        lastShownModalProps<{ onRemoveShortcuts?: () => void }>()?.onRemoveShortcuts?.();
+      });
       await waitFor(() => expect(backend.removePlatformShortcuts).toHaveBeenCalledWith("snes"));
 
       view.unmount();
@@ -1879,8 +1886,12 @@ describe("DangerZone", () => {
 
     // The syncProgress store is real module state (not a vi mock) — it
     // survives vi.resetAllMocks(), so restore the idle default after each test.
+    // act-wrapped: this runs before RTL's cleanup(), so every mounted subscriber
+    // re-renders on the reset.
     afterEach(() => {
-      setSyncProgress({ running: false, stage: "", current: 0, total: 0, message: "", runId: "" });
+      act(() => {
+        setSyncProgress({ running: false, stage: "", current: 0, total: 0, message: "", runId: "" });
+      });
     });
 
     it("disables the bulk removal buttons and shows the hint while a sync runs", async () => {

--- a/src/components/MigrationBlockedPage.test.tsx
+++ b/src/components/MigrationBlockedPage.test.tsx
@@ -385,8 +385,12 @@ describe("MigrationBlockedPage component", () => {
 });
 
 describe("useMigrationStatus hook", () => {
+  // act-wrapped: this teardown runs before RTL's cleanup(), so the hook is still
+  // mounted and the reset notifies its subscriber — a real state update.
   afterEach(() => {
-    clearMigration();
+    act(() => {
+      clearMigration();
+    });
   });
 
   it("returns the current state from getMigrationState() on mount", () => {

--- a/src/components/RomMGameInfoPanel.test.tsx
+++ b/src/components/RomMGameInfoPanel.test.tsx
@@ -318,12 +318,15 @@ describe("RomMGameInfoPanel", () => {
       expect(capturedMigrationBlockedCard.length).toBeGreaterThanOrEqual(1);
     });
 
-    it("renders 'Loading...' before loadData resolves", () => {
+    it("renders 'Loading...' before loadData resolves", async () => {
       // getCachedGameDetail returns a never-resolving promise so the initial
       // loading state stays visible.
       vi.mocked(cachedStore.getCachedGameDetail).mockReturnValue(new Promise(() => {}));
       const { container } = render(<RomMGameInfoPanel appId={testAppId} />);
       expect(container.textContent).toContain("Loading...");
+      // loadData stays pending by design, but the sibling refreshMigrationState
+      // effect does resolve — its store writes have to land inside act.
+      await flushAsync();
     });
 
     it("returns null when cached.found=false → state.error=true and romId=null", async () => {

--- a/src/components/RomMPlaySection.test.tsx
+++ b/src/components/RomMPlaySection.test.tsx
@@ -2330,6 +2330,13 @@ describe("RomMPlaySection", () => {
   // ------------------------------------------------------------------
 
   describe("handleUninstall", () => {
+    // The menu item detaches handleUninstall, so onClick resolves long before the
+    // handler's finally-block setActionPending and before the romm_rom_uninstalled
+    // listener's loadCached re-run. Await this INSIDE the caller's act(...): a
+    // second, separate act would leave a microtask gap between the two for those
+    // updates to escape through.
+    const settleDetachedUninstall = () => new Promise((r) => setTimeout(r, 0));
+
     async function setupUninstallAction(romName = "Some ROM") {
       vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
         found: true,
@@ -2363,6 +2370,7 @@ describe("RomMPlaySection", () => {
           // uninstall is the last one (index 5).
           const uninstall = items[items.length - 1]!;
           await uninstall.props.onClick?.();
+          await settleDetachedUninstall();
         });
         expect(vi.mocked(backend.removeRom)).toHaveBeenCalledWith(42);
         expect(setLaunchOptionsConfirmed).toHaveBeenCalledWith(testAppId, "");
@@ -2387,6 +2395,7 @@ describe("RomMPlaySection", () => {
       vi.mocked(toaster.toast).mockClear();
       await act(async () => {
         await items[items.length - 1]!.props.onClick?.();
+        await settleDetachedUninstall();
       });
       expect(vi.mocked(toaster.toast)).toHaveBeenCalledWith(expect.objectContaining({ body: "ROM uninstalled" }));
     });
@@ -2444,7 +2453,12 @@ describe("RomMPlaySection", () => {
             rejectRemove = reject;
           }),
       );
-      const uninstall = items[items.length - 1]!.props.onClick?.();
+      // The click's synchronous state update belongs inside act; the returned
+      // promise stays pending until rejectRemove below.
+      let uninstall: unknown;
+      await act(async () => {
+        uninstall = items[items.length - 1]!.props.onClick?.();
+      });
       await flushAsync();
 
       // The user leaves the game page while the uninstall is still in flight.

--- a/src/components/SavesTab.test.tsx
+++ b/src/components/SavesTab.test.tsx
@@ -125,6 +125,16 @@ function newSlotModalSubmit(idx = 0): ((name: string) => Promise<void>) | undefi
   return el?.props.onSubmit as ((name: string) => Promise<void>) | undefined;
 }
 
+// Settles the mount-time stranded-version probe (getVersionList → checkLocalDrift).
+// A test that returns before it resolves leaves its setStrandedVersion to land
+// unattributed, outside act.
+const flushAsync = () =>
+  act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+
 describe("SavesTab", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -169,8 +179,9 @@ describe("SavesTab", () => {
       expect(container.textContent).toContain("RomM is offline");
     });
 
-    it("appears live when the store flips to offline (no remount)", () => {
+    it("appears live when the store flips to offline (no remount)", async () => {
       const { container } = render(<SavesTab {...defaultProps()} />);
+      await flushAsync();
       expect(container.textContent).not.toContain("RomM is offline");
       act(() => {
         setRommConnectionState("offline");
@@ -178,9 +189,10 @@ describe("SavesTab", () => {
       expect(container.textContent).toContain("RomM is offline");
     });
 
-    it("clears live when the store flips back to connected (no remount)", () => {
+    it("clears live when the store flips back to connected (no remount)", async () => {
       setRommConnectionState("offline");
       const { container } = render(<SavesTab {...defaultProps()} />);
+      await flushAsync();
       expect(container.textContent).toContain("RomM is offline");
       act(() => {
         setRommConnectionState("connected");
@@ -570,8 +582,9 @@ describe("SavesTab", () => {
   });
 
   describe("event dispatch — version restored + slot deleted", () => {
-    it("dispatches romm_data_changed when a child SlotPanel calls onVersionRestored", () => {
+    it("dispatches romm_data_changed when a child SlotPanel calls onVersionRestored", async () => {
       render(<SavesTab {...defaultProps({ availableSlots: [makeSlot()] })} />);
+      await flushAsync();
       const listener = vi.fn();
       globalThis.addEventListener("romm_data_changed", listener);
       try {
@@ -587,7 +600,7 @@ describe("SavesTab", () => {
       }
     });
 
-    it("re-renders SlotPanel children after onVersionRestored", () => {
+    it("re-renders SlotPanel children after onVersionRestored", async () => {
       // Render with two distinct slots so each SavesTab render produces 2
       // captured-prop entries. The state bump in onVersionRestored triggers a
       // re-render of all panels — the captured-props array grows by 2, not 1.
@@ -596,6 +609,9 @@ describe("SavesTab", () => {
       // verified manually in integration testing, not asserted here.
       const slots = [makeSlot({ slot: "a" }), makeSlot({ slot: "b" })];
       render(<SavesTab {...defaultProps({ activeSlot: "a", availableSlots: slots })} />);
+      // Baseline is taken after the mount probe settles, so the act() below is
+      // the only thing that can add captured props.
+      await flushAsync();
       const initialCount = capturedSlotPanelProps.length;
       expect(initialCount).toBe(2);
       act(() => {
@@ -604,8 +620,9 @@ describe("SavesTab", () => {
       expect(capturedSlotPanelProps.length).toBe(initialCount + 2);
     });
 
-    it("dispatches romm_data_changed when a child SlotPanel calls onSlotDeleted", () => {
+    it("dispatches romm_data_changed when a child SlotPanel calls onSlotDeleted", async () => {
       render(<SavesTab {...defaultProps({ availableSlots: [makeSlot()] })} />);
+      await flushAsync();
       const listener = vi.fn();
       globalThis.addEventListener("romm_data_changed", listener);
       try {

--- a/src/components/SlotSetupWizard.test.tsx
+++ b/src/components/SlotSetupWizard.test.tsx
@@ -159,10 +159,13 @@ describe("SlotSetupWizard", () => {
   });
 
   describe("initial fetch + loading state", () => {
-    it("renders the connecting spinner immediately", () => {
+    it("renders the connecting spinner immediately", async () => {
       const { container } = render(<SlotSetupWizard {...defaultProps()} />);
       expect(container.textContent).toContain("Connecting to RomM…");
       expect(container.querySelector(".romm-throbber")).not.toBeNull();
+      // The spinner is asserted pre-resolution, but the mount fetch still has to
+      // land inside act — otherwise its setState escapes the test that started it.
+      await flushAsync();
     });
 
     it("calls getSaveSetupInfo with the romId on mount", async () => {

--- a/src/components/VersionErrorCard.test.tsx
+++ b/src/components/VersionErrorCard.test.tsx
@@ -45,8 +45,12 @@ describe("useVersionError hook", () => {
   // The hook subscribes to the real in-memory connectionState store. Drive it
   // via setVersionError(...) and reset to null in afterEach so tests don't
   // leak state into siblings (the store is module-singleton).
+  // act-wrapped: this teardown runs before RTL's cleanup(), so the hook is still
+  // mounted and the reset notifies its subscriber — a real state update.
   afterEach(() => {
-    setVersionError(null);
+    act(() => {
+      setVersionError(null);
+    });
   });
 
   it("returns the current error from getVersionError() on mount", () => {

--- a/src/components/saves/SlotPanel.test.tsx
+++ b/src/components/saves/SlotPanel.test.tsx
@@ -96,7 +96,10 @@ function defaultProps(overrides: Partial<React.ComponentProps<typeof SlotPanel>>
   };
 }
 
-const flushAsync = () => new Promise((r) => setTimeout(r, 0));
+const flushAsync = () =>
+  act(async () => {
+    await new Promise((r) => setTimeout(r, 0));
+  });
 
 describe("SlotPanel", () => {
   beforeEach(() => {
@@ -426,7 +429,9 @@ describe("SlotPanel", () => {
 
         const { container, getByText } = render(<SlotPanel {...defaultProps()} />);
         fireEvent.click(container.querySelector("button")!);
-        await vi.advanceTimersByTimeAsync(0);
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(0);
+        });
         fireEvent.click(getByText("Activate Slot"));
         // Flush the awaited switchSlot promise + the setSwitchError state
         await act(async () => {

--- a/src/components/saves/VersionHistoryPanel.test.tsx
+++ b/src/components/saves/VersionHistoryPanel.test.tsx
@@ -49,7 +49,10 @@ function defaultProps(overrides: Partial<React.ComponentProps<typeof VersionHist
   };
 }
 
-const flushAsync = () => new Promise((r) => setTimeout(r, 0));
+const flushAsync = () =>
+  act(async () => {
+    await new Promise((r) => setTimeout(r, 0));
+  });
 
 describe("VersionHistoryPanel", () => {
   beforeEach(() => {

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -1,13 +1,69 @@
 import "@testing-library/jest-dom/vitest";
-import { afterEach, vi } from "vitest";
+import { afterEach, beforeEach, vi } from "vitest";
 import { cleanup } from "@testing-library/react";
 import { createElement, type ReactNode } from "react";
 import { resetDeckyEventBus } from "./test-utils/decky-api-mock";
+
+// A React `act(...)` warning is a defect, but Vitest's default reporter prints no
+// console output for a *passing* test — so a suite that emits stays green, and any
+// grep over that stream proves only that the reporter said nothing. Buffer every
+// console.error and fail the test that emitted it: the attribution is the test's
+// own failure, which no reporter choice can suppress.
+//
+// A test that installs its own vi.spyOn(console, "error") replaces this handler
+// for its duration — that is the sanctioned way to assert on an expected error,
+// and restoring the spy lands back here rather than on the bare console.
+let emittedConsoleErrors: string[] = [];
+let forwardConsoleError: ((...args: unknown[]) => void) | null = null;
+
+// Applies console's own %s-style substitution so the recorded first line reads
+// as printed — React passes the component name as a trailing argument, and a
+// plain join would strand it after the warning's multi-line body. node:util's
+// format() would do this, but it needs @types/node in the typecheck config.
+const formatConsoleArgs = (args: unknown[]): string => {
+  const [template, ...rest] = args;
+  if (typeof template !== "string" || rest.length === 0) return args.map(String).join(" ");
+  let next = 0;
+  const filled = template.replace(/%[sdifoOj]/g, (token) => (next < rest.length ? String(rest[next++]) : token));
+  return [filled, ...rest.slice(next).map(String)].join(" ");
+};
+
+const consoleErrorGuard = (...args: unknown[]) => {
+  emittedConsoleErrors.push(formatConsoleArgs(args));
+  // Forwarded, not swallowed: silencing it here would make a `--reporter=dot`
+  // stderr sweep vacuously clean, which is the blindness this guard exists to remove.
+  forwardConsoleError?.(...args);
+};
+
+beforeEach(() => {
+  emittedConsoleErrors = [];
+  // Captured on first use rather than at module scope: Vitest installs its own
+  // per-test-framing console after this file evaluates, and binding the raw one
+  // would strip every forwarded warning of its `stderr | <test>` header.
+  forwardConsoleError ??= console.error.bind(console);
+  // Re-armed per test, and by assignment rather than vi.spyOn: many test files
+  // call vi.restoreAllMocks() / vi.resetAllMocks() in their own beforeEach, which
+  // runs after this one and would otherwise leave the guard disarmed for the file.
+  console.error = consoleErrorGuard;
+});
 
 afterEach(() => {
   cleanup();
   vi.unstubAllGlobals();
   resetDeckyEventBus();
+
+  // Drained before the throw so one emitting test cannot fail its successors.
+  // Checked after cleanup(), so an unmount-time warning counts too.
+  const emitted = emittedConsoleErrors;
+  emittedConsoleErrors = [];
+  if (emitted.length > 0) {
+    const summary = emitted.map((msg, i) => `  ${i + 1}. ${msg.split("\n")[0]}`).join("\n");
+    throw new Error(
+      `This test emitted ${emitted.length} console.error call(s):\n${summary}\n\n` +
+        "Fix the cause (wrap the state update in act(...), or await the pending work). " +
+        'To assert on an expected error, install vi.spyOn(console, "error").mockImplementation(() => {}) in the test.',
+    );
+  }
 });
 
 // Steam Deck ambient globals — minimal stubs; individual tests refine via vi.mocked.


### PR DESCRIPTION
The frontend suite's warnings were invisible. Vitest's default reporter — what `pnpm test` and `mise run gate` both run — prints no console output for passing tests, so a clean-looking run said nothing about whether the suite emitted anything. Behind that, nine test files were emitting React `act(...)` warnings.

`src/test-setup.ts` now buffers every `console.error` and fails the test that emitted it, naming each warning. The handler is re-armed per test by direct assignment rather than `vi.spyOn`, because many test files call `vi.restoreAllMocks()` / `vi.resetAllMocks()` in their own `beforeEach` — which runs after the setup file's and would silently disarm a spy. Warnings are forwarded rather than swallowed, so a `--reporter=dot` sweep still shows them, and the forward target is captured on first use because Vitest installs its per-test console framing after this file evaluates. The buffer is drained before the throw so one emitting test cannot fail its successors, and it is checked after `cleanup()` so an unmount-time warning still counts. A test that needs to assert on an error path installs its own `console.error` spy, which replaces the handler outright — the failure message says so.

Every existing warning is fixed at its source rather than silenced, across four causes: a flush helper that was not `act`-wrapped; module-singleton store resets in `afterEach` running before the testing library's `cleanup()` and notifying a still-mounted subscriber; tests returning before a mount effect had settled; and one detached handler whose `finally` escaped the gap between two `act` blocks, because `await act(...)` yields to the microtask queue on exit.

No production code changed, and no test's assertions were altered — each settling flush sits after the assertions that were already there.

docs: N/A — test-infrastructure change; no user-visible behaviour, architecture, or data flow is affected.

Closes #1646
