### PR TITLE
fix(ui): bind the game-detail store's async folds to the rom they were read for

### DIFF
--- a/src/utils/gameDetailStore.test.ts
+++ b/src/utils/gameDetailStore.test.ts
@@ -21,6 +21,7 @@ import type { CachedGameDetail } from "../api/backend";
 import type { CoreInfo, DownloadCompleteEvent, SaveStatus } from "../types";
 
 type BiosStatusResult = Awaited<ReturnType<typeof backend.getBiosStatus>>;
+type AchievementProgressResult = Awaited<ReturnType<typeof backend.getAchievementProgress>>;
 
 // getCachedGameDetail / invalidateCachedGameDetail are re-exported through
 // backend.ts but their canonical home is utils — mock the store so both import
@@ -135,6 +136,8 @@ const switchedCoreInfo: CoreInfo = {
     },
   ],
 };
+
+const achievementSummary = (earned: number, total: number) => ({ earned, total, earned_hardcore: 0 });
 
 const biosMissing: BiosStatusResult = {
   bios_status: { platform_slug: "snes", server_count: 3, local_count: 0, all_downloaded: false },
@@ -708,6 +711,105 @@ describe("gameDetailStore", () => {
       });
 
       expect(vi.mocked(cachedStore.getCachedGameDetail)).not.toHaveBeenCalled();
+    });
+  });
+
+  // The mount load fires its background reads and returns; a switch landing
+  // before one of them answers re-keys the entry without closing it, so the
+  // generation the read was issued under is still current.
+  describe("mount-load background refreshes across a version switch", () => {
+    it("does not fold a core answer read for the rom the load resolved", async () => {
+      const previousRomCore = deferred<CoreInfo>();
+      vi.mocked(backend.getPlatformCoreInfo).mockResolvedValue(switchedCoreInfo);
+      vi.mocked(backend.getPlatformCoreInfo).mockReturnValueOnce(previousRomCore.promise);
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(found());
+      subscribe(nextAppId);
+      await flush();
+      expect(vi.mocked(backend.getPlatformCoreInfo)).toHaveBeenCalledExactlyOnceWith(42);
+
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(found(switchedDetail));
+      await act(async () => {
+        dispatchVersionSwitch(nextAppId);
+        await Promise.resolve();
+      });
+      await flush();
+      expect(getGameDetail(nextAppId)).toMatchObject({ romId: 43, activeCoreLabel: "Genesis Plus GX" });
+
+      previousRomCore.resolve(coreInfo);
+      await flush();
+
+      expect(getGameDetail(nextAppId)).toMatchObject({ romId: 43, activeCoreLabel: "Genesis Plus GX" });
+    });
+
+    it("does not fold a BIOS answer read for the rom the load resolved", async () => {
+      const previousRomBios = deferred<BiosStatusResult>();
+      vi.mocked(backend.getBiosStatus).mockReturnValueOnce(previousRomBios.promise);
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(found({ stale_fields: ["bios"] }));
+      subscribe(nextAppId);
+      await flush();
+      expect(vi.mocked(backend.getBiosStatus)).toHaveBeenCalledExactlyOnceWith(42);
+
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(found(switchedDetail));
+      await act(async () => {
+        dispatchVersionSwitch(nextAppId);
+        await Promise.resolve();
+      });
+      await flush();
+      expect(getGameDetail(nextAppId)).toMatchObject({ romId: 43, biosStatus: "ok", biosLabel: "3/3" });
+
+      previousRomBios.resolve(biosMissing);
+      await flush();
+
+      expect(getGameDetail(nextAppId)).toMatchObject({ romId: 43, biosStatus: "ok", biosLabel: "3/3" });
+    });
+
+    it("does not fold an achievement count read for the rom the load resolved", async () => {
+      const previousRomProgress = deferred<AchievementProgressResult>();
+      vi.mocked(backend.getAchievementProgress).mockReturnValueOnce(previousRomProgress.promise);
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(
+        found({ ra_id: 7, stale_fields: ["achievements"], achievement_summary: achievementSummary(7, 70) }),
+      );
+      subscribe(nextAppId);
+      await flush();
+      expect(vi.mocked(backend.getAchievementProgress)).toHaveBeenCalledExactlyOnceWith(42);
+      expect(getGameDetail(nextAppId)).toMatchObject({ achievementEarned: 7, achievementTotal: 70 });
+
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(
+        found({ rom_id: 43, ra_id: 9, achievement_summary: achievementSummary(3, 30) }),
+      );
+      await act(async () => {
+        dispatchVersionSwitch(nextAppId);
+        await Promise.resolve();
+      });
+      await flush();
+      expect(getGameDetail(nextAppId)).toMatchObject({ romId: 43, achievementEarned: 3, achievementTotal: 30 });
+
+      previousRomProgress.resolve({ success: true, earned: 12, total: 70, earned_achievements: [] });
+      await flush();
+
+      expect(getGameDetail(nextAppId)).toMatchObject({ romId: 43, achievementEarned: 3, achievementTotal: 30 });
+    });
+
+    // #1345: a switched-to detail with no achievement summary keeps the shown
+    // count rather than degrading it to 0. That carry-over is the identity
+    // write's doing, and the identity write is deliberately NOT rom-bound — this
+    // pins that the binding above did not turn the carry-over into a reset.
+    it("still keeps the last-known achievement counts when the switched-to detail carries no summary", async () => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(
+        found({ ra_id: 7, achievement_summary: achievementSummary(7, 70) }),
+      );
+      subscribe(nextAppId);
+      await flush();
+      expect(getGameDetail(nextAppId)).toMatchObject({ achievementEarned: 7, achievementTotal: 70 });
+
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(found({ rom_id: 43 }));
+      await act(async () => {
+        dispatchVersionSwitch(nextAppId);
+        await Promise.resolve();
+      });
+      await flush();
+
+      expect(getGameDetail(nextAppId)).toMatchObject({ romId: 43, achievementEarned: 7, achievementTotal: 70 });
     });
   });
 

--- a/src/utils/gameDetailStore.test.ts
+++ b/src/utils/gameDetailStore.test.ts
@@ -18,7 +18,9 @@ import {
 } from "../test-utils/dom-event-listener-spy";
 import { deckyEventListenerCount, emitDeckyEvent } from "../test-utils/decky-api-mock";
 import type { CachedGameDetail } from "../api/backend";
-import type { DownloadCompleteEvent, SaveStatus } from "../types";
+import type { CoreInfo, DownloadCompleteEvent, SaveStatus } from "../types";
+
+type BiosStatusResult = Awaited<ReturnType<typeof backend.getBiosStatus>>;
 
 // getCachedGameDetail / invalidateCachedGameDetail are re-exported through
 // backend.ts but their canonical home is utils — mock the store so both import
@@ -79,6 +81,14 @@ function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void; reje
   return { promise, resolve, reject };
 }
 
+/** Re-key an entry to rom 43 the way the version picker does — without closing
+ *  it, so the generation is unchanged and only the rom identity separates an
+ *  answer read for the previous ROM from the entry's new one. */
+const dispatchVersionSwitch = (appId: number) =>
+  globalThis.dispatchEvent(
+    new CustomEvent("romm_data_changed", { detail: { type: "version_switched", app_id: appId, rom_id: 43 } }),
+  );
+
 const downloadComplete = (romId: number): DownloadCompleteEvent => ({
   rom_id: romId,
   rom_name: "Test ROM",
@@ -88,7 +98,7 @@ const downloadComplete = (romId: number): DownloadCompleteEvent => ({
   launch_options: "",
 });
 
-const coreInfo = {
+const coreInfo: CoreInfo = {
   active_core: "snes9x.so",
   active_core_label: "Snes9x",
   platform_core_label: null,
@@ -97,13 +107,48 @@ const coreInfo = {
   emulators: [
     {
       label: "Snes9x",
-      kind: "libretro" as const,
+      kind: "libretro",
       core_so: "snes9x.so",
       is_default: true,
       bakeable: true,
       reason: null,
     },
   ],
+};
+
+/** The core the entry reads for the ROM it switches TO — distinct from
+ *  {@link coreInfo} so a fold of the previous ROM's answer is visible. */
+const switchedCoreInfo: CoreInfo = {
+  active_core: "genesis_plus_gx.so",
+  active_core_label: "Genesis Plus GX",
+  platform_core_label: null,
+  has_game_override: false,
+  emulator_data_available: true,
+  emulators: [
+    {
+      label: "Genesis Plus GX",
+      kind: "libretro",
+      core_so: "genesis_plus_gx.so",
+      is_default: true,
+      bakeable: true,
+      reason: null,
+    },
+  ],
+};
+
+const biosMissing: BiosStatusResult = {
+  bios_status: { platform_slug: "snes", server_count: 3, local_count: 0, all_downloaded: false },
+  bios_level: "missing",
+  bios_label: "0/3",
+};
+
+/** The cached detail of the ROM a version switch moves the entry to, carrying a
+ *  BIOS level the previous ROM's read would overwrite if it were still folded. */
+const switchedDetail: Partial<CachedGameDetail> = {
+  rom_id: 43,
+  bios_status: { platform_slug: "genesis", server_count: 3, local_count: 3, all_downloaded: true },
+  bios_level: "ok",
+  bios_label: "3/3",
 };
 
 describe("gameDetailStore", () => {
@@ -581,6 +626,43 @@ describe("gameDetailStore", () => {
       expect(vi.mocked(backend.getBiosStatus)).not.toHaveBeenCalled();
     });
 
+    // The entry is re-keyed, not closed, so the generation fence cannot see this:
+    // the core and BIOS answers below were read for the ROM the page has left.
+    it("does not fold a core or BIOS answer read for the rom the entry has since left", async () => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(found());
+      subscribe(nextAppId);
+      await flush();
+      vi.mocked(backend.getPlatformCoreInfo).mockClear();
+      const previousRomCore = deferred<CoreInfo>();
+      vi.mocked(backend.getPlatformCoreInfo).mockResolvedValue(switchedCoreInfo);
+      vi.mocked(backend.getPlatformCoreInfo).mockReturnValueOnce(previousRomCore.promise);
+      vi.mocked(backend.getBiosStatus).mockResolvedValue(biosMissing);
+
+      await act(async () => {
+        dispatchCoreChanged();
+        await Promise.resolve();
+      });
+      expect(vi.mocked(backend.getPlatformCoreInfo)).toHaveBeenCalledExactlyOnceWith(42);
+
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(found(switchedDetail));
+      await act(async () => {
+        dispatchVersionSwitch(nextAppId);
+        await Promise.resolve();
+      });
+      await flush();
+      expect(getGameDetail(nextAppId)).toMatchObject({ romId: 43, activeCoreLabel: "Genesis Plus GX" });
+
+      previousRomCore.resolve(coreInfo);
+      await flush();
+
+      expect(getGameDetail(nextAppId)).toMatchObject({
+        romId: 43,
+        activeCoreLabel: "Genesis Plus GX",
+        biosStatus: "ok",
+        biosLabel: "3/3",
+      });
+    });
+
     it("surfaces a failed read through debugLog instead of leaving it unhandled", async () => {
       vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(found());
       subscribe(nextAppId);
@@ -599,11 +681,6 @@ describe("gameDetailStore", () => {
   });
 
   describe("version_switched notifications", () => {
-    const dispatchSwitch = (appId: number) =>
-      globalThis.dispatchEvent(
-        new CustomEvent("romm_data_changed", { detail: { type: "version_switched", app_id: appId, rom_id: 43 } }),
-      );
-
     it("re-derives the entry for this appId", async () => {
       vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(found());
       subscribe(nextAppId);
@@ -611,7 +688,7 @@ describe("gameDetailStore", () => {
       vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(found({ rom_id: 43, rom_name: "Other version" }));
 
       await act(async () => {
-        dispatchSwitch(nextAppId);
+        dispatchVersionSwitch(nextAppId);
         await Promise.resolve();
       });
       await flush();
@@ -626,7 +703,7 @@ describe("gameDetailStore", () => {
       vi.mocked(cachedStore.getCachedGameDetail).mockClear();
 
       await act(async () => {
-        dispatchSwitch(nextAppId + 1);
+        dispatchVersionSwitch(nextAppId + 1);
         await Promise.resolve();
       });
 
@@ -726,6 +803,63 @@ describe("gameDetailStore", () => {
       await refreshBiosStatus(nextAppId);
 
       expect(getGameDetail(nextAppId)).toMatchObject({ biosStatus: "partial", biosLabel: "1/3" });
+    });
+
+    it("refreshBiosStatus does not fold a level read for the rom the entry has since left", async () => {
+      subscribe(nextAppId);
+      await flush();
+      const previousRom = deferred<BiosStatusResult>();
+      vi.mocked(backend.getBiosStatus).mockReturnValueOnce(previousRom.promise);
+      const inFlight = refreshBiosStatus(nextAppId);
+      expect(vi.mocked(backend.getBiosStatus)).toHaveBeenCalledExactlyOnceWith(42);
+
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(found(switchedDetail));
+      await act(async () => {
+        dispatchVersionSwitch(nextAppId);
+        await Promise.resolve();
+      });
+      await flush();
+      expect(getGameDetail(nextAppId)).toMatchObject({ romId: 43, biosStatus: "ok", biosLabel: "3/3" });
+
+      previousRom.resolve(biosMissing);
+      await inFlight;
+      await flush();
+
+      expect(getGameDetail(nextAppId)).toMatchObject({ romId: 43, biosStatus: "ok", biosLabel: "3/3" });
+    });
+
+    it("refreshCoreAndBios does not fold core or BIOS answers for the rom the entry has since left", async () => {
+      subscribe(nextAppId);
+      await flush();
+      vi.mocked(backend.getPlatformCoreInfo).mockClear();
+      const previousRomCore = deferred<CoreInfo>();
+      vi.mocked(backend.getPlatformCoreInfo).mockResolvedValue(switchedCoreInfo);
+      vi.mocked(backend.getPlatformCoreInfo).mockReturnValueOnce(previousRomCore.promise);
+      vi.mocked(backend.getBiosStatus).mockResolvedValue(biosMissing);
+      const inFlight = refreshCoreAndBios(nextAppId);
+      expect(vi.mocked(backend.getPlatformCoreInfo)).toHaveBeenCalledExactlyOnceWith(42);
+
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(found(switchedDetail));
+      await act(async () => {
+        dispatchVersionSwitch(nextAppId);
+        await Promise.resolve();
+      });
+      await flush();
+      expect(getGameDetail(nextAppId)).toMatchObject({ romId: 43, activeCoreLabel: "Genesis Plus GX" });
+
+      previousRomCore.resolve(coreInfo);
+      await inFlight;
+      await flush();
+
+      expect(getGameDetail(nextAppId)).toMatchObject({
+        romId: 43,
+        activeCoreLabel: "Genesis Plus GX",
+        biosStatus: "ok",
+        biosLabel: "3/3",
+      });
+      // The cache drop is not part of the fold: it only forces the next read to
+      // go to the backend, so it runs even when the fold was refused.
+      expect(vi.mocked(cachedStore.invalidateCachedGameDetail)).toHaveBeenCalledWith(nextAppId);
     });
 
     it("refreshCoreAndBios re-derives both and drops the cached detail", async () => {

--- a/src/utils/gameDetailStore.ts
+++ b/src/utils/gameDetailStore.ts
@@ -228,7 +228,8 @@ function writerForRom(entry: Entry, generation: number, romId: number): Dispatch
 /**
  * Cache-first load: resolve the cached game detail for this appId, fold it into
  * the entry, and fire the background refreshes (save status, metadata,
- * achievements, BIOS, core) whose results are merged in as they land.
+ * achievements, BIOS, core) whose results are merged in as they land — unless a
+ * version switch re-keyed the entry to another ROM while one was open.
  */
 async function loadDetail(appId: number, entry: Entry): Promise<void> {
   const generation = entry.generation;
@@ -267,6 +268,12 @@ async function loadDetail(appId: number, entry: Entry): Promise<void> {
       achievementTotal: cached.achievement_summary?.total ?? prev.achievementTotal,
     }));
 
+    // Every background answer below is bound to the rom THIS load resolved, so a
+    // version switch landing while one is open cannot fold it into a page that
+    // has moved on. The identity write above is the one write that cannot take
+    // the binding — it is what establishes the identity.
+    const writeForRom = writerForRom(entry, generation, romId);
+
     // The live save status carries what the cached detail does not: the active
     // slot, the content-dir flag, and the conflicts. Fire-and-forget — a failed
     // read leaves the cached display standing, and a caller that needs to know
@@ -280,7 +287,7 @@ async function loadDetail(appId: number, entry: Entry): Promise<void> {
     }
 
     if (cached.ra_id && staleFields.includes("achievements")) {
-      refreshAchievementsInBackground(romId, cancelled, write);
+      refreshAchievementsInBackground(romId, cancelled, writeForRom);
     }
 
     if (cached.bios_status) {
@@ -291,13 +298,13 @@ async function loadDetail(appId: number, entry: Entry): Promise<void> {
     }
 
     if (staleFields.includes("bios")) {
-      refreshBiosInBackground(romId, cancelled, write);
+      refreshBiosInBackground(romId, cancelled, writeForRom);
     }
 
     // Core info is sourced from its OWN path (#923), independent of BIOS status,
     // and keyed on rom_id so the active core reflects a per-game DB override
     // (epic #945).
-    refreshCoreInfoInBackground(romId, cancelled, write);
+    refreshCoreInfoInBackground(romId, cancelled, writeForRom);
   } catch (e) {
     // Shared by the mount load and the version-switch re-derive — a failed cache
     // load leaves every subscribed surface stale either way, so surface at warn

--- a/src/utils/gameDetailStore.ts
+++ b/src/utils/gameDetailStore.ts
@@ -206,6 +206,25 @@ function writerFor(entry: Entry, generation: number): Dispatch<SetStateAction<Ga
   };
 }
 
+/** A writer additionally bound to the rom identity a read was issued for: it
+ *  refuses a fold once the entry has moved on to another ROM. A version switch
+ *  re-keys the entry without closing it, so the generation is unchanged and the
+ *  identity is the only thing separating this page's answer from its
+ *  predecessor's.
+ *
+ *  The gate is the question, not the answer: it compares the rom the read was
+ *  ISSUED for against the entry's rom now, where {@link applySaveStatus} can
+ *  compare the answer's own `rom_id` and so also catch a payload about the wrong
+ *  ROM. Neither `CoreInfo` nor the `get_bios_status` payload carries a rom id,
+ *  so that stronger form is not available to the core and BIOS reads. */
+function writerForRom(entry: Entry, generation: number, romId: number): Dispatch<SetStateAction<GameDetailState>> {
+  const write = writerFor(entry, generation);
+  return (update) => {
+    if (entry.state.romId !== romId) return;
+    write(update);
+  };
+}
+
 /**
  * Cache-first load: resolve the cached game detail for this appId, fold it into
  * the entry, and fire the background refreshes (save status, metadata,
@@ -376,7 +395,8 @@ export function noteSaveSyncDisplay(appId: number, display: SaveSyncDisplay): vo
 }
 
 /** Re-read the BIOS level after a firmware download. Leaves the shown level
- *  alone when the read fails or reports no BIOS need. */
+ *  alone when the read fails, when it reports no BIOS need, or when a version
+ *  switch re-keyed the entry while the read was open. */
 export async function refreshBiosStatus(appId: number): Promise<void> {
   const entry = _entries.get(appId);
   const romId = entry?.state.romId;
@@ -384,9 +404,10 @@ export async function refreshBiosStatus(appId: number): Promise<void> {
   const generation = entry.generation;
   const refreshed = await getBiosStatus(romId).catch(() => NO_BIOS_STATUS);
   if (!refreshed.bios_status) return;
-  writerFor(
+  writerForRom(
     entry,
     generation,
+    romId,
   )((prev) => ({
     ...prev,
     biosStatus: refreshed.bios_level,
@@ -401,6 +422,12 @@ export async function refreshBiosStatus(appId: number): Promise<void> {
  * `biosNeeded` is re-derived from the refreshed status rather than kept: the
  * active core just changed, so the BIOS requirement may have changed with it
  * (#923).
+ *
+ * A version switch landing while the two reads are open re-keys the entry, and
+ * the answers are then about the ROM it moved off — so the fold is refused. The
+ * cache drop still runs either way: it only forces the next read to go to the
+ * backend, so it cannot show anything wrong, while skipping it would make the
+ * cache's correctness depend on the switch path having dropped it first.
  */
 export async function refreshCoreAndBios(appId: number): Promise<void> {
   const entry = _entries.get(appId);
@@ -411,9 +438,10 @@ export async function refreshCoreAndBios(appId: number): Promise<void> {
     getPlatformCoreInfo(romId),
     getBiosStatus(romId).catch(() => NO_BIOS_STATUS),
   ]);
-  writerFor(
+  writerForRom(
     entry,
     generation,
+    romId,
   )((prev) => ({
     ...prev,
     ...extractCoreInfo(coreInfo),
@@ -483,9 +511,10 @@ async function handleCoreChange(entry: Entry): Promise<void> {
   // level/label still come from the (now core-free) BIOS status — the active
   // core just switched, so the BIOS requirements may have changed.
   const [coreInfo, biosResult] = await Promise.all([getPlatformCoreInfo(romId), getBiosStatus(romId)]);
-  writerFor(
+  writerForRom(
     entry,
     generation,
+    romId,
   )((prev) => ({
     ...prev,
     ...extractCoreInfo(coreInfo),

--- a/src/utils/gameDetailStore.ts
+++ b/src/utils/gameDetailStore.ts
@@ -270,8 +270,11 @@ async function loadDetail(appId: number, entry: Entry): Promise<void> {
 
     // Every background answer below is bound to the rom THIS load resolved, so a
     // version switch landing while one is open cannot fold it into a page that
-    // has moved on. The identity write above is the one write that cannot take
-    // the binding — it is what establishes the identity.
+    // has moved on. Two writes stay on the unbound `write` deliberately: the
+    // identity write above, which installs the very identity a binding would
+    // check against, and the `cached.bios_status` fold below, which runs in the
+    // same tick as it — no await in between for a switch to land in, so binding
+    // it would be a no-op.
     const writeForRom = writerForRom(entry, generation, romId);
 
     // The live save status carries what the cached detail does not: the active


### PR DESCRIPTION
The store fences every async write with a generation counter, which covers an entry being closed
and reopened. A version switch does neither: it swaps the rom inside the entry and leaves the
generation untouched. So an answer to a read issued for the previous rom folded into the page the
user had already switched to — the wrong rom's active core, BIOS level and achievement counts,
standing until the next notification corrected them.

The save-status path already had a second, rom-level guard for exactly this reason. Six other folds
did not: `refreshBiosStatus`, `refreshCoreAndBios`, `handleCoreChange`, and the mount load's three
background helpers for BIOS, core info and achievements. The mount load's three are the more likely
instances — they run on every page open, so they are far more often in flight when a switch lands
than the on-demand refreshes are.

All six now write through `writerForRom`, which refuses a fold whose rom is no longer the entry's.
The guard sits inside the returned dispatch, so it evaluates when the answer lands rather than when
the read was issued. It is the weaker of the two available forms — the captured rom compared against
the entry's, rather than the answer's own rom id — because neither the core-info nor the BIOS nor
the achievement payload carries one. The stronger form stays where the payload allows it.

Two writes deliberately stay unbound and are now named as such in the code: the identity write,
which installs the identity a binding would compare against, and its BIOS sibling in the same
synchronous run, where a binding could never fire.

Each of the six carries a regression test that fails without the binding on its final fold
assertion, with the switch provably landing before the answer — the mid-test assertions pin that the
read went out for the old rom and the entry had already moved to the new one.

Not a regression: this is how the code behaved before the store existed. It is being closed now
because `CustomPlayButton` and `RomMGameInfoPanel` are about to subscribe to the same store, at
which point one wrong fold would reach three surfaces instead of one.

docs: N/A — no page documents this store's fold behaviour; the vocabulary entry in CONTEXT.md is
unchanged by this fix.

Closes #1656
