### PR TITLE
fix(ui): order the game detail store's loads so a slower one cannot reinstall a stale identity

### DIFF
--- a/src/utils/gameDetailStore.test.ts
+++ b/src/utils/gameDetailStore.test.ts
@@ -117,9 +117,10 @@ const coreInfo: CoreInfo = {
   ],
 };
 
-/** The core the entry reads for the ROM it switches TO — distinct from
- *  {@link coreInfo} so a fold of the previous ROM's answer is visible. */
-const switchedCoreInfo: CoreInfo = {
+/** The answer a second core read returns — after a version switch, or after a
+ *  re-read of the same rom — distinct from {@link coreInfo} so a fold of the
+ *  first read's answer is visible. */
+const laterCoreInfo: CoreInfo = {
   active_core: "genesis_plus_gx.so",
   active_core_label: "Genesis Plus GX",
   platform_core_label: null,
@@ -637,7 +638,7 @@ describe("gameDetailStore", () => {
       await flush();
       vi.mocked(backend.getPlatformCoreInfo).mockClear();
       const previousRomCore = deferred<CoreInfo>();
-      vi.mocked(backend.getPlatformCoreInfo).mockResolvedValue(switchedCoreInfo);
+      vi.mocked(backend.getPlatformCoreInfo).mockResolvedValue(laterCoreInfo);
       vi.mocked(backend.getPlatformCoreInfo).mockReturnValueOnce(previousRomCore.promise);
       vi.mocked(backend.getBiosStatus).mockResolvedValue(biosMissing);
 
@@ -714,13 +715,136 @@ describe("gameDetailStore", () => {
     });
   });
 
+  // #1674 — a version switch and a re-read both re-derive the entry without
+  // closing it, so two loads can be open at once and can finish in either order.
+  // The identity write is the one write no rom binding can fence, because it is
+  // what installs the identity such a binding would compare against.
+  describe("out-of-order loads", () => {
+    /** What the overtaken mount load resolves: a different rom, differing in
+     *  every field of the identity write so a fold of it is visible whichever
+     *  field is read. */
+    const overtakenDetail = found({
+      rom_id: 42,
+      rom_name: "Mount ROM",
+      platform_slug: "snes",
+      installed: true,
+      fs_size_bytes: 4096,
+      save_sync_enabled: true,
+      save_sync_display: { status: "conflict", label: "Conflict", last_sync_check_at: null },
+      ra_id: 7,
+      achievement_summary: achievementSummary(7, 70),
+    });
+
+    const switchedIdentity = found({
+      rom_id: 43,
+      rom_name: "Other version",
+      platform_slug: "genesis",
+      installed: false,
+      fs_size_bytes: 2048,
+      ra_id: 9,
+      achievement_summary: achievementSummary(3, 30),
+    });
+
+    it("refuses the identity write of a load the version switch overtook", async () => {
+      const mountLoad = deferred<CachedGameDetail>();
+      vi.mocked(cachedStore.getCachedGameDetail).mockReturnValueOnce(mountLoad.promise);
+      subscribe(nextAppId);
+      await flush();
+      expect(getGameDetail(nextAppId).romId).toBeNull();
+
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(switchedIdentity);
+      await act(async () => {
+        dispatchVersionSwitch(nextAppId);
+        await Promise.resolve();
+      });
+      await flush();
+      expect(getGameDetail(nextAppId).romId).toBe(43);
+
+      mountLoad.resolve(overtakenDetail);
+      await flush();
+
+      expect(getGameDetail(nextAppId)).toMatchObject({
+        romId: 43,
+        romName: "Other version",
+        platformSlug: "genesis",
+        installed: false,
+        fsSizeBytes: 2048,
+        saveSyncEnabled: false,
+        saveSyncStatus: null,
+        saveSyncLabel: "",
+        raId: 9,
+        achievementEarned: 3,
+        achievementTotal: 30,
+      });
+      // The overtaken load is abandoned whole, not merely refused its write: the
+      // save-sync read its own detail asked for is never issued either.
+      expect(vi.mocked(backend.getSaveStatus)).not.toHaveBeenCalled();
+    });
+
+    // The uninstall's re-read is issued first and lands last. Without the
+    // ordering fence the page would end up describing a ROM as gone that the
+    // download has since put back.
+    it("lets a later re-read of the same rom win over an earlier one that lands after it", async () => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(found({ installed: true, fs_size_bytes: 4096 }));
+      subscribe(nextAppId);
+      await flush();
+
+      const afterUninstall = deferred<CachedGameDetail>();
+      vi.mocked(cachedStore.getCachedGameDetail).mockReturnValueOnce(afterUninstall.promise);
+      await act(async () => {
+        globalThis.dispatchEvent(new CustomEvent("romm_rom_uninstalled", { detail: { rom_id: 42 } }));
+        await Promise.resolve();
+      });
+
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(found({ installed: true, fs_size_bytes: 8192 }));
+      await act(async () => {
+        emitDeckyEvent<[DownloadCompleteEvent]>("download_complete", downloadComplete(42));
+        await Promise.resolve();
+      });
+      await flush();
+      // The newest load is never the stale one — a deliberate re-read of the same
+      // rom lands rather than being refused by its own fence.
+      expect(getGameDetail(nextAppId)).toMatchObject({ romId: 42, installed: true, fsSizeBytes: 8192 });
+
+      afterUninstall.resolve(found({ installed: false, fs_size_bytes: null }));
+      await flush();
+
+      expect(getGameDetail(nextAppId)).toMatchObject({ romId: 42, installed: true, fsSizeBytes: 8192 });
+    });
+
+    // Same rom throughout, so the rom binding admits the earlier answer — the
+    // load sequence is the only thing that can tell the two apart.
+    it("drops a background answer read under a load a later load overtook", async () => {
+      const overtakenCore = deferred<CoreInfo>();
+      vi.mocked(backend.getPlatformCoreInfo).mockReturnValueOnce(overtakenCore.promise);
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(found({ installed: false }));
+      subscribe(nextAppId);
+      await flush();
+      expect(vi.mocked(backend.getPlatformCoreInfo)).toHaveBeenCalledExactlyOnceWith(42);
+
+      vi.mocked(backend.getPlatformCoreInfo).mockResolvedValue(laterCoreInfo);
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(found({ installed: true }));
+      await act(async () => {
+        emitDeckyEvent<[DownloadCompleteEvent]>("download_complete", downloadComplete(42));
+        await Promise.resolve();
+      });
+      await flush();
+      expect(getGameDetail(nextAppId)).toMatchObject({ romId: 42, activeCoreLabel: "Genesis Plus GX" });
+
+      overtakenCore.resolve(coreInfo);
+      await flush();
+
+      expect(getGameDetail(nextAppId).activeCoreLabel).toBe("Genesis Plus GX");
+    });
+  });
+
   // The mount load fires its background reads and returns; a switch landing
   // before one of them answers re-keys the entry without closing it, so the
   // generation the read was issued under is still current.
   describe("mount-load background refreshes across a version switch", () => {
     it("does not fold a core answer read for the rom the load resolved", async () => {
       const previousRomCore = deferred<CoreInfo>();
-      vi.mocked(backend.getPlatformCoreInfo).mockResolvedValue(switchedCoreInfo);
+      vi.mocked(backend.getPlatformCoreInfo).mockResolvedValue(laterCoreInfo);
       vi.mocked(backend.getPlatformCoreInfo).mockReturnValueOnce(previousRomCore.promise);
       vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(found());
       subscribe(nextAppId);
@@ -935,7 +1059,7 @@ describe("gameDetailStore", () => {
       await flush();
       vi.mocked(backend.getPlatformCoreInfo).mockClear();
       const previousRomCore = deferred<CoreInfo>();
-      vi.mocked(backend.getPlatformCoreInfo).mockResolvedValue(switchedCoreInfo);
+      vi.mocked(backend.getPlatformCoreInfo).mockResolvedValue(laterCoreInfo);
       vi.mocked(backend.getPlatformCoreInfo).mockReturnValueOnce(previousRomCore.promise);
       vi.mocked(backend.getBiosStatus).mockResolvedValue(biosMissing);
       const inFlight = refreshCoreAndBios(nextAppId);

--- a/src/utils/gameDetailStore.ts
+++ b/src/utils/gameDetailStore.ts
@@ -133,6 +133,11 @@ interface Entry {
   /** Bumped when the entry is torn down, so a read that resolves afterwards
    *  cannot write into a state nobody is showing any more. */
   generation: number;
+  /** Bumped by every load. Two loads for one appId can be open at once — a
+   *  version switch and a re-read both re-derive the entry without closing it —
+   *  and can finish in either order, so a load that no longer holds this number
+   *  has been overtaken and writes nothing. */
+  loadSeq: number;
   saveStatusInFlight: InFlightSaveStatus | null;
   detachListeners: () => void;
 }
@@ -178,6 +183,7 @@ function openEntry(appId: number): Entry {
     state: DEFAULT_STATE,
     listeners: new Set(),
     generation: 0,
+    loadSeq: 0,
     saveStatusInFlight: null,
     detachListeners: () => {},
   };
@@ -208,9 +214,11 @@ function writerFor(entry: Entry, generation: number): Dispatch<SetStateAction<Ga
 
 /** A writer additionally bound to the rom identity a read was issued for: it
  *  refuses a fold once the entry has moved on to another ROM. A version switch
- *  re-keys the entry without closing it, so the generation is unchanged and the
+ *  re-keys the entry without closing it, so the generation is unchanged, and for
+ *  a read issued outside a load — a BIOS re-read, a core-change handler — the
  *  identity is the only thing separating this page's answer from its
- *  predecessor's.
+ *  predecessor's. A read issued by {@link loadDetail} is fenced by that load's
+ *  sequence number too, which separates two answers about the SAME ROM.
  *
  *  The gate is the question, not the answer: it compares the rom the read was
  *  ISSUED for against the entry's rom now, where {@link applySaveStatus} can
@@ -230,10 +238,22 @@ function writerForRom(entry: Entry, generation: number, romId: number): Dispatch
  * the entry, and fire the background refreshes (save status, metadata,
  * achievements, BIOS, core) whose results are merged in as they land — unless a
  * version switch re-keyed the entry to another ROM while one was open.
+ *
+ * Loads are ordered by {@link Entry.loadSeq} rather than by the order their
+ * reads happen to resolve: a load a later one has overtaken writes nothing at
+ * all. The identity write below is why that fence has to exist alongside the rom
+ * binding — it is what INSTALLS the identity every other write compares itself
+ * against, so binding it to a rom would refuse the very switch that re-keys the
+ * entry (#1674). An overtaken load therefore leaves the newer load's identity
+ * standing, including when that newer load found nothing to install: the older
+ * answer describes a state the newer load has already been told is gone.
  */
 async function loadDetail(appId: number, entry: Entry): Promise<void> {
   const generation = entry.generation;
-  const cancelled = () => entry.generation !== generation;
+  const loadSeq = ++entry.loadSeq;
+  // Two separate ends: the generation covers an entry nobody is showing any
+  // more, the sequence a load a later one has moved past.
+  const cancelled = () => entry.generation !== generation || entry.loadSeq !== loadSeq;
   const write = writerFor(entry, generation);
   try {
     const cached = await getCachedGameDetail(appId);
@@ -270,11 +290,13 @@ async function loadDetail(appId: number, entry: Entry): Promise<void> {
 
     // Every background answer below is bound to the rom THIS load resolved, so a
     // version switch landing while one is open cannot fold it into a page that
-    // has moved on. Two writes stay on the unbound `write` deliberately: the
-    // identity write above, which installs the very identity a binding would
-    // check against, and the `cached.bios_status` fold below, which runs in the
-    // same tick as it — no await in between for a switch to land in, so binding
-    // it would be a no-op.
+    // has moved on — and, through `cancelled`, to this load, so an answer a
+    // later load of the SAME rom has already superseded is dropped rather than
+    // overwriting the newer one. Two writes stay on the unbound `write`: the
+    // identity write above, which installs the very identity a rom binding would
+    // check against, and the `cached.bios_status` fold below. Both run in the
+    // same tick as the `cancelled()` check that admitted this load, with no
+    // await in between for a newer load to land in.
     const writeForRom = writerForRom(entry, generation, romId);
 
     // The live save status carries what the cached detail does not: the active
@@ -462,7 +484,11 @@ export async function refreshCoreAndBios(appId: number): Promise<void> {
   invalidateCachedGameDetail(appId);
 }
 
-/** Re-read the cached detail after something invalidated it. */
+/** Re-read the cached detail after something invalidated it. A re-read is a new
+ *  load and so takes the newest sequence number at the moment it is issued: no
+ *  load issued before it can undo it. It is not exempt from the fence — a load
+ *  issued after it refuses it in turn, which is what keeps two re-reads in
+ *  order. */
 async function reloadDetail(appId: number, entry: Entry): Promise<void> {
   invalidateCachedGameDetail(appId);
   await loadDetail(appId, entry);


### PR DESCRIPTION
The store fences async writes with a generation counter and, since #1656, with the rom a read was
issued for. Neither can order two loads of the same appId against each other. A version switch and a
re-read both re-derive the entry without closing it, so the generation is unchanged — and the
identity write is the one write a rom binding cannot fence, because it is what installs the identity
every other write compares itself against.

So two loads could finish in either order. A mount load still awaiting its read when a version switch
completed would, once it landed, set the entry back to the rom the user had switched away from and
drag its name, install state, size and achievement counts along with it.

Each load now takes a sequence number from its entry, and the `cancelled()` closure that already
guarded against teardown answers the second question too. A load a later one has moved past returns
before writing anything — the identity write, the BIOS fold from the cached detail, and the three
background reads it would have fired.

Those background reads are fenced deliberately rather than left to the rom binding alone. Two loads
of the same rom leave the entry's rom unchanged, so the binding admits the older answer; a core
change landing between the two loads is exactly the case where "same rom" stops meaning "same
content". A newer load exists because something changed and re-derives everything, so the older
answers are superseded by construction.

When the newest load finds nothing to install it writes nothing, and the entry keeps what it has
rather than adopting the older load's answer — that answer describes a state the newer load has
already been told is gone.

No second writer wrapper: between the guard that admits a load and the two writes that stay unbound
there is no await, so a write-time check would be unreachable. The ordering that makes that true is
stated where an editor adding an await will read it.

docs: N/A — no page describes this store's internals, and the change alters no flow and no
user-facing surface beyond the page no longer describing the wrong ROM.

Closes #1674
