### PR TITLE
fix(downloads): do not bake a launch command for a download the system cannot launch

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -156,6 +156,24 @@ stored as a separate boolean ([ADR-0008](docs/adr/0008-rom-install-launch-file-a
 [#129](https://github.com/danielcopper/decky-romm-sync/issues/129); it is an additive 1:N child of `rom_installs`
 (deferred until those land), and `file_path` + `rom_dir` are its forward-compatible projection.
 
+### Launchable install / no launch target
+
+A downloaded ROM whose recorded **launch file** is something the system cannot act on — a PS3 `.pkg` installer (the game
+is still sealed inside the package), a bare disc track `.bin`. `detect_launch_file` ends in "largest file by size", so a
+download none of its format rules recognise still yields a `file_path`; `RomInstall.launchable` records whether that
+path is a real launch target, decided once at download-complete against the system's live ES-DE accept-list
+([#1652](https://github.com/danielcopper/decky-romm-sync/issues/1652)).
+
+"No launch target" is a statement about the **launch command**, never about the download. The files stay on disk, the
+install row is written, and uninstall works normally — installing the package by hand in the emulator is the documented
+RetroDECK procedure and a refusal that discarded the download would leave the user worse off. What is withheld is the
+baked `launch_options`: an unlaunchable install resolves to the empty path in the `DiscLaunchResolver` seam, so every
+bake site emits the same empty launch command an **un-downloaded** ROM's shortcut carries.
+
+Unlaunchable is always a **proven** verdict, never the absence of one: an unreadable accept-list, an unknown system, and
+a pre-migration row all read as launchable. The foil is a **folder-boot** install, whose `file_path` extension is
+irrelevant because the baked target is the game directory.
+
 ### platform_slug (denormalized)
 
 The RomM platform identifier (e.g. `gba`, `psx`) carried as a plain string on the rows that need it (`roms`,

--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -1056,6 +1056,59 @@ domain functions (`needs_m3u`, `detect_launch_file`) take `m3u_supported`, never
 bundled `.m3u` is left inert on disk, never deleted. When `es_systems.xml` cannot be found the answer defaults to
 `False` (safe: a missing playlist only degrades disc-switching, a wrong one breaks the launch).
 
+#### Launch-target validation
+
+`detect_launch_file` ends in "largest file by size". When none of its format-specific rules match, whatever happens to
+be biggest becomes the launch target, is written into `RomInstall.file_path`, and becomes the shortcut's launch command
+— with nothing checking whether the system can act on it. A PS3 title distributed as `.pkg` + `.rap` is the reported
+case ([#1582](https://github.com/danielcopper/decky-romm-sync/issues/1582)): a PKG is an installer, the game is still
+sealed inside it, no `EBOOT.BIN` exists anywhere in the download, so every rule misses and the multi-gigabyte package is
+baked. The download reports success and the failure only surfaces when the user presses play.
+
+**The verdict is decided once, at record time.** `_record_install_io` — the single seam both the single-file and
+multi-file download paths pass through — calls `is_launchable_target` (`domain/rom_files.py`) and records the answer on
+`RomInstall.launchable`. The check reads the target system's live ES-DE accept-list through the
+`SystemSupportedExtensionsFn` Protocol, the same seam `DiscLaunchResolver` intersects the disc set with. Two cases pass
+without consulting it:
+
+- **An empty accept-list** — the source could not answer (unknown system, no ES-DE installation). A missing answer must
+  never turn a working install into an unlaunchable one, so it accepts.
+- **A folder-boot layout** (`FOLDER_BOOT_MARKERS`) — the baked target is the game _directory_, not the nested
+  `EBOOT.BIN` that `file_path` records, and ES-DE spells the directory case `.ps3dir`. The marker match is positive
+  evidence that the plugin recognised the layout, so no extension is examined. Without this carve-out every working PS3
+  dump would be rejected: `file_path` ends in `.bin`, which ps3's accept-list (`.desktop .iso .ps3 .ps3dir`) does not
+  carry.
+
+Everything else is decided by the recorded launch file's extension. `.pkg` is absent from ps3's list; a bare track
+`.bin` is absent from dreamcast's (`.cdi .chd .cue .dat .elf .gdi .iso .lst .m3u .7z .zip`), which is why a multi-file
+GDI rip without a `.cue` is caught by the same rule.
+
+**The files are always kept.** An unlaunchable download is a real install: the row is written, the ROM is uninstallable
+through the normal path, and nothing is deleted. Refusing the install would discard a package whose remaining use is
+exactly to be installed by hand in the emulator — the documented RetroDECK procedure for PSN titles — leaving the user
+worse off than the silent failure this replaces. What is withheld is only the launch command.
+
+**One seam withholds it everywhere.** `DiscLaunchResolver.resolve_bake_path` returns `""` for an install with
+`launchable is False`, before any disc work, and `build_launch_options` renders an empty path as the empty launch
+command. Every launch-bake site already draws its path from that resolver — library sync's `installed_paths` map,
+download-complete's re-bake, the core-change re-bake, the startup relaunch-options heal, the disc picker — so none of
+them can compose a command for content nothing can boot, and none needed a guard of its own. The resulting shortcut
+carries the same empty `launch_options` an un-downloaded ROM's does. An unlaunchable install stays **in** the
+`installed_paths` map (it _is_ downloaded, and `collapse_sibling_groups` reads the key set to choose a sibling group's
+representative) and maps to the empty path.
+
+The frontend closes the loop in two places: the shared launch gate blocks with `no_launch_target` before any save-sync
+work — for both the Play button and the global launch watcher — and the game-detail page's **ROM File** section states
+that the download has no launchable format and that the files are on disk. Re-checking a recorded verdict once the user
+has installed the package in the emulator is separate work
+([#1654](https://github.com/danielcopper/decky-romm-sync/issues/1654)).
+
+**Where the knowledge comes from.** The accept-list is read from the plugin's own `es_systems.xml` parser
+(`CoreResolver.get_supported_extensions`), wired in as `DownloadServiceConfig.system_extensions`. That parser duplicates
+one emu-atlas already has, and the resolver adoption is meant to remove it — so the consuming call site is deliberately
+a single `self._system_extensions(system)` behind one Protocol-typed config field. Swapping the source is a change to
+that wiring line.
+
 Filesystem writes go through `DownloadFileAdapter`. ZIP extraction is ZIP-slip protected and streamed: `extract_zip`
 copies each member in chunks and reports byte progress through an optional callback, so a multi-file ROM emits
 `download_progress` frames with `status: "extracting"` (`bytes_downloaded`/`total_bytes` over the **uncompressed**

--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -1092,10 +1092,18 @@ worse off than the silent failure this replaces. What is withheld is only the la
 `launchable is False`, before any disc work, and `build_launch_options` renders an empty path as the empty launch
 command. Every launch-bake site already draws its path from that resolver — library sync's `installed_paths` map,
 download-complete's re-bake, the core-change re-bake, the startup relaunch-options heal, the disc picker — so none of
-them can compose a command for content nothing can boot, and none needed a guard of its own. The resulting shortcut
-carries the same empty `launch_options` an un-downloaded ROM's does. An unlaunchable install stays **in** the
-`installed_paths` map (it _is_ downloaded, and `collapse_sibling_groups` reads the key set to choose a sibling group's
-representative) and maps to the empty path.
+them can compose a command for content nothing can boot, and none needed a guard of its own. An unlaunchable install
+stays **in** the `installed_paths` map (it _is_ downloaded, and `collapse_sibling_groups` reads the key set to choose a
+sibling group's representative) and maps to the empty path.
+
+Empty is the **established** uninstalled state, not one invented here: `addShortcut` leaves a new shortcut's options
+untouched when the command is `""` (`src/utils/steamShortcuts.ts`), the sync update/adoption path writes `""` explicitly
+(`rewriteShortcutIdentity`, `src/utils/syncManager.ts`), and an uninstall records `""` as the ROM's
+`applied_launch_options` (`services/rom_removal.py`). **An empty launch command therefore means two things, and nothing
+may infer which**: "not downloaded" and "downloaded but not launchable" are indistinguishable at the Steam-shortcut
+layer — the shortcut holds `""` either way. Only the data layer separates them (no `rom_installs` row versus a row with
+`launchable = 0`), so a consumer that needs to tell them apart must ask the install record, never read emptiness as "not
+downloaded". The rule is restated on `build_launch_options` itself, where a later reader will hit it.
 
 The frontend closes the loop in two places: the shared launch gate blocks with `no_launch_target` before any save-sync
 work — for both the Play button and the global launch watcher — and the game-detail page's **ROM File** section states

--- a/docs/architecture/database-design.md
+++ b/docs/architecture/database-design.md
@@ -594,6 +594,22 @@ migration (the app only ever wrote `'user'` / `'smart'`), so the rewrite can nev
 `enabled_collections` bucket rename (`user → standard`) is the separate schema migration **v12 → v13** in
 `domain/state_migrations.py`.
 
+`023_add_rom_install_launchable.sql` (`user_version = 23`) adds `rom_installs.launchable INTEGER NOT NULL DEFAULT 1` —
+whether the system can act on the install's `file_path` at all
+([#1652](https://github.com/danielcopper/decky-romm-sync/issues/1652)). `detect_launch_file` ends in "largest file by
+size", so a download none of its format rules recognise still produces a `file_path`, and that path became the
+shortcut's launch command with nothing checking it; the reported case is a PS3 title shipped as `.pkg` + `.rap`, where
+the PKG is an installer and the game is still sealed inside it
+([#1582](https://github.com/danielcopper/decky-romm-sync/issues/1582)). The verdict is decided once at download-complete
+and recorded here; the behavior it drives is in
+[Launch-target validation](backend-architecture.md#launch-target-validation).
+
+`NOT NULL DEFAULT 1` — existing rows are launchable **by assumption, not by re-assessment**. They were downloaded under
+the old behaviour and their shortcuts work (or do not) exactly as before; flipping any of them to `0` would need an
+accept-list this DDL cannot consult. A ROM re-downloaded after the migration gets a real verdict. Unlaunchable is always
+a proven verdict, never the absence of one — the same reason the aggregate field and the check's unknown-system branch
+both default to launchable.
+
 ## The runtime Unit of Work
 
 The schema is read and written at runtime through a **Unit of Work** (UoW) — the atomic transaction boundary one

--- a/docs/user-guide/managing-games.md
+++ b/docs/user-guide/managing-games.md
@@ -271,6 +271,20 @@ no playlist either way.
     loose files — or, on cartridge systems, as a stray `.m3u`. The fix only affects new downloads; re-download the game
     to get the single clean ES-DE entry.
 
+### When a download has nothing launchable
+
+A few titles are distributed as an **installer** rather than as playable content — most commonly a PS3 game shipped as a
+`.pkg` (plus a `.rap` licence file), where the game stays sealed inside the package until an emulator installs it. A
+disc rip that arrived as raw `.bin` tracks with no `.cue` or `.gdi` alongside them has the same problem.
+
+The plugin checks what the download actually produced against the list of formats the system can open. When nothing in
+it qualifies, the shortcut is left **without a launch command** and the game's **ROM File** section says so, instead of
+writing a command that would fail the first time you press Play. Pressing Play shows the same explanation.
+
+**Your download is kept.** The files stay on disk where the ROM would normally live, and **Uninstall** works as usual —
+because installing the package by hand in the emulator is exactly what you would do next. See
+[the troubleshooting entry](troubleshooting.md#the-download-has-no-launchable-file) for how.
+
 ## Picking a Disc for Multi-Disc Games
 
 When an installed game has more than one disc, a small **disc dropdown** appears on the game detail page, right next to

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -33,6 +33,26 @@ for details.
 **Fix**: Open the game's detail page and tap **Download** in the RomM Sync panel. The game will be playable once the
 download completes.
 
+### The download has no launchable file
+
+**Symptom**: The download finished, but pressing Play shows a toast saying the download has no file the emulator can
+launch. The game's detail page repeats it under **ROM File**.
+
+**What happened**: Some titles are distributed as an _installer_ rather than as playable content. The clearest case is a
+PS3 game shipped as a `.pkg` (plus a `.rap` licence file): the game is sealed inside the package until an emulator
+installs it, so there is nothing for a shortcut to launch. The same applies to a disc rip that arrived as raw `.bin`
+tracks with no `.cue` or `.gdi` alongside them.
+
+Rather than write a launch command that cannot work, the plugin leaves the shortcut without one and says so. **Your
+download is not deleted** — the files are on disk exactly where the ROM would normally live.
+
+**Fix**: Install the content in the emulator yourself. For a PS3 `.pkg`, that is RetroDECK's documented procedure — open
+**RetroDECK → Configurator → Open Emulator → RPCS3**, use **File → Install Packages (PKG)**, point it at the downloaded
+`.pkg`, and install the `.rap` licence the same way. Launching from Steam once a package is installed is not supported
+yet; start it from RPCS3 in the meantime.
+
+To find the files, open the game's detail page — the **ROM File** section shows the filename the download produced.
+
 ### Controller doesn't work in RetroArch menus
 
 **Symptom**: The game plays fine, but the RetroArch Quick Menu (L3+R3) can't be navigated with the controller — only

--- a/py_modules/adapters/repositories/rom_install.py
+++ b/py_modules/adapters/repositories/rom_install.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     import sqlite3
     from collections.abc import Iterator
 
-_COLUMNS = "rom_id, file_path, rom_dir, platform_slug, system, installed_at"
+_COLUMNS = "rom_id, file_path, rom_dir, platform_slug, system, installed_at, launchable"
 
 
 def _row_to_install(row: sqlite3.Row) -> RomInstall:
@@ -22,11 +22,16 @@ def _row_to_install(row: sqlite3.Row) -> RomInstall:
         platform_slug=row["platform_slug"],
         system=row["system"],
         installed_at=row["installed_at"],
+        launchable=bool(row["launchable"]),
     )
 
 
 class SqliteRomInstallRepository(BaseRepository):
-    """Install records — present only while a ROM is downloaded; ``rom_dir`` is NULL for single-file ROMs."""
+    """Install records — present only while a ROM is downloaded; ``rom_dir`` is NULL for single-file ROMs.
+
+    ``launchable`` is a SQLite INTEGER (STRICT tables have no BOOLEAN affinity)
+    round-tripped as a Python bool.
+    """
 
     def get(self, rom_id: int) -> RomInstall | None:
         row = self._conn.execute(
@@ -37,7 +42,7 @@ class SqliteRomInstallRepository(BaseRepository):
 
     def save(self, install: RomInstall) -> None:
         self._conn.execute(
-            f"INSERT OR REPLACE INTO rom_installs ({_COLUMNS}) VALUES (?, ?, ?, ?, ?, ?)",
+            f"INSERT OR REPLACE INTO rom_installs ({_COLUMNS}) VALUES (?, ?, ?, ?, ?, ?, ?)",
             (
                 install.rom_id,
                 install.file_path,
@@ -45,6 +50,7 @@ class SqliteRomInstallRepository(BaseRepository):
                 install.platform_slug,
                 install.system,
                 install.installed_at,
+                int(install.launchable),
             ),
         )
 

--- a/py_modules/bootstrap/services.py
+++ b/py_modules/bootstrap/services.py
@@ -286,6 +286,7 @@ def wire_services(cfg: WiringConfig) -> dict[str, Any]:
             active_core=active_core_resolver,
             disc_resolver=disc_launch_resolver,
             m3u_support=cfg.callbacks.m3u_support,
+            system_extensions=cfg.callbacks.system_extensions,
             uow_factory=cfg.callbacks.uow_factory,
             rom_remover=rom_remover_binding.get,
         ),

--- a/py_modules/db/migrations/023_add_rom_install_launchable.sql
+++ b/py_modules/db/migrations/023_add_rom_install_launchable.sql
@@ -1,0 +1,32 @@
+-- =============================================================================
+-- 023_add_rom_install_launchable.sql — record whether an install can be launched
+-- #1652 (an unlaunchable download is baked into a shortcut anyway)
+-- =============================================================================
+--
+-- ``detect_launch_file`` ends in "largest file by size", so a download none of
+-- its format rules recognise still yields a ``file_path`` — and that path became
+-- the shortcut's launch command with nothing checking whether the system can
+-- boot it. A PS3 title distributed as ``.pkg`` + ``.rap`` is the reported case:
+-- the PKG is an installer, the game is sealed inside it, and the shortcut hands
+-- RPCS3 an argument it cannot act on. The download reports success; the failure
+-- only appears when the user presses play.
+--
+--   * rom_installs.launchable — whether the system's accept-list covers
+--     ``file_path`` (or the install is a recognised folder-boot layout).
+--
+-- The files stay on disk either way: a refusal that discarded the download would
+-- be worse than the silent failure it replaces, because installing the package
+-- by hand in RPCS3 is the documented RetroDECK procedure. An install with
+-- ``launchable = 0`` keeps its row, its files, and its uninstall path; only the
+-- baked launch command is withheld, and the game page states why.
+--
+-- NOT NULL DEFAULT 1 — existing rows are launchable by assumption, not by
+-- re-assessment. They were downloaded under the old behaviour and their
+-- shortcuts work (or do not) exactly as before; flipping any of them to 0 here
+-- would need an accept-list this DDL cannot consult. A ROM re-downloaded after
+-- this migration gets a real verdict.
+--
+-- Transaction-safe DDL only — the runner (adapters/sqlite_migrations.py) wraps
+-- BEGIN/COMMIT and stamps PRAGMA user_version = 23.
+-- -----------------------------------------------------------------------------
+ALTER TABLE rom_installs ADD COLUMN launchable INTEGER NOT NULL DEFAULT 1;  -- 0 = downloaded, no launch target

--- a/py_modules/domain/rom_files.py
+++ b/py_modules/domain/rom_files.py
@@ -192,6 +192,42 @@ def folder_boot_root(launch_path: str, rom_dir: str | None) -> str | None:
     return None
 
 
+def is_launchable_target(file_path: str, rom_dir: str | None, supported_extensions: frozenset[str]) -> bool:
+    """Whether the system can actually launch *file_path* — the download's recorded launch file.
+
+    :func:`detect_launch_file` ends in "largest file by size", so when no
+    format-specific rule matches, whatever happens to be biggest becomes the
+    launch target. A PS3 title distributed as ``.pkg`` + ``.rap`` has no
+    ``EBOOT.BIN`` at all: the PKG is an installer, the game is still sealed
+    inside it, and baking it produces a shortcut the emulator cannot act on.
+    This is the check that catches that before the launch command is written.
+
+    *supported_extensions* is the target system's live accept-list (ES-DE's
+    per-system ``<extension>`` set, lowercased and dot-prefixed). Two cases pass
+    without consulting it:
+
+    - **An empty accept-list** — the source could not answer (unknown system, no
+      ES-DE installation). Default-safe: a missing answer must never turn a
+      working install into an unlaunchable one, so it accepts.
+    - **A folder-boot layout** (:data:`FOLDER_BOOT_MARKERS`) — the baked target
+      is the game *directory*, not the nested ``EBOOT.BIN`` that
+      ``file_path`` records (ES-DE spells the directory case ``.ps3dir``). The
+      marker match is positive evidence that the plugin recognised the layout,
+      so no extension is examined.
+
+    Everything else is decided by the recorded launch file's extension. A
+    ``.pkg`` is absent from ps3's accept-list; a bare track ``.bin`` is absent
+    from dreamcast's — both are caught here.
+
+    Pure path algebra plus a set membership, stdlib only.
+    """
+    if not supported_extensions:
+        return True
+    if folder_boot_root(file_path, rom_dir) is not None:
+        return True
+    return os.path.splitext(file_path)[1].lower() in supported_extensions
+
+
 def folder_boot_layout_root(files: list[str]) -> str | None:
     """Return the game root of a folder-boot layout among *files*, or ``None``.
 

--- a/py_modules/domain/rom_install.py
+++ b/py_modules/domain/rom_install.py
@@ -6,7 +6,10 @@ uninstall. References its Rom by ``rom_id``. Always carries the specific launch
 for folder-backed (multi-file) ROMs — it is ``None`` for single-file ROMs, which
 live as a bare file in the shared system directory and own no folder. The
 denormalized ``platform_slug``/``system`` let migration and save-sort read this
-record without joining the registry.
+record without joining the registry. ``launchable`` records whether the system
+can act on that launch file at all — a download whose content the emulator
+cannot boot (a PS3 ``.pkg`` installer) is still a real install with real files
+on disk, it just has no launch target to bake.
 """
 
 from __future__ import annotations
@@ -24,6 +27,11 @@ class RomInstall:
     platform_slug: str
     system: str
     installed_at: str
+    # Defaults to True so an install whose launchability was never assessed —
+    # a row written before the column existed, a test fixture — keeps the
+    # launch command it already had. Unlaunchable is a proven verdict, never
+    # an absence of one.
+    launchable: bool = True
 
     @classmethod
     def mark_installed(
@@ -35,11 +43,15 @@ class RomInstall:
         platform_slug: str,
         system: str,
         installed_at: str,
+        launchable: bool = True,
     ) -> RomInstall:
         """Record a freshly downloaded ROM installed at ISO timestamp ``installed_at``.
 
         ``rom_dir`` is the dedicated per-ROM directory for a folder-backed
         (multi-file) ROM, or ``None`` for a single-file ROM that owns no folder.
+        ``launchable`` is the caller's verdict on whether the system can act on
+        ``file_path`` (``domain.rom_files.is_launchable_target``); ``False``
+        records a real install with no launch target.
         """
         if rom_id <= 0:
             raise ValueError("rom_id must be positive")
@@ -50,6 +62,7 @@ class RomInstall:
             platform_slug=platform_slug,
             system=system,
             installed_at=installed_at,
+            launchable=launchable,
         )
 
     def relocate(self, new_rom_dir: str | None, new_file_path: str) -> None:

--- a/py_modules/domain/shortcut_data.py
+++ b/py_modules/domain/shortcut_data.py
@@ -142,6 +142,14 @@ def _direct_launch_args(command: str) -> str:
 def build_launch_options(invocation: str, path: str) -> str:
     """Compose the Steam shortcut launch command from *invocation* and ROM *path*.
 
+    An empty *path* means the ROM has **no launch target** — it is not
+    downloaded, or it is downloaded but nothing in it is something the system
+    can boot (``RomInstall.launchable is False``, resolved to ``""`` by the
+    disc-resolver seam every bake site draws its path from). It yields the empty
+    launch command, the same placeholder an un-downloaded ROM's shortcut
+    carries. Composing one anyway would hand the emulator a bare ``""``
+    argument, which is the silent-failure this rule exists to prevent.
+
     The path is double-quoted so paths with spaces survive the launcher's
     ``exec "$@"``. Embedded ``\\`` and ``"`` in the path are backslash-escaped
     (backslash first, then quote) so a server-controlled ROM filename cannot
@@ -149,6 +157,8 @@ def build_launch_options(invocation: str, path: str) -> str:
     emulator invocation. Only the path is escaped — *invocation* is trusted
     build-time text whose own ``-e "..."`` quoting must survive verbatim.
     """
+    if not path:
+        return ""
     escaped = path.replace("\\", "\\\\").replace('"', '\\"')
     return f'{invocation} "{escaped}"'
 
@@ -188,7 +198,11 @@ def build_shortcuts_data(
 
     *installed_paths* maps ``rom_id`` to the resolved on-disk launch path. An
     installed ROM gets a full launch command in ``launch_options``; a ROM absent
-    from the map gets ``""`` (empty placeholder) until it is downloaded.
+    from the map gets ``""`` (empty placeholder) until it is downloaded. An
+    installed ROM the system cannot launch (``RomInstall.launchable is False``)
+    stays IN the map — it is downloaded, and the sibling-group representative
+    choice reads the key set — but maps to the empty path, which
+    :func:`build_launch_options` renders as the same empty placeholder.
 
     *core_overrides* maps ``rom_id`` to the **already-resolved**
     :class:`EmulatorInvocation` the ROM launches with (its full active emulator —

--- a/py_modules/domain/shortcut_data.py
+++ b/py_modules/domain/shortcut_data.py
@@ -142,13 +142,25 @@ def _direct_launch_args(command: str) -> str:
 def build_launch_options(invocation: str, path: str) -> str:
     """Compose the Steam shortcut launch command from *invocation* and ROM *path*.
 
-    An empty *path* means the ROM has **no launch target** — it is not
-    downloaded, or it is downloaded but nothing in it is something the system
-    can boot (``RomInstall.launchable is False``, resolved to ``""`` by the
-    disc-resolver seam every bake site draws its path from). It yields the empty
-    launch command, the same placeholder an un-downloaded ROM's shortcut
-    carries. Composing one anyway would hand the emulator a bare ``""``
-    argument, which is the silent-failure this rule exists to prevent.
+    An empty *path* means the ROM has **no launch target**, and yields the empty
+    launch command. Composing one anyway would hand the emulator a bare ``""``
+    argument — the silent failure this rule exists to prevent.
+
+    **An empty launch command means two different things, and nothing may infer
+    which.** A ROM that is *not downloaded* and one that is *downloaded but not
+    launchable* (``RomInstall.launchable is False``, resolved to ``""`` by the
+    disc-resolver seam every bake site draws its path from) produce the same
+    empty string, and at the Steam-shortcut layer the two are indistinguishable:
+    the shortcut holds ``""`` either way. Only the data layer separates them —
+    no ``rom_installs`` row versus a row with ``launchable = 0``. Never read
+    emptiness as "not downloaded"; ask the install record.
+
+    Empty is the established uninstalled state, not a new one invented here:
+    ``addShortcut`` leaves a new shortcut's options untouched when the command
+    is ``""`` (``src/utils/steamShortcuts.ts``), the sync update/adoption path
+    writes ``""`` explicitly (``rewriteShortcutIdentity`` in
+    ``src/utils/syncManager.ts``), and an uninstall records ``""`` as the ROM's
+    ``applied_launch_options`` (``services/rom_removal.py``).
 
     The path is double-quoted so paths with spaces survive the launcher's
     ``exec "$@"``. Embedded ``\\`` and ``"`` in the path are backslash-escaped

--- a/py_modules/models/state.py
+++ b/py_modules/models/state.py
@@ -36,7 +36,9 @@ class InstalledRomEntry(TypedDict):
 
     Identified by ``rom_id``. ``rom_dir`` is set only for ROMs
     extracted from a multi-file archive (otherwise the parent directory
-    is inferred from ``file_path``).
+    is inferred from ``file_path``). ``launchable`` is ``False`` for a ROM that
+    is downloaded and on disk but whose content the system cannot boot — its
+    shortcut carries no launch command.
     """
 
     rom_id: int
@@ -45,6 +47,7 @@ class InstalledRomEntry(TypedDict):
     system: str
     platform_slug: str
     installed_at: str
+    launchable: bool
     rom_dir: NotRequired[str]
 
 

--- a/py_modules/services/disc_launch_resolver.py
+++ b/py_modules/services/disc_launch_resolver.py
@@ -79,7 +79,16 @@ class DiscLaunchResolver:
         return enumerate_discs(files, supported or None)
 
     def resolve_bake_path(self, install: RomInstall, discs: list[Disc], selected_disc: str | None) -> str:
-        """Return the path to bake into launch_options for *install*.
+        """Return the path to bake into launch_options for *install*, or ``""`` when it has none.
+
+        An install the system cannot launch (``launchable is False`` — a PS3
+        ``.pkg`` installer, a bare track ``.bin``; #1652) resolves to the empty
+        string before any disc work. That is the seam the whole guard rests on:
+        every launch-bake site already draws its path from here, and
+        :func:`build_launch_options` renders an empty path as the empty launch
+        command, so no site can compose a command for content nothing can boot.
+        The files stay on disk and the install row stays intact — only the
+        command is withheld.
 
         *discs* is the result of :meth:`enumerate_discs` (passed in so a caller
         that already enumerated for the picker does not re-scan). Resolves the
@@ -95,6 +104,8 @@ class DiscLaunchResolver:
         folder-boot marker, so a resolved disc path is never rewritten;
         ``file_path`` itself is left untouched.
         """
+        if not install.launchable:
+            return ""
         path, stale = resolve_launch_path(install.file_path, discs, selected_disc)
         if stale:
             self._logger.warning(

--- a/py_modules/services/downloads.py
+++ b/py_modules/services/downloads.py
@@ -22,6 +22,7 @@ from domain.rom_files import (
     detect_launch_file,
     es_de_collapse_rename,
     folder_boot_layout_root,
+    is_launchable_target,
     is_multi_file_download,
     needs_m3u,
     resolve_extract_dir_name,
@@ -51,6 +52,7 @@ if TYPE_CHECKING:
         Sleeper,
         SystemM3uSupportFn,
         SystemResolver,
+        SystemSupportedExtensionsFn,
         UnitOfWorkFactory,
     )
 
@@ -116,6 +118,10 @@ class DownloadServiceConfig:
     active_core: ActiveCoreReader
     disc_resolver: DiscResolver
     m3u_support: SystemM3uSupportFn
+    # The live per-system accept-list. The one place the launch-target check
+    # reads its knowledge from, so swapping the source (emu-atlas, #1652) is a
+    # change to this wiring line and nothing else.
+    system_extensions: SystemSupportedExtensionsFn
     uow_factory: UnitOfWorkFactory
     # Deferred access to RomRemovalService.remove_rom — the two services form a
     # construction cycle, so the composition root binds it after both exist
@@ -139,6 +145,7 @@ class DownloadService:
         self._active_core = config.active_core
         self._disc_resolver = config.disc_resolver
         self._m3u_support = config.m3u_support
+        self._system_extensions = config.system_extensions
         self._uow_factory = config.uow_factory
         self._rom_remover = config.rom_remover
 
@@ -504,6 +511,13 @@ class DownloadService:
         Returns ``(file_path, None)`` on success or ``(None, error)`` when the
         invariant rejects the data.
         """
+        # Recorded, never acted on: an unlaunchable download keeps its files and
+        # its row, and only the shortcut's launch command is withheld. Refusing
+        # the install instead would delete a package the user's remaining option
+        # is to install by hand in the emulator (#1582, #1652).
+        launchable = is_launchable_target(file_path, rom_dir, self._system_extensions(system))
+        if not launchable:
+            self._logger.warning(f"No launch target for rom_id={rom_id}: {system} cannot launch '{file_path}'")
         try:
             install = RomInstall.mark_installed(
                 rom_id=int(rom_id),
@@ -512,6 +526,7 @@ class DownloadService:
                 platform_slug=rom_detail.get("platform_slug", ""),
                 system=system,
                 installed_at=self._clock.now().isoformat(),
+                launchable=launchable,
             )
         except ValueError as e:
             cleanup()
@@ -1477,6 +1492,7 @@ class DownloadService:
             "system": install.system,
             "platform_slug": install.platform_slug,
             "installed_at": install.installed_at,
+            "launchable": install.launchable,
         }
         return entry
 

--- a/py_modules/services/library/sync_orchestrator.py
+++ b/py_modules/services/library/sync_orchestrator.py
@@ -1913,10 +1913,10 @@ class SyncOrchestrator:
         library — a single ``iter_all()`` is the cheapest way to cover them all.
         Each path is the disc-resolved launch path: a multi-disc ROM resolves its
         persisted ``selected_disc`` pin against its install directory (a
-        single-disc ROM resolves to its own ``file_path``, unchanged). Only ROMs
-        with a current install record appear in the map; ROMs not downloaded are
-        absent, so :func:`build_shortcuts_data` emits an empty placeholder launch
-        command for them.
+        single-disc ROM resolves to its own ``file_path``, unchanged), or ``""``
+        when the install has no launch target. Only ROMs with a current install
+        record appear in the map; a ROM not downloaded is absent, and both cases
+        reach :func:`build_shortcuts_data` as the same empty launch command.
         """
         with self._uow_factory() as uow:
             paths: dict[int, str] = {}
@@ -1934,9 +1934,9 @@ class SyncOrchestrator:
         only the unit's ROMs via ``get(rom_id)``. Each path is the disc-resolved
         launch path — a multi-disc ROM resolves its persisted ``selected_disc``
         pin against its install directory (a single-disc ROM resolves to its own
-        ``file_path``, unchanged). ROMs with no install record are absent, so
-        :func:`build_shortcuts_data` emits an empty placeholder launch command for
-        them.
+        ``file_path``, unchanged), or ``""`` when the install has no launch
+        target. A ROM with no install record is absent; both cases reach
+        :func:`build_shortcuts_data` as the same empty launch command.
         """
         with self._uow_factory() as uow:
             paths: dict[int, str] = {}

--- a/py_modules/services/protocols/cross_service.py
+++ b/py_modules/services/protocols/cross_service.py
@@ -81,7 +81,9 @@ class DiscResolver(Protocol):
     single-file ROM); :meth:`resolve_bake_path` resolves the pin over that list;
     :meth:`resolve_for_install` is the bake-site convenience that does both. A
     non-multi-disc ROM resolves to its own ``file_path`` unchanged; a stale pin
-    degrades to the default with a WARNING rather than raising.
+    degrades to the default with a WARNING rather than raising; an install the
+    system cannot launch (``launchable is False``) resolves to ``""``, which
+    every bake site renders as the empty launch command.
     """
 
     def enumerate_discs(self, install: RomInstall) -> list[Disc]: ...

--- a/py_modules/services/protocols/paths.py
+++ b/py_modules/services/protocols/paths.py
@@ -111,9 +111,12 @@ class SystemSupportedExtensionsFn(Protocol):
 
     Backed by the same per-system ``<extension>`` list in ``es_systems.xml`` as
     :class:`SystemM3uSupportFn`, so a service can intersect the live accept-list
-    with the disc-image set and never offer a disc the emulator cannot launch.
+    with the disc-image set and never offer a disc the emulator cannot launch,
+    and a completed download can be checked for whether the system can launch it
+    at all before a launch command is baked.
     Default-safe: an empty frozenset for an unknown system or when
-    ``es_systems.xml`` cannot be found (the caller falls back to the full disc set).
+    ``es_systems.xml`` cannot be found (every caller treats the empty answer as
+    "cannot tell" and falls back to its permissive branch, never to a refusal).
     """
 
     def __call__(self, system_name: str) -> frozenset[str]: ...

--- a/src/components/CustomPlayButton.test.tsx
+++ b/src/components/CustomPlayButton.test.tsx
@@ -1635,6 +1635,49 @@ describe("CustomPlayButton — shared launch gate (ADR-0015)", () => {
     expect(consumeLaunchSkip(100)).toBe(true);
   });
 
+  it("no launch target → toast explaining the files were kept, no launch (#1652)", async () => {
+    // A PS3 title downloaded as a .pkg installer: on disk, recorded, but nothing
+    // RPCS3 can boot. The gate blocks before any save work and the press must
+    // say so — a silent bail would read as a dead button.
+    vi.mocked(backend.getInstalledRom).mockResolvedValue({
+      rom_id: 42,
+      file_name: "Puppeteer.pkg",
+      file_path: "/roms/ps3/Puppeteer/Puppeteer.pkg",
+      system: "ps3",
+      platform_slug: "ps3",
+      installed_at: "2026-01-01T00:00:00Z",
+      launchable: false,
+    });
+    vi.mocked(backend.probeReachability).mockResolvedValue({ online: true });
+
+    await clickPlay();
+
+    expect(toaster.toast).toHaveBeenCalledWith({
+      title: "RomM Sync",
+      body: "This download has no file the emulator can launch. The files are on disk — see the game page.",
+    });
+    expect(vi.mocked(SteamClient.Apps.RunGame)).not.toHaveBeenCalled();
+    // Blocked before the save-sync work — no upload for a session that never starts.
+    expect(vi.mocked(backend.preLaunchSync)).not.toHaveBeenCalled();
+  });
+
+  it("a launchable install passes the launch-target step and launches", async () => {
+    vi.mocked(backend.getInstalledRom).mockResolvedValue({
+      rom_id: 42,
+      file_name: "game.chd",
+      file_path: "/roms/psx/game.chd",
+      system: "psx",
+      platform_slug: "psx",
+      installed_at: "2026-01-01T00:00:00Z",
+      launchable: true,
+    });
+    vi.mocked(backend.probeReachability).mockResolvedValue({ online: true });
+
+    await clickPlay();
+
+    await waitFor(() => expect(vi.mocked(SteamClient.Apps.RunGame)).toHaveBeenCalledWith("gid-1", "", -1, 100));
+  });
+
   it("offline + local drift → OfflineDriftModal; start_anyway launches", async () => {
     vi.mocked(backend.probeReachability).mockResolvedValue({ online: false });
     vi.mocked(backend.checkLocalDrift).mockResolvedValue({ drifted: true, rom_id: 42 });

--- a/src/components/CustomPlayButton.tsx
+++ b/src/components/CustomPlayButton.tsx
@@ -50,6 +50,7 @@ import { showFallbackLaunchModal } from "./FallbackLaunchModal";
 import { showStopGameModal } from "./StopGameModal";
 import { getMigrationState } from "../utils/migrationStore";
 import { runLaunchGate, markLaunchSkipped } from "../utils/launchGate";
+import { NO_LAUNCH_TARGET_TOAST_BODY, romHasLaunchTarget } from "../utils/launchTarget";
 import type { GateVerdict, LaunchGateOps, PreLaunchSyncOutcome } from "../utils/launchGate";
 import { isSessionActive } from "../utils/sessionManager";
 import { isAppRunning } from "../utils/runningApps";
@@ -598,6 +599,7 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
   // page-open-stale `getRommConnectionState()` flag no longer gates the launch.
   const makePlayButtonOps = (rid: number): LaunchGateOps => ({
     migrationPending: () => getMigrationState().pending,
+    hasLaunchTarget: () => romHasLaunchTarget(rid, "CustomPlayButton"),
     ensureTrackingConfigured: () => ensureTrackingConfigured(rid),
     checkCoreChange: () => confirmCoreChangeIfNeeded(rid),
     checkReachability: async () => {
@@ -693,9 +695,13 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
         return "done";
       case "abort":
       case "block":
-        // abort: the user saw setup/core UI and declined. block: migration
-        // pending (the QAM/page already surfaces it). Either way, bail silently
-        // to "play" without launching.
+        // abort: the user saw setup/core UI and declined. block/migration_pending:
+        // the QAM/page already surfaces it. Both bail silently to "play".
+        // block/no_launch_target has no such standing surface at the moment of the
+        // press — the page states it, but the press must not read as a dead button.
+        if (verdict.decision === "block" && verdict.reason === "no_launch_target") {
+          toaster.toast({ title: "RomM Sync", body: NO_LAUNCH_TARGET_TOAST_BODY });
+        }
         setState("play");
         return "done";
       case "conflict": {

--- a/src/components/RomMGameInfoPanel.test.tsx
+++ b/src/components/RomMGameInfoPanel.test.tsx
@@ -573,6 +573,7 @@ describe("RomMGameInfoPanel", () => {
         system: "snes",
         platform_slug: "snes",
         installed_at: "2024-01-01",
+        launchable: true,
       });
       const { container, queryByText } = render(<RomMGameInfoPanel appId={testAppId} />);
       await flushAsync();
@@ -606,6 +607,7 @@ describe("RomMGameInfoPanel", () => {
         system: "snes",
         platform_slug: "snes",
         installed_at: "2024-01-01",
+        launchable: true,
       });
       const { queryByText } = render(<RomMGameInfoPanel appId={testAppId} />);
       await flushAsync();
@@ -649,6 +651,7 @@ describe("RomMGameInfoPanel", () => {
         system: "snes",
         platform_slug: "snes",
         installed_at: "2024-01-01",
+        launchable: true,
       });
       const { queryByText } = render(<RomMGameInfoPanel appId={testAppId} />);
       await flushAsync();
@@ -675,6 +678,61 @@ describe("RomMGameInfoPanel", () => {
       expect(vi.mocked(cachedStore.invalidateCachedGameDetail)).toHaveBeenCalledWith(testAppId);
     });
 
+    it("an unlaunchable install states why the game will not start and that the files were kept (#1652)", async () => {
+      // A PS3 title downloaded as a .pkg installer. The install is real — the
+      // section still renders its filename — but the game page is the one place
+      // that explains why no launch command was written.
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
+        found: true,
+        rom_id: 100,
+        installed: true,
+        platform_name: "PlayStation 3",
+        metadata: makeMetadata(),
+        stale_fields: [],
+      });
+      vi.mocked(backend.getInstalledRom).mockResolvedValue({
+        rom_id: 100,
+        file_name: "Puppeteer.pkg",
+        file_path: "/roms/ps3/Puppeteer/Puppeteer.pkg",
+        system: "ps3",
+        platform_slug: "ps3",
+        installed_at: "2024-01-01",
+        launchable: false,
+      });
+      const { container, queryByText } = render(<RomMGameInfoPanel appId={testAppId} />);
+      await flushAsync();
+
+      expect(queryByText("ROM File")).not.toBeNull();
+      expect(queryByText("Puppeteer.pkg")).not.toBeNull();
+      expect(container.textContent).toContain("nothing here is a format ps3 can launch");
+      expect(container.textContent).toContain("The files are on disk");
+    });
+
+    it("a launchable install shows the filename with no no-launch-target notice", async () => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
+        found: true,
+        rom_id: 100,
+        installed: true,
+        platform_name: "Super Nintendo",
+        metadata: makeMetadata(),
+        stale_fields: [],
+      });
+      vi.mocked(backend.getInstalledRom).mockResolvedValue({
+        rom_id: 100,
+        file_name: "test.sfc",
+        file_path: "/roms/test.sfc",
+        system: "snes",
+        platform_slug: "snes",
+        installed_at: "2024-01-01",
+        launchable: true,
+      });
+      const { container, queryByText } = render(<RomMGameInfoPanel appId={testAppId} />);
+      await flushAsync();
+
+      expect(queryByText("test.sfc")).not.toBeNull();
+      expect(container.textContent).not.toContain("The files are on disk");
+    });
+
     it("download_complete: mismatching rom_id → section stays hidden, no fetch", async () => {
       vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
         found: true,
@@ -691,6 +749,7 @@ describe("RomMGameInfoPanel", () => {
         system: "snes",
         platform_slug: "snes",
         installed_at: "2024-01-01",
+        launchable: true,
       });
       const { queryByText } = render(<RomMGameInfoPanel appId={testAppId} />);
       await flushAsync();

--- a/src/components/RomMGameInfoPanel.tsx
+++ b/src/components/RomMGameInfoPanel.tsx
@@ -1015,20 +1015,23 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => { //
   // A downloaded ROM the system cannot launch keeps its files and its row; only
   // the shortcut's launch command is withheld. This is the one place that says
   // so — without it the game simply never starts and nothing explains why.
+  const noLaunchTargetNote =
+    state.installedRom && !state.installedRom.launchable
+      ? createElement(
+          "div",
+          { key: "no-launch-target", className: "romm-panel-muted", style: { marginTop: "4px" } },
+          `Downloaded, but nothing here is a format ${state.installedRom.system} can launch — no launch ` +
+            `command was set. The files are on disk; install them in the emulator to play.`,
+        )
+      : null;
+
   const romFileSection =
     state.installed && state.installedRom
       ? section(
           "rom-file",
           "ROM File",
           infoRow("filename", "Filename", state.installedRom.file_name),
-          state.installedRom.launchable
-            ? null
-            : createElement(
-                "div",
-                { key: "no-launch-target", className: "romm-panel-muted", style: { marginTop: "4px" } },
-                `Downloaded, but nothing here is a format ${state.installedRom.system} can launch — no launch ` +
-                  `command was set. The files are on disk; install them in the emulator to play.`,
-              ),
+          noLaunchTargetNote,
         )
       : null;
 

--- a/src/components/RomMGameInfoPanel.tsx
+++ b/src/components/RomMGameInfoPanel.tsx
@@ -1012,9 +1012,24 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => { //
     : section("game-info", null, ...gameInfoContent);
 
   // --- ROM File section (only when installed) ---
+  // A downloaded ROM the system cannot launch keeps its files and its row; only
+  // the shortcut's launch command is withheld. This is the one place that says
+  // so — without it the game simply never starts and nothing explains why.
   const romFileSection =
     state.installed && state.installedRom
-      ? section("rom-file", "ROM File", infoRow("filename", "Filename", state.installedRom.file_name))
+      ? section(
+          "rom-file",
+          "ROM File",
+          infoRow("filename", "Filename", state.installedRom.file_name),
+          state.installedRom.launchable
+            ? null
+            : createElement(
+                "div",
+                { key: "no-launch-target", className: "romm-panel-muted", style: { marginTop: "4px" } },
+                `Downloaded, but nothing here is a format ${state.installedRom.system} can launch — no launch ` +
+                  `command was set. The files are on disk; install them in the emulator to play.`,
+              ),
+        )
       : null;
 
   // --- BIOS & Core section (two-column layout when platform needs BIOS) ---

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -47,6 +47,13 @@ export interface InstalledRom {
   system: string;
   platform_slug: string;
   installed_at: string;
+  /**
+   * False when the ROM is downloaded and on disk but the system cannot launch
+   * what it contains — a PS3 `.pkg` installer, a bare disc track. Its shortcut
+   * carries no launch command; the files are kept so the user can install them
+   * by hand in the emulator.
+   */
+  launchable: boolean;
 }
 
 export interface RetroArchInputCheck {

--- a/src/utils/launchGate.test.ts
+++ b/src/utils/launchGate.test.ts
@@ -26,6 +26,7 @@ function makeOps(overrides: Partial<LaunchGateOps> = {}): LaunchGateOps {
   const okSync: PreLaunchSyncOutcome = { success: true, message: "" };
   return {
     migrationPending: vi.fn(() => false),
+    hasLaunchTarget: vi.fn(async () => true),
     ensureTrackingConfigured: vi.fn(async (): Promise<"proceed" | "abort"> => "proceed"),
     checkCoreChange: vi.fn(async () => true),
     checkReachability: vi.fn(async () => true),
@@ -43,8 +44,30 @@ describe("runLaunchGate — verdict branches", () => {
       reason: "migration_pending",
     });
     // Later steps must not run once migration blocks.
+    expect(ops.hasLaunchTarget).not.toHaveBeenCalled();
     expect(ops.ensureTrackingConfigured).not.toHaveBeenCalled();
     expect(ops.checkReachability).not.toHaveBeenCalled();
+  });
+
+  it("blocks with no_launch_target when the ROM has no launch target", async () => {
+    const ops = makeOps({ hasLaunchTarget: vi.fn(async () => false) });
+    await expect(runLaunchGate(100, 42, ops)).resolves.toEqual({
+      decision: "block",
+      reason: "no_launch_target",
+    });
+    // The save-sync work must not run: there is no session for a synced save to
+    // belong to, and a pre-launch upload before a launch that never happens is
+    // pure risk.
+    expect(ops.ensureTrackingConfigured).not.toHaveBeenCalled();
+    expect(ops.preLaunchSync).not.toHaveBeenCalled();
+    expect(ops.checkReachability).not.toHaveBeenCalled();
+  });
+
+  it("proceeds past the launch-target step when the ROM has one", async () => {
+    const ops = makeOps({ hasLaunchTarget: vi.fn(async () => true) });
+    await expect(runLaunchGate(100, 42, ops)).resolves.toEqual({ decision: "allow" });
+    expect(ops.hasLaunchTarget).toHaveBeenCalled();
+    expect(ops.ensureTrackingConfigured).toHaveBeenCalled();
   });
 
   it("aborts when tracking setup returns abort", async () => {

--- a/src/utils/launchGate.ts
+++ b/src/utils/launchGate.ts
@@ -38,7 +38,8 @@ export interface PreLaunchSyncOutcome {
  *                          internal error was swallowed). Launch may proceed.
  *   - `block`            — a hard precondition failed and the user has not yet
  *                          been shown UI for it. `reason` selects the caller's
- *                          message (`not_installed`, `migration_pending`).
+ *                          message (`not_installed`, `migration_pending`,
+ *                          `no_launch_target`).
  *   - `abort`            — the user was shown UI (tracking-setup or core-change)
  *                          and chose not to proceed. The caller bails silently,
  *                          with no further message — the user already decided.
@@ -52,7 +53,7 @@ export interface PreLaunchSyncOutcome {
  */
 export type GateVerdict =
   | { decision: "allow" }
-  | { decision: "block"; reason: "not_installed" | "migration_pending" }
+  | { decision: "block"; reason: "not_installed" | "migration_pending" | "no_launch_target" }
   | { decision: "abort" }
   | { decision: "conflict"; conflicts: SyncConflict[] }
   | { decision: "offline_drift" }
@@ -70,6 +71,14 @@ export interface LaunchGateOps {
    * a pending migration risks silent save-data loss.
    */
   migrationPending: () => boolean;
+
+  /**
+   * Does this ROM have a launch target at all? `false` for a ROM that is
+   * downloaded and on disk but whose content the system cannot boot — its
+   * shortcut carries no launch command, so letting the launch through would
+   * start nothing and say nothing. Blocks with `block`/`no_launch_target`.
+   */
+  hasLaunchTarget: () => Promise<boolean>;
 
   /**
    * Ensure save-slot tracking is configured for this ROM. Returns `"proceed"`
@@ -111,11 +120,12 @@ export interface LaunchGateOps {
  *
  * Step order (each step's failure short-circuits the rest):
  *   1. migration pending      -> block / migration_pending
- *   2. ensureTrackingConfigured -> "abort" => abort
- *   3. checkCoreChange        -> cancel => abort
- *   4. checkReachability      -> online vs offline split
- *   5a. online:  preLaunchSync -> conflict | sync_failed | allow
- *   5b. offline: checkLocalDrift -> offline_drift | allow
+ *   2. hasLaunchTarget        -> block / no_launch_target
+ *   3. ensureTrackingConfigured -> "abort" => abort
+ *   4. checkCoreChange        -> cancel => abort
+ *   5. checkReachability      -> online vs offline split
+ *   6a. online:  preLaunchSync -> conflict | sync_failed | allow
+ *   6b. offline: checkLocalDrift -> offline_drift | allow
  *
  * The gate NEVER throws and NEVER blocks the user on an internal error: the
  * whole body is wrapped so any thrown error (from an injected callback or
@@ -133,22 +143,29 @@ export async function runLaunchGate(_appId: number, _romId: number, ops: LaunchG
       return { decision: "block", reason: "migration_pending" };
     }
 
-    // 2. Save-slot tracking setup. "abort" means the user saw setup UI and
+    // 2. No launch target — the ROM is downloaded but nothing in it is
+    //    something this system can boot. Block before the save-sync work: there
+    //    is no session coming that a synced save would belong to.
+    if (!(await ops.hasLaunchTarget())) {
+      return { decision: "block", reason: "no_launch_target" };
+    }
+
+    // 3. Save-slot tracking setup. "abort" means the user saw setup UI and
     //    declined — bail silently.
     if ((await ops.ensureTrackingConfigured()) === "abort") {
       return { decision: "abort" };
     }
 
-    // 3. Emulator core-change confirm. Cancel => bail silently.
+    // 4. Emulator core-change confirm. Cancel => bail silently.
     if (!(await ops.checkCoreChange())) {
       return { decision: "abort" };
     }
 
-    // 4. Fresh reachability probe decides the sync branch.
+    // 5. Fresh reachability probe decides the sync branch.
     const online = await ops.checkReachability();
 
     if (online) {
-      // 5a. Online — run pre-launch sync and map its outcome.
+      // 6a. Online — run pre-launch sync and map its outcome.
       const sync = await ops.preLaunchSync();
       if (sync.conflicts && sync.conflicts.length > 0) {
         return { decision: "conflict", conflicts: sync.conflicts };
@@ -159,7 +176,7 @@ export async function runLaunchGate(_appId: number, _romId: number, ops: LaunchG
       return { decision: "allow" };
     }
 
-    // 5b. Offline — block only when the local save has drifted; otherwise allow.
+    // 6b. Offline — block only when the local save has drifted; otherwise allow.
     if (await ops.checkLocalDrift()) {
       return { decision: "offline_drift" };
     }

--- a/src/utils/launchInterceptor.test.ts
+++ b/src/utils/launchInterceptor.test.ts
@@ -150,6 +150,7 @@ describe("launchInterceptor — full funnel watcher", () => {
       system: "snes",
       platform_slug: "snes",
       installed_at: "2026-01-01T00:00:00Z",
+      launchable: true,
     });
     // Skip-set empty by default — a marked appId is set per-test.
     vi.mocked(sessionManager.getAppIdRomIdMapSnapshot).mockReturnValue({ "1234": 42 });
@@ -513,6 +514,21 @@ describe("launchInterceptor — full funnel watcher", () => {
       expect(toaster.toast).toHaveBeenCalledWith({
         title: "RomM Sync",
         body: "Pending RetroDECK migration. Open the plugin QAM to migrate or dismiss.",
+      });
+      expect(runGameMock()).not.toHaveBeenCalled();
+    });
+
+    it("no_launch_target block → explains the download was kept, no relaunch", async () => {
+      vi.mocked(launchGate.runLaunchGate).mockResolvedValue({ decision: "block", reason: "no_launch_target" });
+
+      register();
+      const handler = captureHandler();
+      handler(77, "1234", "LaunchApp", 0);
+      await flush();
+
+      expect(toaster.toast).toHaveBeenCalledWith({
+        title: "RomM Sync",
+        body: "This download has no file the emulator can launch. The files are on disk — see the game page.",
       });
       expect(runGameMock()).not.toHaveBeenCalled();
     });

--- a/src/utils/launchInterceptor.ts
+++ b/src/utils/launchInterceptor.ts
@@ -37,6 +37,7 @@ import { setSaveSortMigrationStatus } from "./saveSortMigrationStore";
 import { getAppIdRomIdMapSnapshot, isSessionActive } from "./sessionManager";
 import { isAppRunning } from "./runningApps";
 import { runLaunchGate, markLaunchSkipped, consumeLaunchSkip } from "./launchGate";
+import { NO_LAUNCH_TARGET_TOAST_BODY, romHasLaunchTarget } from "./launchTarget";
 import type { GateVerdict, LaunchGateOps, PreLaunchSyncOutcome } from "./launchGate";
 import { reconfirmLaunchOptions } from "./launchOptionsReconcile";
 import { capturePruneLeaseAdmission, isPruneLeaseAdmissionCurrent, type PruneLeaseAdmission } from "./pruneLease";
@@ -166,6 +167,7 @@ async function preLaunchSyncWatcher(romId: number): Promise<PreLaunchSyncOutcome
 function makeWatcherOps(romId: number, prompts: LaunchPrompts): LaunchGateOps {
   return {
     migrationPending: () => getMigrationState().pending,
+    hasLaunchTarget: () => romHasLaunchTarget(romId, "Watcher"),
     ensureTrackingConfigured: async (): Promise<"proceed"> => {
       await ensureTrackingConfiguredWatcher(romId);
       return "proceed";
@@ -250,6 +252,8 @@ async function handleWatcherVerdict(
     case "block":
       if (verdict.reason === "migration_pending") {
         toaster.toast({ title: "RomM Sync", body: MIGRATION_TOAST_BODY });
+      } else if (verdict.reason === "no_launch_target") {
+        toaster.toast({ title: "RomM Sync", body: NO_LAUNCH_TARGET_TOAST_BODY });
       }
       return "done";
     case "conflict": {

--- a/src/utils/launchTarget.test.ts
+++ b/src/utils/launchTarget.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { romHasLaunchTarget, NO_LAUNCH_TARGET_TOAST_BODY } from "./launchTarget";
+import * as backend from "../api/backend";
+import type { InstalledRom } from "../types/api";
+
+vi.mock("../api/backend", () => ({
+  getInstalledRom: vi.fn(),
+  logError: vi.fn(),
+}));
+
+function installed(overrides: Partial<InstalledRom> = {}): InstalledRom {
+  return {
+    rom_id: 42,
+    file_name: "game.iso",
+    file_path: "/roms/ps3/game.iso",
+    system: "ps3",
+    platform_slug: "ps3",
+    installed_at: "2026-01-01T00:00:00Z",
+    launchable: true,
+    ...overrides,
+  };
+}
+
+describe("romHasLaunchTarget", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("is true for an install the system can launch", async () => {
+    vi.mocked(backend.getInstalledRom).mockResolvedValue(installed());
+    await expect(romHasLaunchTarget(42, "Watcher")).resolves.toBe(true);
+  });
+
+  it("is false for an install recorded as unlaunchable", async () => {
+    vi.mocked(backend.getInstalledRom).mockResolvedValue(
+      installed({ file_name: "Puppeteer.pkg", file_path: "/roms/ps3/Puppeteer/Puppeteer.pkg", launchable: false }),
+    );
+    await expect(romHasLaunchTarget(42, "Watcher")).resolves.toBe(false);
+  });
+
+  it("is true when there is no install record — not this check's business", async () => {
+    // The not-downloaded case has its own handling; this probe answers only
+    // "downloaded, but nothing bootable".
+    vi.mocked(backend.getInstalledRom).mockResolvedValue(null);
+    await expect(romHasLaunchTarget(42, "Watcher")).resolves.toBe(true);
+  });
+
+  it("fails open and logs when the read throws", async () => {
+    vi.mocked(backend.getInstalledRom).mockRejectedValue(new Error("bridge down"));
+
+    await expect(romHasLaunchTarget(42, "CustomPlayButton")).resolves.toBe(true);
+    expect(vi.mocked(backend.logError)).toHaveBeenCalledWith(
+      expect.stringContaining("CustomPlayButton launch-target check threw (allowing launch)"),
+    );
+  });
+});
+
+describe("NO_LAUNCH_TARGET_TOAST_BODY", () => {
+  it("tells the user the files were kept and where to look", async () => {
+    // The copy is the whole user-facing payoff of the block — a bare "cannot
+    // launch" would read as "the download failed", which is the opposite of
+    // what happened.
+    expect(NO_LAUNCH_TARGET_TOAST_BODY).toContain("on disk");
+    expect(NO_LAUNCH_TARGET_TOAST_BODY).toContain("game page");
+  });
+});

--- a/src/utils/launchTarget.ts
+++ b/src/utils/launchTarget.ts
@@ -1,0 +1,38 @@
+/**
+ * The launch-target probe both launch paths run before starting a ROM.
+ *
+ * A download can succeed and still leave nothing the system can boot — a PS3
+ * title shipped as a `.pkg` installer, a disc rip whose only sizeable file is a
+ * raw track. The backend records that verdict on the install (`launchable`) and
+ * withholds the shortcut's launch command, so a launch would start nothing and
+ * explain nothing. This is the read the gate blocks on.
+ *
+ * Lives apart from `launchGate.ts` because the gate itself performs no I/O —
+ * every side effect reaches it as an injected callback, and this is the callback
+ * both the Play button and the global watcher inject.
+ */
+
+import { getInstalledRom, logError } from "../api/backend";
+
+/**
+ * Toast copy both launch paths surface on a `no_launch_target` block. Says what
+ * happened, that nothing was thrown away, and where the detail lives.
+ */
+export const NO_LAUNCH_TARGET_TOAST_BODY =
+  "This download has no file the emulator can launch. The files are on disk — see the game page.";
+
+/**
+ * Does `romId` have a launch target? `context` names the caller in the error log.
+ *
+ * Fails **open**: a transport hiccup or a missing install record resolves to
+ * `true`. Blocking is reserved for a verdict the backend actually returned —
+ * a launch trapped behind a failed probe is worse than one that starts nothing,
+ * because the ROM whose install record is unreadable is usually fine.
+ */
+export async function romHasLaunchTarget(romId: number, context: string): Promise<boolean> {
+  const installed = await getInstalledRom(romId).catch((e) => {
+    logError(`${context} launch-target check threw (allowing launch): ${e}`);
+    return null;
+  });
+  return installed == null || installed.launchable;
+}

--- a/tests/_factories.py
+++ b/tests/_factories.py
@@ -73,6 +73,7 @@ def _make_testable_plugin():
         _platform_core_reader: Any
         _active_core: Any
         _m3u_supported: Any
+        _system_extensions: Any
         _renderer_rss: Any
         _renderer_gc: Any
 

--- a/tests/adapters/repositories/test_rom_install.py
+++ b/tests/adapters/repositories/test_rom_install.py
@@ -24,7 +24,13 @@ def _seed_rom(uow: SqliteUnitOfWork, rom_id: int) -> None:
     )
 
 
-def _install(rom_id: int, *, path: str = "/roms/snes/game.sfc", rom_dir: str | None = None) -> RomInstall:
+def _install(
+    rom_id: int,
+    *,
+    path: str = "/roms/snes/game.sfc",
+    rom_dir: str | None = None,
+    launchable: bool = True,
+) -> RomInstall:
     return RomInstall(
         rom_id=rom_id,
         file_path=path,
@@ -32,6 +38,7 @@ def _install(rom_id: int, *, path: str = "/roms/snes/game.sfc", rom_dir: str | N
         platform_slug="snes",
         system="snes",
         installed_at="2026-02-02T00:00:00Z",
+        launchable=launchable,
     )
 
 
@@ -53,6 +60,25 @@ class TestRoundTrip:
         assert loaded is not None
         assert loaded.rom_dir is None
         assert loaded == install
+
+    def test_unlaunchable_round_trips_as_bool(self, uow: SqliteUnitOfWork):
+        """``launchable`` crosses the STRICT-table INTEGER column and reads back a bool (#1652)."""
+        _seed_rom(uow, 7)
+        install = _install(7, path="/roms/ps3/Game/Game.pkg", rom_dir="/roms/ps3/Game", launchable=False)
+        uow.rom_installs.save(install)
+
+        loaded = uow.rom_installs.get(7)
+        assert loaded is not None
+        assert loaded.launchable is False
+        assert loaded == install
+
+    def test_launchable_round_trips_as_bool(self, uow: SqliteUnitOfWork):
+        _seed_rom(uow, 8)
+        uow.rom_installs.save(_install(8, launchable=True))
+
+        loaded = uow.rom_installs.get(8)
+        assert loaded is not None
+        assert loaded.launchable is True
 
 
 class TestMiss:

--- a/tests/adapters/test_sqlite_migrations.py
+++ b/tests/adapters/test_sqlite_migrations.py
@@ -79,8 +79,9 @@ def _set_user_version(db_path: str, version: int) -> None:
 # + 015_add_applied_launch_options + 016_add_cover_source
 # + 017_add_last_sync_server_hash + 018_rename_rom_save_states
 # + 019_add_collection_sync_state + 020_add_fetch_generation
-# + 021_add_rom_fs_size + 022_rename_collection_kind_user_to_standard).
-_SHIPPED_VERSION = 22
+# + 021_add_rom_fs_size + 022_rename_collection_kind_user_to_standard
+# + 023_add_rom_install_launchable).
+_SHIPPED_VERSION = 23
 
 # Tables after every shipped migration: the v1 set plus 006's play-session outbox,
 # 012's per-platform completion stamp, and 019's per-collection completion stamp,
@@ -1470,6 +1471,75 @@ class Test022RenameCollectionKindUserToStandard:
         db_path = str(tmp_path / "romm_sync.db")
         apply_migrations(db_path)
         assert _user_version(db_path) == _SHIPPED_VERSION
+
+
+class Test023AddRomInstallLaunchable:
+    """023 — adds the NOT NULL DEFAULT 1 launchable column to rom_installs only (#1652)."""
+
+    def test_adds_launchable_to_rom_installs_only(self, tmp_path: Path):
+        db_path = str(tmp_path / "romm_sync.db")
+
+        apply_migrations(db_path)
+
+        assert _user_version(db_path) == _SHIPPED_VERSION
+        assert "launchable" in _columns(db_path, "rom_installs")
+        assert "launchable" not in _columns(db_path, "roms")
+
+    def test_launchable_absent_before_023(self, tmp_path: Path):
+        db_path = str(tmp_path / "romm_sync.db")
+        apply_migrations(db_path, str(_only_migrations_through(tmp_path, 22)))
+
+        assert _user_version(db_path) == 22
+        assert "launchable" not in _columns(db_path, "rom_installs")
+
+    def test_existing_row_reads_launchable_across_the_migration(self, tmp_path: Path):
+        # An install downloaded before 023 was never assessed. It keeps the launch
+        # command it already had — the backfill asserts launchable, it does not
+        # re-derive it from an accept-list this DDL cannot consult.
+        db_path = str(tmp_path / "romm_sync.db")
+        apply_migrations(db_path, str(_only_migrations_through(tmp_path, 22)))
+        conn = sqlite3.connect(db_path, isolation_level=None)
+        try:
+            conn.execute(
+                "INSERT INTO roms (rom_id, platform_slug, name, fs_name, last_synced_at) "
+                "VALUES (1, 'ps3', 'Game', 'game', '2026-07-20T10:00:00')"
+            )
+            conn.execute(
+                "INSERT INTO rom_installs (rom_id, file_path, rom_dir, platform_slug, system, installed_at) "
+                "VALUES (1, '/roms/ps3/Game/PS3_GAME/USRDIR/EBOOT.BIN', '/roms/ps3/Game', 'ps3', 'ps3', "
+                "'2026-07-20T10:00:00')"
+            )
+        finally:
+            conn.close()
+
+        assert apply_migrations(db_path) == _SHIPPED_VERSION
+
+        conn = sqlite3.connect(db_path)
+        try:
+            row = conn.execute("SELECT launchable, file_path FROM rom_installs WHERE rom_id = 1").fetchone()
+        finally:
+            conn.close()
+        assert row == (1, "/roms/ps3/Game/PS3_GAME/USRDIR/EBOOT.BIN")
+
+    def test_launchable_zero_round_trips(self, tmp_path: Path):
+        db_path = str(tmp_path / "romm_sync.db")
+        apply_migrations(db_path)
+
+        conn = sqlite3.connect(db_path, isolation_level=None)
+        try:
+            conn.execute(
+                "INSERT INTO roms (rom_id, platform_slug, name, fs_name, last_synced_at) "
+                "VALUES (7, 'ps3', 'Game', 'game', '2026-07-20T10:00:00')"
+            )
+            conn.execute(
+                "INSERT INTO rom_installs "
+                "(rom_id, file_path, rom_dir, platform_slug, system, installed_at, launchable) "
+                "VALUES (7, '/roms/ps3/Game/game.pkg', '/roms/ps3/Game', 'ps3', 'ps3', '2026-07-20T10:00:00', 0)"
+            )
+            stored = conn.execute("SELECT launchable FROM rom_installs WHERE rom_id = 7").fetchone()[0]
+        finally:
+            conn.close()
+        assert stored == 0
 
         conn = sqlite3.connect(db_path)
         try:

--- a/tests/contract/test_download_read.py
+++ b/tests/contract/test_download_read.py
@@ -54,10 +54,12 @@ async def test_get_installed_rom_installed_shape(harness):
         "system",
         "platform_slug",
         "installed_at",
+        "launchable",
     }
     assert result["rom_id"] == 42
     assert result["file_name"] == "pokemon.gba"
     assert result["platform_slug"] == "gba"
+    assert result["launchable"] is True
     assert isinstance(result["file_path"], str)
 
 

--- a/tests/contract/test_saves_setup_migration_005_reconfirms_legacy_rom.py
+++ b/tests/contract/test_saves_setup_migration_005_reconfirms_legacy_rom.py
@@ -28,7 +28,7 @@ def _rewind_to_v4(db_path: str) -> None:
 
     Bootstrap stamps the DB at the latest version with the full schema. To replay
     the real 005 upgrade path the runner must see a genuine v4 database: the
-    version stamp AND the pre-006/007/008/009/010/012/015/016/017/018/019/020/021 schema
+    version stamp AND the pre-006/007/008/009/010/012/015/016/017/018/019/020/021/023 schema
     (006's play-session outbox table absent and ``note_id`` present, 007's
     ``last_played`` column absent, 008's version-metadata columns absent, 009's
     ``last_session_start_monotonic`` column absent, 010's sibling_group_key index
@@ -37,8 +37,8 @@ def _rewind_to_v4(db_path: str) -> None:
     absent, 017's ``last_sync_server_hash`` column absent, 018's save-sync
     scalar table under its pre-rename name ``rom_save_states``, 019's
     collection_sync_state table absent, 020's fetch-generation columns
-    absent, and 021's ``fs_size_bytes`` column absent) so the sequential
-    005→…→021 re-run applies cleanly.
+    absent, 021's ``fs_size_bytes`` column absent, and 023's ``launchable``
+    column absent) so the sequential 005→…→023 re-run applies cleanly.
     """
     conn = sqlite3.connect(db_path, isolation_level=None)
     try:
@@ -67,6 +67,8 @@ def _rewind_to_v4(db_path: str) -> None:
         conn.execute("ALTER TABLE roms DROP COLUMN last_fetch_id")
         # Reverse 021 so its ADD COLUMN re-applies instead of duplicating.
         conn.execute("ALTER TABLE roms DROP COLUMN fs_size_bytes")
+        # Reverse 023 so its ADD COLUMN re-applies instead of duplicating.
+        conn.execute("ALTER TABLE rom_installs DROP COLUMN launchable")
         # Reverse 017 so its ADD COLUMN re-applies instead of duplicating.
         conn.execute("ALTER TABLE rom_save_files DROP COLUMN last_sync_server_hash")
         # Reverse 018 so 005's `UPDATE rom_save_states` finds the table under its

--- a/tests/domain/test_rom_files.py
+++ b/tests/domain/test_rom_files.py
@@ -11,6 +11,7 @@ from domain.rom_files import (
     es_de_collapse_rename,
     folder_boot_layout_root,
     folder_boot_root,
+    is_launchable_target,
     is_multi_file_download,
     needs_m3u,
     resolve_extract_dir_name,
@@ -387,6 +388,80 @@ class TestFolderBootRoot:
         rom_dir = "/roms/ps3/MyGame"
         launch = "/roms/ps3/MyGame/ps3_game/USRDIR/EBOOT.BIN"
         assert folder_boot_root(launch, rom_dir) is None
+
+
+class TestIsLaunchableTarget:
+    """Tests for is_launchable_target — can the system launch the recorded launch file?
+
+    The accept-lists below are ES-DE's real per-system ``<extension>`` sets for
+    the systems each case names, so a passing test is not a tautology over a
+    made-up list.
+    """
+
+    # ES-DE's ps3 accept-list. ``.ps3dir`` is how it spells the directory case;
+    # ``.desktop`` is a shortcut to an already-installed game, not ROM content.
+    PS3 = frozenset({".desktop", ".iso", ".ps3", ".ps3dir"})
+    # ES-DE's dreamcast accept-list. Note the absence of ``.bin`` — a GDI rip's
+    # raw track is not a launch target for any of these emulators.
+    DREAMCAST = frozenset({".cdi", ".chd", ".cue", ".dat", ".elf", ".gdi", ".iso", ".lst", ".m3u", ".7z", ".zip"})
+
+    def test_ps3_pkg_is_not_launchable(self):
+        # The reported case (#1582): a PS3 title shipped as .pkg + .rap. No rule
+        # in detect_launch_file matches, the fallback picks the multi-gigabyte
+        # package, and a PKG is an installer — the game is still sealed inside.
+        assert is_launchable_target("/roms/ps3/Puppeteer/Puppeteer.pkg", "/roms/ps3/Puppeteer", self.PS3) is False
+
+    def test_dreamcast_track_bin_is_not_launchable(self):
+        # A multi-file GDI rip without a .cue: the fallback bakes the largest
+        # track file, and dreamcast's accept-list carries no .bin.
+        assert is_launchable_target("/roms/dc/Game/track03.bin", "/roms/dc/Game", self.DREAMCAST) is False
+
+    def test_folder_boot_eboot_is_launchable(self):
+        # A working PS3 disc dump. file_path records the nested EBOOT.BIN, whose
+        # .bin extension is absent from ps3's list — but the bake target is the
+        # game DIRECTORY (ADR-0019), which ES-DE spells .ps3dir. Rejecting this
+        # would break every PS3 dump that launches today.
+        launch = "/roms/ps3/MyGame/PS3_GAME/USRDIR/EBOOT.BIN"
+        assert is_launchable_target(launch, "/roms/ps3/MyGame", self.PS3) is True
+
+    def test_folder_boot_nested_one_level_deeper_is_launchable(self):
+        # The same dump extracted one level deeper still resolves to a game root
+        # inside rom_dir, so the folder-boot carve-out still applies.
+        launch = "/roms/ps3/MyGame/InnerGame/PS3_GAME/USRDIR/EBOOT.BIN"
+        assert is_launchable_target(launch, "/roms/ps3/MyGame", self.PS3) is True
+
+    def test_desktop_entry_is_launchable(self):
+        # ES-DE lists .desktop for ps3 — a shortcut to an already-installed game.
+        assert is_launchable_target("/roms/ps3/Game.desktop", None, self.PS3) is True
+
+    def test_bare_eboot_without_marker_is_not_launchable(self):
+        # An EBOOT.BIN outside the PS3_GAME/USRDIR run gets no carve-out, and
+        # RPCS3 rejects a nested EBOOT path anyway ("Invalid file or folder",
+        # ADR-0019). Falls through to the extension check, which has no .bin.
+        assert is_launchable_target("/roms/ps3/MyGame/EBOOT.BIN", "/roms/ps3/MyGame", self.PS3) is False
+
+    def test_empty_accept_list_accepts(self):
+        # ES-DE could not answer (unknown system, no ES-DE installation). A
+        # missing answer must never turn a working install unlaunchable.
+        assert is_launchable_target("/roms/ps3/Puppeteer/Puppeteer.pkg", "/roms/ps3/Puppeteer", frozenset()) is True
+
+    def test_single_file_iso_is_launchable(self):
+        assert is_launchable_target("/roms/ps3/Game.iso", None, self.PS3) is True
+
+    def test_uppercase_extension_is_launchable(self):
+        # The accept-list is lowercased; a server-supplied .ISO must still match.
+        assert is_launchable_target("/roms/ps3/Game.ISO", None, self.PS3) is True
+
+    def test_extensionless_file_is_not_launchable(self):
+        assert is_launchable_target("/roms/dc/Game/readme", "/roms/dc/Game", self.DREAMCAST) is False
+
+    def test_empty_extract_dir_as_launch_path_is_not_launchable(self):
+        # detect_launch_file fell back to the extract dir itself (nothing inside).
+        # There is no launch target, and the directory name carries no extension.
+        assert is_launchable_target("/roms/dc/Game", "/roms/dc/Game", self.DREAMCAST) is False
+
+    def test_m3u_playlist_is_launchable(self):
+        assert is_launchable_target("/roms/dc/Game/Game.m3u", "/roms/dc/Game", self.DREAMCAST) is True
 
 
 class TestFolderBootLayoutRoot:

--- a/tests/domain/test_rom_install.py
+++ b/tests/domain/test_rom_install.py
@@ -23,6 +23,34 @@ class TestMarkInstalled:
         assert install.platform_slug == "psx"
         assert install.system == "psx"
         assert install.installed_at == "2026-05-28T10:00:00"
+        assert install.launchable is True
+
+    def test_launchable_defaults_to_true(self):
+        """Unlaunchable is a proven verdict, never the absence of one (#1652)."""
+        install = RomInstall.mark_installed(
+            rom_id=1,
+            file_path="/roms/psx/game.cue",
+            rom_dir=None,
+            platform_slug="psx",
+            system="psx",
+            installed_at="2026-05-28T10:00:00",
+        )
+        assert install.launchable is True
+
+    def test_records_an_unlaunchable_install(self):
+        """A download the system cannot boot is still a real install — files and row kept."""
+        install = RomInstall.mark_installed(
+            rom_id=42,
+            file_path="/roms/ps3/Puppeteer/Puppeteer.pkg",
+            rom_dir="/roms/ps3/Puppeteer",
+            platform_slug="ps3",
+            system="ps3",
+            installed_at="2026-05-28T10:00:00",
+            launchable=False,
+        )
+        assert install.launchable is False
+        assert install.file_path == "/roms/ps3/Puppeteer/Puppeteer.pkg"
+        assert install.rom_dir == "/roms/ps3/Puppeteer"
 
     def test_single_file_has_no_rom_dir(self):
         """A single-file ROM owns no folder — ``rom_dir`` is ``None``."""
@@ -77,3 +105,17 @@ class TestRelocate:
         install.relocate(None, "/new/roms/n64/zelda.z64")
         assert install.rom_dir is None
         assert install.file_path == "/new/roms/n64/zelda.z64"
+
+    def test_relocate_preserves_the_launchable_verdict(self):
+        """A home migration moves the same content — it cannot make it launchable."""
+        install = RomInstall.mark_installed(
+            rom_id=3,
+            file_path="/old/roms/ps3/Game/Game.pkg",
+            rom_dir="/old/roms/ps3/Game",
+            platform_slug="ps3",
+            system="ps3",
+            installed_at="2026-05-28T10:00:00",
+            launchable=False,
+        )
+        install.relocate("/new/roms/ps3/Game", "/new/roms/ps3/Game/Game.pkg")
+        assert install.launchable is False

--- a/tests/domain/test_shortcut_data.py
+++ b/tests/domain/test_shortcut_data.py
@@ -293,6 +293,23 @@ class TestBuildShortcutsData:
         assert result[0]["launch_options"] == 'flatpak run net.retrodeck.retrodeck "/roms/snes/installed.sfc"'
         assert result[1]["launch_options"] == ""
 
+    def test_installed_rom_with_no_launch_target_gets_empty_launch_options(self):
+        # The install resolved to the empty path (launchable is False, #1652). It
+        # is still IN the map — it IS downloaded — but its shortcut carries the
+        # same empty launch command an un-downloaded ROM's does, never a command
+        # composed around a bare "".
+        roms = [{"id": 1, "name": "Sealed In A PKG"}]
+        result = build_shortcuts_data(roms, "/plugin", {1: ""}, {})
+        assert result[0]["launch_options"] == ""
+
+    def test_no_launch_target_beats_a_core_override(self):
+        # An emulator override cannot resurrect a launch command for content the
+        # system cannot boot — no ``-e`` form is composed either.
+        roms = [{"id": 1, "name": "Sealed In A PKG"}]
+        overrides = {1: EmulatorInvocation.libretro("pcsx_rearmed_libretro")}
+        result = build_shortcuts_data(roms, "/plugin", {1: ""}, overrides)
+        assert result[0]["launch_options"] == ""
+
     def test_installed_rom_with_core_override_bakes_e_form(self):
         # A rom_id present in core_overrides bakes the -e override into its launch.
         roms = [{"id": 1, "name": "PSX Game"}]

--- a/tests/domain/test_shortcut_data.py
+++ b/tests/domain/test_shortcut_data.py
@@ -148,8 +148,13 @@ class TestBuildLaunchOptions:
         result = build_launch_options(RETRODECK_INVOCATION, "/roms/dc/My Game.chd")
         assert result == 'flatpak run net.retrodeck.retrodeck "/roms/dc/My Game.chd"'
 
-    def test_empty_path_still_quoted(self):
-        assert build_launch_options(RETRODECK_INVOCATION, "") == 'flatpak run net.retrodeck.retrodeck ""'
+    def test_empty_path_yields_no_launch_command(self):
+        # An empty path is the "no launch target" signal — not downloaded, or
+        # downloaded with nothing the system can boot. Quoting it would hand the
+        # emulator a bare "" argument, which is the failure #1652 exists to
+        # prevent; the shortcut gets the same empty command an uninstalled ROM's
+        # carries instead.
+        assert build_launch_options(RETRODECK_INVOCATION, "") == ""
 
     def test_folder_boot_direct_composes_full_mgs4_command(self):
         # End-to-end: the direct invocation + the quoted game folder reproduce the

--- a/tests/fakes/fake_disc_resolver.py
+++ b/tests/fakes/fake_disc_resolver.py
@@ -29,9 +29,10 @@ class FakeDiscResolver:
     ``resolve_for_install`` mirror the real resolver's
     :func:`domain.disc_selection.resolve_launch_path` decision over the seeded
     discs, so a non-multi-disc ROM resolves to ``install.file_path`` unchanged and
-    a pin resolves to the matching disc's path. ``calls`` records each
-    ``(rom_dir, selected_disc)`` resolve so consumer tests can assert the seam
-    was queried with the right pin.
+    a pin resolves to the matching disc's path. An install the system cannot
+    launch (``launchable is False``) resolves to ``""`` before any disc work, as
+    the real resolver does. ``calls`` records each ``(rom_dir, selected_disc)``
+    resolve so consumer tests can assert the seam was queried with the right pin.
     """
 
     def __init__(self) -> None:
@@ -49,6 +50,8 @@ class FakeDiscResolver:
 
     def resolve_bake_path(self, install: RomInstall, discs: list[Disc], selected_disc: str | None) -> str:
         self.calls.append((install.rom_dir, selected_disc))
+        if not install.launchable:
+            return ""
         path, _stale = resolve_launch_path(install.file_path, discs, selected_disc)
         return path
 

--- a/tests/services/test_disc_bake_sites.py
+++ b/tests/services/test_disc_bake_sites.py
@@ -48,7 +48,14 @@ def _discs() -> list[Disc]:
     ]
 
 
-def _seed_multi_disc(uow: FakeUnitOfWork, *, rom_id: int, selected_disc: str | None, app_id: int | None = 99) -> None:
+def _seed_multi_disc(
+    uow: FakeUnitOfWork,
+    *,
+    rom_id: int,
+    selected_disc: str | None,
+    app_id: int | None = 99,
+    launchable: bool = True,
+) -> None:
     with uow:
         uow.roms.save(
             Rom(
@@ -68,6 +75,7 @@ def _seed_multi_disc(uow: FakeUnitOfWork, *, rom_id: int, selected_disc: str | N
                 platform_slug="psx",
                 system="psx",
                 installed_at="2026-01-01T00:00:00+00:00",
+                launchable=launchable,
             )
         )
         if selected_disc is not None:
@@ -136,6 +144,21 @@ class TestSyncOrchestratorBakeSite:
         # file_path is disc 1 (not an m3u) → default resolves to disc 1.
         assert orch._scan_installed_paths() == {1: _DISC1_PATH}
 
+    def test_scan_installed_paths_maps_an_unlaunchable_install_to_the_empty_path(self, disc_resolver):
+        # The ROM stays IN the map — it IS downloaded, and collapse_sibling_groups
+        # reads the key set to pick a group's representative — but carries no
+        # launch path, so build_shortcuts_data emits the empty launch command (#1652).
+        uow = FakeUnitOfWork()
+        _seed_multi_disc(uow, rom_id=1, selected_disc=_DISC2, launchable=False)
+        orch = self._orchestrator(FakeUnitOfWorkFactory(uow=uow), disc_resolver)
+        assert orch._scan_installed_paths() == {1: ""}
+
+    def test_read_installed_paths_maps_an_unlaunchable_install_to_the_empty_path(self, disc_resolver):
+        uow = FakeUnitOfWork()
+        _seed_multi_disc(uow, rom_id=1, selected_disc=_DISC2, launchable=False)
+        orch = self._orchestrator(FakeUnitOfWorkFactory(uow=uow), disc_resolver)
+        assert orch._read_installed_paths({1}) == {1: ""}
+
 
 # ── downloads bake site ──────────────────────────────────────────────────
 
@@ -158,6 +181,7 @@ class TestDownloadsBakeSite:
                 active_core=FakeActiveCoreResolver(default=(None, None)),
                 disc_resolver=disc_resolver,
                 m3u_support=lambda system_name: False,
+                system_extensions=lambda system_name: frozenset(),
                 uow_factory=uow_factory,
                 rom_remover=lambda: AsyncMock(),
             )
@@ -178,3 +202,13 @@ class TestDownloadsBakeSite:
         svc = self._service(FakeUnitOfWorkFactory(uow=uow), disc_resolver)
         _app_id, _core_so, bake_path = svc._resolve_bound_app_id(1, _DISC1_PATH)
         assert bake_path == _DISC1_PATH
+
+    def test_resolve_bound_app_id_returns_the_empty_path_for_an_unlaunchable_install(self, disc_resolver):
+        # download_complete's re-bake reads through the same seam, so the freshly
+        # downloaded ROM's shortcut gets no launch command either (#1652).
+        uow = FakeUnitOfWork()
+        _seed_multi_disc(uow, rom_id=1, selected_disc=_DISC2, app_id=1234, launchable=False)
+        svc = self._service(FakeUnitOfWorkFactory(uow=uow), disc_resolver)
+        app_id, _core_so, bake_path = svc._resolve_bound_app_id(1, _DISC1_PATH)
+        assert app_id == 1234
+        assert bake_path == ""

--- a/tests/services/test_disc_launch_resolver.py
+++ b/tests/services/test_disc_launch_resolver.py
@@ -38,7 +38,9 @@ class FakeSystemExtensions:
         return self.by_system.get(system_name, frozenset())
 
 
-def _install(*, rom_id: int = 1, file_path: str, rom_dir: str | None, system: str = "psx") -> RomInstall:
+def _install(
+    *, rom_id: int = 1, file_path: str, rom_dir: str | None, system: str = "psx", launchable: bool = True
+) -> RomInstall:
     return RomInstall(
         rom_id=rom_id,
         file_path=file_path,
@@ -46,6 +48,7 @@ def _install(*, rom_id: int = 1, file_path: str, rom_dir: str | None, system: st
         platform_slug=system,
         system=system,
         installed_at="2026-01-01T00:00:00+00:00",
+        launchable=launchable,
     )
 
 
@@ -230,4 +233,45 @@ class TestFolderBootTarget:
         # guard that the folder rule cannot perturb a bare single-file ROM.
         resolver = _build(FakeFileLister(), FakeSystemExtensions(), logger)
         install = _install(file_path="/roms/snes/game.sfc", rom_dir=None)
+        assert resolver.resolve_for_install(install, None) == "/roms/snes/game.sfc"
+
+
+class TestNoLaunchTarget:
+    """An install the system cannot launch resolves to the empty path (#1652).
+
+    This is the single seam the whole guard rests on: every launch-bake site
+    draws its path from here, and ``build_launch_options`` renders an empty path
+    as the empty launch command — so no bake site can compose a command for
+    content nothing can boot.
+    """
+
+    def test_unlaunchable_install_resolves_to_empty_path(self, logger):
+        rom_dir = "/roms/ps3/Puppeteer"
+        pkg = f"{rom_dir}/Puppeteer.pkg"
+        resolver = _build(FakeFileLister({rom_dir: [pkg]}), FakeSystemExtensions(), logger)
+        install = _install(file_path=pkg, rom_dir=rom_dir, system="ps3", launchable=False)
+        assert resolver.resolve_for_install(install, None) == ""
+
+    def test_unlaunchable_single_file_resolves_to_empty_path(self, logger):
+        resolver = _build(FakeFileLister(), FakeSystemExtensions(), logger)
+        install = _install(file_path="/roms/ps3/Game.pkg", rom_dir=None, system="ps3", launchable=False)
+        assert resolver.resolve_for_install(install, None) == ""
+
+    def test_unlaunchable_install_ignores_a_disc_pin(self, logger):
+        # The refusal precedes disc resolution — a pin cannot resurrect a launch
+        # target for content the system cannot boot.
+        files = {
+            "/roms/psx/game": [
+                "/roms/psx/game/Game (Disc 1).cue",
+                "/roms/psx/game/Game (Disc 2).cue",
+            ]
+        }
+        resolver = _build(FakeFileLister(files), FakeSystemExtensions(), logger)
+        install = _install(file_path="/roms/psx/game/Game (Disc 1).cue", rom_dir="/roms/psx/game", launchable=False)
+        assert resolver.resolve_for_install(install, "Game (Disc 2).cue") == ""
+
+    def test_launchable_install_is_unaffected(self, logger):
+        # Regression guard: the default verdict changes nothing.
+        resolver = _build(FakeFileLister(), FakeSystemExtensions(), logger)
+        install = _install(file_path="/roms/snes/game.sfc", rom_dir=None, launchable=True)
         assert resolver.resolve_for_install(install, None) == "/roms/snes/game.sfc"

--- a/tests/services/test_downloads.py
+++ b/tests/services/test_downloads.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import os
 import sqlite3
 from datetime import UTC, datetime
@@ -119,6 +120,10 @@ def plugin():
     # Default platform m3u-support for the DownloadService ``m3u_support`` seam.
     # Tests that simulate a non-m3u platform (Switch/Xbox 360) flip this to False.
     p._m3u_supported = True
+    # Per-system ES-DE accept-lists for the DownloadService ``system_extensions``
+    # seam. Empty by default — an unseeded system reads as "cannot tell", which
+    # the launch-target check treats as launchable.
+    p._system_extensions: dict[str, frozenset[str]] = {}
 
     import decky
 
@@ -185,6 +190,10 @@ def plugin():
             # Default-True so the existing M3U/launch-file tests are unaffected;
             # a test that exercises a non-m3u platform repoints this seam.
             m3u_support=lambda system_name: p._m3u_supported,
+            # Default-empty ("ES-DE could not answer") so the launch-target check
+            # accepts every existing test's install; a test that exercises the
+            # check seeds ``p._system_extensions`` with a real accept-list.
+            system_extensions=lambda system_name: p._system_extensions.get(system_name, frozenset()),
             uow_factory=FakeUnitOfWorkFactory(p._uow),
             # Late-bound remover for the #1298 sibling supersede — resolved at call
             # time, by which point ``p._rom_removal_service`` is constructed below.
@@ -561,6 +570,126 @@ class TestRomInstallForeignKey:
                 )
             )
         assert uow.committed is False
+
+
+class TestRecordInstallLaunchTarget:
+    """The launch-target verdict recorded at install time (#1652).
+
+    The accept-lists seeded here are ES-DE's real per-system ``<extension>``
+    sets, so a passing case is not a tautology over a made-up list.
+    """
+
+    _PS3 = frozenset({".desktop", ".iso", ".ps3", ".ps3dir"})
+    _DREAMCAST = frozenset({".cdi", ".chd", ".cue", ".dat", ".elf", ".gdi", ".iso", ".lst", ".m3u", ".7z", ".zip"})
+
+    def _record(self, plugin, *, file_path, rom_dir, system, cleanup=lambda: None):
+        _seed_rom(plugin._uow, 42)
+        return plugin._download_service._record_install_io(
+            rom_id=42,
+            rom_detail={"platform_slug": system},
+            file_path=file_path,
+            rom_dir=rom_dir,
+            system=system,
+            cleanup=cleanup,
+        )
+
+    def test_ps3_pkg_records_an_unlaunchable_install_and_keeps_the_files(self, plugin):
+        # The reported case (#1582). The row is written, the install is NOT
+        # refused, and cleanup is NEVER called — the package stays on disk so the
+        # user can install it by hand in RPCS3.
+        plugin._system_extensions = {"ps3": self._PS3}
+        cleanup_calls = []
+
+        file_path, error = self._record(
+            plugin,
+            file_path="/roms/ps3/Puppeteer/Puppeteer.pkg",
+            rom_dir="/roms/ps3/Puppeteer",
+            system="ps3",
+            cleanup=lambda: cleanup_calls.append(1),
+        )
+
+        assert error is None
+        assert file_path == "/roms/ps3/Puppeteer/Puppeteer.pkg"
+        assert cleanup_calls == []
+        install = plugin._uow.rom_installs.get(42)
+        assert install is not None
+        assert install.launchable is False
+        assert install.file_path == "/roms/ps3/Puppeteer/Puppeteer.pkg"
+        assert install.rom_dir == "/roms/ps3/Puppeteer"
+
+    def test_dreamcast_track_bin_records_an_unlaunchable_install(self, plugin):
+        # A multi-file GDI rip with no .cue: the fallback picks the largest track
+        # file, and dreamcast's accept-list carries no .bin.
+        plugin._system_extensions = {"dreamcast": self._DREAMCAST}
+
+        _, error = self._record(
+            plugin, file_path="/roms/dc/Game/track03.bin", rom_dir="/roms/dc/Game", system="dreamcast"
+        )
+
+        assert error is None
+        install = plugin._uow.rom_installs.get(42)
+        assert install is not None
+        assert install.launchable is False
+
+    def test_ps3_folder_boot_dump_stays_launchable(self, plugin):
+        # The carve-out that protects every working PS3 dump: file_path records
+        # the nested EBOOT (a .bin, absent from ps3's list) but the bake target
+        # is the game directory, which ES-DE spells .ps3dir (ADR-0019).
+        plugin._system_extensions = {"ps3": self._PS3}
+
+        _, error = self._record(
+            plugin,
+            file_path="/roms/ps3/MyGame/PS3_GAME/USRDIR/EBOOT.BIN",
+            rom_dir="/roms/ps3/MyGame",
+            system="ps3",
+        )
+
+        assert error is None
+        install = plugin._uow.rom_installs.get(42)
+        assert install is not None
+        assert install.launchable is True
+
+    def test_desktop_entry_stays_launchable(self, plugin):
+        plugin._system_extensions = {"ps3": self._PS3}
+
+        _, error = self._record(plugin, file_path="/roms/ps3/Game.desktop", rom_dir=None, system="ps3")
+
+        assert error is None
+        install = plugin._uow.rom_installs.get(42)
+        assert install is not None
+        assert install.launchable is True
+
+    def test_unknown_system_stays_launchable(self, plugin):
+        # ES-DE could not answer (empty accept-list). A missing answer must never
+        # turn a working install into an unlaunchable one.
+        plugin._system_extensions = {}
+
+        _, error = self._record(
+            plugin, file_path="/roms/ps3/Puppeteer/Puppeteer.pkg", rom_dir="/roms/ps3/Puppeteer", system="ps3"
+        )
+
+        assert error is None
+        install = plugin._uow.rom_installs.get(42)
+        assert install is not None
+        assert install.launchable is True
+
+    def test_unlaunchable_install_is_logged(self, plugin, caplog):
+        plugin._system_extensions = {"ps3": self._PS3}
+
+        with caplog.at_level(logging.WARNING):
+            self._record(
+                plugin, file_path="/roms/ps3/Puppeteer/Puppeteer.pkg", rom_dir="/roms/ps3/Puppeteer", system="ps3"
+            )
+
+        assert any("No launch target for rom_id=42" in r.message for r in caplog.records)
+
+    def test_launchable_install_logs_nothing(self, plugin, caplog):
+        plugin._system_extensions = {"ps3": self._PS3}
+
+        with caplog.at_level(logging.WARNING):
+            self._record(plugin, file_path="/roms/ps3/Game.iso", rom_dir=None, system="ps3")
+
+        assert not any("No launch target" in r.message for r in caplog.records)
 
 
 class TestRecordInstallFsSizeWriteBack:

--- a/tests/services/test_downloads.py
+++ b/tests/services/test_downloads.py
@@ -649,6 +649,33 @@ class TestRecordInstallLaunchTarget:
         assert install is not None
         assert install.launchable is True
 
+    def test_ps3_folder_boot_dump_still_bakes_the_game_directory_end_to_end(self, plugin):
+        # The one shape that can silently break a working install, walked end to
+        # end: record the install through the real check, then resolve the
+        # persisted row through the REAL DiscLaunchResolver the bake sites use.
+        # A False verdict anywhere in that chain collapses the bake path to ""
+        # and the PS3 dump loses the launch command it has today. No installed
+        # ROM in a typical library has this shape, so only this fixture pins it.
+        from services.disc_launch_resolver import DiscLaunchResolver, DiscLaunchResolverConfig
+
+        plugin._system_extensions = {"ps3": self._PS3}
+        rom_dir = "/roms/ps3/MyGame"
+        eboot = f"{rom_dir}/PS3_GAME/USRDIR/EBOOT.BIN"
+
+        self._record(plugin, file_path=eboot, rom_dir=rom_dir, system="ps3")
+
+        install = plugin._uow.rom_installs.get(42)
+        assert install is not None
+        assert install.launchable is True
+        resolver = DiscLaunchResolver(
+            config=DiscLaunchResolverConfig(
+                list_files=lambda _directory: [eboot],
+                system_extensions=lambda system_name: plugin._system_extensions.get(system_name, frozenset()),
+                logger=logging.getLogger("test_downloads"),
+            ),
+        )
+        assert resolver.resolve_for_install(install, None) == rom_dir
+
     def test_desktop_entry_stays_launchable(self, plugin):
         plugin._system_extensions = {"ps3": self._PS3}
 

--- a/tests/services/test_downloads.py
+++ b/tests/services/test_downloads.py
@@ -123,7 +123,7 @@ def plugin():
     # Per-system ES-DE accept-lists for the DownloadService ``system_extensions``
     # seam. Empty by default — an unseeded system reads as "cannot tell", which
     # the launch-target check treats as launchable.
-    p._system_extensions: dict[str, frozenset[str]] = {}
+    p._system_extensions = {}
 
     import decky
 

--- a/tests/services/test_downloads.py
+++ b/tests/services/test_downloads.py
@@ -669,7 +669,7 @@ class TestRecordInstallLaunchTarget:
         assert install.launchable is True
         resolver = DiscLaunchResolver(
             config=DiscLaunchResolverConfig(
-                list_files=lambda _directory: [eboot],
+                list_files=lambda directory: [eboot] if directory == rom_dir else [],
                 system_extensions=lambda system_name: plugin._system_extensions.get(system_name, frozenset()),
                 logger=logging.getLogger("test_downloads"),
             ),


### PR DESCRIPTION
`detect_launch_file` ends in "largest file by size". When no format-specific rule matches, the biggest file in a download became the launch target and was baked into the shortcut's command, with nothing checking whether the system can launch that file at all.

Reported in #1582: a PS3 title distributed as `.pkg` + `.rap`. A PKG is an installer — the game is sealed inside it and there is no `EBOOT.BIN` anywhere in the download — so every rule missed and the multi-gigabyte package was baked. The download reported success, the shortcut appeared, and the failure only surfaced when the user pressed play.

**The check.** `domain/rom_files.is_launchable_target` validates the resolved target against the accept-list ES-DE publishes for the system, read through the existing `CoreResolver.get_supported_extensions`. Two carve-outs: an empty accept-list accepts, because the source could not answer rather than answered "no"; and a folder-boot layout accepts without examining an extension, because the marker match is itself positive evidence the layout was recognised and the baked target is a directory, which ES-DE spells `.ps3dir`.

A bare `EBOOT.BIN` outside the `PS3_GAME/USRDIR/` marker run is judged unlaunchable, deliberately. ADR-0019 records the measurement that RPCS3 rejects the nested EBOOT as a target (`Booting '…/EBOOT.BIN' failed`), and ps3's accept-list carries no `.bin`. Carving it out would preserve a launch command that cannot work — the defect this change removes.

**Downloaded files are kept.** Refusing at record time would run `_record_install_io`'s cleanup and delete the extracted directory, which for a PKG destroys the one thing the user still needs: the package, to install by hand in RPCS3 — the procedure RetroDECK documents for PSN titles. So the install is recorded and only the launch command is withheld. `RomInstall` gains `launchable`; migration 023 backfills existing rows to launchable by assumption rather than re-assessment, since a re-assessment would need an accept-list the DDL cannot consult, and those shortcuts behave exactly as before.

**The guard sits at two seams, not at the six bake sites.** `DiscLaunchResolver.resolve_bake_path` returns `""` for an unlaunchable install, and `build_launch_options` renders an empty path as an empty command. Library sync, download-complete, the core-change re-bake, the startup relaunch heal and the disc picker inherit the behaviour with no per-site branching — including the core-change re-bake, which would otherwise have quietly re-baked a command onto an unlaunchable ROM the moment its emulator changed.

An empty launch command was already the state an uninstalled ROM carries: `addShortcut` skips the write for it, `rewriteShortcutIdentity` writes it on both the update and adoption paths, and uninstall records it. It now carries a second meaning — downloaded but not launchable — which is indistinguishable at the Steam-shortcut layer and separable only at the data layer, by the presence of a `rom_installs` row with `launchable = 0`. That rule is written into the `build_launch_options` docstring with its evidence sites, so emptiness is never read as "not downloaded".

**Verified on hardware.** A PS3 dump installed through the plugin records `launchable = 1` and bakes the game directory, not the EBOOT — the folder-boot path the fixtures could only assert in isolation. Against the live installed library, all twelve existing installs keep their launch command, and every accept-list consulted was non-empty, so none passed through the unknown-system carve-out.

The check reads the plugin's own `es_systems.xml` parser for now. Whether a system can launch a file is machine-derived knowledge that belongs in emu-atlas (danielcopper/emu-atlas#36); the consuming call site is a single Protocol-typed seam so swapping the source is a wiring change.

Part of #1652
