### PR TITLE
fix(ui): keep the play row mounted when the content-dir banner appears

### DIFF
--- a/src/components/RomMPlaySection.test.tsx
+++ b/src/components/RomMPlaySection.test.tsx
@@ -3810,6 +3810,9 @@ describe("RomMPlaySection", () => {
       expect(container.textContent).not.toContain("Write Saves to Content Directory");
       // The play row still renders (game remains playable).
       expect(container.querySelector('[data-testid="play-button"]')).not.toBeNull();
+      // And it is the container's own first child: the banner-less case must add
+      // no wrapper, or the row stops being where the injected panel puts it.
+      expect(container.firstElementChild).toBe(container.querySelector(".romm-play-section-row"));
     });
 
     // The store keeps the content-dir fact whether or not save sync is on, so a
@@ -3852,6 +3855,72 @@ describe("RomMPlaySection", () => {
       await flushAsync();
       expect(vi.mocked(backend.getSaveStatus)).not.toHaveBeenCalled();
       expect(container.textContent).not.toContain("Write Saves to Content Directory");
+    });
+
+    // #1682 — the banner is a conditional SIBLING of the play row, never a
+    // branch returning a different root element. Identity is asserted on the DOM
+    // nodes rather than on a mount counter in the CustomPlayButton mock: the
+    // nodes are what React's reconciler actually preserves or replaces, and the
+    // row is the subtree whose remount resets the real play button. Both tests
+    // also assert the banner crossing in and out, so neither can pass by the
+    // flip never happening.
+    it("keeps the play row's DOM nodes when the banner appears (flag lands after first paint)", async () => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
+        found: true,
+        rom_id: 42,
+        save_sync_enabled: true,
+      });
+      stubSaveStatus(42, false);
+      const { container } = render(<RomMPlaySection appId={testAppId} />);
+      await flushAsync();
+      expect(container.textContent).not.toContain("Write Saves to Content Directory");
+
+      const rowBefore = container.querySelector(".romm-play-section-row");
+      const playButtonBefore = container.querySelector('[data-testid="play-button"]');
+      expect(rowBefore).not.toBeNull();
+      expect(playButtonBefore).not.toBeNull();
+
+      stubSaveStatus(42, true);
+      await act(async () => {
+        globalThis.dispatchEvent(new CustomEvent("romm_data_changed", { detail: { type: "save_sync", rom_id: 42 } }));
+        await Promise.resolve();
+      });
+      await flushAsync();
+
+      expect(container.textContent).toContain("Write Saves to Content Directory");
+      expect(container.querySelector(".romm-play-section-row")).toBe(rowBefore);
+      expect(container.querySelector('[data-testid="play-button"]')).toBe(playButtonBefore);
+    });
+
+    it("keeps the play row's DOM nodes when the banner goes away (save sync switched off)", async () => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
+        found: true,
+        rom_id: 42,
+        save_sync_enabled: true,
+      });
+      stubSaveStatus(42, true);
+      const { container } = render(<RomMPlaySection appId={testAppId} />);
+      await flushAsync();
+      expect(container.textContent).toContain("Write Saves to Content Directory");
+
+      const rowBefore = container.querySelector(".romm-play-section-row");
+      const playButtonBefore = container.querySelector('[data-testid="play-button"]');
+      expect(rowBefore).not.toBeNull();
+      expect(playButtonBefore).not.toBeNull();
+
+      await act(async () => {
+        globalThis.dispatchEvent(
+          new CustomEvent("romm_data_changed", {
+            detail: { type: "save_sync_settings", save_sync_enabled: false },
+          }),
+        );
+        await Promise.resolve();
+      });
+      await flushAsync();
+
+      expect(container.textContent).not.toContain("Write Saves to Content Directory");
+      expect(container.querySelector(".romm-play-section-row")).toBe(rowBefore);
+      expect(container.querySelector('[data-testid="play-button"]')).toBe(playButtonBefore);
     });
 
     it("logs via debugLog when the save-status read rejects (non-vacuous catch)", async () => {

--- a/src/components/RomMPlaySection.tsx
+++ b/src/components/RomMPlaySection.tsx
@@ -10,7 +10,7 @@
  * Save Sync and BIOS items only appear when relevant.
  */
 
-import { useState, useEffect, FC, createElement } from "react";
+import { useState, useEffect, FC, Fragment, createElement } from "react";
 import { toaster } from "@decky/api";
 import {
   ConfirmModal,
@@ -1042,6 +1042,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
   const playSectionRow = createElement(
     Focusable,
     {
+      key: "play-row",
       "data-romm": "true",
       className: `romm-play-section-row ${basicAppDetailsSectionStylerClasses?.PlaySection || ""}`.trim(),
       "flow-children": "right",
@@ -1135,19 +1136,23 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
   // the local RetroArch config, not about our setting); the banner asks the user
   // to change that config to re-enable save sync, so it is only worth showing to
   // someone who has save sync on.
-  if (detail.savefilesInContentDir && detail.saveSyncEnabled) {
-    return createElement(
-      "div",
-      { style: { display: "flex", flexDirection: "column" } },
-      createElement(WarningCard, {
-        key: "savefiles-content-dir-warning",
-        title: "Save sync off",
-        message:
-          "RetroArch's 'Write Saves to Content Directory' is enabled, so saves go next to the ROM and can't be synced. Turn it off in RetroArch → Settings → Saving to re-enable save sync.",
-      }),
-      playSectionRow,
-    );
-  }
-
-  return playSectionRow;
+  //
+  // The banner is a keyed sibling under a Fragment, never a branch returning a
+  // different root: the flag lands a moment after the row first paints, and a
+  // root whose element type changes makes React unmount the whole row — the play
+  // button drops back to "loading" and re-runs its init (#1682). A Fragment adds
+  // no DOM node, so the row stays a direct child of the injected panel either way.
+  return createElement(
+    Fragment,
+    null,
+    detail.savefilesInContentDir && detail.saveSyncEnabled
+      ? createElement(WarningCard, {
+          key: "savefiles-content-dir-warning",
+          title: "Save sync off",
+          message:
+            "RetroArch's 'Write Saves to Content Directory' is enabled, so saves go next to the ROM and can't be synced. Turn it off in RetroArch → Settings → Saving to re-enable save sync.",
+        })
+      : null,
+    playSectionRow,
+  );
 };


### PR DESCRIPTION
`RomMPlaySection` returned two structurally different trees: a `div` wrapping the warning card and
the play row when RetroArch writes saves next to the content, and the bare play row — a `Focusable` —
otherwise. React reconciles by element type at a position, so every flip of that condition unmounted
the whole subtree and mounted a fresh one. The play button dropped back to `"loading"` and rendered
nothing until its own init resolved, and its in-flight-download rehydration ran a second time.

The flip is routine rather than exotic. `savefilesInContentDir` starts false in the store's default
state and is written only when a save status lands, so on an affected ROM it fires once per page
open, a moment after the row first paints — and again whenever save sync is toggled with the page
open.

The section now returns one Fragment in both cases, with the banner as a keyed sibling of the row. A
Fragment emits no DOM node, so the banner-less case renders the DOM it always did and the row stays a
direct child of the injected overview panel. The deleted wrapper contributed only a column flex
direction, which is the stacking its parent already does; it carried no class, padding or background
and was not focusable, so neither layout nor gamepad traversal depended on it.

Both directions are covered by tests asserting node identity across the flip — the row's element and
the play button's element must be the same nodes afterwards — each with the banner's arrival or
departure pinned in the same test, so neither can pass by the condition never changing. A third
assertion pins that the banner-less case adds no wrapper.

docs: N/A — the three pages that mention the banner describe when it appears, which is unchanged;
none describes its container.

Closes #1682
