### PR TITLE
fix(ui): stop reporting a slow connection check as "RomM offline"

### DIFF
--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -105,6 +105,11 @@ the RomM database was reset and this device's registration disappeared with it �
 **RomM offline** badge stays clear and the surface tells you what's missing instead. If you see such a message while the
 badge is clear, the fix is on the RomM side (re-sync the library, or re-check the game), not with your network.
 
+A slow answer isn't a failure either. The check a game page runs when it opens can take a while on a busy server or over
+a remote connection; while it's still outstanding the page simply keeps waiting, and the **RomM offline** badge appears
+only once something actually reports the server as unreachable. A page that takes a few seconds to settle is not the
+same thing as a page that found RomM missing.
+
 When the missing thing is this device's own registration — the RomM database was wiped or restored and the id this
 device was issued no longer exists — you don't have to do anything. Both when the plugin loads (installing an update
 counts, since that reloads it) and before every save-sync (before a game launches, after it exits, or a manual sync),

--- a/src/components/RomMPlaySection.test.tsx
+++ b/src/components/RomMPlaySection.test.tsx
@@ -29,6 +29,7 @@ import * as cachedStore from "../utils/cachedGameDetailStore";
 import * as connectionState from "../utils/connectionState";
 import * as sectionRefresh from "../utils/sectionRefresh";
 import * as playSectionUtils from "../utils/playSection";
+import * as saveStatusUtils from "../utils/saveStatus";
 import * as formatters from "../utils/formatters";
 import { getGameDetail } from "../utils/gameDetailStore";
 import { useVersionError } from "./VersionErrorCard";
@@ -1125,6 +1126,81 @@ describe("RomMPlaySection", () => {
         await flushAsync();
       });
       expect(connectionState.getRommConnectionState()).toBe("connected");
+    });
+
+    it("#1670 — a newer check ABANDONED before it answered does not silence the open page's verdict", async () => {
+      vi.mocked(playSectionUtils.timeoutMs).mockReturnValue(Promise.reject(new Error("timeout")));
+      const stillOpen = deferredConnection();
+      render(<RomMPlaySection appId={testAppId} />);
+      await flushAsync();
+
+      // A second page opens over it and closes again before the server answers
+      // it — so it never writes a verdict of its own.
+      deferredConnection();
+      const { unmount } = render(<RomMPlaySection appId={testAppId + 1} />);
+      await flushAsync();
+      unmount();
+
+      // The first page is still on screen, and its answer is now the only one
+      // anybody is going to get. Ordering on the newest ANSWER rather than the
+      // newest question is what keeps it from being discarded here.
+      await act(async () => {
+        stillOpen.resolve({ success: false, message: "" });
+        await flushAsync();
+      });
+      expect(connectionState.getRommConnectionState()).toBe("offline");
+    });
+
+    it("#1670 — a testConnection that throws SYNCHRONOUSLY still settles the badge and logs", async () => {
+      // The callable bridge is injected by the plugin loader; a synchronous
+      // throw out of it must not vanish into the fire-and-forget check.
+      vi.mocked(backend.testConnection).mockImplementation(() => {
+        throw new Error("bridge gone");
+      });
+      render(<RomMPlaySection appId={testAppId} />);
+      await flushAsync();
+      expect(connectionState.getRommConnectionState()).toBe("offline");
+      expect(vi.mocked(backend.debugLog)).toHaveBeenCalledWith(expect.stringContaining("connection check failed"));
+    });
+
+    it("#1670 — the save-status check runs on the ROM identity, NOT on the connection verdict", async () => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
+        found: true,
+        rom_id: 1671,
+        save_sync_enabled: true,
+      });
+      // The verdict is negative — a check gated on "connected" would skip.
+      vi.mocked(backend.testConnection).mockResolvedValue({ success: false, message: "" });
+      vi.mocked(backend.getSaveStatus).mockResolvedValue({
+        rom_id: 1671,
+        files: [],
+        playtime: {
+          total_seconds: 0,
+          session_count: 0,
+          last_session_start: null,
+          last_session_duration_sec: null,
+          last_played: null,
+        },
+        device_id: "d",
+        last_sync_check_at: null,
+      });
+      vi.mocked(saveStatusUtils.hasAnySaveConflict).mockReturnValue(true);
+      const listener = vi.fn();
+      globalThis.addEventListener("romm_data_changed", listener);
+      try {
+        render(<RomMPlaySection appId={testAppId} />);
+        await flushAsync();
+        // Non-vacuous on two counts: the verdict really was negative, and
+        // has_conflict is carried by THIS component's dispatch alone — the
+        // store's own save-status read emits nothing.
+        expect(connectionState.getRommConnectionState()).toBe("offline");
+        const saveSyncEv = listener.mock.calls
+          .map((c) => c[0] as CustomEvent)
+          .find((e) => e.detail.type === "save_sync");
+        expect(saveSyncEv?.detail).toMatchObject({ type: "save_sync", rom_id: 1671, has_conflict: true });
+      } finally {
+        globalThis.removeEventListener("romm_data_changed", listener);
+      }
     });
 
     it("#1670 — a rejected testConnection is still a reachability signal → 'offline'", async () => {

--- a/src/components/RomMPlaySection.test.tsx
+++ b/src/components/RomMPlaySection.test.tsx
@@ -220,6 +220,26 @@ const flushAsync = () =>
     await Promise.resolve();
   });
 
+type ConnectionResult = Awaited<ReturnType<typeof backend.testConnection>>;
+
+// Hold testConnection open so a test can land its verdict at a chosen moment —
+// the late-answer case #1670 turns on. The returned `resolve` reads the captured
+// one at call time, since the mock body only runs once the component renders.
+function deferredConnection(): { resolve: (r: ConnectionResult) => void } {
+  let settle: (r: ConnectionResult) => void = () => {};
+  vi.mocked(backend.testConnection).mockImplementation(
+    () =>
+      new Promise<ConnectionResult>((res) => {
+        settle = res;
+      }),
+  );
+  return {
+    resolve: (r) => {
+      settle(r);
+    },
+  };
+}
+
 // Inspect the most recent showContextMenu(menuElement, target) call.
 function lastContextMenuElement(): ReactElement | null {
   const calls = vi.mocked(showContextMenu).mock.calls;
@@ -1004,13 +1024,126 @@ describe("RomMPlaySection", () => {
       expect(connectionState.getRommConnectionState()).not.toBe("offline");
     });
 
-    it("on timeout (timeoutMs rejects first) → catch sets 'offline'", async () => {
+    // -----------------------------------------------------------------
+    // #1670 — the check ran twice per mount (the save-sync flag flipping
+    // re-keyed its effect), and the second run's 5s deadline was reported as a
+    // verdict even though the server answered seconds later.
+    // -----------------------------------------------------------------
+
+    it("#1670 — issues exactly ONE testConnection per mount, even though save-sync flips mid-mount", async () => {
+      // save_sync_enabled starts false in the store and flips true when the
+      // cached detail lands — the flip that used to re-run the connection check.
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
+        found: true,
+        rom_id: 1670,
+        save_sync_enabled: true,
+        save_sync_display: { status: "synced", label: "ok", last_sync_check_at: null },
+      });
+      vi.mocked(backend.getSaveStatus).mockResolvedValue({
+        rom_id: 1670,
+        files: [],
+        playtime: {
+          total_seconds: 0,
+          session_count: 0,
+          last_session_start: null,
+          last_session_duration_sec: null,
+          last_played: null,
+        },
+        device_id: "d",
+        last_sync_check_at: null,
+      });
+      vi.mocked(backend.testConnection).mockResolvedValue({ success: true, message: "ok" });
+      render(<RomMPlaySection appId={testAppId} />);
+      await flushAsync();
+      // Non-vacuous: the flip really happened, so a check keyed on it WOULD have
+      // re-run. One call is then proof the check is no longer keyed on it.
+      expect(getGameDetail(testAppId).saveSyncEnabled).toBe(true);
+      expect(vi.mocked(backend.testConnection)).toHaveBeenCalledTimes(1);
+      expect(connectionState.getRommConnectionState()).toBe("connected");
+    });
+
+    it("#1670 — a check that misses the deadline stays 'checking' and shows no offline badge", async () => {
       vi.mocked(playSectionUtils.timeoutMs).mockReturnValue(Promise.reject(new Error("timeout")));
-      // testConnection never resolves — race goes to timeoutMs.
+      // testConnection has not answered yet — the race goes to timeoutMs.
       vi.mocked(backend.testConnection).mockImplementation(() => new Promise(() => {}));
+      const { container } = render(<RomMPlaySection appId={testAppId} />);
+      await flushAsync();
+      // A deadline is not a verdict: unknown, not unreachable.
+      expect(connectionState.getRommConnectionState()).toBe("checking");
+      expect(container.textContent).not.toContain("RomM offline");
+      expect(vi.mocked(backend.debugLog)).toHaveBeenCalledWith(expect.stringContaining("connection check unanswered"));
+    });
+
+    it("#1670 — the verdict that lands AFTER the deadline still settles the badge", async () => {
+      vi.mocked(playSectionUtils.timeoutMs).mockReturnValue(Promise.reject(new Error("timeout")));
+      const late = deferredConnection();
+      const { container } = render(<RomMPlaySection appId={testAppId} />);
+      await flushAsync();
+      expect(connectionState.getRommConnectionState()).toBe("checking");
+
+      // The server answers 2.5s past the deadline, as it did in the recorded
+      // session — that answer is the verdict, not the deadline.
+      await act(async () => {
+        late.resolve({ success: true, message: "ok" });
+        await flushAsync();
+      });
+      expect(connectionState.getRommConnectionState()).toBe("connected");
+      expect(container.textContent).not.toContain("RomM offline");
+    });
+
+    it("#1670 — a late verdict for an UNMOUNTED page is dropped", async () => {
+      vi.mocked(playSectionUtils.timeoutMs).mockReturnValue(Promise.reject(new Error("timeout")));
+      const late = deferredConnection();
+      const { unmount } = render(<RomMPlaySection appId={testAppId} />);
+      await flushAsync();
+      unmount();
+      // A page nobody is looking at must not write the shared badge.
+      await act(async () => {
+        late.resolve({ success: false, message: "" });
+        await flushAsync();
+      });
+      expect(connectionState.getRommConnectionState()).toBe("checking");
+    });
+
+    it("#1670 — a late verdict does not clobber the state a NEWER check already settled", async () => {
+      vi.mocked(playSectionUtils.timeoutMs).mockReturnValue(Promise.reject(new Error("timeout")));
+      const stale = deferredConnection();
+      render(<RomMPlaySection appId={testAppId} />);
+      await flushAsync();
+      expect(connectionState.getRommConnectionState()).toBe("checking");
+
+      // A second game page opens and gets its answer inside the deadline.
+      vi.mocked(backend.testConnection).mockResolvedValue({ success: true, message: "ok" });
+      render(<RomMPlaySection appId={testAppId + 1} />);
+      await flushAsync();
+      expect(connectionState.getRommConnectionState()).toBe("connected");
+
+      // The first page's answer arrives afterwards. It is the answer to an older
+      // question and must not replace the newer one's.
+      await act(async () => {
+        stale.resolve({ success: false, message: "" });
+        await flushAsync();
+      });
+      expect(connectionState.getRommConnectionState()).toBe("connected");
+    });
+
+    it("#1670 — a rejected testConnection is still a reachability signal → 'offline'", async () => {
+      // Distinct from the deadline above: the CALL failed, which is a verdict.
+      vi.mocked(playSectionUtils.timeoutMs).mockReturnValue(Promise.reject(new Error("timeout")));
+      vi.mocked(backend.testConnection).mockRejectedValue(new Error("net"));
       render(<RomMPlaySection appId={testAppId} />);
       await flushAsync();
       expect(connectionState.getRommConnectionState()).toBe("offline");
+      expect(vi.mocked(backend.debugLog)).toHaveBeenCalledWith(expect.stringContaining("connection check failed"));
+    });
+
+    it("#1670 — every state transition is logged with its previous state, next state and reason", async () => {
+      vi.mocked(backend.testConnection).mockResolvedValue({ success: false, message: "" });
+      render(<RomMPlaySection appId={testAppId} />);
+      await flushAsync();
+      expect(vi.mocked(backend.debugLog)).toHaveBeenCalledWith(
+        "connectionState: checking -> offline (authoritative verdict)",
+      );
     });
 
     it("dispatches romm_data_changed with has_conflict when connected + save_sync_enabled", async () => {

--- a/src/components/RomMPlaySection.tsx
+++ b/src/components/RomMPlaySection.tsx
@@ -65,7 +65,6 @@ import { formatBytes, formatLastPlayed, formatPlaytime } from "../utils/formatte
 import { biosColorForLevel } from "../utils/biosColor";
 import { timeoutMs } from "../utils/playSection";
 import {
-  getGameDetail,
   noteSaveSyncDisplay,
   refreshBiosStatus,
   refreshCoreAndBios,
@@ -77,6 +76,20 @@ import {
  *  on the pair, not the appId alone: a version switch re-binds the appId to a
  *  new rom_id whose artwork has to be applied afresh (#1298 item 3). */
 const artworkApplied = new Map<number, number>();
+
+/** How long the authoritative connection check may run before the wait itself is
+ *  worth a log line. It is NOT a deadline after which the server counts as
+ *  unreachable — see the check below. */
+const CONNECTION_CHECK_DEADLINE_MS = 5000;
+
+/** Id of the most recently STARTED connection check across every mounted play
+ *  section. A check that has been superseded must not write its verdict: the
+ *  newer one has already reset the shared state to "checking" and will settle it
+ *  itself, so an older answer would replace a fresher question's state. Ids are
+ *  handed out here rather than per component because the state they guard is
+ *  module-level too — two play sections briefly overlap while Steam swaps game
+ *  pages. */
+let latestConnectionCheck = 0;
 
 /** Resolve the LAST PLAYED display, preferring our restored cross-device
  *  `last_played` (ISO-8601, from `reconcile_playtime` / native play sessions,
@@ -146,8 +159,10 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
   const connectionState = useRommConnectionState();
   const [actionPending, setActionPending] = useState<string | null>(null);
 
-  // Drive the offline recovery probe while this game page is mounted (#1345).
-  // A module-level guard keeps the ~30s re-probe single-instance and offline-only.
+  // Drive the reachability heartbeat while this game page is mounted (#1345) —
+  // it reports in both directions, so the badge follows the server going away as
+  // well as coming back. A module-level guard keeps the ~30s re-probe
+  // single-instance however many pages register it.
   useEffect(() => registerConnectionHeartbeat(), []);
 
   useEffect(() => {
@@ -171,35 +186,23 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
       .catch((e) => debugLog(`Auto-artwork error: ${e}`));
   }, [appId, detail.romId]);
 
-  // Background connection check — runs after initial cached render
-  // If connected + installed + save sync enabled, also runs background save status check
+  // Connection check — exactly one per mount, issued before this page's other
+  // RomM reads rather than behind them. Keyed on appId alone: the verdict is
+  // about the server, so nothing this page later learns about the ROM can change
+  // it, and re-running the check when a store field settled meant the FIRST
+  // (fast, idle-backend) answer was discarded as cancelled and the second one
+  // queued behind the mount's own calls until it missed its deadline (#1670).
   useEffect(() => {
+    const checkId = ++latestConnectionCheck;
     let cancelled = false;
-
-    // Background save-status check — detects new conflicts once the connection
-    // check confirms the server is reachable (save-sync only). The read itself
-    // and the state it produces belong to the store; what stays here is the
-    // conflict notification for the other save-sync surfaces. Playtime
-    // reconcile-on-view is a separate, connectivity-independent effect (#1345).
-    async function doSaveCheck(isCancelled: boolean) {
-      const { romId, saveSyncEnabled } = getGameDetail(appId);
-      if (!romId || !saveSyncEnabled) return;
-      try {
-        const saveStatus = await refreshSaveStatus(appId);
-        if (isCancelled || !saveStatus) return;
-        globalThis.dispatchEvent(
-          new CustomEvent("romm_data_changed", {
-            detail: { type: "save_sync", rom_id: romId, has_conflict: hasAnySaveConflict(saveStatus) },
-          }),
-        );
-      } catch (e) {
-        detach(debugLog(`RomMPlaySection: background save check error: ${e}`));
-      }
-    }
-
     // Once testConnection() lands an authoritative verdict, the fast probe must
     // not override it (avoids a late probe clobbering a "connected" badge).
     let settled = false;
+
+    /** An answer this check obtained is only still worth writing while it is the
+     *  newest question asked: after unmount, and after a later check started,
+     *  writing it would put a stale verdict over a fresh one. */
+    const superseded = () => cancelled || checkId !== latestConnectionCheck;
 
     // Fast offline-badge probe (ADR-0015): the slow `testConnection()` below
     // goes through the retrying heartbeat (3 attempts + backoff, up to ~90s on a
@@ -221,48 +224,92 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
         });
       // The fast probe is an EARLY hint, not the authority. Bail if testConnection
       // already settled an authoritative verdict (so a late probe can't clobber
-      // "connected"), or if cancelled / not offline. The shared store notifies
+      // "connected"), or if superseded / not offline. The shared store notifies
       // its subscribers on the change (#1345).
-      if (cancelled || settled || !offline) return;
-      setRommConnectionState("offline");
+      if (superseded() || settled || !offline) return;
+      setRommConnectionState("offline", "fast probe");
+    };
+
+    const applyVerdict = (result: Awaited<ReturnType<typeof testConnection>>) => {
+      if (superseded()) return;
+      settled = true; // authoritative verdict in hand — a late fast probe must not override it
+      if (result.reason === "version_error") {
+        setVersionError(result.message);
+        setRommConnectionState("offline", "version error");
+        return;
+      }
+      setRommConnectionState(result.success ? "connected" : "offline", "authoritative verdict");
     };
 
     const check = async () => {
       // Reset stale connection state immediately so downstream consumers
       // (e.g. CustomPlayButton) don't stay stuck on a previous "offline"
-      setRommConnectionState("checking");
+      setRommConnectionState("checking", "connection check started");
 
       // Snappy offline badge — runs concurrently with the precise check below.
       detach(fastOfflineProbe());
 
-      try {
-        const result = await Promise.race([testConnection(), timeoutMs(5000)]);
-        if (cancelled) return;
-        settled = true; // authoritative verdict in hand — a late fast probe must not override it
-        if (result.reason === "version_error") {
-          setVersionError(result.message);
-          setRommConnectionState("offline");
-          return;
-        }
-        const connected = result.success;
-        setRommConnectionState(connected ? "connected" : "offline");
+      // The verdict is consumed by its OWN handlers, not by the race below, so
+      // an answer that arrives after the deadline is still applied. A rejection
+      // is a different thing from a slow answer: the call itself failed, which
+      // is a reachability signal, so it settles the badge offline.
+      const verdict = testConnection().then(applyVerdict, (e: unknown) => {
+        if (superseded()) return;
+        settled = true;
+        detach(debugLog(`RomMPlaySection(${appId}): connection check failed: ${e}`));
+        setRommConnectionState("offline", "check failed");
+      });
 
-        if (connected) {
-          // Background save status check to detect new conflicts (save-sync only)
-          await doSaveCheck(cancelled);
-        }
-      } catch {
-        if (!cancelled) {
-          settled = true;
-          setRommConnectionState("offline");
-        }
-      }
+      // Missing the deadline means UNKNOWN, not unreachable: the badge stays at
+      // "checking" and the outstanding call above settles it whenever it lands.
+      // Reporting the deadline as a verdict is what put "RomM offline" on a page
+      // whose server answered seconds later (#1670).
+      await Promise.race([verdict, timeoutMs(CONNECTION_CHECK_DEADLINE_MS)]).catch(() => {
+        if (superseded() || settled) return;
+        detach(
+          debugLog(
+            `RomMPlaySection(${appId}): connection check unanswered after ${CONNECTION_CHECK_DEADLINE_MS}ms — holding "checking" until the verdict lands`,
+          ),
+        );
+      });
     };
     detach(check());
     return () => {
       cancelled = true;
     };
-  }, [detail.saveSyncEnabled, appId]);
+  }, [appId]);
+
+  // Background save-status check — detects new conflicts for a save-sync ROM.
+  // The read itself and the state it produces belong to the store; what stays
+  // here is the conflict notification for the other save-sync surfaces. Keyed on
+  // the ROM identity and the save-sync flag, which is all it consumes: it is not
+  // a reader of the connection verdict, and waiting behind one only meant the
+  // read landed after the store's own had settled, costing a second round-trip
+  // for the same answer. Playtime reconcile-on-view is a separate, equally
+  // connectivity-independent effect (#1345).
+  useEffect(() => {
+    const romId = detail.romId;
+    if (!romId || !detail.saveSyncEnabled) return;
+    let cancelled = false;
+
+    const doSaveCheck = async () => {
+      try {
+        const saveStatus = await refreshSaveStatus(appId);
+        if (cancelled || !saveStatus) return;
+        globalThis.dispatchEvent(
+          new CustomEvent("romm_data_changed", {
+            detail: { type: "save_sync", rom_id: romId, has_conflict: hasAnySaveConflict(saveStatus) },
+          }),
+        );
+      } catch (e) {
+        detach(debugLog(`RomMPlaySection: background save check error: ${e}`));
+      }
+    };
+    detach(doSaveCheck());
+    return () => {
+      cancelled = true;
+    };
+  }, [appId, detail.romId, detail.saveSyncEnabled]);
 
   // Reconcile-on-view (#868) — pull-only: folds RomM's play-session history into
   // the local total so a session played on another device shows up the moment the

--- a/src/components/RomMPlaySection.tsx
+++ b/src/components/RomMPlaySection.tsx
@@ -82,14 +82,17 @@ const artworkApplied = new Map<number, number>();
  *  unreachable — see the check below. */
 const CONNECTION_CHECK_DEADLINE_MS = 5000;
 
-/** Id of the most recently STARTED connection check across every mounted play
- *  section. A check that has been superseded must not write its verdict: the
- *  newer one has already reset the shared state to "checking" and will settle it
- *  itself, so an older answer would replace a fresher question's state. Ids are
- *  handed out here rather than per component because the state they guard is
- *  module-level too — two play sections briefly overlap while Steam swaps game
- *  pages. */
-let latestConnectionCheck = 0;
+/** Source of connection-check ids, in start order. Ids are handed out at module
+ *  level rather than per component because the state they order is module-level
+ *  too — two play sections briefly overlap while Steam swaps game pages. */
+let connectionCheckSeq = 0;
+
+/** Id of the newest check that has WRITTEN a verdict. An older check must not
+ *  write over it — its answer is to a question a newer one has already answered.
+ *  Ordering on the write rather than on the start is what keeps a check that is
+ *  abandoned before it answers (its page closed while the server was still
+ *  thinking) from silencing the verdict of a page that is still open. */
+let lastSettledCheckId = 0;
 
 /** Resolve the LAST PLAYED display, preferring our restored cross-device
  *  `last_played` (ISO-8601, from `reconcile_playtime` / native play sessions,
@@ -124,7 +127,12 @@ interface PlaytimeState {
   playtime: string;
 }
 
-import { setRommConnectionState, setVersionError, useRommConnectionState } from "../utils/connectionState";
+import {
+  setRommConnectionState,
+  setVersionError,
+  useRommConnectionState,
+  type RommConnectionState,
+} from "../utils/connectionState";
 import { registerConnectionHeartbeat } from "../utils/connectionHeartbeat";
 import { useVersionError } from "./VersionErrorCard";
 import { useMigrationStatus } from "./MigrationBlockedPage";
@@ -193,16 +201,26 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
   // (fast, idle-backend) answer was discarded as cancelled and the second one
   // queued behind the mount's own calls until it missed its deadline (#1670).
   useEffect(() => {
-    const checkId = ++latestConnectionCheck;
+    const checkId = ++connectionCheckSeq;
     let cancelled = false;
     // Once testConnection() lands an authoritative verdict, the fast probe must
     // not override it (avoids a late probe clobbering a "connected" badge).
     let settled = false;
 
-    /** An answer this check obtained is only still worth writing while it is the
-     *  newest question asked: after unmount, and after a later check started,
-     *  writing it would put a stale verdict over a fresh one. */
-    const superseded = () => cancelled || checkId !== latestConnectionCheck;
+    /** An answer this check obtained is only still worth writing while nothing
+     *  newer has answered: after unmount, and after a later check wrote its own
+     *  verdict, writing it would put a stale verdict over a fresh one. A newer
+     *  check that has merely STARTED does not supersede — it may yet be
+     *  abandoned unanswered, and then this check's answer is the only one
+     *  anybody is going to get. */
+    const superseded = () => cancelled || checkId < lastSettledCheckId;
+
+    /** Write a verdict and record this check as the newest one to have answered.
+     *  The single place either happens, so the two cannot drift apart. */
+    const settleWith = (next: RommConnectionState, reason: string) => {
+      lastSettledCheckId = checkId;
+      setRommConnectionState(next, reason);
+    };
 
     // Fast offline-badge probe (ADR-0015): the slow `testConnection()` below
     // goes through the retrying heartbeat (3 attempts + backoff, up to ~90s on a
@@ -227,7 +245,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
       // "connected"), or if superseded / not offline. The shared store notifies
       // its subscribers on the change (#1345).
       if (superseded() || settled || !offline) return;
-      setRommConnectionState("offline", "fast probe");
+      settleWith("offline", "fast probe");
     };
 
     const applyVerdict = (result: Awaited<ReturnType<typeof testConnection>>) => {
@@ -235,10 +253,30 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
       settled = true; // authoritative verdict in hand — a late fast probe must not override it
       if (result.reason === "version_error") {
         setVersionError(result.message);
-        setRommConnectionState("offline", "version error");
+        settleWith("offline", "version error");
         return;
       }
-      setRommConnectionState(result.success ? "connected" : "offline", "authoritative verdict");
+      settleWith(result.success ? "connected" : "offline", "authoritative verdict");
+    };
+
+    /** Obtain the verdict and apply it. Declared async so a SYNCHRONOUS throw
+     *  out of the callable bridge arrives here as a rejection instead of
+     *  escaping into the fire-and-forget `check()` unlogged — a bridge that
+     *  cannot be called at all is as much a reachability signal as a rejected
+     *  promise. Only the CALL is guarded: a throw out of applyVerdict is a
+     *  subscriber's defect, not a verdict, and must not be reported as one. */
+    const runVerdict = async () => {
+      let result: Awaited<ReturnType<typeof testConnection>>;
+      try {
+        result = await testConnection();
+      } catch (e) {
+        if (superseded()) return;
+        settled = true;
+        detach(debugLog(`RomMPlaySection(${appId}): connection check failed: ${e}`));
+        settleWith("offline", "check failed");
+        return;
+      }
+      applyVerdict(result);
     };
 
     const check = async () => {
@@ -249,16 +287,9 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
       // Snappy offline badge — runs concurrently with the precise check below.
       detach(fastOfflineProbe());
 
-      // The verdict is consumed by its OWN handlers, not by the race below, so
-      // an answer that arrives after the deadline is still applied. A rejection
-      // is a different thing from a slow answer: the call itself failed, which
-      // is a reachability signal, so it settles the badge offline.
-      const verdict = testConnection().then(applyVerdict, (e: unknown) => {
-        if (superseded()) return;
-        settled = true;
-        detach(debugLog(`RomMPlaySection(${appId}): connection check failed: ${e}`));
-        setRommConnectionState("offline", "check failed");
-      });
+      // The verdict is consumed by runVerdict, not by the race below, so an
+      // answer that arrives after the deadline is still applied.
+      const verdict = runVerdict();
 
       // Missing the deadline means UNKNOWN, not unreachable: the badge stays at
       // "checking" and the outstanding call above settles it whenever it lands.

--- a/src/utils/connectionState.test.ts
+++ b/src/utils/connectionState.test.ts
@@ -8,11 +8,13 @@ import {
   setServerRetryProgress,
   onServerRetryProgressChange,
 } from "./connectionState";
+import { debugLog } from "../api/backend";
 
 describe("connectionState store (#1345)", () => {
   beforeEach(() => {
     // Reset the module-level store to the neutral state between tests.
     setRommConnectionState("checking");
+    vi.mocked(debugLog).mockClear();
   });
 
   it("notifies subscribers on a real change", () => {
@@ -56,6 +58,32 @@ describe("connectionState store (#1345)", () => {
     reportServerReachable(false);
     expect(a).toHaveBeenCalledExactlyOnceWith("offline");
     expect(b).toHaveBeenCalledExactlyOnceWith("offline");
+  });
+
+  // A dozen call sites write this state and the user only sees the result, so
+  // the transition has to name the signal behind it (#1670).
+  it("logs each transition with its previous state, next state and reason", () => {
+    setRommConnectionState("offline", "fast probe");
+    expect(vi.mocked(debugLog)).toHaveBeenCalledExactlyOnceWith("connectionState: checking -> offline (fast probe)");
+  });
+
+  it("logs 'unspecified' when a caller names no reason", () => {
+    setRommConnectionState("connected");
+    expect(vi.mocked(debugLog)).toHaveBeenCalledExactlyOnceWith("connectionState: checking -> connected (unspecified)");
+  });
+
+  it("reportServerReachable names itself as the reason", () => {
+    reportServerReachable(true);
+    expect(vi.mocked(debugLog)).toHaveBeenCalledExactlyOnceWith(
+      "connectionState: checking -> connected (reachability report)",
+    );
+  });
+
+  it("logs nothing when the state is unchanged", () => {
+    setRommConnectionState("offline", "fast probe");
+    vi.mocked(debugLog).mockClear();
+    setRommConnectionState("offline", "authoritative verdict");
+    expect(vi.mocked(debugLog)).not.toHaveBeenCalled();
   });
 });
 

--- a/src/utils/connectionState.ts
+++ b/src/utils/connectionState.ts
@@ -10,6 +10,8 @@
  */
 
 import { useEffect, useState } from "react";
+import { debugLog } from "../api/backend";
+import { detach } from "./detach";
 
 export type RommConnectionState = "checking" | "connected" | "offline";
 
@@ -22,10 +24,17 @@ export function getRommConnectionState(): RommConnectionState {
 
 /** Set the connection state, notifying subscribers only when it actually
  *  changes. Feed real reachability signals through {@link reportServerReachable};
- *  this direct setter is for the play section's own `checking`/verdict flow. */
-export function setRommConnectionState(s: RommConnectionState): void {
+ *  this direct setter is for the play section's own `checking`/verdict flow.
+ *
+ *  `reason` names the signal that produced the transition, and is logged with
+ *  it. A dozen call sites write this state and the user only ever sees the
+ *  result, so without the reason on the transition itself a wrong "RomM offline"
+ *  cannot be attributed to the signal that caused it from a log alone (#1670). */
+export function setRommConnectionState(s: RommConnectionState, reason = "unspecified"): void {
   if (_state === s) return;
+  const previous = _state;
   _state = s;
+  detach(debugLog(`connectionState: ${previous} -> ${s} (${reason})`));
   connectionListeners.forEach((l) => l(s));
 }
 
@@ -34,7 +43,7 @@ export function setRommConnectionState(s: RommConnectionState): void {
  *  `SERVER_UNREACHABLE` / offline probe) → `offline`. Only feed it signals that
  *  genuinely mean the server is reachable or not — never an arbitrary error. */
 export function reportServerReachable(ok: boolean): void {
-  setRommConnectionState(ok ? "connected" : "offline");
+  setRommConnectionState(ok ? "connected" : "offline", "reachability report");
 }
 
 export function onRommConnectionChange(cb: (s: RommConnectionState) => void): () => void {

--- a/src/utils/launchInterceptor.test.ts
+++ b/src/utils/launchInterceptor.test.ts
@@ -37,6 +37,9 @@ vi.mock("../api/backend", () => ({
   renewPruneConflictLease: vi.fn(),
   logInfo: vi.fn(),
   logError: vi.fn(),
+  // Not called by launchInterceptor itself — the real connectionState store it
+  // reports reachability into logs each transition through it.
+  debugLog: vi.fn(),
 }));
 
 // The reconcile helper confirm-sets the resolved command onto the shortcut.


### PR DESCRIPTION
The game-detail page told users their RomM server was offline while it was answering normally.
Six of ten page opens in one recorded session showed the badge, with fast opens in between, which
is why it read as intermittent.

Two defects compounded. The connection check lived in an effect keyed on the save-sync flag, which
starts `false` and flips to `true` when the cached detail lands — so the check ran twice per mount.
The first run hit an idle backend and answered in ~0.2s, and that answer was discarded, because the
flip had already marked it cancelled. The second ran after the mount had dispatched its burst of
RomM calls and queued behind them. And when its five-second race deadline passed first, the
deadline was written as a verdict: `offline`. The real answer did arrive — 7.58s in the case above
— but nothing consumed it, so the badge and the SAVES tab's "slot switching is disabled" notice
stood until Steam remounted the panel on its own.

The check now has its own effect keyed on `[appId]`, so it runs once and issues before the burst.
Missing the deadline is treated as *unknown*: the state holds at `checking`, the outstanding call
keeps running, and its answer is applied whenever it lands. `checking` is a neutral state — every
consumer compares against `offline` — so nothing is disabled and no badge is shown while it holds.
The background save check moves to its own effect and no longer waits for the connection verdict;
its read coalesces with the one the store already issues on load, so this removes a round-trip
rather than adding one.

Verdicts are ordered by the newest *answer*, not the newest question. A check records its id only
when it writes a state, so a still-mounted page's verdict is no longer discarded because another
page started a check and disappeared before settling. Ordering by the question would have left a
genuinely offline server unbadged until the next heartbeat tick.

A failure remains a failure: a rejected call, or a call bridge that cannot be reached at all, still
reports `offline`. Only the *call* is guarded — a throw out of the verdict handler is a subscriber's
defect, not a reachability signal, and reporting it as one would be the same silent failure in a new
place.

Every connection-state transition now logs previous state, next state and the reason. The absence of
that line is why this defect needed a live session to find rather than a log read.

This does not address the underlying congestion: the page still fires a burst of concurrent calls on
mount and the reads queue behind it. That is the structural half, and it belongs with the remaining
component moves onto the per-appId store (#993).

Closes #1670
