### PR TITLE
fix(platforms): map RomM's "new-nintendo-3ds" slug to the n3ds system

### DIFF
--- a/defaults/config.json
+++ b/defaults/config.json
@@ -73,6 +73,7 @@
     "neogeo": "neogeo",
     "neogeocd": "neogeocd",
     "nes": "nes",
+    "new-nintendo-3ds": "n3ds",
     "ngc": "gc",
     "ngp": "ngp",
     "ngpc": "ngpc",

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -383,7 +383,7 @@ src/                                 # Frontend TypeScript
   types/                             # TypeScript interfaces and Steam API declarations
   utils/                             # Shortcut CRUD, sync, downloads, collections, session manager
 bin/rom-launcher                     # Pure exec wrapper — runs the launch command baked into the shortcut
-defaults/config.json                 # platform_map: 149 platform slug -> RetroDECK system mappings
+defaults/config.json                 # platform_map: 150 platform slug -> RetroDECK system mappings
 tests/                               # Backend unit tests, mirroring py_modules/ layout
 ```
 

--- a/tests/adapters/romm/test_http.py
+++ b/tests/adapters/romm/test_http.py
@@ -827,6 +827,18 @@ class TestPlatformMap:
         assert "snes" in pm
         assert len(pm) > 50  # Should have many entries
 
+    def test_both_romm_3ds_platforms_resolve_to_one_system(self, plugin):
+        """RomM carries "3ds" and "new-nintendo-3ds" as separate platforms.
+
+        RetroDECK has one 3DS system for both, so the map must collapse them.
+        Without the second key ``resolve_system`` passes it through verbatim
+        (ADR-0010 §5) and the download lands in a folder ES-DE never scans
+        (#1678).
+        """
+        adapter = plugin._http_adapter
+        assert adapter.resolve_system("3ds") == "n3ds"
+        assert adapter.resolve_system("new-nintendo-3ds") == "n3ds"
+
     def test_missing_config_returns_empty_map(self, tmp_path):
         """A plugin_dir with no config.json degrades to an empty map, not an error.
 


### PR DESCRIPTION
RomM carries Nintendo 3DS and New Nintendo 3DS as two separate platforms, and a library whose folder is named after the second one reports "new-nintendo-3ds" as the platform slug. That key was missing from platform_map, so resolve_system passed it through verbatim and downloads landed in a roms/new-nintendo-3ds/ folder that ES-DE never scans — the titles installed but nothing launched.

RetroDECK has one 3DS system for both, so both slugs collapse to n3ds.

Closes #1678