### PR TITLE
chore(saves): name the compiled core the core in save-sync tests

### DIFF
--- a/tests/adapters/test_gavel_native.py
+++ b/tests/adapters/test_gavel_native.py
@@ -1,4 +1,4 @@
-"""Tests for the GavelNativeAdapter — the compiled save-sync decision kernels.
+"""Tests for the GavelNativeAdapter — the compiled save-sync decision core.
 
 Two of the tiers guarding the shipped shared object live here, for both of the
 decisions it owns (the upload-409 ladder and the full per-file sync action):

--- a/tests/adapters/test_gavel_native_table_vectors.py
+++ b/tests/adapters/test_gavel_native_table_vectors.py
@@ -32,7 +32,7 @@ _VECTORS_DIR = Path(__file__).parent.parent / "domain" / "gavel_vectors" / "deci
 
 
 @pytest.fixture(scope="module")
-def kernel() -> ComputeSyncActionFn:
+def core() -> ComputeSyncActionFn:
     """The compiled core, bound the way production binds it."""
     return GavelNativeAdapter().compute_sync_action
 
@@ -81,12 +81,12 @@ assert _ARGVALUES, f"no gavel decision-table vectors loaded from {_VECTORS_DIR}"
 
 @pytest.mark.parametrize(("vector_input", "expected", "rationale"), _ARGVALUES, ids=_IDS)
 def test_compute_sync_action_conforms(
-    kernel: ComputeSyncActionFn,
+    core: ComputeSyncActionFn,
     vector_input: dict[str, Any],
     expected: dict[str, Any],
     rationale: str | None,
 ) -> None:
-    result = kernel(
+    result = core(
         vector_input["local_file"],
         vector_input["server_saves_in_slot"],
         vector_input["files_state"],


### PR DESCRIPTION
The wording predates the compiled core. `domain/sync_action.py` used to hold a second implementation
of the same decision, so "kernel" could name either one. It holds only the `SyncAction` vocabulary
now, and both files here have exactly one subject: the compiled core.

Renames the module-scoped fixture `kernel` to `core` in the decision-table vector test, and drops the
plural from the `test_gavel_native.py` module docstring.

No test logic and no expectation changes.

docs: N/A — test-local naming, no behaviour, flow or architecture change.
