### PR TITLE
refactor(ui): hold the game-detail page's shared state in one per-appId store

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -317,6 +317,17 @@ A one-run, one-action lease for a frontend-owned Steam operation during Prune. T
 before touching Steam and complete that same token afterward. Duplicate, stale, unknown, and late unclaimed tokens are
 non-authoritative and cannot mutate Steam.
 
+### Game-detail store
+
+The single holder of the state one Steam game page shares across its surfaces (`src/utils/gameDetailStore.ts`): the
+bound `rom_id`, install state, save-sync status, BIOS level and core selection, plus the reads that produce them. One
+entry per appId — the first surface to subscribe opens it, the last to unsubscribe closes it, so a page that is off
+screen holds nothing and listens to nothing. The `romm_data_changed` DOM bus keeps carrying the notifications and
+carries no state: one handler per appId folds an event into the entry, and every subscriber renders from that one fold
+rather than from its own copy. Overlapping reads for one appId share a single request, so a payload-less notification
+costs one `get_save_status` round-trip however many surfaces are mounted. The foil to a surface's **own** state — the
+play row's PLAYTIME / LAST PLAYED pair, which nothing else reads and which stays in the component.
+
 ### Collection kind (Standard / Smart / Virtual)
 
 The axis on which a RomM collection is classified for syncing — the internal literal `standard` / `smart` / `virtual`

--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -868,8 +868,9 @@ layout keys and models them as a `SaveLayout` value object (`domain/save_layout.
 the four save-sync entry points (`pre_launch_sync`, `post_exit_sync`, `sync_rom_saves`, `sync_all_saves`) return a
 benign skip (`{success: false, reason: "savefiles_in_content_dir", …}` — the game still launches, no error), and
 `get_save_status` carries an additive `savefiles_in_content_dir: true` flag so the game-detail play section shows a
-banner asking the user to turn the setting back off. Actually _syncing_ ROM-adjacent saves stays unsupported (the
-deferred multi-emulator work).
+banner asking the user to turn the setting back off — only while save sync is enabled, since the banner asks for a
+RetroArch change whose sole purpose is to make save sync work. Actually _syncing_ ROM-adjacent saves stays unsupported
+(the deferred multi-emulator work).
 
 This blind spot is **persistent**: RetroDECK only restores the `false` default on a full config reset or first-run
 install — never on a normal launch (verified 2026-06-09) — so the plugin reads the layout live on every sync rather than

--- a/src/components/RomMPlaySection.test.tsx
+++ b/src/components/RomMPlaySection.test.tsx
@@ -106,7 +106,6 @@ vi.mock("../utils/playSection", () => ({
 }));
 vi.mock("../utils/sectionRefresh", () => ({
   refreshAchievementsInBackground: vi.fn(),
-  refreshActiveSlotInBackground: vi.fn(),
   refreshBiosInBackground: vi.fn(),
   refreshCoreInfoInBackground: vi.fn(),
 }));

--- a/src/components/RomMPlaySection.test.tsx
+++ b/src/components/RomMPlaySection.test.tsx
@@ -5,10 +5,10 @@
 // catches (no state change, no log call) are exempt — and even then, prefer
 // dropping the test over keeping one with zero expects.
 //
-// The module-scope `artworkApplied: Set<number>` in RomMPlaySection.tsx
-// persists across tests within this file. To avoid Set state bleeding
-// between tests we use a unique `testAppId` per test (incremented in
-// `beforeEach`) — Option A in the playbook.
+// The module-scope `artworkApplied` map in RomMPlaySection.tsx and the
+// per-appId entries in utils/gameDetailStore.ts both persist across tests
+// within this file. To avoid that state bleeding between tests we use a unique
+// `testAppId` per test (incremented in `beforeEach`) — Option A in the playbook.
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { render, act, waitFor } from "@testing-library/react";
@@ -428,19 +428,19 @@ describe("RomMPlaySection", () => {
   // C. loadCached flow
   // ------------------------------------------------------------------
 
-  describe("loadCached mount flow", () => {
+  describe("cache-first mount flow", () => {
     it("does nothing when cached.found is false", async () => {
       vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
         found: false,
       });
       render(<RomMPlaySection appId={testAppId} />);
       await flushAsync();
-      expect(sectionRefresh.refreshActiveSlotInBackground).not.toHaveBeenCalled();
+      expect(backend.getSaveStatus).not.toHaveBeenCalled();
       expect(sectionRefresh.refreshAchievementsInBackground).not.toHaveBeenCalled();
       expect(sectionRefresh.refreshBiosInBackground).not.toHaveBeenCalled();
     });
 
-    it("applies cached fields and dispatches active-slot/achievements/BIOS/core background refreshes", async () => {
+    it("applies cached fields and dispatches save-status/achievements/BIOS/core background refreshes", async () => {
       vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
         found: true,
         rom_id: 99,
@@ -466,11 +466,10 @@ describe("RomMPlaySection", () => {
       render(<RomMPlaySection appId={testAppId} />);
       await flushAsync();
 
-      expect(sectionRefresh.refreshActiveSlotInBackground).toHaveBeenCalledWith(
-        99,
-        expect.any(Function),
-        expect.any(Function),
-      );
+      // The live save status is what carries the active slot, the content-dir
+      // flag and the conflicts — the store reads it once for the whole page
+      // rather than each surface reading its own copy (#993).
+      expect(backend.getSaveStatus).toHaveBeenCalledWith(99);
       expect(backend.getRomMetadata).toHaveBeenCalledWith(99);
       expect(sectionRefresh.refreshAchievementsInBackground).toHaveBeenCalledWith(
         99,
@@ -545,7 +544,7 @@ describe("RomMPlaySection", () => {
         render(<RomMPlaySection appId={testAppId} />);
         await flushAsync();
         // A failed cache load leaves the play section stale — warn-level, not debug.
-        expect(logErrorSpy).toHaveBeenCalledWith(expect.stringContaining("loadCached error"));
+        expect(logErrorSpy).toHaveBeenCalledWith(expect.stringContaining("load error"));
       } finally {
         logErrorSpy.mockRestore();
       }
@@ -757,7 +756,7 @@ describe("RomMPlaySection", () => {
         });
         await flushAsync();
 
-        expect(logErrorSpy).toHaveBeenCalledWith(expect.stringContaining("loadCached error"));
+        expect(logErrorSpy).toHaveBeenCalledWith(expect.stringContaining("load error"));
       } finally {
         logErrorSpy.mockRestore();
       }
@@ -1362,8 +1361,9 @@ describe("RomMPlaySection", () => {
       const before = domListenerCount("romm_data_changed");
       const { unmount } = render(<RomMPlaySection appId={testAppId} />);
       await flushAsync();
-      // Two listeners: RomMPlaySection's own + the child VersionPicker's (it also
-      // refreshes on version_switched, #1297). Both are removed on unmount.
+      // Two listeners: the game-detail store's, opened by this section's
+      // subscription, + the child VersionPicker's (it also refreshes on
+      // version_switched, #1297). Both are removed on unmount.
       expect(domListenerCount("romm_data_changed")).toBe(before + 2);
       unmount();
       expect(domListenerCount("romm_data_changed")).toBe(before);
@@ -1701,6 +1701,50 @@ describe("RomMPlaySection", () => {
         await Promise.resolve();
       });
       expect(vi.mocked(backend.getSaveStatus)).not.toHaveBeenCalled();
+    });
+
+    // #975 — the cross-game bleed. While the cached detail is still in flight
+    // this section has no rom_id of its own; a save_sync for ANOTHER game used
+    // to be adopted anyway and its status shown here.
+    it("save_sync: a foreign rom_id arriving before the detail resolves leaves the display untouched", async () => {
+      // Hold the cached-detail read open so the identity stays unresolved.
+      vi.mocked(cachedStore.getCachedGameDetail).mockReturnValue(new Promise(() => {}));
+      const { container } = render(<RomMPlaySection appId={testAppId} />);
+      await flushAsync();
+
+      const foreignSaveStatus = {
+        rom_id: 999,
+        files: [],
+        playtime: {
+          total_seconds: 0,
+          session_count: 0,
+          last_session_start: null,
+          last_session_duration_sec: null,
+          last_played: null,
+        },
+        device_id: "d",
+        last_sync_check_at: null,
+        // The other game writes its saves next to the ROM — showing THIS game's
+        // page a "Save sync off" banner is exactly the bleed.
+        savefiles_in_content_dir: true,
+        save_sync_display: { status: "none" as const, label: "foreign-label", last_sync_check_at: null },
+      };
+      vi.mocked(backend.getSaveStatus).mockResolvedValue(foreignSaveStatus);
+
+      await act(async () => {
+        globalThis.dispatchEvent(new CustomEvent("romm_data_changed", { detail: { type: "save_sync", rom_id: 999 } }));
+        globalThis.dispatchEvent(
+          new CustomEvent("romm_data_changed", {
+            detail: { type: "save_sync", rom_id: 999, save_status: foreignSaveStatus },
+          }),
+        );
+        await Promise.resolve();
+      });
+      await flushAsync();
+
+      expect(vi.mocked(backend.getSaveStatus)).not.toHaveBeenCalled();
+      expect(container.textContent).not.toContain("Save sync off");
+      expect(container.textContent).not.toContain("Write Saves to Content Directory");
     });
 
     it("save_sync: uses detail.save_status when present (no fetch)", async () => {
@@ -3361,19 +3405,28 @@ describe("RomMPlaySection", () => {
     });
 
     it("legacy slot warning shows when activeSlot null and saveSyncEnabled true", async () => {
-      // The component's initial activeSlot is "default" (not null); we'd need
-      // refreshActiveSlotInBackground to set it to null. Easier: re-mock the
-      // refresh helper to apply the null directly via the setter callback.
+      // The shared state starts on activeSlot "default" (not null), so the
+      // warning only appears once a real save status reports the legacy
+      // slot:null — which is what the store's save-status read folds in.
       vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
         found: true,
         rom_id: 42,
         save_sync_enabled: true,
         save_sync_display: { status: "none", label: "No saves", last_sync_check_at: null },
       });
-      vi.mocked(sectionRefresh.refreshActiveSlotInBackground).mockImplementation((_romId, _cancelled, setter) => {
-        act(() => {
-          setter((prev) => ({ ...prev, activeSlot: null }));
-        });
+      vi.mocked(backend.getSaveStatus).mockResolvedValue({
+        rom_id: 42,
+        files: [],
+        playtime: {
+          total_seconds: 0,
+          session_count: 0,
+          last_session_start: null,
+          last_session_duration_sec: null,
+          last_played: null,
+        },
+        device_id: "d",
+        last_sync_check_at: null,
+        active_slot: null,
       });
       const { container } = render(<RomMPlaySection appId={testAppId} />);
       await flushAsync();
@@ -3563,18 +3616,18 @@ describe("RomMPlaySection", () => {
       expect(container.textContent).not.toContain("Write Saves to Content Directory");
     });
 
-    it("logs via debugLog when the content-dir probe rejects (non-vacuous catch)", async () => {
+    it("logs via debugLog when the save-status read rejects (non-vacuous catch)", async () => {
       vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
         found: true,
         rom_id: 42,
         save_sync_enabled: true,
       });
-      // Reject from getSaveStatus — the probe's catch must log, and the banner
-      // must stay hidden (flag defaults to false).
+      // Reject from getSaveStatus — the connection check's catch must log, and
+      // the banner must stay hidden (flag defaults to false).
       vi.mocked(backend.getSaveStatus).mockRejectedValue(new Error("cfgfail"));
       const { container } = render(<RomMPlaySection appId={testAppId} />);
       await flushAsync();
-      expect(vi.mocked(backend.debugLog)).toHaveBeenCalledWith(expect.stringContaining("content-dir probe error"));
+      expect(vi.mocked(backend.debugLog)).toHaveBeenCalledWith(expect.stringContaining("background save check error"));
       expect(container.textContent).not.toContain("Write Saves to Content Directory");
     });
   });

--- a/src/components/RomMPlaySection.test.tsx
+++ b/src/components/RomMPlaySection.test.tsx
@@ -30,6 +30,7 @@ import * as connectionState from "../utils/connectionState";
 import * as sectionRefresh from "../utils/sectionRefresh";
 import * as playSectionUtils from "../utils/playSection";
 import * as formatters from "../utils/formatters";
+import { getGameDetail } from "../utils/gameDetailStore";
 import { useVersionError } from "./VersionErrorCard";
 import { useMigrationStatus } from "./MigrationBlockedPage";
 
@@ -3531,10 +3532,10 @@ describe("RomMPlaySection", () => {
   // ------------------------------------------------------------------
 
   describe("savefiles_in_content_dir warning banner (#239)", () => {
-    // The content-dir probe reads getSaveStatus live (NOT getCachedGameDetail),
-    // gated only on romId + saveSyncEnabled — intentionally NOT on connectivity,
-    // so the banner surfaces offline. These tests force the connection check
-    // offline to prove the banner does not depend on a connected server.
+    // The flag reaches the section with the store's save-status fold, and the
+    // backend derives it from a LOCAL retroarch.cfg read — so the banner must
+    // surface even while RomM is unreachable. One test below forces the
+    // connection check offline to pin that.
     function stubSaveStatus(romId: number, savefilesInContentDir: boolean) {
       vi.mocked(backend.getSaveStatus).mockResolvedValue({
         rom_id: romId,
@@ -3599,6 +3600,35 @@ describe("RomMPlaySection", () => {
       await flushAsync();
       expect(container.textContent).not.toContain("Write Saves to Content Directory");
       // The play row still renders (game remains playable).
+      expect(container.querySelector('[data-testid="play-button"]')).not.toBeNull();
+    });
+
+    // The store keeps the content-dir fact whether or not save sync is on, so a
+    // save_sync notification can fold it in for a game whose sync is off — e.g.
+    // after "Delete Local Saves" from this page's own RomM Actions menu, which is
+    // not gated on the setting. The banner asks the user to change a RetroArch
+    // setting in order to re-enable save sync, so it has nothing to say to
+    // someone who has save sync switched off.
+    it("does NOT render the banner while save sync is disabled, even once the flag is known", async () => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
+        found: true,
+        rom_id: 42,
+        save_sync_enabled: false,
+      });
+      const { container } = render(<RomMPlaySection appId={testAppId} />);
+      await flushAsync();
+      stubSaveStatus(42, true);
+
+      await act(async () => {
+        globalThis.dispatchEvent(new CustomEvent("romm_data_changed", { detail: { type: "save_sync", rom_id: 42 } }));
+        await Promise.resolve();
+      });
+      await flushAsync();
+
+      // Assert the fact actually reached the store — otherwise the banner's
+      // absence below would prove nothing.
+      expect(getGameDetail(testAppId).savefilesInContentDir).toBe(true);
+      expect(container.textContent).not.toContain("Write Saves to Content Directory");
       expect(container.querySelector('[data-testid="play-button"]')).not.toBeNull();
     });
 

--- a/src/components/RomMPlaySection.tsx
+++ b/src/components/RomMPlaySection.tsx
@@ -1053,7 +1053,11 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
   // Content-dir warning (#239) — prominent banner above the play row when
   // RetroArch writes saves to the content directory. The play row still renders
   // below it: the game remains fully playable, only save sync is unavailable.
-  if (detail.savefilesInContentDir) {
+  // The store holds the flag whether or not save sync is on (it is a fact about
+  // the local RetroArch config, not about our setting); the banner asks the user
+  // to change that config to re-enable save sync, so it is only worth showing to
+  // someone who has save sync on.
+  if (detail.savefilesInContentDir && detail.saveSyncEnabled) {
     return createElement(
       "div",
       { style: { display: "flex", flexDirection: "column" } },

--- a/src/components/RomMPlaySection.tsx
+++ b/src/components/RomMPlaySection.tsx
@@ -10,8 +10,8 @@
  * Save Sync and BIOS items only appear when relevant.
  */
 
-import { useState, useEffect, useRef, FC, createElement } from "react";
-import { addEventListener, removeEventListener, toaster } from "@decky/api";
+import { useState, useEffect, FC, createElement } from "react";
+import { toaster } from "@decky/api";
 import {
   ConfirmModal,
   DialogButton,
@@ -35,14 +35,8 @@ import { saveSyncToastBody } from "../utils/saveSyncToast";
 import { scrollToTop } from "../utils/scrollHelpers";
 import { getEventTarget } from "../utils/events";
 import {
-  getCachedGameDetail,
-  invalidateCachedGameDetail,
   testConnection,
   probeReachability,
-  getSaveStatus,
-  isCallableFailure,
-  getBiosStatus,
-  getPlatformCoreInfo,
   getSgdbResolution,
   getRomMetadata,
   refreshCoverArtwork,
@@ -54,7 +48,6 @@ import {
   clearGameCore,
   reconcilePlaytime,
   debugLog,
-  logError,
 } from "../api/backend";
 import { setLaunchOptionsConfirmed } from "../utils/steamShortcuts";
 import {
@@ -68,26 +61,22 @@ import {
 } from "../utils/pruneLease";
 import { updatePlaytimeDisplay } from "../patches/metadataPatches";
 import { buildEmulatorMenu } from "../utils/emulatorMenu";
-import type { BiosStatus, DownloadCompleteEvent, EmulatorOption, SaveStatus } from "../types";
-import type { RommDataChangedDetail } from "../types/events";
 import { formatBytes, formatLastPlayed, formatPlaytime } from "../utils/formatters";
 import { biosColorForLevel } from "../utils/biosColor";
+import { timeoutMs } from "../utils/playSection";
 import {
-  applySaveSyncDisplay,
-  extractBiosInfo,
-  extractCoreInfo,
-  resolveSaveSyncLabel,
-  timeoutMs,
-} from "../utils/playSection";
-import {
-  refreshAchievementsInBackground,
-  refreshActiveSlotInBackground,
-  refreshBiosInBackground,
-  refreshCoreInfoInBackground,
-} from "../utils/sectionRefresh";
+  getGameDetail,
+  noteSaveSyncDisplay,
+  refreshBiosStatus,
+  refreshCoreAndBios,
+  refreshSaveStatus,
+  useGameDetail,
+} from "../utils/gameDetailStore";
 
-/** Track which appIds have had auto-artwork applied this session */
-const artworkApplied = new Set<number>();
+/** Which rom_id each appId has had auto-artwork applied for this session. Keyed
+ *  on the pair, not the appId alone: a version switch re-binds the appId to a
+ *  new rom_id whose artwork has to be applied afresh (#1298 item 3). */
+const artworkApplied = new Map<number, number>();
 
 /** Resolve the LAST PLAYED display, preferring our restored cross-device
  *  `last_played` (ISO-8601, from `reconcile_playtime` / native play sessions,
@@ -108,44 +97,18 @@ interface RomMPlaySectionProps {
   appId: number;
 }
 
-interface InfoState {
-  romId: number | null;
-  romName: string;
-  platformSlug: string;
-  /** Local install state (#1395). Drives the SPACE REQUIRED cell, which shows
-   *  only while the ROM is NOT installed (mirroring Steam hiding the size once
-   *  a game is on disk). */
-  installed: boolean;
-  /** Server-reported ROM size in bytes (#1395), or `null` when unknown. Rendered
-   *  as the SPACE REQUIRED cell for an uninstalled ROM; a null value hides it. */
-  fsSizeBytes: number | null;
+/** The play section's own display state. Everything the game page's surfaces
+ *  share — rom identity, install state, save sync, BIOS, core — lives in the
+ *  per-appId game-detail store instead; what stays here is the PLAYTIME /
+ *  LAST PLAYED pair, which is read from Steam's overview and belongs to this
+ *  row alone. */
+interface PlaytimeState {
   lastPlayed: string;
   /** Restored cross-device `last_played` (ISO-8601) from `reconcile_playtime`,
    *  or `null` until the server yields one. Preferred over Steam's device-local
    *  `rt_last_time_played` when rendering LAST PLAYED (#1294). */
   restoredLastPlayed: string | null;
   playtime: string;
-  saveSyncEnabled: boolean;
-  saveSyncStatus: "synced" | "pending" | "conflict" | "none" | null;
-  saveSyncLabel: string;
-  /** RetroArch `savefiles_in_content_dir=true` — saves go next to the ROM and
-   *  can't be synced (#239). Derived from a LOCAL retroarch.cfg read, so it is
-   *  populated even offline (independent of connectivity). Drives the prominent
-   *  "Save sync off" WarningCard. */
-  savefilesInContentDir: boolean;
-  biosNeeded: boolean;
-  biosStatus: "ok" | "partial" | "missing" | "unmanaged" | null; // NOSONAR(typescript:S4323) — inline union inside InfoState; extracting an alias adds indirection for no reuse benefit.
-  biosLabel: string;
-  activeCoreLabel: string | null;
-  activeCoreIsDefault: boolean;
-  emulators: EmulatorOption[];
-  emulatorDataAvailable: boolean;
-  platformCoreLabel: string | null;
-  hasGameOverride: boolean;
-  activeSlot: string | null;
-  raId: number | null;
-  achievementEarned: number;
-  achievementTotal: number;
 }
 
 import { setRommConnectionState, setVersionError, useRommConnectionState } from "../utils/connectionState";
@@ -153,106 +116,6 @@ import { registerConnectionHeartbeat } from "../utils/connectionHeartbeat";
 import { useVersionError } from "./VersionErrorCard";
 import { useMigrationStatus } from "./MigrationBlockedPage";
 import { detach } from "../utils/detach";
-
-/** Cache-first initial render. Resolves the cached game detail for this appId,
- *  pushes it into InfoState, and fires the background refresh tasks (active
- *  slot, artwork, metadata, achievements, BIOS) whose results are merged in
- *  later. Module-scope so the FC body stays focused on rendering. */
-async function loadCached(
-  appId: number,
-  cancelled: () => boolean,
-  romIdRef: React.RefObject<number | null>,
-  setter: React.Dispatch<React.SetStateAction<InfoState>>,
-) {
-  try {
-    const cached = await getCachedGameDetail(appId);
-    if (cancelled() || !cached.found) return;
-
-    const romId = cached.rom_id!;
-    romIdRef.current = romId;
-
-    // Process save sync from backend-computed display fields
-    let saveSyncStatus: "synced" | "pending" | "conflict" | "none" | null = null;
-    let saveSyncLabel = "";
-    if (cached.save_sync_enabled && cached.save_sync_display) {
-      saveSyncStatus = cached.save_sync_display.status;
-      saveSyncLabel = resolveSaveSyncLabel(cached.save_sync_display);
-    }
-
-    if (cancelled()) return;
-    setter((prev) => ({
-      ...prev,
-      romId,
-      romName: cached.rom_name || "",
-      platformSlug: cached.platform_slug || "",
-      installed: cached.installed ?? false,
-      fsSizeBytes: cached.fs_size_bytes ?? null,
-      saveSyncEnabled: cached.save_sync_enabled ?? false,
-      saveSyncStatus,
-      saveSyncLabel,
-      raId: cached.ra_id ?? null,
-      // Keep the last-known count when the re-derived cache has no achievement
-      // summary (e.g. a version switch during an offline window, where the
-      // backend progress cache is cold) — don't degrade a shown "7/70" to 0
-      // (#1345). A genuine earned:0 is a real object, so it still shows through.
-      achievementEarned: cached.achievement_summary?.earned ?? prev.achievementEarned,
-      achievementTotal: cached.achievement_summary?.total ?? prev.achievementTotal,
-    }));
-
-    // Background: fetch active_slot from save status (not in cached data)
-    if (cached.save_sync_enabled) {
-      refreshActiveSlotInBackground(romId, cancelled, setter);
-    }
-
-    // Auto-apply SGDB artwork on first visit (fire-and-forget)
-    // Only mark as applied after success so transient failures allow retry on next visit
-    if (!artworkApplied.has(appId)) {
-      applyArtwork(romId, appId)
-        .then(() => {
-          artworkApplied.add(appId);
-        })
-        .catch((e) => debugLog(`Auto-artwork error: ${e}`));
-    }
-
-    const staleFields = cached.stale_fields ?? [];
-
-    // Background: fetch metadata if stale
-    if (romId && staleFields.includes("metadata")) {
-      getRomMetadata(romId).catch((e) => debugLog(`Background metadata fetch error: ${e}`));
-    }
-
-    // Achievements: render from cache, background refresh if stale
-    if (cached.ra_id && staleFields.includes("achievements")) {
-      refreshAchievementsInBackground(romId, cancelled, setter);
-    }
-
-    // BIOS: render from cache first, background refresh if stale
-    const cachedBios = cached.bios_status;
-    if (cachedBios) {
-      setter((prev) => ({
-        ...prev,
-        ...extractBiosInfo(cached.bios_level ?? null, cached.bios_label ?? null),
-      }));
-    }
-
-    if (staleFields.includes("bios")) {
-      refreshBiosInBackground(romId, cancelled, setter);
-    }
-
-    // Core info: sourced from its OWN path (#923), independent of BIOS status.
-    // Fetched non-blocking so the core button / badge can render once cores are
-    // known, regardless of whether the platform needs BIOS. Keyed on rom_id so
-    // the active core reflects a per-game DB override (epic #945).
-    if (romId) {
-      refreshCoreInfoInBackground(romId, cancelled, setter);
-    }
-  } catch (e) {
-    // Shared by the mount load and the version-switch re-derive — a failed cache
-    // load leaves the play section stale either way, so surface at warn level
-    // (debugLog is dropped at the default log level).
-    logError(`RomMPlaySection: loadCached error: ${e}`);
-  }
-}
 
 // S3776 is raised on the declaration line, so its NOSONAR must stay there. prettier-ignore stops
 // Prettier from relocating the trailing comment into the body (which would break the suppression).
@@ -268,200 +131,45 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
   const initialLastPlayed = formatLastPlayed(overview?.rt_last_time_played ?? 0);
   const initialPlaytime = formatPlaytime(overview?.minutes_playtime_forever ?? 0);
 
-  const [info, setInfo] = useState<InfoState>({
-    romId: null,
-    romName: "",
-    platformSlug: "",
-    installed: false,
-    fsSizeBytes: null,
+  // Every field the game page's surfaces share — rom identity, install state,
+  // save sync, BIOS, core selection — comes from the per-appId store, which owns
+  // the reads and the romm_data_changed fold for all of them (#993).
+  const detail = useGameDetail(appId);
+  const [playtimeInfo, setPlaytimeInfo] = useState<PlaytimeState>({
     lastPlayed: initialLastPlayed,
     restoredLastPlayed: null,
     playtime: initialPlaytime,
-    saveSyncEnabled: false,
-    saveSyncStatus: null,
-    saveSyncLabel: "",
-    savefilesInContentDir: false,
-    biosNeeded: false,
-    biosStatus: null,
-    biosLabel: "",
-    activeCoreLabel: null,
-    activeCoreIsDefault: true,
-    emulators: [],
-    emulatorDataAvailable: true,
-    platformCoreLabel: null,
-    hasGameOverride: false,
-    activeSlot: "default",
-    raId: null,
-    achievementEarned: 0,
-    achievementTotal: 0,
   });
   // Badge derives from the shared store so it appears/disappears live on any
   // reachability signal (mount check, a failed/succeeded call, or the offline
   // recovery probe), not just at this mount's check (#1345).
   const connectionState = useRommConnectionState();
   const [actionPending, setActionPending] = useState<string | null>(null);
-  const romIdRef = useRef<number | null>(null);
 
   // Drive the offline recovery probe while this game page is mounted (#1345).
   // A module-level guard keeps the ~30s re-probe single-instance and offline-only.
   useEffect(() => registerConnectionHeartbeat(), []);
 
-  // Cache-first load: render instantly from cached data, then check connection in background
   useEffect(() => {
     mountPruneLeaseOwner(`game-detail:${appId}`);
-    let cancelled = false;
-
-    detach(loadCached(appId, () => cancelled, romIdRef, setInfo));
-
-    // Per-event-type handlers — each owns one branch of the data-changed dispatch.
-    // Defined inside useEffect to share the cancelled/romIdRef/setInfo closure.
-    const handleSaveSyncSettingsChange = async (
-      detail: Extract<RommDataChangedDetail, { type: "save_sync_settings" }>,
-    ) => {
-      const enabled = detail.save_sync_enabled;
-      if (enabled) {
-        const rid = romIdRef.current;
-        if (rid) {
-          const result = await getSaveStatus(rid).catch(() => null);
-          if (result && isCallableFailure(result)) return;
-          const saveStatus: SaveStatus | null = result;
-          const { status: ss, label: sl } = applySaveSyncDisplay(saveStatus?.save_sync_display, saveStatus);
-          setInfo((prev) => ({
-            ...prev,
-            saveSyncEnabled: true,
-            saveSyncStatus: ss,
-            saveSyncLabel: sl,
-            savefilesInContentDir: !!saveStatus?.savefiles_in_content_dir,
-          }));
-        } else {
-          setInfo((prev) => ({ ...prev, saveSyncEnabled: true }));
-        }
-      } else {
-        // Save sync turned off entirely — the content-dir banner is meaningless.
-        setInfo((prev) => ({
-          ...prev,
-          saveSyncEnabled: false,
-          saveSyncStatus: null,
-          saveSyncLabel: "",
-          savefilesInContentDir: false,
-        }));
-      }
-    };
-
-    const handleCoreChange = async (_detail: Extract<RommDataChangedDetail, { type: "core_changed" }>) => {
-      const rid = romIdRef.current;
-      if (!rid) return;
-      // Core data comes from the dedicated core-info path (#923), keyed on the
-      // rom_id from a ref to avoid a stale-closure read of InfoState. The active
-      // core reflects the per-game DB override (epic #945). BIOS level/label
-      // still come from the (now core-free) BIOS status — the active core just
-      // switched, so the BIOS requirements may have changed.
-      const [coreInfo, biosResult] = await Promise.all([getPlatformCoreInfo(rid), getBiosStatus(rid)]);
-      if (cancelled) return;
-      setInfo((prev) => ({
-        ...prev,
-        ...extractCoreInfo(coreInfo),
-        // The new core may need different (or no) BIOS — re-derive biosNeeded
-        // from the refreshed status so the missing-BIOS badge keys off the
-        // active core, not the core that was active at mount (#923).
-        biosNeeded: !!biosResult.bios_status,
-        biosStatus: biosResult.bios_level,
-        biosLabel: biosResult.bios_label ?? "",
-      }));
-    };
-
-    const handleSaveSyncChange = async (detail: Extract<RommDataChangedDetail, { type: "save_sync" }>) => {
-      const romId = romIdRef.current ?? detail.rom_id;
-      if (!romId) return;
-      // If event specifies a rom_id, skip if it's not for this game
-      if (detail.rom_id && romIdRef.current && detail.rom_id !== romIdRef.current) return;
-      const fetched = detail.save_status ?? (await getSaveStatus(romId).catch(() => null));
-      if (fetched && isCallableFailure(fetched)) return;
-      const saveStatus: SaveStatus | null = fetched;
-      const { status: saveSyncStatus, label: saveSyncLabel } = applySaveSyncDisplay(
-        saveStatus?.save_sync_display,
-        saveStatus,
-      );
-      setInfo((prev) => ({
-        ...prev,
-        saveSyncStatus,
-        saveSyncLabel,
-        activeSlot: saveStatus && "active_slot" in saveStatus ? (saveStatus.active_slot ?? null) : prev.activeSlot,
-      }));
-    };
-
-    const handleVersionSwitched = async (detail: Extract<RommDataChangedDetail, { type: "version_switched" }>) => {
-      if (detail.app_id !== appId) return;
-      // A version switch re-bound this appId to a new rom_id. The picker already
-      // invalidated the cached detail, so re-run the cache-first load to re-derive
-      // the info badges (save-sync / BIOS / core rows) and romId for the new
-      // version. Reset the artwork-applied gate first so the Steam tile's SGDB art
-      // re-applies for the new rom_id (#1298 item 3) — loadCached only applies it
-      // when the appId is absent from the set.
-      artworkApplied.delete(appId);
-      await loadCached(appId, () => cancelled, romIdRef, setInfo);
-    };
-
-    const onDataChanged = (e: Event) => {
-      detach(
-        (async () => {
-          try {
-            const detail = (e as CustomEvent).detail;
-            switch (detail?.type) {
-              case "save_sync_settings":
-                await handleSaveSyncSettingsChange(detail);
-                break;
-              case "core_changed":
-                await handleCoreChange(detail);
-                break;
-              case "save_sync":
-                await handleSaveSyncChange(detail);
-                break;
-              case "version_switched":
-                await handleVersionSwitched(detail);
-                break;
-            }
-          } catch (err) {
-            detach(debugLog(`RomMPlaySection: onDataChanged error: ${err}`));
-          }
-        })(),
-      );
-    };
-    globalThis.addEventListener("romm_data_changed", onDataChanged);
-
-    // Install-state reactivity (#1395) — the SPACE REQUIRED cell is shown only
-    // while the ROM is uninstalled, so a download or an uninstall must re-derive
-    // the cached detail (installed + fs_size_bytes). Mirrors DiscSelector's
-    // download_complete (@decky/api backend event) + romm_rom_uninstalled (DOM
-    // CustomEvent) wiring. Each invalidates the cached detail first so the re-run
-    // reads the fresh install state rather than a stale entry inside the 3s TTL,
-    // then re-runs loadCached so the whole info block stays consistent.
-    const onDownloadComplete = addEventListener<[DownloadCompleteEvent]>(
-      "download_complete",
-      (evt: DownloadCompleteEvent) => {
-        if (evt.rom_id !== romIdRef.current) return;
-        invalidateCachedGameDetail(appId);
-        detach(loadCached(appId, () => cancelled, romIdRef, setInfo));
-      },
-    );
-
-    const onUninstalled = (e: Event) => {
-      const rid = (e as CustomEvent).detail?.rom_id;
-      if (rid !== romIdRef.current) return;
-      invalidateCachedGameDetail(appId);
-      detach(loadCached(appId, () => cancelled, romIdRef, setInfo));
-    };
-    globalThis.addEventListener("romm_rom_uninstalled", onUninstalled);
-
     return () => {
-      cancelled = true;
       detach(cancelArtworkApply(appId));
       detach(releasePruneLeasesByOwner(`game-detail:${appId}`));
-      globalThis.removeEventListener("romm_data_changed", onDataChanged);
-      removeEventListener("download_complete", onDownloadComplete);
-      globalThis.removeEventListener("romm_rom_uninstalled", onUninstalled);
     };
   }, [appId]);
+
+  // Auto-apply SGDB artwork on first visit, once per (appId, rom_id) — so a
+  // version switch re-applies for the newly bound rom_id (#1298 item 3). Only
+  // marked applied after success, so a transient failure retries next visit.
+  useEffect(() => {
+    const romId = detail.romId;
+    if (!romId || artworkApplied.get(appId) === romId) return;
+    applyArtwork(romId, appId)
+      .then(() => {
+        artworkApplied.set(appId, romId);
+      })
+      .catch((e) => debugLog(`Auto-artwork error: ${e}`));
+  }, [appId, detail.romId]);
 
   // Background connection check — runs after initial cached render
   // If connected + installed + save sync enabled, also runs background save status check
@@ -469,32 +177,21 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
     let cancelled = false;
 
     // Background save-status check — detects new conflicts once the connection
-    // check confirms the server is reachable (save-sync only). Playtime
+    // check confirms the server is reachable (save-sync only). The read itself
+    // and the state it produces belong to the store; what stays here is the
+    // conflict notification for the other save-sync surfaces. Playtime
     // reconcile-on-view is a separate, connectivity-independent effect (#1345).
     async function doSaveCheck(isCancelled: boolean) {
-      const romId = romIdRef.current;
-      if (!romId || !info.saveSyncEnabled) return;
+      const { romId, saveSyncEnabled } = getGameDetail(appId);
+      if (!romId || !saveSyncEnabled) return;
       try {
-        const saveStatus = await getSaveStatus(romId);
-        if (isCancelled) return;
-        if (isCallableFailure(saveStatus)) {
-          detach(debugLog(`RomMPlaySection: background save check deferred: ${saveStatus.message}`));
-          return;
-        }
-        const hasConflict = hasAnySaveConflict(saveStatus);
+        const saveStatus = await refreshSaveStatus(appId);
+        if (isCancelled || !saveStatus) return;
         globalThis.dispatchEvent(
           new CustomEvent("romm_data_changed", {
-            detail: { type: "save_sync", rom_id: romId, has_conflict: hasConflict },
+            detail: { type: "save_sync", rom_id: romId, has_conflict: hasAnySaveConflict(saveStatus) },
           }),
         );
-        const { status: ss, label: sl } = applySaveSyncDisplay(saveStatus.save_sync_display, saveStatus);
-        setInfo((prev) => ({
-          ...prev,
-          saveSyncStatus: ss,
-          saveSyncLabel: sl,
-          savefilesInContentDir: !!saveStatus.savefiles_in_content_dir,
-          activeSlot: "active_slot" in saveStatus ? (saveStatus.active_slot ?? null) : prev.activeSlot,
-        }));
       } catch (e) {
         detach(debugLog(`RomMPlaySection: background save check error: ${e}`));
       }
@@ -565,7 +262,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
     return () => {
       cancelled = true;
     };
-  }, [info.saveSyncEnabled, appId]);
+  }, [detail.saveSyncEnabled, appId]);
 
   // Reconcile-on-view (#868) — pull-only: folds RomM's play-session history into
   // the local total so a session played on another device shows up the moment the
@@ -573,12 +270,12 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
   // returns the LOCAL total even when the server is unreachable, so it re-injects
   // real playtime into a rebuilt/rebound Steam overview instead of leaving it at
   // "PLAYTIME None". Runs once romId is known (its own effect, so it fires after
-  // loadCached populates romId rather than racing the connection check). Pushes
+  // the store resolves romId rather than racing the connection check). Pushes
   // the total through updatePlaytimeDisplay (the write-chokepoint), which emits
   // romm_playtime_changed; the reactive PLAYTIME effect (#869) refreshes the
   // display on the same mount. A 0 total no-ops in updatePlaytimeDisplay.
   useEffect(() => {
-    const romId = info.romId;
+    const romId = detail.romId;
     if (!romId) return;
     let cancelled = false;
 
@@ -597,7 +294,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
           // covers the sub-minute total case where updatePlaytimeDisplay emits no
           // signal. Skipped on a failed read — no cross-device push offline.
           const steamSecs = appStore.GetAppOverviewByAppID(appId)?.rt_last_time_played ?? 0;
-          setInfo((prev) => ({
+          setPlaytimeInfo((prev) => ({
             ...prev,
             restoredLastPlayed: result.last_played,
             lastPlayed: resolveLastPlayed(result.last_played, steamSecs),
@@ -614,42 +311,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
     return () => {
       cancelled = true;
     };
-  }, [info.romId, appId]);
-
-  // Content-dir warning probe (#239) — populates `savefilesInContentDir` from a
-  // dedicated getSaveStatus call that is INTENTIONALLY NOT gated on connectivity.
-  // The backend derives `savefiles_in_content_dir` from a LOCAL retroarch.cfg
-  // read (independent of `server_query_failed`), so the banner must surface even
-  // when RomM is offline. The connected-only `doSaveCheck` above can't be relied
-  // on for this. We read getSaveStatus live (not getCachedGameDetail, which does
-  // not carry the flag and may be stale) and consume ONLY the content-dir flag —
-  // the server-dependent save-sync display is owned by doSaveCheck / the event
-  // handlers. Runs once romId + saveSyncEnabled are known.
-  useEffect(() => {
-    let cancelled = false;
-    const romId = info.romId;
-    if (!romId || !info.saveSyncEnabled) return;
-
-    async function probeContentDir(rid: number, isCancelled: () => boolean) {
-      try {
-        const saveStatus = await getSaveStatus(rid);
-        if (isCancelled()) return;
-        if (isCallableFailure(saveStatus)) {
-          detach(debugLog(`RomMPlaySection: content-dir probe deferred: ${saveStatus.message}`));
-          return;
-        }
-        const inContentDir = saveStatus.savefiles_in_content_dir === true;
-        setInfo((prev) => ({ ...prev, savefilesInContentDir: inContentDir }));
-      } catch (e) {
-        detach(debugLog(`RomMPlaySection: content-dir probe error: ${e}`));
-      }
-    }
-
-    detach(probeContentDir(romId, () => cancelled));
-    return () => {
-      cancelled = true;
-    };
-  }, [info.romId, info.saveSyncEnabled]);
+  }, [detail.romId, appId]);
 
   // Reactive PLAYTIME display (#869) — re-read Steam's overview whenever the
   // playtime write-chokepoint (updatePlaytimeDisplay) fires romm_playtime_changed
@@ -659,11 +321,11 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
   // the SAME mount — no navigate-away/back remount required.
   useEffect(() => {
     const onPlaytimeChanged = (e: Event) => {
-      const detail = (e as CustomEvent<{ appId?: number } | null>).detail;
-      if (detail?.appId !== appId) return;
+      const payload = (e as CustomEvent<{ appId?: number } | null>).detail;
+      if (payload?.appId !== appId) return;
       const ov = appStore.GetAppOverviewByAppID(appId);
       if (!ov) return;
-      setInfo((prev) => ({
+      setPlaytimeInfo((prev) => ({
         ...prev,
         playtime: formatPlaytime(ov.minutes_playtime_forever ?? 0),
         lastPlayed: resolveLastPlayed(prev.restoredLastPlayed, ov.rt_last_time_played ?? 0),
@@ -691,11 +353,11 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
 
   const handleRefreshArtwork = async () => {
     if (actionPending) return;
-    if (!info.romId) {
+    if (!detail.romId) {
       toaster.toast({ title: "RomM Sync", body: "ROM info not loaded yet" });
       return;
     }
-    const romId = info.romId;
+    const romId = detail.romId;
     setActionPending("artwork");
     const admission = capturePruneLeaseAdmission(`game-detail:${appId}`);
     try {
@@ -750,7 +412,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
             createElement(SgdbGamePickerModalContent, {
               romId,
               appId,
-              romName: info.romName,
+              romName: detail.romName,
               candidates: resolution.candidates,
               onApplied: () => {},
             }),
@@ -771,13 +433,13 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
   };
 
   const handleRefreshMetadata = async () => {
-    if (actionPending || !info.romId) return;
+    if (actionPending || !detail.romId) return;
     setActionPending("metadata");
     try {
-      await getRomMetadata(info.romId);
+      await getRomMetadata(detail.romId);
       toaster.toast({ title: "RomM Sync", body: "Metadata refreshed" });
       globalThis.dispatchEvent(
-        new CustomEvent("romm_data_changed", { detail: { type: "metadata", rom_id: info.romId } }),
+        new CustomEvent("romm_data_changed", { detail: { type: "metadata", rom_id: detail.romId } }),
       );
     } catch {
       toaster.toast({ title: "RomM Sync", body: "Failed to refresh metadata" });
@@ -787,10 +449,10 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
   };
 
   const handleSyncSaves = async () => {
-    if (actionPending || !info.romId) return;
+    if (actionPending || !detail.romId) return;
     setActionPending("savesync");
     try {
-      const result = await syncRomSaves(info.romId);
+      const result = await syncRomSaves(detail.romId);
       if (result.success) {
         // Directional completion toast via the shared helper — the single source
         // of that copy across every save-sync surface (#1481).
@@ -813,10 +475,10 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
           toaster.toast({ title: "RomM Save Sync", body: `${c} conflict(s) need resolution` });
         }
         globalThis.dispatchEvent(
-          new CustomEvent("romm_data_changed", { detail: { type: "save_sync", rom_id: info.romId } }),
+          new CustomEvent("romm_data_changed", { detail: { type: "save_sync", rom_id: detail.romId } }),
         );
         // Refresh save sync status — last_sync_check_at was just set by the backend
-        setInfo((prev) => ({ ...prev, saveSyncStatus: "synced" as const, saveSyncLabel: "Just now" }));
+        noteSaveSyncDisplay(appId, { status: "synced", label: "Just now", last_sync_check_at: null });
       } else {
         toaster.toast({ title: "RomM Sync", body: result.message || "Save sync failed" });
       }
@@ -828,30 +490,17 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
   };
 
   const handleDownloadBios = async () => {
-    if (actionPending || !info.platformSlug) return;
+    if (actionPending || !detail.platformSlug) return;
     setActionPending("bios");
     try {
-      const result = await downloadAllFirmware(info.platformSlug);
+      const result = await downloadAllFirmware(detail.platformSlug);
       if (result.success) {
         toaster.toast({ title: "RomM Sync", body: `BIOS downloaded (${result.downloaded ?? 0} files)` });
         globalThis.dispatchEvent(
-          new CustomEvent("romm_data_changed", { detail: { type: "bios", platform_slug: info.platformSlug } }),
+          new CustomEvent("romm_data_changed", { detail: { type: "bios", platform_slug: detail.platformSlug } }),
         );
         // Refresh BIOS status — getBiosStatus ships pre-computed level/label so we don't re-derive.
-        if (info.romId) {
-          const refreshed = await getBiosStatus(info.romId).catch(() => ({
-            bios_status: null as BiosStatus | null,
-            bios_level: null as "ok" | "partial" | "missing" | "unmanaged" | null,
-            bios_label: null as string | null,
-          }));
-          if (refreshed.bios_status) {
-            setInfo((prev) => ({
-              ...prev,
-              biosStatus: refreshed.bios_level,
-              biosLabel: refreshed.bios_label ?? "",
-            }));
-          }
-        }
+        await refreshBiosStatus(appId);
       } else {
         toaster.toast({ title: "RomM Sync", body: result.message || "BIOS download failed" });
       }
@@ -863,11 +512,11 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
   };
 
   const handleUninstall = async () => {
-    if (actionPending || !info.romId) return;
+    if (actionPending || !detail.romId) return;
     setActionPending("uninstall");
     const admission = capturePruneLeaseAdmission(`game-detail:${appId}`);
     try {
-      const result = await removeRom(info.romId);
+      const result = await removeRom(detail.romId);
       if (result.success) {
         await withPruneLease(
           result.prune_lease_token,
@@ -876,12 +525,12 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
             if (isPruneLeaseCancelled(signal)) return;
             await setLaunchOptionsConfirmed(appId, "").catch(() => false);
             if (isPruneLeaseCancelled(signal)) return;
-            globalThis.dispatchEvent(new CustomEvent("romm_rom_uninstalled", { detail: { rom_id: info.romId } }));
+            globalThis.dispatchEvent(new CustomEvent("romm_rom_uninstalled", { detail: { rom_id: detail.romId } }));
           },
           `game-detail:${appId}`,
           admission,
         );
-        toaster.toast({ title: "RomM Sync", body: `${info.romName || "ROM"} uninstalled` });
+        toaster.toast({ title: "RomM Sync", body: `${detail.romName || "ROM"} uninstalled` });
       } else {
         toaster.toast({ title: "RomM Sync", body: result.message || "Uninstall failed" });
       }
@@ -899,8 +548,8 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
   };
 
   const handleDeleteSaves = () => {
-    if (actionPending || !info.romId) return;
-    const romId = info.romId;
+    if (actionPending || !detail.romId) return;
+    const romId = detail.romId;
     showModal(
       createElement(ConfirmModal, {
         strTitle: "Delete Local Saves",
@@ -916,8 +565,8 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
                 const result = await deleteLocalSaves(romId);
                 if (result.success) {
                   toaster.toast({ title: "RomM Sync", body: result.message });
-                  // Directly update PlaySection status — no local saves remain
-                  setInfo((prev) => ({ ...prev, saveSyncStatus: "none" as const, saveSyncLabel: "No saves" }));
+                  // Directly update the shown status — no local saves remain
+                  noteSaveSyncDisplay(appId, { status: "none", label: "No saves", last_sync_check_at: null });
                   globalThis.dispatchEvent(
                     new CustomEvent("romm_data_changed", { detail: { type: "save_sync", rom_id: romId } }),
                   );
@@ -938,30 +587,8 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
 
   /** Refresh the core badge + BIOS state from their dedicated paths and notify
    *  sibling components after a successful override pin/clear. */
-  const refreshCoreDisplay = async (romId: number, platformSlug: string) => {
-    // Core data comes from the dedicated core-info path (#923), keyed on rom_id
-    // so the per-game DB override (epic #945) reads back as the active core.
-    // BIOS level/label still come from getBiosStatus — the active core just
-    // switched, so the BIOS requirements may have changed.
-    const [coreInfo, refreshed] = await Promise.all([
-      getPlatformCoreInfo(romId),
-      getBiosStatus(romId).catch(() => ({
-        bios_status: null as BiosStatus | null,
-        bios_level: null as "ok" | "partial" | "missing" | "unmanaged" | null,
-        bios_label: null as string | null,
-      })),
-    ]);
-    setInfo((prev) => ({
-      ...prev,
-      ...extractCoreInfo(coreInfo),
-      // Re-derive biosNeeded from the refreshed status so the missing-BIOS
-      // badge keys off the now-active core (#923).
-      biosNeeded: !!refreshed.bios_status,
-      biosStatus: refreshed.bios_level,
-      biosLabel: refreshed.bios_label ?? "",
-    }));
-    // Invalidate the frontend cache and notify other components (e.g. GameInfoPanel)
-    invalidateCachedGameDetail(appId);
+  const refreshCoreDisplay = async (platformSlug: string) => {
+    await refreshCoreAndBios(appId);
     globalThis.dispatchEvent(
       new CustomEvent("romm_data_changed", { detail: { type: "core_changed", platform_slug: platformSlug } }),
     );
@@ -975,7 +602,6 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
    *  carry no launch_options/app_id: persist-only, no SetAppLaunchOptions. */
   const applyCoreResult = async (
     result: Awaited<ReturnType<typeof setGameCore>>,
-    romId: number,
     platformSlug: string,
     successBody: string,
     admission: PruneLeaseAdmission,
@@ -1000,20 +626,20 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
       }
       // Confirmed (or uninstalled/unbound: nothing to confirm) → success.
       toaster.toast({ title: "RomM Sync", body: successBody });
-      await refreshCoreDisplay(romId, platformSlug);
+      await refreshCoreDisplay(platformSlug);
     }, `game-detail:${appId}`, admission);
   };
 
   const handleChangeGameCore = async (coreLabel: string) => {
-    const romId = info.romId;
-    if (!romId || !info.platformSlug) return;
-    const platformSlug = info.platformSlug;
+    const romId = detail.romId;
+    if (!romId || !detail.platformSlug) return;
+    const platformSlug = detail.platformSlug;
     detach(debugLog(`handleChangeGameCore: romId=${romId} coreLabel=${coreLabel}`));
     const admission = capturePruneLeaseAdmission(`game-detail:${appId}`);
     try {
       const result = await setGameCore(romId, coreLabel);
       detach(debugLog(`handleChangeGameCore: result success=${result.success}`));
-      await applyCoreResult(result, romId, platformSlug, `Core set to ${coreLabel}`, admission);
+      await applyCoreResult(result, platformSlug, `Core set to ${coreLabel}`, admission);
     } catch (e) {
       // The core pin is persisted before the Steam continuation runs, so a
       // teardown cancellation is not a "failed to set core" the user must see.
@@ -1026,15 +652,15 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
   };
 
   const handleResetGameCore = async () => {
-    const romId = info.romId;
-    if (!romId || !info.platformSlug) return;
-    const platformSlug = info.platformSlug;
+    const romId = detail.romId;
+    if (!romId || !detail.platformSlug) return;
+    const platformSlug = detail.platformSlug;
     detach(debugLog(`handleResetGameCore: romId=${romId}`));
     const admission = capturePruneLeaseAdmission(`game-detail:${appId}`);
     try {
       const result = await clearGameCore(romId);
       detach(debugLog(`handleResetGameCore: result success=${result.success}`));
-      await applyCoreResult(result, romId, platformSlug, "Now following the system core", admission);
+      await applyCoreResult(result, platformSlug, "Now following the system core", admission);
     } catch (e) {
       if (isPruneLeaseCancellation(e, admission)) {
         detach(debugLog(`handleResetGameCore: continuation was cancelled: ${e}`));
@@ -1050,12 +676,12 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
     // every bakeable emulator entry PINS the per-game override.
     showContextMenu(
       buildEmulatorMenu({
-        emulators: info.emulators,
-        emulatorDataAvailable: info.emulatorDataAvailable,
-        activeLabel: info.activeCoreLabel,
-        platformCoreLabel: info.platformCoreLabel,
+        emulators: detail.emulators,
+        emulatorDataAvailable: detail.emulatorDataAvailable,
+        activeLabel: detail.activeCoreLabel,
+        platformCoreLabel: detail.platformCoreLabel,
         followSystem: {
-          hasGameOverride: info.hasGameOverride,
+          hasGameOverride: detail.hasGameOverride,
           onFollowSystem: () => {
             detach(handleResetGameCore());
           },
@@ -1201,25 +827,25 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
   // Played / Playtime, and the cell disappears once the ROM is on disk. Being
   // first also keeps it clear of the romm-info-items nowrap + overflow:hidden
   // clip, which drops cells from the right edge.
-  if (!info.installed && info.fsSizeBytes != null) {
-    infoItems.push(infoItem("space-required", "SPACE REQUIRED", formatBytes(info.fsSizeBytes)));
+  if (!detail.installed && detail.fsSizeBytes != null) {
+    infoItems.push(infoItem("space-required", "SPACE REQUIRED", formatBytes(detail.fsSizeBytes)));
   }
 
   // Last Played
-  if (info.lastPlayed) {
-    infoItems.push(infoItem("last-played", "LAST PLAYED", info.lastPlayed));
+  if (playtimeInfo.lastPlayed) {
+    infoItems.push(infoItem("last-played", "LAST PLAYED", playtimeInfo.lastPlayed));
   }
 
   // Playtime
-  if (info.playtime) {
-    infoItems.push(infoItem("playtime", "PLAYTIME", info.playtime));
+  if (playtimeInfo.playtime) {
+    infoItems.push(infoItem("playtime", "PLAYTIME", playtimeInfo.playtime));
   }
 
   // Achievements badge (only when RA data available)
-  if (info.raId) {
-    const hasEarned = info.achievementEarned > 0;
+  if (detail.raId) {
+    const hasEarned = detail.achievementEarned > 0;
     const countLabel =
-      info.achievementTotal > 0 ? `${info.achievementEarned}/${info.achievementTotal}` : `${info.achievementEarned}`;
+      detail.achievementTotal > 0 ? `${detail.achievementEarned}/${detail.achievementTotal}` : `${detail.achievementEarned}`;
 
     // Generate sparkle dots at random fixed positions (only when earned > 0)
     // Positions are deterministic per-index so they don't shift on re-render
@@ -1283,7 +909,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
   }
 
   // Save Sync moved to dedicated tab — show legacy slot warning only
-  if (info.activeSlot == null && info.saveSyncEnabled) {
+  if (detail.activeSlot == null && detail.saveSyncEnabled) {
     infoItems.push(
       createElement(
         "div",
@@ -1305,8 +931,8 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
 
   // BIOS warning (only when files are actually missing — "ok" and "unmanaged"
   // are non-actionable here and live in the BIOS tab, not on the play section)
-  if (info.biosNeeded && info.biosStatus && info.biosStatus !== "ok" && info.biosStatus !== "unmanaged") {
-    const biosColor = biosColorForLevel(info.biosStatus);
+  if (detail.biosNeeded && detail.biosStatus && detail.biosStatus !== "ok" && detail.biosStatus !== "unmanaged") {
+    const biosColor = biosColorForLevel(detail.biosStatus);
     infoItems.push(
       createElement(
         "div",
@@ -1329,7 +955,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
             className: "romm-status-dot",
             style: { backgroundColor: biosColor },
           }),
-          info.biosLabel,
+          detail.biosLabel,
         ),
       ),
     );
@@ -1395,7 +1021,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
         createElement(FaGamepad, { size: 18, color: "#553e98" }),
       ),
       // Core selection button (only when multiple emulators to choose between)
-      ...(info.emulators.length > 1
+      ...(detail.emulators.length > 1
         ? [
             createElement(
               DialogButton,
@@ -1406,7 +1032,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
                 onFocus: scrollToTop,
                 title: "Emulator Core",
               },
-              createElement(FaMicrochip, { size: 18, color: info.activeCoreIsDefault ? "#8f98a0" : "#d4a72c" }),
+              createElement(FaMicrochip, { size: 18, color: detail.activeCoreIsDefault ? "#8f98a0" : "#d4a72c" }),
             ),
           ]
         : []),
@@ -1427,7 +1053,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
   // Content-dir warning (#239) — prominent banner above the play row when
   // RetroArch writes saves to the content directory. The play row still renders
   // below it: the game remains fully playable, only save sync is unavailable.
-  if (info.savefilesInContentDir) {
+  if (detail.savefilesInContentDir) {
     return createElement(
       "div",
       { style: { display: "flex", flexDirection: "column" } },

--- a/src/utils/gameDetailStore.test.ts
+++ b/src/utils/gameDetailStore.test.ts
@@ -507,7 +507,7 @@ describe("gameDetailStore", () => {
       expect(getGameDetail(nextAppId).saveSyncEnabled).toBe(true);
     });
 
-    it("disabling clears the display and the content-dir banner without a read", async () => {
+    it("disabling clears the sync-derived display without a read, keeping the content-dir fact", async () => {
       vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(found({ save_sync_enabled: true }));
       vi.mocked(backend.getSaveStatus).mockResolvedValue(saveStatus({ savefiles_in_content_dir: true }));
       subscribe(nextAppId);
@@ -525,7 +525,9 @@ describe("gameDetailStore", () => {
         saveSyncEnabled: false,
         saveSyncStatus: null,
         saveSyncLabel: "",
-        savefilesInContentDir: false,
+        // The local RetroArch config did not change with the setting, so the
+        // fact stands; whether it is worth showing is each surface's call.
+        savefilesInContentDir: true,
       });
     });
   });

--- a/src/utils/gameDetailStore.test.ts
+++ b/src/utils/gameDetailStore.test.ts
@@ -1,0 +1,697 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import * as backend from "../api/backend";
+import * as cachedStore from "./cachedGameDetailStore";
+import {
+  getGameDetail,
+  noteSaveSyncDisplay,
+  refreshBiosStatus,
+  refreshCoreAndBios,
+  refreshSaveStatus,
+  subscribeGameDetail,
+  useGameDetail,
+} from "./gameDetailStore";
+import {
+  installDomEventListenerSpy,
+  uninstallDomEventListenerSpy,
+  domListenerCount,
+} from "../test-utils/dom-event-listener-spy";
+import { deckyEventListenerCount, emitDeckyEvent } from "../test-utils/decky-api-mock";
+import type { CachedGameDetail } from "../api/backend";
+import type { DownloadCompleteEvent, SaveStatus } from "../types";
+
+// getCachedGameDetail / invalidateCachedGameDetail are re-exported through
+// backend.ts but their canonical home is utils — mock the store so both import
+// paths land on the same vi.fn.
+vi.mock("./cachedGameDetailStore", () => ({
+  getCachedGameDetail: vi.fn(),
+  invalidateCachedGameDetail: vi.fn(),
+}));
+
+// Each test works on its own appId so one test's entry can never be another's.
+let appIdSeq = 5000;
+let nextAppId = 0;
+
+// Every subscription opened by a test is released afterwards — an entry with a
+// live subscriber keeps its DOM listeners attached.
+const openSubscriptions: Array<() => void> = [];
+
+function subscribe(appId: number, cb: () => void = () => {}): () => void {
+  const unsubscribe = subscribeGameDetail(appId, cb);
+  openSubscriptions.push(unsubscribe);
+  return unsubscribe;
+}
+
+const flush = () =>
+  act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+
+function saveStatus(overrides: Partial<SaveStatus> = {}): SaveStatus {
+  return {
+    rom_id: 42,
+    files: [],
+    playtime: {
+      total_seconds: 0,
+      session_count: 0,
+      last_session_start: null,
+      last_session_duration_sec: null,
+      last_played: null,
+    },
+    device_id: "device",
+    last_sync_check_at: null,
+    save_sync_display: { status: "synced", label: "Up to date", last_sync_check_at: null },
+    ...overrides,
+  };
+}
+
+/** A deferred stand-in for a callable, so a test can hold a read open across an
+ *  event and settle it afterwards. */
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void; reject: (e: unknown) => void } {
+  let resolve!: (value: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+const downloadComplete = (romId: number): DownloadCompleteEvent => ({
+  rom_id: romId,
+  rom_name: "Test ROM",
+  platform_name: "SNES",
+  file_path: "/roms/test.sfc",
+  app_id: null,
+  launch_options: "",
+});
+
+const coreInfo = {
+  active_core: "snes9x.so",
+  active_core_label: "Snes9x",
+  platform_core_label: null,
+  has_game_override: false,
+  emulator_data_available: true,
+  emulators: [
+    {
+      label: "Snes9x",
+      kind: "libretro" as const,
+      core_so: "snes9x.so",
+      is_default: true,
+      bakeable: true,
+      reason: null,
+    },
+  ],
+};
+
+describe("gameDetailStore", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    nextAppId = ++appIdSeq;
+    installDomEventListenerSpy();
+
+    vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({ found: false });
+    vi.mocked(backend.getSaveStatus).mockResolvedValue(saveStatus());
+    vi.mocked(backend.getPlatformCoreInfo).mockResolvedValue(coreInfo);
+    vi.mocked(backend.getBiosStatus).mockResolvedValue({ bios_status: null, bios_level: null, bios_label: null });
+    vi.mocked(backend.getAchievementProgress).mockResolvedValue({ success: true, earned: 0, total: 0 });
+    vi.mocked(backend.getRomMetadata).mockResolvedValue({} as never);
+    vi.mocked(backend.debugLog).mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    openSubscriptions.splice(0).forEach((unsubscribe) => unsubscribe());
+    uninstallDomEventListenerSpy();
+  });
+
+  const found = (overrides: Partial<CachedGameDetail> = {}): CachedGameDetail => ({
+    found: true,
+    rom_id: 42,
+    rom_name: "Test ROM",
+    platform_slug: "snes",
+    ...overrides,
+  });
+
+  describe("subscription lifecycle", () => {
+    it("reports the neutral default for an appId nobody is subscribed to", () => {
+      expect(getGameDetail(nextAppId)).toMatchObject({ romId: null, installed: false, activeSlot: "default" });
+    });
+
+    it("loads the cached detail on first subscribe and notifies with the folded state", async () => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(
+        found({ installed: true, fs_size_bytes: 4096, ra_id: 7, achievement_summary: { earned: 3, total: 50 } }),
+      );
+      const notified = vi.fn();
+      subscribe(nextAppId, notified);
+      await flush();
+
+      expect(vi.mocked(cachedStore.getCachedGameDetail)).toHaveBeenCalledWith(nextAppId);
+      expect(notified).toHaveBeenCalled();
+      expect(getGameDetail(nextAppId)).toMatchObject({
+        romId: 42,
+        romName: "Test ROM",
+        platformSlug: "snes",
+        installed: true,
+        fsSizeBytes: 4096,
+        raId: 7,
+        achievementEarned: 3,
+        achievementTotal: 50,
+      });
+    });
+
+    it("serves a second subscriber from the same entry — one cached-detail read, both notified", async () => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(found());
+      const first = vi.fn();
+      const second = vi.fn();
+      subscribe(nextAppId, first);
+      subscribe(nextAppId, second);
+      await flush();
+
+      expect(vi.mocked(cachedStore.getCachedGameDetail)).toHaveBeenCalledTimes(1);
+      expect(first).toHaveBeenCalled();
+      expect(second).toHaveBeenCalled();
+    });
+
+    it("stops notifying an unsubscribed caller even when its load is still in flight", async () => {
+      const cached = deferred<CachedGameDetail>();
+      vi.mocked(cachedStore.getCachedGameDetail).mockReturnValue(cached.promise);
+      const notified = vi.fn();
+      const unsubscribe = subscribe(nextAppId, notified);
+
+      unsubscribe();
+      cached.resolve(found());
+      await flush();
+
+      expect(notified).not.toHaveBeenCalled();
+      expect(getGameDetail(nextAppId).romId).toBeNull();
+    });
+
+    it("attaches the entry's listeners on the first subscribe and detaches them on the last unsubscribe", async () => {
+      const dataChangedBefore = domListenerCount("romm_data_changed");
+      const uninstalledBefore = domListenerCount("romm_rom_uninstalled");
+      const downloadBefore = deckyEventListenerCount("download_complete");
+
+      const first = subscribe(nextAppId);
+      const second = subscribe(nextAppId);
+      await flush();
+      expect(domListenerCount("romm_data_changed")).toBe(dataChangedBefore + 1);
+      expect(domListenerCount("romm_rom_uninstalled")).toBe(uninstalledBefore + 1);
+      expect(deckyEventListenerCount("download_complete")).toBe(downloadBefore + 1);
+
+      first();
+      expect(domListenerCount("romm_data_changed")).toBe(dataChangedBefore + 1);
+      second();
+      expect(domListenerCount("romm_data_changed")).toBe(dataChangedBefore);
+      expect(domListenerCount("romm_rom_uninstalled")).toBe(uninstalledBefore);
+      expect(deckyEventListenerCount("download_complete")).toBe(downloadBefore);
+    });
+
+    it("logs at warn level when the cached-detail read rejects", async () => {
+      const logError = vi.spyOn(backend, "logError").mockImplementation(() => {});
+      try {
+        vi.mocked(cachedStore.getCachedGameDetail).mockRejectedValue(new Error("boom"));
+        subscribe(nextAppId);
+        await flush();
+        expect(logError).toHaveBeenCalledWith(expect.stringContaining("load error"));
+      } finally {
+        logError.mockRestore();
+      }
+    });
+
+    it("useGameDetail renders the current state and re-renders on every change", async () => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(found({ installed: true }));
+      const { result, unmount } = renderHook(() => useGameDetail(nextAppId));
+      expect(result.current.romId).toBeNull();
+
+      await flush();
+      expect(result.current).toMatchObject({ romId: 42, installed: true });
+
+      act(() => {
+        noteSaveSyncDisplay(nextAppId, { status: "none", label: "No saves", last_sync_check_at: null });
+      });
+      expect(result.current.saveSyncLabel).toBe("No saves");
+
+      unmount();
+      expect(domListenerCount("romm_data_changed")).toBe(0);
+    });
+  });
+
+  describe("refreshSaveStatus", () => {
+    beforeEach(() => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(found({ save_sync_enabled: true }));
+    });
+
+    it("folds the read into the shared state", async () => {
+      subscribe(nextAppId);
+      vi.mocked(backend.getSaveStatus).mockResolvedValue(
+        saveStatus({ active_slot: "slot-a", savefiles_in_content_dir: true }),
+      );
+      await flush();
+
+      expect(vi.mocked(backend.getSaveStatus)).toHaveBeenCalledWith(42);
+      expect(getGameDetail(nextAppId)).toMatchObject({
+        activeSlot: "slot-a",
+        savefilesInContentDir: true,
+        saveSyncStatus: "synced",
+        saveSyncLabel: "Up to date",
+      });
+      expect(getGameDetail(nextAppId).saveStatus).not.toBeNull();
+    });
+
+    it("shares one request between overlapping callers", async () => {
+      subscribe(nextAppId);
+      await flush();
+      vi.mocked(backend.getSaveStatus).mockClear();
+      const pending = deferred<SaveStatus>();
+      vi.mocked(backend.getSaveStatus).mockReturnValue(pending.promise);
+
+      const first = refreshSaveStatus(nextAppId);
+      const second = refreshSaveStatus(nextAppId);
+      pending.resolve(saveStatus({ active_slot: "shared" }));
+      const [firstStatus, secondStatus] = await Promise.all([first, second]);
+
+      expect(vi.mocked(backend.getSaveStatus)).toHaveBeenCalledTimes(1);
+      expect(firstStatus).toBe(secondStatus);
+      expect(getGameDetail(nextAppId).activeSlot).toBe("shared");
+    });
+
+    it("issues a fresh request once the shared one has settled", async () => {
+      subscribe(nextAppId);
+      await flush();
+      vi.mocked(backend.getSaveStatus).mockClear();
+
+      await refreshSaveStatus(nextAppId);
+      await refreshSaveStatus(nextAppId);
+
+      expect(vi.mocked(backend.getSaveStatus)).toHaveBeenCalledTimes(2);
+    });
+
+    it("leaves the shown display untouched when the backend refuses the read", async () => {
+      subscribe(nextAppId);
+      await flush();
+      const before = getGameDetail(nextAppId);
+      vi.mocked(backend.getSaveStatus).mockResolvedValue({
+        success: false,
+        reason: "prune_active",
+        message: "Cleanup is active.",
+      });
+
+      await expect(refreshSaveStatus(nextAppId)).resolves.toBeNull();
+      expect(getGameDetail(nextAppId).saveSyncLabel).toBe(before.saveSyncLabel);
+      expect(vi.mocked(backend.debugLog)).toHaveBeenCalledWith(expect.stringContaining("save status refused"));
+    });
+
+    it("rejects on a failed call and frees the shared slot for the next caller", async () => {
+      subscribe(nextAppId);
+      await flush();
+      vi.mocked(backend.getSaveStatus).mockRejectedValueOnce(new Error("offline"));
+
+      await expect(refreshSaveStatus(nextAppId)).rejects.toThrow("offline");
+
+      vi.mocked(backend.getSaveStatus).mockResolvedValue(saveStatus({ active_slot: "after-retry" }));
+      await refreshSaveStatus(nextAppId);
+      expect(getGameDetail(nextAppId).activeSlot).toBe("after-retry");
+    });
+
+    it("does nothing while the rom identity is unresolved", async () => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({ found: false });
+      subscribe(nextAppId);
+      await flush();
+
+      await expect(refreshSaveStatus(nextAppId)).resolves.toBeNull();
+      expect(vi.mocked(backend.getSaveStatus)).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("save_sync notifications", () => {
+    const dispatchSaveSync = (detail: Record<string, unknown>) =>
+      globalThis.dispatchEvent(new CustomEvent("romm_data_changed", { detail: { type: "save_sync", ...detail } }));
+
+    it("re-reads the status for a matching rom_id", async () => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(found());
+      subscribe(nextAppId);
+      await flush();
+      vi.mocked(backend.getSaveStatus).mockClear();
+      vi.mocked(backend.getSaveStatus).mockResolvedValue(saveStatus({ active_slot: "re-read" }));
+
+      await act(async () => {
+        dispatchSaveSync({ rom_id: 42 });
+        await Promise.resolve();
+      });
+      await flush();
+
+      expect(vi.mocked(backend.getSaveStatus)).toHaveBeenCalledWith(42);
+      expect(getGameDetail(nextAppId).activeSlot).toBe("re-read");
+    });
+
+    it("ignores a notification for another rom_id", async () => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(found());
+      subscribe(nextAppId);
+      await flush();
+      vi.mocked(backend.getSaveStatus).mockClear();
+
+      await act(async () => {
+        dispatchSaveSync({ rom_id: 999 });
+        await Promise.resolve();
+      });
+
+      expect(vi.mocked(backend.getSaveStatus)).not.toHaveBeenCalled();
+    });
+
+    // #975 — the cross-game bleed. The old per-component handler fell back to
+    // the EVENT's rom_id while its own was still null, so a notification for
+    // another game fetched and displayed that game's save status here.
+    it("#975: drops a foreign rom_id while this appId's identity is still unresolved", async () => {
+      const cached = deferred<CachedGameDetail>();
+      vi.mocked(cachedStore.getCachedGameDetail).mockReturnValue(cached.promise);
+      subscribe(nextAppId);
+      await flush();
+      expect(getGameDetail(nextAppId).romId).toBeNull();
+
+      const foreign = saveStatus({ rom_id: 999, active_slot: null, savefiles_in_content_dir: true });
+      vi.mocked(backend.getSaveStatus).mockResolvedValue(foreign);
+      await act(async () => {
+        dispatchSaveSync({ rom_id: 999 });
+        // The same event carrying the other game's status inline — the shape
+        // that would land without a read at all.
+        dispatchSaveSync({ rom_id: 999, save_status: foreign });
+        await Promise.resolve();
+      });
+      await flush();
+
+      expect(vi.mocked(backend.getSaveStatus)).not.toHaveBeenCalled();
+      expect(getGameDetail(nextAppId)).toMatchObject({
+        romId: null,
+        activeSlot: "default",
+        savefilesInContentDir: false,
+        saveStatus: null,
+      });
+
+      // The load that was in flight all along still brings this ROM's own state.
+      cached.resolve(found({ save_sync_enabled: true }));
+      vi.mocked(backend.getSaveStatus).mockResolvedValue(saveStatus({ active_slot: "ours" }));
+      await flush();
+      expect(getGameDetail(nextAppId)).toMatchObject({ romId: 42, activeSlot: "ours" });
+    });
+
+    it("uses a status carried on the notification instead of re-reading it", async () => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(found());
+      subscribe(nextAppId);
+      await flush();
+      vi.mocked(backend.getSaveStatus).mockClear();
+
+      await act(async () => {
+        dispatchSaveSync({ rom_id: 42, save_status: saveStatus({ active_slot: "inline" }) });
+        await Promise.resolve();
+      });
+
+      expect(vi.mocked(backend.getSaveStatus)).not.toHaveBeenCalled();
+      expect(getGameDetail(nextAppId).activeSlot).toBe("inline");
+    });
+  });
+
+  describe("save_sync_settings notifications", () => {
+    const dispatchSettings = (enabled: boolean) =>
+      globalThis.dispatchEvent(
+        new CustomEvent("romm_data_changed", {
+          detail: { type: "save_sync_settings", save_sync_enabled: enabled },
+        }),
+      );
+
+    it("enabling re-reads the status", async () => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(found());
+      subscribe(nextAppId);
+      await flush();
+      vi.mocked(backend.getSaveStatus).mockClear();
+
+      await act(async () => {
+        dispatchSettings(true);
+        await Promise.resolve();
+      });
+      await flush();
+
+      expect(vi.mocked(backend.getSaveStatus)).toHaveBeenCalledWith(42);
+      expect(getGameDetail(nextAppId).saveSyncEnabled).toBe(true);
+    });
+
+    it("disabling clears the display and the content-dir banner without a read", async () => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(found({ save_sync_enabled: true }));
+      vi.mocked(backend.getSaveStatus).mockResolvedValue(saveStatus({ savefiles_in_content_dir: true }));
+      subscribe(nextAppId);
+      await flush();
+      expect(getGameDetail(nextAppId).savefilesInContentDir).toBe(true);
+      vi.mocked(backend.getSaveStatus).mockClear();
+
+      await act(async () => {
+        dispatchSettings(false);
+        await Promise.resolve();
+      });
+
+      expect(vi.mocked(backend.getSaveStatus)).not.toHaveBeenCalled();
+      expect(getGameDetail(nextAppId)).toMatchObject({
+        saveSyncEnabled: false,
+        saveSyncStatus: null,
+        saveSyncLabel: "",
+        savefilesInContentDir: false,
+      });
+    });
+  });
+
+  describe("core_changed notifications", () => {
+    const dispatchCoreChanged = () =>
+      globalThis.dispatchEvent(
+        new CustomEvent("romm_data_changed", { detail: { type: "core_changed", platform_slug: "snes" } }),
+      );
+
+    it("re-reads core info and BIOS keyed on the rom_id", async () => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(found());
+      subscribe(nextAppId);
+      await flush();
+      vi.mocked(backend.getPlatformCoreInfo).mockClear();
+      vi.mocked(backend.getBiosStatus).mockClear();
+      vi.mocked(backend.getBiosStatus).mockResolvedValue({
+        bios_status: { platform_slug: "snes", server_count: 3, local_count: 0, all_downloaded: false },
+        bios_level: "missing",
+        bios_label: "0/3",
+      });
+
+      await act(async () => {
+        dispatchCoreChanged();
+        await Promise.resolve();
+      });
+      await flush();
+
+      expect(vi.mocked(backend.getPlatformCoreInfo)).toHaveBeenCalledWith(42);
+      expect(vi.mocked(backend.getBiosStatus)).toHaveBeenCalledWith(42);
+      expect(getGameDetail(nextAppId)).toMatchObject({
+        activeCoreLabel: "Snes9x",
+        biosNeeded: true,
+        biosStatus: "missing",
+        biosLabel: "0/3",
+      });
+    });
+
+    it("skips the reads while the rom identity is unresolved", async () => {
+      subscribe(nextAppId);
+      await flush();
+      vi.mocked(backend.getPlatformCoreInfo).mockClear();
+      vi.mocked(backend.getBiosStatus).mockClear();
+
+      await act(async () => {
+        dispatchCoreChanged();
+        await Promise.resolve();
+      });
+
+      expect(vi.mocked(backend.getPlatformCoreInfo)).not.toHaveBeenCalled();
+      expect(vi.mocked(backend.getBiosStatus)).not.toHaveBeenCalled();
+    });
+
+    it("surfaces a failed read through debugLog instead of leaving it unhandled", async () => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(found());
+      subscribe(nextAppId);
+      await flush();
+      vi.mocked(backend.getBiosStatus).mockRejectedValue(new Error("handler-boom"));
+      vi.mocked(backend.debugLog).mockClear();
+
+      await act(async () => {
+        dispatchCoreChanged();
+        await Promise.resolve();
+      });
+      await flush();
+
+      expect(vi.mocked(backend.debugLog)).toHaveBeenCalledWith(expect.stringContaining("onDataChanged error"));
+    });
+  });
+
+  describe("version_switched notifications", () => {
+    const dispatchSwitch = (appId: number) =>
+      globalThis.dispatchEvent(
+        new CustomEvent("romm_data_changed", { detail: { type: "version_switched", app_id: appId, rom_id: 43 } }),
+      );
+
+    it("re-derives the entry for this appId", async () => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(found());
+      subscribe(nextAppId);
+      await flush();
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(found({ rom_id: 43, rom_name: "Other version" }));
+
+      await act(async () => {
+        dispatchSwitch(nextAppId);
+        await Promise.resolve();
+      });
+      await flush();
+
+      expect(getGameDetail(nextAppId)).toMatchObject({ romId: 43, romName: "Other version" });
+    });
+
+    it("ignores a switch for another appId", async () => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(found());
+      subscribe(nextAppId);
+      await flush();
+      vi.mocked(cachedStore.getCachedGameDetail).mockClear();
+
+      await act(async () => {
+        dispatchSwitch(nextAppId + 1);
+        await Promise.resolve();
+      });
+
+      expect(vi.mocked(cachedStore.getCachedGameDetail)).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("install-state notifications", () => {
+    it("re-derives from a fresh cached detail on download_complete for this ROM", async () => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(found({ installed: false }));
+      subscribe(nextAppId);
+      await flush();
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(found({ installed: true }));
+
+      await act(async () => {
+        emitDeckyEvent<[DownloadCompleteEvent]>("download_complete", downloadComplete(42));
+        await Promise.resolve();
+      });
+      await flush();
+
+      expect(vi.mocked(cachedStore.invalidateCachedGameDetail)).toHaveBeenCalledWith(nextAppId);
+      expect(getGameDetail(nextAppId).installed).toBe(true);
+    });
+
+    it("re-derives on romm_rom_uninstalled for this ROM", async () => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(found({ installed: true }));
+      subscribe(nextAppId);
+      await flush();
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(found({ installed: false }));
+
+      await act(async () => {
+        globalThis.dispatchEvent(new CustomEvent("romm_rom_uninstalled", { detail: { rom_id: 42 } }));
+        await Promise.resolve();
+      });
+      await flush();
+
+      expect(getGameDetail(nextAppId).installed).toBe(false);
+    });
+
+    it("ignores install events for another ROM", async () => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(found({ installed: false }));
+      subscribe(nextAppId);
+      await flush();
+      vi.mocked(cachedStore.getCachedGameDetail).mockClear();
+
+      await act(async () => {
+        emitDeckyEvent<[DownloadCompleteEvent]>("download_complete", downloadComplete(999));
+        globalThis.dispatchEvent(new CustomEvent("romm_rom_uninstalled", { detail: { rom_id: 999 } }));
+        await Promise.resolve();
+      });
+
+      expect(vi.mocked(cachedStore.getCachedGameDetail)).not.toHaveBeenCalled();
+      expect(getGameDetail(nextAppId).installed).toBe(false);
+    });
+  });
+
+  describe("explicit refreshes", () => {
+    beforeEach(() => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(found());
+    });
+
+    it("noteSaveSyncDisplay records a display the caller already knows to be true", async () => {
+      subscribe(nextAppId);
+      await flush();
+
+      noteSaveSyncDisplay(nextAppId, { status: "synced", label: "Just now", last_sync_check_at: null });
+
+      expect(getGameDetail(nextAppId)).toMatchObject({ saveSyncStatus: "synced", saveSyncLabel: "Just now" });
+    });
+
+    it("refreshBiosStatus adopts a refreshed level", async () => {
+      subscribe(nextAppId);
+      await flush();
+      vi.mocked(backend.getBiosStatus).mockResolvedValue({
+        bios_status: { platform_slug: "snes", server_count: 3, local_count: 3, all_downloaded: true },
+        bios_level: "ok",
+        bios_label: "3/3",
+      });
+
+      await refreshBiosStatus(nextAppId);
+
+      expect(getGameDetail(nextAppId)).toMatchObject({ biosStatus: "ok", biosLabel: "3/3" });
+    });
+
+    it("refreshBiosStatus leaves the shown level alone when the read fails", async () => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(
+        found({
+          bios_status: { platform_slug: "snes", server_count: 3, local_count: 1, all_downloaded: false },
+          bios_level: "partial",
+          bios_label: "1/3",
+        }),
+      );
+      subscribe(nextAppId);
+      await flush();
+      vi.mocked(backend.getBiosStatus).mockRejectedValue(new Error("offline"));
+
+      await refreshBiosStatus(nextAppId);
+
+      expect(getGameDetail(nextAppId)).toMatchObject({ biosStatus: "partial", biosLabel: "1/3" });
+    });
+
+    it("refreshCoreAndBios re-derives both and drops the cached detail", async () => {
+      subscribe(nextAppId);
+      await flush();
+      vi.mocked(backend.getBiosStatus).mockResolvedValue({
+        bios_status: { platform_slug: "snes", server_count: 1, local_count: 0, all_downloaded: false },
+        bios_level: "missing",
+        bios_label: "0/1",
+      });
+
+      await refreshCoreAndBios(nextAppId);
+
+      expect(getGameDetail(nextAppId)).toMatchObject({
+        activeCoreLabel: "Snes9x",
+        biosNeeded: true,
+        biosStatus: "missing",
+      });
+      expect(vi.mocked(cachedStore.invalidateCachedGameDetail)).toHaveBeenCalledWith(nextAppId);
+    });
+
+    it("refreshCoreAndBios clears the BIOS need when the refreshed read fails", async () => {
+      subscribe(nextAppId);
+      await flush();
+      vi.mocked(backend.getBiosStatus).mockRejectedValue(new Error("offline"));
+
+      await refreshCoreAndBios(nextAppId);
+
+      expect(getGameDetail(nextAppId)).toMatchObject({ activeCoreLabel: "Snes9x", biosNeeded: false });
+    });
+
+    it("does nothing for an appId nobody is subscribed to", async () => {
+      noteSaveSyncDisplay(nextAppId, { status: "none", label: "No saves", last_sync_check_at: null });
+      await refreshBiosStatus(nextAppId);
+      await refreshCoreAndBios(nextAppId);
+
+      expect(vi.mocked(backend.getBiosStatus)).not.toHaveBeenCalled();
+      expect(vi.mocked(backend.getPlatformCoreInfo)).not.toHaveBeenCalled();
+      expect(getGameDetail(nextAppId).saveSyncLabel).toBe("");
+    });
+  });
+});

--- a/src/utils/gameDetailStore.test.ts
+++ b/src/utils/gameDetailStore.test.ts
@@ -116,7 +116,12 @@ describe("gameDetailStore", () => {
     vi.mocked(backend.getSaveStatus).mockResolvedValue(saveStatus());
     vi.mocked(backend.getPlatformCoreInfo).mockResolvedValue(coreInfo);
     vi.mocked(backend.getBiosStatus).mockResolvedValue({ bios_status: null, bios_level: null, bios_label: null });
-    vi.mocked(backend.getAchievementProgress).mockResolvedValue({ success: true, earned: 0, total: 0 });
+    vi.mocked(backend.getAchievementProgress).mockResolvedValue({
+      success: true,
+      earned: 0,
+      total: 0,
+      earned_achievements: [],
+    });
     vi.mocked(backend.getRomMetadata).mockResolvedValue({} as never);
     vi.mocked(backend.debugLog).mockResolvedValue(undefined);
   });
@@ -141,7 +146,12 @@ describe("gameDetailStore", () => {
 
     it("loads the cached detail on first subscribe and notifies with the folded state", async () => {
       vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(
-        found({ installed: true, fs_size_bytes: 4096, ra_id: 7, achievement_summary: { earned: 3, total: 50 } }),
+        found({
+          installed: true,
+          fs_size_bytes: 4096,
+          ra_id: 7,
+          achievement_summary: { earned: 3, total: 50, earned_hardcore: 0 },
+        }),
       );
       const notified = vi.fn();
       subscribe(nextAppId, notified);
@@ -288,6 +298,42 @@ describe("gameDetailStore", () => {
       expect(vi.mocked(backend.getSaveStatus)).toHaveBeenCalledTimes(2);
     });
 
+    // A version switch re-keys the entry to a new rom_id without closing it, so
+    // the generation is unchanged and the open read is the only thing that could
+    // still speak for the previous ROM.
+    it("does not serve a read left open across a version switch to the new rom", async () => {
+      const previousRom = deferred<SaveStatus>();
+      vi.mocked(backend.getSaveStatus).mockReturnValueOnce(previousRom.promise);
+      subscribe(nextAppId);
+      await flush();
+      expect(vi.mocked(backend.getSaveStatus)).toHaveBeenCalledWith(42);
+
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(found({ rom_id: 43, save_sync_enabled: true }));
+      vi.mocked(backend.getSaveStatus).mockResolvedValue(saveStatus({ rom_id: 43, active_slot: "new-version" }));
+
+      await act(async () => {
+        globalThis.dispatchEvent(
+          new CustomEvent("romm_data_changed", {
+            detail: { type: "version_switched", app_id: nextAppId, rom_id: 43 },
+          }),
+        );
+        await Promise.resolve();
+      });
+      await flush();
+
+      expect(vi.mocked(backend.getSaveStatus)).toHaveBeenCalledWith(43);
+      expect(getGameDetail(nextAppId)).toMatchObject({ romId: 43, activeSlot: "new-version" });
+
+      previousRom.resolve(saveStatus({ rom_id: 42, active_slot: "old-version", savefiles_in_content_dir: true }));
+      await flush();
+
+      expect(getGameDetail(nextAppId)).toMatchObject({
+        romId: 43,
+        activeSlot: "new-version",
+        savefilesInContentDir: false,
+      });
+    });
+
     it("leaves the shown display untouched when the backend refuses the read", async () => {
       subscribe(nextAppId);
       await flush();
@@ -394,6 +440,31 @@ describe("gameDetailStore", () => {
       vi.mocked(backend.getSaveStatus).mockResolvedValue(saveStatus({ active_slot: "ours" }));
       await flush();
       expect(getGameDetail(nextAppId)).toMatchObject({ romId: 42, activeSlot: "ours" });
+    });
+
+    // `rom_id` and `save_status` are independently optional on the event, so a
+    // dispatch carrying a status but no rom_id would pass the handler's identity
+    // check on the event itself — the shape #975 took.
+    it("drops an inline status for another rom when the notification carries no rom_id", async () => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(found());
+      subscribe(nextAppId);
+      await flush();
+      vi.mocked(backend.getSaveStatus).mockClear();
+
+      await act(async () => {
+        dispatchSaveSync({
+          save_status: saveStatus({ rom_id: 999, active_slot: "foreign", savefiles_in_content_dir: true }),
+        });
+        await Promise.resolve();
+      });
+
+      expect(vi.mocked(backend.getSaveStatus)).not.toHaveBeenCalled();
+      expect(getGameDetail(nextAppId)).toMatchObject({
+        romId: 42,
+        activeSlot: "default",
+        savefilesInContentDir: false,
+        saveStatus: null,
+      });
     });
 
     it("uses a status carried on the notification instead of re-reading it", async () => {

--- a/src/utils/gameDetailStore.ts
+++ b/src/utils/gameDetailStore.ts
@@ -309,7 +309,7 @@ export function refreshSaveStatus(appId: number): Promise<SaveStatus | null> {
   const romId = entry.state.romId;
   if (!romId) return Promise.resolve(null);
   const inFlight = entry.saveStatusInFlight;
-  if (inFlight && inFlight.romId === romId) return inFlight.promise;
+  if (inFlight?.romId === romId) return inFlight.promise;
 
   const request = readSaveStatus(entry, romId, entry.generation);
   entry.saveStatusInFlight = { romId, promise: request };

--- a/src/utils/gameDetailStore.ts
+++ b/src/utils/gameDetailStore.ts
@@ -436,7 +436,10 @@ async function handleSaveSyncSettingsChange(
   detail: Extract<RommDataChangedDetail, { type: "save_sync_settings" }>,
 ): Promise<void> {
   if (!detail.save_sync_enabled) {
-    // Save sync turned off entirely — the content-dir banner is meaningless.
+    // Only the sync-derived display is cleared. `savefilesInContentDir` stays as
+    // read: it describes the local RetroArch config, which the setting does not
+    // change, and each surface decides for itself whether the fact is worth
+    // showing while sync is off.
     writerFor(
       entry,
       entry.generation,
@@ -445,7 +448,6 @@ async function handleSaveSyncSettingsChange(
       saveSyncEnabled: false,
       saveSyncStatus: null,
       saveSyncLabel: "",
-      savefilesInContentDir: false,
     }));
     return;
   }

--- a/src/utils/gameDetailStore.ts
+++ b/src/utils/gameDetailStore.ts
@@ -1,0 +1,528 @@
+/**
+ * Per-appId game-detail store — the shared state of one Steam game page.
+ *
+ * A game page mounts several RomM surfaces at once (the play section today, the
+ * play button and the info panel next). Each used to fetch the cached detail,
+ * keep its own `romId` / install / save-sync / BIOS / core copies, and run its
+ * own near-duplicate `romm_data_changed` handlers, so the copies could disagree
+ * (#993). Here there is one entry per appId: the first subscriber opens it,
+ * loads the detail, and attaches the entry's event listeners; the last
+ * unsubscribe tears the whole entry down.
+ *
+ * The DOM bus is unchanged — it still carries the notifications. What moved is
+ * the state: one handler per appId folds an event into the entry, and every
+ * subscriber re-renders from the same fold.
+ *
+ * Overlapping reads for one appId share a single request ({@link
+ * refreshSaveStatus}), so a payload-less `save_sync` notification costs one
+ * `get_save_status` round-trip however many surfaces are mounted.
+ *
+ * Follows the module-scope store shape of utils/connectionState.ts — state in
+ * the module, a getter, a subscribe that hands back its own unsubscribe, and a
+ * `use…()` hook over the same state — keyed by appId, and with the subscription
+ * owning the entry's lifetime rather than only carrying a callback.
+ */
+
+import { useCallback, useSyncExternalStore, type Dispatch, type SetStateAction } from "react";
+import { addEventListener, removeEventListener } from "@decky/api";
+import {
+  debugLog,
+  getBiosStatus,
+  getCachedGameDetail,
+  getPlatformCoreInfo,
+  getRomMetadata,
+  getSaveStatus,
+  invalidateCachedGameDetail,
+  isCallableFailure,
+  logError,
+} from "../api/backend";
+import type { DownloadCompleteEvent, SaveStatus, SaveSyncDisplay } from "../types";
+import type { RommDataChangedDetail } from "../types/events";
+import { detach } from "./detach";
+import {
+  applySaveSyncDisplay,
+  extractBiosInfo,
+  extractCoreInfo,
+  resolveSaveSyncLabel,
+  type BiosInfoFields,
+  type CoreInfoFields,
+} from "./playSection";
+import {
+  refreshAchievementsInBackground,
+  refreshBiosInBackground,
+  refreshCoreInfoInBackground,
+} from "./sectionRefresh";
+
+/** The state one game page's surfaces share. BIOS and core-selection fields are
+ *  flat (rather than nested) because the background refresh helpers in
+ *  sectionRefresh.ts merge themselves into any state carrying those fields. */
+export interface GameDetailState extends BiosInfoFields, CoreInfoFields {
+  /** The rom_id bound to this appId, or `null` while the cached detail is still
+   *  in flight and for an appId RomM does not know. Every rom-keyed read and
+   *  every incoming notification is matched against it. */
+  romId: number | null;
+  romName: string;
+  platformSlug: string;
+  installed: boolean;
+  /** Server-reported ROM size in bytes, or `null` when unknown. */
+  fsSizeBytes: number | null;
+  saveSyncEnabled: boolean;
+  /** The last save status read for this ROM, `null` until one lands. Carries the
+   *  conflicts and slot detail the saves surfaces need; the resolved display
+   *  pair below is the same payload projected for the badges. */
+  saveStatus: SaveStatus | null;
+  saveSyncStatus: "synced" | "pending" | "conflict" | "none" | null; // NOSONAR(typescript:S4323) — inline union inside GameDetailState; extracting an alias adds indirection for no reuse benefit.
+  saveSyncLabel: string;
+  /** RetroArch `savefiles_in_content_dir=true` — saves go next to the ROM and
+   *  can't be synced (#239). Derived from a LOCAL retroarch.cfg read, so it is
+   *  populated even while RomM is unreachable. */
+  savefilesInContentDir: boolean;
+  activeSlot: string | null;
+  raId: number | null;
+  achievementEarned: number;
+  achievementTotal: number;
+}
+
+const DEFAULT_STATE: GameDetailState = {
+  romId: null,
+  romName: "",
+  platformSlug: "",
+  installed: false,
+  fsSizeBytes: null,
+  saveSyncEnabled: false,
+  saveStatus: null,
+  saveSyncStatus: null,
+  saveSyncLabel: "",
+  savefilesInContentDir: false,
+  activeSlot: "default",
+  raId: null,
+  achievementEarned: 0,
+  achievementTotal: 0,
+  biosNeeded: false,
+  biosStatus: null,
+  biosLabel: "",
+  activeCoreLabel: null,
+  activeCoreIsDefault: true,
+  emulators: [],
+  emulatorDataAvailable: true,
+  platformCoreLabel: null,
+  hasGameOverride: false,
+};
+
+type BiosStatusResult = Awaited<ReturnType<typeof getBiosStatus>>;
+
+/** Stand-in for a BIOS read that failed, read as "no BIOS need known".
+ *  {@link refreshBiosStatus} leaves the shown level standing on it;
+ *  {@link refreshCoreAndBios} re-derives from it, because a core switch may
+ *  genuinely have removed the requirement. */
+const NO_BIOS_STATUS: BiosStatusResult = { bios_status: null, bios_level: null, bios_label: null };
+
+interface Entry {
+  state: GameDetailState;
+  listeners: Set<(state: GameDetailState) => void>;
+  /** Bumped when the entry is torn down, so a read that resolves afterwards
+   *  cannot write into a state nobody is showing any more. */
+  generation: number;
+  saveStatusInFlight: Promise<SaveStatus | null> | null;
+  detachListeners: () => void;
+}
+
+const _entries = new Map<number, Entry>();
+
+/** Read this appId's shared state without subscribing. Returns the neutral
+ *  default for an appId no surface is currently subscribed to. */
+export function getGameDetail(appId: number): GameDetailState {
+  return _entries.get(appId)?.state ?? DEFAULT_STATE;
+}
+
+/**
+ * Subscribe to one appId's shared state. The first subscriber opens the entry —
+ * loading the cached detail and attaching the entry's event listeners — and the
+ * last unsubscribe closes it again, so nothing is left listening for a game page
+ * that is no longer on screen.
+ */
+export function subscribeGameDetail(appId: number, cb: (state: GameDetailState) => void): () => void {
+  const entry = openEntry(appId);
+  entry.listeners.add(cb);
+  return () => {
+    entry.listeners.delete(cb);
+    if (entry.listeners.size === 0 && _entries.get(appId) === entry) closeEntry(appId, entry);
+  };
+}
+
+/** Subscribe to one appId's shared state from a component. Re-renders the
+ *  caller on every change; drops its subscription on unmount. Reads through
+ *  React's external-store primitive rather than mirroring into local state, so
+ *  a component handed a different appId renders that appId's state on the same
+ *  pass instead of its predecessor's. */
+export function useGameDetail(appId: number): GameDetailState {
+  const subscribe = useCallback((onChange: () => void) => subscribeGameDetail(appId, onChange), [appId]);
+  const snapshot = useCallback(() => getGameDetail(appId), [appId]);
+  return useSyncExternalStore(subscribe, snapshot);
+}
+
+function openEntry(appId: number): Entry {
+  const existing = _entries.get(appId);
+  if (existing) return existing;
+  const entry: Entry = {
+    state: DEFAULT_STATE,
+    listeners: new Set(),
+    generation: 0,
+    saveStatusInFlight: null,
+    detachListeners: () => {},
+  };
+  _entries.set(appId, entry);
+  entry.detachListeners = attachListeners(appId, entry);
+  detach(loadDetail(appId, entry));
+  return entry;
+}
+
+function closeEntry(appId: number, entry: Entry): void {
+  entry.generation++;
+  entry.saveStatusInFlight = null;
+  entry.detachListeners();
+  _entries.delete(appId);
+}
+
+/** A `setState`-shaped writer bound to one generation of one entry: it applies
+ *  the update and notifies subscribers, and no-ops once that generation is gone.
+ *  Shaped this way so the sectionRefresh helpers can write straight into the
+ *  entry the way they write into a component's state. */
+function writerFor(entry: Entry, generation: number): Dispatch<SetStateAction<GameDetailState>> {
+  return (update) => {
+    if (entry.generation !== generation) return;
+    entry.state = typeof update === "function" ? update(entry.state) : update;
+    entry.listeners.forEach((listener) => listener(entry.state));
+  };
+}
+
+/**
+ * Cache-first load: resolve the cached game detail for this appId, fold it into
+ * the entry, and fire the background refreshes (save status, metadata,
+ * achievements, BIOS, core) whose results are merged in as they land.
+ */
+async function loadDetail(appId: number, entry: Entry): Promise<void> {
+  const generation = entry.generation;
+  const cancelled = () => entry.generation !== generation;
+  const write = writerFor(entry, generation);
+  try {
+    const cached = await getCachedGameDetail(appId);
+    const romId = cached.rom_id;
+    // A detail without a rom_id is nothing this store can key on — every read
+    // below and every notification match runs off that identity.
+    if (cancelled() || !cached.found || !romId) return;
+
+    let saveSyncStatus: GameDetailState["saveSyncStatus"] = null;
+    let saveSyncLabel = "";
+    if (cached.save_sync_enabled && cached.save_sync_display) {
+      saveSyncStatus = cached.save_sync_display.status;
+      saveSyncLabel = resolveSaveSyncLabel(cached.save_sync_display);
+    }
+
+    write((prev) => ({
+      ...prev,
+      romId,
+      romName: cached.rom_name || "",
+      platformSlug: cached.platform_slug || "",
+      installed: cached.installed ?? false,
+      fsSizeBytes: cached.fs_size_bytes ?? null,
+      saveSyncEnabled: cached.save_sync_enabled ?? false,
+      saveSyncStatus,
+      saveSyncLabel,
+      raId: cached.ra_id ?? null,
+      // Keep the last-known count when the re-derived cache has no achievement
+      // summary (e.g. a version switch during an offline window, where the
+      // backend progress cache is cold) — don't degrade a shown "7/70" to 0
+      // (#1345). A genuine earned:0 is a real object, so it still shows through.
+      achievementEarned: cached.achievement_summary?.earned ?? prev.achievementEarned,
+      achievementTotal: cached.achievement_summary?.total ?? prev.achievementTotal,
+    }));
+
+    // The live save status carries what the cached detail does not: the active
+    // slot, the content-dir flag, and the conflicts. Fire-and-forget — a failed
+    // read leaves the cached display standing, and a caller that needs to know
+    // reads it again itself.
+    if (cached.save_sync_enabled) detach(refreshSaveStatus(appId));
+
+    const staleFields = cached.stale_fields ?? [];
+
+    if (staleFields.includes("metadata")) {
+      getRomMetadata(romId).catch((e) => debugLog(`Background metadata fetch error: ${e}`));
+    }
+
+    if (cached.ra_id && staleFields.includes("achievements")) {
+      refreshAchievementsInBackground(romId, cancelled, write);
+    }
+
+    if (cached.bios_status) {
+      write((prev) => ({
+        ...prev,
+        ...extractBiosInfo(cached.bios_level ?? null, cached.bios_label ?? null),
+      }));
+    }
+
+    if (staleFields.includes("bios")) {
+      refreshBiosInBackground(romId, cancelled, write);
+    }
+
+    // Core info is sourced from its OWN path (#923), independent of BIOS status,
+    // and keyed on rom_id so the active core reflects a per-game DB override
+    // (epic #945).
+    refreshCoreInfoInBackground(romId, cancelled, write);
+  } catch (e) {
+    // Shared by the mount load and the version-switch re-derive — a failed cache
+    // load leaves every subscribed surface stale either way, so surface at warn
+    // level (debugLog is dropped at the default log level).
+    logError(`gameDetailStore: load error: ${e}`);
+  }
+}
+
+/**
+ * Read this ROM's save status and fold it into the entry.
+ *
+ * Callers that overlap share one request: the second caller gets the first
+ * caller's promise instead of a second `get_save_status` round-trip. Resolves to
+ * `null` — leaving the shown display untouched — when the identity is not
+ * resolved yet, or when the backend refuses the read (a prune-active refusal is
+ * not a save-status answer). Rejects when the call itself fails, so each caller
+ * reports the failure in its own terms. Whether a ROM with save sync switched
+ * off is worth reading at all is the caller's call, not this one's.
+ */
+export function refreshSaveStatus(appId: number): Promise<SaveStatus | null> {
+  const entry = _entries.get(appId);
+  if (!entry) return Promise.resolve(null);
+  if (entry.saveStatusInFlight) return entry.saveStatusInFlight;
+  const romId = entry.state.romId;
+  if (!romId) return Promise.resolve(null);
+
+  const request = readSaveStatus(entry, romId, entry.generation);
+  entry.saveStatusInFlight = request;
+  // Free the slot once this request settles, whichever way it settles. Both
+  // arms of `then` are the same bookkeeping, and giving it a rejection arm is
+  // what keeps this branch from surfacing as an unhandled rejection — the
+  // rejection callers see is the one on `request` itself.
+  const release = () => {
+    if (entry.saveStatusInFlight === request) entry.saveStatusInFlight = null;
+  };
+  request.then(release, release);
+  return request;
+}
+
+/** The read itself, as an async function so a synchronous throw comes back as a
+ *  rejection like every other failure — a caller that gets a promise must not
+ *  also have to guard the call. */
+async function readSaveStatus(entry: Entry, romId: number, generation: number): Promise<SaveStatus | null> {
+  const result = await getSaveStatus(romId);
+  if (isCallableFailure(result)) {
+    detach(debugLog(`gameDetailStore: save status refused: ${result.message}`));
+    return null;
+  }
+  applySaveStatus(entry, generation, result);
+  return result;
+}
+
+/** Fold a save status — freshly read or carried on a notification — into the
+ *  entry. The single place a save status becomes shown state, so no two
+ *  surfaces can derive it differently. */
+function applySaveStatus(entry: Entry, generation: number, status: SaveStatus): void {
+  const { status: saveSyncStatus, label: saveSyncLabel } = applySaveSyncDisplay(status.save_sync_display, status);
+  writerFor(
+    entry,
+    generation,
+  )((prev) => ({
+    ...prev,
+    saveStatus: status,
+    saveSyncStatus,
+    saveSyncLabel,
+    savefilesInContentDir: status.savefiles_in_content_dir === true,
+    activeSlot: "active_slot" in status ? (status.active_slot ?? null) : prev.activeSlot,
+  }));
+}
+
+/** Record a save-sync display a surface already knows to be true — the "Just
+ *  now" after a manual sync, the "No saves" after a local delete — without
+ *  waiting for a round-trip to confirm it. */
+export function noteSaveSyncDisplay(appId: number, display: SaveSyncDisplay): void {
+  const entry = _entries.get(appId);
+  if (!entry) return;
+  writerFor(
+    entry,
+    entry.generation,
+  )((prev) => ({
+    ...prev,
+    saveSyncStatus: display.status,
+    saveSyncLabel: resolveSaveSyncLabel(display),
+  }));
+}
+
+/** Re-read the BIOS level after a firmware download. Leaves the shown level
+ *  alone when the read fails or reports no BIOS need. */
+export async function refreshBiosStatus(appId: number): Promise<void> {
+  const entry = _entries.get(appId);
+  const romId = entry?.state.romId;
+  if (!entry || !romId) return;
+  const generation = entry.generation;
+  const refreshed = await getBiosStatus(romId).catch(() => NO_BIOS_STATUS);
+  if (!refreshed.bios_status) return;
+  writerFor(
+    entry,
+    generation,
+  )((prev) => ({
+    ...prev,
+    biosStatus: refreshed.bios_level,
+    biosLabel: refreshed.bios_label ?? "",
+  }));
+}
+
+/**
+ * Re-read core selection and BIOS after an override was pinned or cleared, and
+ * drop the cached detail so the next read sees the new core.
+ *
+ * `biosNeeded` is re-derived from the refreshed status rather than kept: the
+ * active core just changed, so the BIOS requirement may have changed with it
+ * (#923).
+ */
+export async function refreshCoreAndBios(appId: number): Promise<void> {
+  const entry = _entries.get(appId);
+  const romId = entry?.state.romId;
+  if (!entry || !romId) return;
+  const generation = entry.generation;
+  const [coreInfo, refreshed] = await Promise.all([
+    getPlatformCoreInfo(romId),
+    getBiosStatus(romId).catch(() => NO_BIOS_STATUS),
+  ]);
+  writerFor(
+    entry,
+    generation,
+  )((prev) => ({
+    ...prev,
+    ...extractCoreInfo(coreInfo),
+    biosNeeded: !!refreshed.bios_status,
+    biosStatus: refreshed.bios_level,
+    biosLabel: refreshed.bios_label ?? "",
+  }));
+  invalidateCachedGameDetail(appId);
+}
+
+/** Re-read the cached detail after something invalidated it. */
+async function reloadDetail(appId: number, entry: Entry): Promise<void> {
+  invalidateCachedGameDetail(appId);
+  await loadDetail(appId, entry);
+}
+
+async function handleSaveSyncSettingsChange(
+  appId: number,
+  entry: Entry,
+  detail: Extract<RommDataChangedDetail, { type: "save_sync_settings" }>,
+): Promise<void> {
+  if (!detail.save_sync_enabled) {
+    // Save sync turned off entirely — the content-dir banner is meaningless.
+    writerFor(
+      entry,
+      entry.generation,
+    )((prev) => ({
+      ...prev,
+      saveSyncEnabled: false,
+      saveSyncStatus: null,
+      saveSyncLabel: "",
+      savefilesInContentDir: false,
+    }));
+    return;
+  }
+  writerFor(entry, entry.generation)((prev) => ({ ...prev, saveSyncEnabled: true }));
+  await refreshSaveStatus(appId).catch(() => null);
+}
+
+async function handleSaveSyncChange(
+  appId: number,
+  entry: Entry,
+  detail: Extract<RommDataChangedDetail, { type: "save_sync" }>,
+): Promise<void> {
+  const romId = entry.state.romId;
+  // An event that cannot be proven to be about THIS game is dropped, and an
+  // unresolved rom_id proves nothing (#975): adopting the event's own rom_id
+  // here would show another game's save status on this page. Nothing is lost —
+  // the load in flight brings this ROM's status with it.
+  if (!romId) return;
+  if (detail.rom_id && detail.rom_id !== romId) return;
+  if (detail.save_status) {
+    applySaveStatus(entry, entry.generation, detail.save_status);
+    return;
+  }
+  await refreshSaveStatus(appId).catch(() => null);
+}
+
+async function handleCoreChange(entry: Entry): Promise<void> {
+  const romId = entry.state.romId;
+  if (!romId) return;
+  const generation = entry.generation;
+  // Core data comes from the dedicated core-info path (#923), keyed on rom_id so
+  // the active core reflects a per-game DB override (epic #945). BIOS
+  // level/label still come from the (now core-free) BIOS status — the active
+  // core just switched, so the BIOS requirements may have changed.
+  const [coreInfo, biosResult] = await Promise.all([getPlatformCoreInfo(romId), getBiosStatus(romId)]);
+  writerFor(
+    entry,
+    generation,
+  )((prev) => ({
+    ...prev,
+    ...extractCoreInfo(coreInfo),
+    biosNeeded: !!biosResult.bios_status,
+    biosStatus: biosResult.bios_level,
+    biosLabel: biosResult.bios_label ?? "",
+  }));
+}
+
+function attachListeners(appId: number, entry: Entry): () => void {
+  const onDataChanged = (e: Event) => {
+    detach(
+      (async () => {
+        try {
+          const detail = (e as CustomEvent).detail;
+          switch (detail?.type) {
+            case "save_sync_settings":
+              await handleSaveSyncSettingsChange(appId, entry, detail);
+              break;
+            case "core_changed":
+              await handleCoreChange(entry);
+              break;
+            case "save_sync":
+              await handleSaveSyncChange(appId, entry, detail);
+              break;
+            case "version_switched":
+              // A version switch re-bound this appId to a new rom_id. The picker
+              // already invalidated the cached detail, so re-deriving the whole
+              // entry is enough to re-key every rom_id-driven read.
+              if (detail.app_id === appId) await loadDetail(appId, entry);
+              break;
+          }
+        } catch (err) {
+          detach(debugLog(`gameDetailStore: onDataChanged error: ${err}`));
+        }
+      })(),
+    );
+  };
+  globalThis.addEventListener("romm_data_changed", onDataChanged);
+
+  // Install-state reactivity (#1395): a download or an uninstall changes
+  // `installed` + `fs_size_bytes`, so the cached detail is dropped first and the
+  // whole entry re-derived — reading it back inside the 3s TTL would return the
+  // pre-change state.
+  const onDownloadComplete = addEventListener<[DownloadCompleteEvent]>("download_complete", (evt) => {
+    if (evt.rom_id !== entry.state.romId) return;
+    detach(reloadDetail(appId, entry));
+  });
+
+  const onUninstalled = (e: Event) => {
+    const romId = (e as CustomEvent).detail?.rom_id;
+    if (romId !== entry.state.romId) return;
+    detach(reloadDetail(appId, entry));
+  };
+  globalThis.addEventListener("romm_rom_uninstalled", onUninstalled);
+
+  return () => {
+    globalThis.removeEventListener("romm_data_changed", onDataChanged);
+    removeEventListener("download_complete", onDownloadComplete);
+    globalThis.removeEventListener("romm_rom_uninstalled", onUninstalled);
+  };
+}

--- a/src/utils/gameDetailStore.ts
+++ b/src/utils/gameDetailStore.ts
@@ -117,13 +117,23 @@ type BiosStatusResult = Awaited<ReturnType<typeof getBiosStatus>>;
  *  genuinely have removed the requirement. */
 const NO_BIOS_STATUS: BiosStatusResult = { bios_status: null, bios_level: null, bios_label: null };
 
+/** A save-status read still in flight, together with the rom identity it was
+ *  issued for. A version switch re-keys the entry to a new rom_id without
+ *  closing it, so the generation is unchanged and the identity is the only thing
+ *  that distinguishes an answer about this page's ROM from one about its
+ *  predecessor. */
+interface InFlightSaveStatus {
+  romId: number;
+  promise: Promise<SaveStatus | null>;
+}
+
 interface Entry {
   state: GameDetailState;
   listeners: Set<(state: GameDetailState) => void>;
   /** Bumped when the entry is torn down, so a read that resolves afterwards
    *  cannot write into a state nobody is showing any more. */
   generation: number;
-  saveStatusInFlight: Promise<SaveStatus | null> | null;
+  saveStatusInFlight: InFlightSaveStatus | null;
   detachListeners: () => void;
 }
 
@@ -281,28 +291,34 @@ async function loadDetail(appId: number, entry: Entry): Promise<void> {
  * Read this ROM's save status and fold it into the entry.
  *
  * Callers that overlap share one request: the second caller gets the first
- * caller's promise instead of a second `get_save_status` round-trip. Resolves to
- * `null` — leaving the shown display untouched — when the identity is not
- * resolved yet, or when the backend refuses the read (a prune-active refusal is
- * not a save-status answer). Rejects when the call itself fails, so each caller
- * reports the failure in its own terms. Whether a ROM with save sync switched
- * off is worth reading at all is the caller's call, not this one's.
+ * caller's promise instead of a second `get_save_status` round-trip — but only
+ * while it is a read of the rom_id bound to this appId now. A read left open
+ * across a version switch is about the previous ROM, so a caller arriving after
+ * the switch gets a fresh read rather than the answer to a question about
+ * another game.
+ *
+ * Resolves to `null` — leaving the shown display untouched — when the identity
+ * is not resolved yet, or when the backend refuses the read (a prune-active
+ * refusal is not a save-status answer). Rejects when the call itself fails, so
+ * each caller reports the failure in its own terms. Whether a ROM with save sync
+ * switched off is worth reading at all is the caller's call, not this one's.
  */
 export function refreshSaveStatus(appId: number): Promise<SaveStatus | null> {
   const entry = _entries.get(appId);
   if (!entry) return Promise.resolve(null);
-  if (entry.saveStatusInFlight) return entry.saveStatusInFlight;
   const romId = entry.state.romId;
   if (!romId) return Promise.resolve(null);
+  const inFlight = entry.saveStatusInFlight;
+  if (inFlight && inFlight.romId === romId) return inFlight.promise;
 
   const request = readSaveStatus(entry, romId, entry.generation);
-  entry.saveStatusInFlight = request;
+  entry.saveStatusInFlight = { romId, promise: request };
   // Free the slot once this request settles, whichever way it settles. Both
   // arms of `then` are the same bookkeeping, and giving it a rejection arm is
   // what keeps this branch from surfacing as an unhandled rejection — the
   // rejection callers see is the one on `request` itself.
   const release = () => {
-    if (entry.saveStatusInFlight === request) entry.saveStatusInFlight = null;
+    if (entry.saveStatusInFlight?.promise === request) entry.saveStatusInFlight = null;
   };
   request.then(release, release);
   return request;
@@ -323,8 +339,12 @@ async function readSaveStatus(entry: Entry, romId: number, generation: number): 
 
 /** Fold a save status — freshly read or carried on a notification — into the
  *  entry. The single place a save status becomes shown state, so no two
- *  surfaces can derive it differently. */
+ *  surfaces can derive it differently, and the last gate on whose status it is:
+ *  a status whose `rom_id` is not the one bound to this appId is another game's
+ *  (#975), whether it arrived on a notification carrying no `rom_id` of its own
+ *  or from a read issued before a version switch re-keyed the entry. */
 function applySaveStatus(entry: Entry, generation: number, status: SaveStatus): void {
+  if (status.rom_id !== entry.state.romId) return;
   const { status: saveSyncStatus, label: saveSyncLabel } = applySaveSyncDisplay(status.save_sync_display, status);
   writerFor(
     entry,

--- a/src/utils/sectionRefresh.test.ts
+++ b/src/utils/sectionRefresh.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { Dispatch, SetStateAction } from "react";
 import {
-  refreshActiveSlotInBackground,
   refreshBiosInBackground,
   refreshCoreInfoInBackground,
   refreshAchievementsInBackground,
@@ -9,11 +8,6 @@ import {
 import * as backend from "../api/backend";
 import { libretroEmu } from "../test-utils/coreFixtures";
 import type { EmulatorOption } from "../types";
-
-interface ActiveSlotState {
-  activeSlot: string | null;
-  unrelated: number;
-}
 
 interface BiosState {
   biosNeeded: boolean;
@@ -56,97 +50,6 @@ function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void; reje
   });
   return { promise, resolve, reject };
 }
-
-describe("refreshActiveSlotInBackground", () => {
-  beforeEach(() => vi.restoreAllMocks());
-
-  it("applies active_slot to the setter when not cancelled", async () => {
-    vi.mocked(backend.getSaveStatus).mockResolvedValueOnce({
-      active_slot: "slot-2",
-    } as unknown as Awaited<ReturnType<typeof backend.getSaveStatus>>);
-
-    const setter = vi.fn<(updater: (prev: ActiveSlotState) => ActiveSlotState) => void>();
-    refreshActiveSlotInBackground(1, () => false, setter as unknown as Dispatch<SetStateAction<ActiveSlotState>>);
-    await flushMicrotasks();
-
-    expect(setter).toHaveBeenCalledOnce();
-    const updater = setter.mock.calls[0]![0];
-    expect(updater({ activeSlot: null, unrelated: 7 })).toEqual({
-      activeSlot: "slot-2",
-      unrelated: 7,
-    });
-  });
-
-  it("skips the setter when cancelled", async () => {
-    vi.mocked(backend.getSaveStatus).mockResolvedValueOnce({
-      active_slot: "slot-2",
-    } as unknown as Awaited<ReturnType<typeof backend.getSaveStatus>>);
-
-    const setter = vi.fn();
-    refreshActiveSlotInBackground(1, () => true, setter);
-    await flushMicrotasks();
-
-    expect(setter).not.toHaveBeenCalled();
-  });
-
-  it("re-reads the cancelled closure after the await (cancelled mid-await)", async () => {
-    const d = deferred<{ active_slot: string }>();
-    vi.mocked(backend.getSaveStatus).mockReturnValueOnce(
-      d.promise as unknown as ReturnType<typeof backend.getSaveStatus>,
-    );
-
-    let cancelled = false;
-    const setter = vi.fn();
-    refreshActiveSlotInBackground(1, () => cancelled, setter);
-
-    // Cancel before the backend call resolves — proves we re-read the closure.
-    cancelled = true;
-    d.resolve({ active_slot: "slot-2" });
-    await flushMicrotasks();
-
-    expect(setter).not.toHaveBeenCalled();
-  });
-
-  it("swallows backend errors without invoking the setter", async () => {
-    vi.mocked(backend.getSaveStatus).mockRejectedValueOnce(new Error("network"));
-    const setter = vi.fn();
-    refreshActiveSlotInBackground(1, () => false, setter);
-    await flushMicrotasks();
-    // active-slot's `.catch` has no observable side effect beyond skipping the
-    // setter; asserting the setter never fires is the post-catch state.
-    expect(setter).not.toHaveBeenCalled();
-  });
-
-  it("preserves the active slot on a prune-active callable failure", async () => {
-    vi.mocked(backend.getSaveStatus).mockResolvedValueOnce({
-      success: false,
-      reason: "prune_active",
-      message: "Cleanup is active.",
-    });
-    const setter = vi.fn();
-
-    refreshActiveSlotInBackground(1, () => false, setter);
-    await flushMicrotasks();
-
-    expect(setter).not.toHaveBeenCalled();
-  });
-
-  it("falls back to null when active_slot is missing", async () => {
-    vi.mocked(backend.getSaveStatus).mockResolvedValueOnce({
-      active_slot: null,
-    } as unknown as Awaited<ReturnType<typeof backend.getSaveStatus>>);
-
-    const setter = vi.fn<(updater: (prev: ActiveSlotState) => ActiveSlotState) => void>();
-    refreshActiveSlotInBackground(1, () => false, setter as unknown as Dispatch<SetStateAction<ActiveSlotState>>);
-    await flushMicrotasks();
-
-    const updater = setter.mock.calls[0]![0];
-    expect(updater({ activeSlot: "x", unrelated: 1 })).toEqual({
-      activeSlot: null,
-      unrelated: 1,
-    });
-  });
-});
 
 describe("refreshBiosInBackground", () => {
   beforeEach(() => vi.restoreAllMocks());

--- a/src/utils/sectionRefresh.ts
+++ b/src/utils/sectionRefresh.ts
@@ -8,37 +8,12 @@
  */
 
 import type { Dispatch, SetStateAction } from "react";
-import {
-  getSaveStatus,
-  getBiosStatus,
-  getPlatformCoreInfo,
-  getAchievementProgress,
-  debugLog,
-  isCallableFailure,
-} from "../api/backend";
+import { getBiosStatus, getPlatformCoreInfo, getAchievementProgress, debugLog } from "../api/backend";
 import { extractBiosInfo, extractCoreInfo, type BiosInfoFields, type CoreInfoFields } from "./playSection";
-
-interface ActiveSlotFields {
-  activeSlot: string | null;
-}
 
 interface AchievementFields {
   achievementEarned: number;
   achievementTotal: number;
-}
-
-export function refreshActiveSlotInBackground<S extends ActiveSlotFields>(
-  romId: number,
-  cancelled: () => boolean,
-  setter: Dispatch<SetStateAction<S>>,
-): void {
-  getSaveStatus(romId)
-    .then((saveStatus) => {
-      if (!cancelled() && !isCallableFailure(saveStatus) && "active_slot" in saveStatus) {
-        setter((prev) => ({ ...prev, activeSlot: saveStatus.active_slot ?? null }));
-      }
-    })
-    .catch(() => {});
 }
 
 export function refreshBiosInBackground<S extends BiosInfoFields>(


### PR DESCRIPTION
Three components mount on the same Steam game-detail page and each kept its own copy of the
bound rom_id, install state, save-sync status, BIOS level and core selection, coordinating
through the `romm_data_changed` DOM event. Their `save_sync` / `save_sync_settings` /
`core_changed` handlers were written twice and had drifted apart.

`src/utils/gameDetailStore.ts` now holds that state, one entry per appId: the first surface to
subscribe opens it, the last to unsubscribe closes it, so a page that is off screen holds
nothing and listens to nothing. The DOM bus is unchanged and keeps carrying the notifications —
one handler per appId folds an event into the entry, and every subscriber renders from that one
fold. The 25 dispatch sites are untouched.

`RomMPlaySection` is the first surface moved onto it, and the only one in this change;
`CustomPlayButton` and `RomMGameInfoPanel` follow separately. Its `romIdRef` bookkeeping is
gone. What stays local is what only it reads: the PLAYTIME / LAST PLAYED pair.

The drift is what produced #975. `RomMGameInfoPanel` already dropped a save-sync notification it
could not attribute to the page's rom; `RomMPlaySection` instead fell back to the event's own
rom_id while its identity was still unresolved, so a notification about another game fetched and
displayed that game's save status. One handler cannot diverge from itself, and it now drops what
it cannot attribute.

Two guards keep an answer bound to the rom it was asked about. The shared in-flight save-status
request is keyed by rom, so a version switch that lands mid-request issues a fresh read instead
of being handed the previous rom's; and a status is only folded when its rom_id matches the
entry's. The generation counter cannot cover this on its own — a version switch does not close
and reopen the entry, it swaps the rom inside it.

Overlapping reads for one appId share a single request. Thirteen of fifteen `save_sync`
notifications carry no status, so each listener used to read for itself; the sharing is what
makes that cost one round-trip rather than one per mounted surface, without changing a single
dispatch site.

The content-dir banner is now gated on save sync being enabled, matching its sibling two lines
above. On main every writer of that flag sat behind the setting, so the banner could not appear
with save sync off; consolidating the folds moved the write onto the notification path, and the
gate restores the previous behavior with the fact in the store and the policy at the display.

`refreshActiveSlotInBackground` lost its last caller to this change and is deleted with its
tests.

Closes #975
Refs #993
