### PR TITLE
fix(ui): follow the BIOS requirement across a version switch

### DIFF
--- a/src/components/RomMGameInfoPanel.test.tsx
+++ b/src/components/RomMGameInfoPanel.test.tsx
@@ -3487,6 +3487,32 @@ describe("RomMGameInfoPanel", () => {
         expect(container.textContent).not.toContain("BIOS");
       });
 
+      it("leaves the BIOS tab for the info tab when the requirement is cleared under it", async () => {
+        vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(detailNeedingBios(1, 1));
+        vi.mocked(backend.getPlatformCoreInfo).mockResolvedValue(coreInfoFor("Snes9x", "snes9x_libretro.so"));
+        const { container } = render(<RomMGameInfoPanel appId={testAppId} />);
+        await flushAsync();
+        await openBiosTab();
+        expect(container.textContent).toContain("Snes9x");
+
+        vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
+          found: true,
+          rom_id: 2,
+          platform_slug: "snes",
+          metadata: makeMetadata(),
+          stale_fields: [],
+        });
+        await switchVersion();
+
+        // The tab the user was standing on is gated on the requirement, so
+        // clearing it removes the button. Without the fallback `activeTab` stays
+        // "bios", the body resolves to null, and the panel is a lone GAME INFO
+        // button over an empty pane — which is why the assertion is on the info
+        // tab's BODY and not on its button.
+        expect(container.textContent).not.toContain("Snes9x");
+        expect(container.textContent).toContain("No metadata available");
+      });
+
       it("re-keys the level and the active core to the new active version", async () => {
         vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(detailNeedingBios(1, 1));
         vi.mocked(backend.getPlatformCoreInfo).mockResolvedValue(coreInfoFor("Snes9x", "snes9x_libretro.so"));

--- a/src/components/RomMGameInfoPanel.test.tsx
+++ b/src/components/RomMGameInfoPanel.test.tsx
@@ -31,7 +31,7 @@ import {
   setServerRetryProgress,
   getServerRetryProgress,
 } from "../utils/connectionState";
-import type { MigrationStatus, SaveSortMigrationStatus, RomMetadata, DownloadCompleteEvent } from "../types";
+import type { MigrationStatus, SaveSortMigrationStatus, RomMetadata, DownloadCompleteEvent, CoreInfo } from "../types";
 
 // Type-only imports — vi.mock(...) below replaces the runtime impl, but
 // pinning captured-props shapes to the real component keeps assertions in
@@ -3416,6 +3416,128 @@ describe("RomMGameInfoPanel", () => {
       await flushAsync();
       expect(vi.mocked(backend.getAchievements)).toHaveBeenCalledWith(2);
       expect(vi.mocked(backend.getAchievementProgress)).toHaveBeenCalledWith(2);
+    });
+
+    // #1681 — BIOS is the third per-rom tab. The requirement is core-dependent
+    // and the core override is keyed on rom_id, so both the level and the
+    // "Active Core" row it is shown against must follow the new active version.
+    describe("BIOS tab across a version switch (#1681)", () => {
+      /** A `get_platform_core_info` answer whose active core is `label` — the
+       *  BIOS tab's "Active Core" row reads it. */
+      const coreInfoFor = (label: string, coreSo: string): CoreInfo => ({
+        active_core: coreSo,
+        active_core_label: label,
+        platform_core_label: null,
+        has_game_override: false,
+        emulator_data_available: true,
+        emulators: [{ label, kind: "libretro", core_so: coreSo, is_default: true, bakeable: true, reason: null }],
+      });
+
+      /** A cached detail whose core needs BIOS, `localCount` of 3 files present. */
+      const detailNeedingBios = (romId: number, localCount: number) => ({
+        found: true,
+        rom_id: romId,
+        platform_slug: "snes",
+        bios_status: {
+          platform_slug: "snes",
+          server_count: 3,
+          local_count: localCount,
+          all_downloaded: localCount === 3,
+        } as never,
+        bios_level: localCount === 3 ? ("ok" as const) : ("partial" as const),
+        metadata: makeMetadata(),
+        stale_fields: [],
+      });
+
+      const switchVersion = async () => {
+        await act(async () => {
+          globalThis.dispatchEvent(
+            new CustomEvent("romm_data_changed", {
+              detail: { type: "version_switched", app_id: testAppId, rom_id: 2 },
+            }),
+          );
+        });
+        await flushAsync();
+      };
+
+      const openBiosTab = async () => {
+        await act(async () => {
+          globalThis.dispatchEvent(new CustomEvent("romm_tab_switch", { detail: { tab: "bios" } }));
+        });
+        await flushAsync();
+      };
+
+      it("clears the requirement when the switched-to version's core needs none", async () => {
+        vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(detailNeedingBios(1, 1));
+        const { container } = render(<RomMGameInfoPanel appId={testAppId} />);
+        await flushAsync();
+        expect(container.textContent).toContain("BIOS");
+
+        // The new active version's core needs no BIOS — the cached detail
+        // carries no bios_status at all.
+        vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
+          found: true,
+          rom_id: 2,
+          platform_slug: "snes",
+          metadata: makeMetadata(),
+          stale_fields: [],
+        });
+        await switchVersion();
+
+        expect(container.textContent).not.toContain("BIOS");
+      });
+
+      it("re-keys the level and the active core to the new active version", async () => {
+        vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(detailNeedingBios(1, 1));
+        vi.mocked(backend.getPlatformCoreInfo).mockResolvedValue(coreInfoFor("Snes9x", "snes9x_libretro.so"));
+        const { container } = render(<RomMGameInfoPanel appId={testAppId} />);
+        await flushAsync();
+        await openBiosTab();
+        expect(container.textContent).toContain("1/3 files ready");
+        expect(container.textContent).toContain("Snes9x");
+
+        vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(detailNeedingBios(2, 3));
+        vi.mocked(backend.getPlatformCoreInfo).mockClear();
+        vi.mocked(backend.getPlatformCoreInfo).mockResolvedValue(coreInfoFor("bsnes", "bsnes_libretro.so"));
+        await switchVersion();
+
+        expect(vi.mocked(backend.getPlatformCoreInfo)).toHaveBeenCalledWith(2);
+        expect(container.textContent).toContain("All ready (3/3)");
+        expect(container.textContent).toContain("bsnes");
+        expect(container.textContent).not.toContain("Snes9x");
+      });
+
+      // The over-fix this change invites: a read that FAILED is "we don't know",
+      // not "no BIOS need", so it may not blank the tab.
+      it("leaves the shown level standing when the switch's cache read fails", async () => {
+        vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(detailNeedingBios(1, 1));
+        const { container } = render(<RomMGameInfoPanel appId={testAppId} />);
+        await flushAsync();
+        await openBiosTab();
+        expect(container.textContent).toContain("1/3 files ready");
+
+        vi.mocked(cachedStore.getCachedGameDetail).mockRejectedValue(new Error("offline"));
+        vi.mocked(backend.debugLog).mockClear();
+        await switchVersion();
+
+        expect(container.textContent).toContain("1/3 files ready");
+        expect(vi.mocked(backend.debugLog)).toHaveBeenCalledWith(expect.stringContaining("onDataChanged error"));
+      });
+
+      it("leaves the shown active core standing when the new version's core read fails", async () => {
+        vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(detailNeedingBios(1, 1));
+        vi.mocked(backend.getPlatformCoreInfo).mockResolvedValue(coreInfoFor("Snes9x", "snes9x_libretro.so"));
+        const { container } = render(<RomMGameInfoPanel appId={testAppId} />);
+        await flushAsync();
+        await openBiosTab();
+        expect(container.textContent).toContain("Snes9x");
+
+        vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(detailNeedingBios(2, 3));
+        vi.mocked(backend.getPlatformCoreInfo).mockRejectedValue(new Error("offline"));
+        await switchVersion();
+
+        expect(container.textContent).toContain("Snes9x");
+      });
     });
   });
 

--- a/src/components/RomMGameInfoPanel.tsx
+++ b/src/components/RomMGameInfoPanel.tsx
@@ -613,6 +613,11 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => { //
         achievementsLoading: false,
         biosStatus,
         biosLevel,
+        // The BIOS tab's button is gated on `biosStatus`, so clearing it while
+        // the user stands on that tab would hide the button and leave the body
+        // empty with nothing selected. Send them back to the tab every version
+        // has.
+        activeTab: !biosStatus && prev.activeTab === "bios" ? "info" : prev.activeTab,
       }));
       // Re-fetch slot configuration (slotConfirmed) + slots for the new rom_id,
       // mirroring loadData's save-sync branch — this is the authority that keeps

--- a/src/components/RomMGameInfoPanel.tsx
+++ b/src/components/RomMGameInfoPanel.tsx
@@ -577,6 +577,10 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => { //
       // the fresh cache (mirroring a fresh mount) so the tab-activation effects
       // re-fetch for the new rom_id — covering both the sitting-on-a-tab case
       // (romId changes → the effect re-runs) and the open-a-tab-later case.
+      //
+      // BIOS is the third per-rom tab: the requirement is core-dependent and the
+      // core override is keyed on rom_id, so the new version's core may need
+      // different files — or none, which hides the tab (#1681).
       if (detail.app_id !== appId) return;
       const cached = await getCachedGameDetail(appId);
       if (cancelled || !cached.found) return;
@@ -585,6 +589,10 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => { //
       achievementsLoadedRef.current = false;
       slotsLoadedRef.current = false;
       const saveStatus = newRomId != null ? saveStatusFromCache(newRomId, cached.save_status) : null;
+      const biosStatus = biosStatusFromCache(cached.bios_status);
+      // bios_level comes from the backend cache (compute_bios_level) — thread it
+      // through, never re-derive. null when there's no BIOS need.
+      const biosLevel = biosStatus ? (cached.bios_level ?? null) : null;
       setState((prev) => ({
         ...prev,
         romId: newRomId,
@@ -603,6 +611,8 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => { //
         achievements: [],
         achievementProgress: null,
         achievementsLoading: false,
+        biosStatus,
+        biosLevel,
       }));
       // Re-fetch slot configuration (slotConfirmed) + slots for the new rom_id,
       // mirroring loadData's save-sync branch — this is the authority that keeps
@@ -610,7 +620,16 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => { //
       if (cached.save_sync_enabled && newRomId != null) {
         refreshSlotState(newRomId, setState);
       }
-      if (newRomId) await refreshCoverArtInBackground(newRomId, () => cancelled, setState);
+      if (newRomId) {
+        await Promise.all([
+          refreshCoverArtInBackground(newRomId, () => cancelled, setState),
+          // The BIOS tab's "Active Core" row and its per-file core lines come
+          // from the dedicated core-info path (#923), keyed on rom_id so a
+          // per-game override follows the switch. A failed read keeps the
+          // previous reading rather than blanking it.
+          refreshCoreInfoInBackground(newRomId, () => cancelled, setState),
+        ]);
+      }
     };
 
     const handleMetadataChange = async (detail: Extract<RommDataChangedDetail, { type: "metadata" }>) => {

--- a/src/components/RomMPlaySection.test.tsx
+++ b/src/components/RomMPlaySection.test.tsx
@@ -79,11 +79,11 @@ vi.mock("../utils/formatters", () => ({
 }));
 vi.mock("../utils/playSection", () => ({
   applySaveSyncDisplay: vi.fn(() => ({ status: null, label: "" })),
-  extractBiosInfo: vi.fn(() => ({
-    biosNeeded: true,
-    biosStatus: "ok",
-    biosLabel: "OK",
-  })),
+  extractBiosInfo: vi.fn((status: unknown) =>
+    status
+      ? { biosNeeded: true, biosStatus: "ok", biosLabel: "OK" }
+      : { biosNeeded: false, biosStatus: null, biosLabel: "" },
+  ),
   extractCoreInfo: vi.fn(
     (c: {
       active_core_label?: string | null;
@@ -298,11 +298,14 @@ describe("RomMPlaySection", () => {
       status: "synced",
       label: "synced label",
     });
-    vi.mocked(playSectionUtils.extractBiosInfo).mockReturnValue({
-      biosNeeded: true,
-      biosStatus: "ok",
-      biosLabel: "OK",
-    });
+    // Honours the requirement argument the way the real helper does: an absent
+    // `bios_status` is the answer "no BIOS need" and yields the cleared shape
+    // (#1690). A fixed return here would fold a BIOS need into every mount.
+    vi.mocked(playSectionUtils.extractBiosInfo).mockImplementation((status) =>
+      status
+        ? { biosNeeded: true, biosStatus: "ok", biosLabel: "OK" }
+        : { biosNeeded: false, biosStatus: null, biosLabel: "" },
+    );
     vi.mocked(playSectionUtils.extractCoreInfo).mockReturnValue({
       activeCoreLabel: null,
       activeCoreIsDefault: true,
@@ -510,11 +513,16 @@ describe("RomMPlaySection", () => {
         expect.any(Function),
         expect.any(Function),
       );
-      // Assert exact arg shape: (cached.bios_level, cached.bios_label). The BIOS
-      // status dict is no longer passed — extractBiosInfo takes only the
-      // pre-computed level/label (#923). Catches arg-order regressions that a
-      // bare .toHaveBeenCalled() would miss.
-      expect(playSectionUtils.extractBiosInfo).toHaveBeenCalledWith("ok", "OK");
+      // Assert exact arg shape: (cached.bios_status, cached.bios_level,
+      // cached.bios_label). The requirement itself leads, so its absence can
+      // clear the row (#1690); the level and label stay pre-computed by the
+      // backend (#923). Catches arg-order regressions that a bare
+      // .toHaveBeenCalled() would miss.
+      expect(playSectionUtils.extractBiosInfo).toHaveBeenCalledWith(
+        expect.objectContaining({ platform_slug: "snes" }),
+        "ok",
+        "OK",
+      );
       // resolveSaveSyncLabel is called with the cached save_sync_display.
       expect(playSectionUtils.resolveSaveSyncLabel).toHaveBeenCalledWith(
         expect.objectContaining({ status: "synced", label: "label" }),

--- a/src/components/RomMPlaySection.test.tsx
+++ b/src/components/RomMPlaySection.test.tsx
@@ -79,9 +79,8 @@ vi.mock("../utils/formatters", () => ({
 }));
 vi.mock("../utils/playSection", () => ({
   applySaveSyncDisplay: vi.fn(() => ({ status: null, label: "" })),
-  // Keyed on the requirement argument, not a fixed return — see the re-stub in
-  // beforeEach for why that distinction decides whether this file's other tests
-  // mean anything.
+  // Must stay in sync with the beforeEach re-stub (resetAllMocks wipes this impl) —
+  // a fixed return folds a BIOS need into every mount that resolves a rom.
   extractBiosInfo: vi.fn((status: unknown) =>
     status
       ? { biosNeeded: true, biosStatus: "ok", biosLabel: "OK" }

--- a/src/components/RomMPlaySection.test.tsx
+++ b/src/components/RomMPlaySection.test.tsx
@@ -79,6 +79,9 @@ vi.mock("../utils/formatters", () => ({
 }));
 vi.mock("../utils/playSection", () => ({
   applySaveSyncDisplay: vi.fn(() => ({ status: null, label: "" })),
+  // Keyed on the requirement argument, not a fixed return — see the re-stub in
+  // beforeEach for why that distinction decides whether this file's other tests
+  // mean anything.
   extractBiosInfo: vi.fn((status: unknown) =>
     status
       ? { biosNeeded: true, biosStatus: "ok", biosLabel: "OK" }
@@ -298,9 +301,13 @@ describe("RomMPlaySection", () => {
       status: "synced",
       label: "synced label",
     });
-    // Honours the requirement argument the way the real helper does: an absent
-    // `bios_status` is the answer "no BIOS need" and yields the cleared shape
-    // (#1690). A fixed return here would fold a BIOS need into every mount.
+    // MUST honour the requirement argument, the way the real helper does: an
+    // absent `bios_status` is the answer "no BIOS need" and yields the cleared
+    // shape (#1690). The store folds this in unconditionally, so a fixed return
+    // here would fold a BIOS need into EVERY mount — including the cached
+    // details below that carry no `bios_status` — and every test in this file
+    // that renders one would then be asserting against a row state production
+    // never produces.
     vi.mocked(playSectionUtils.extractBiosInfo).mockImplementation((status) =>
       status
         ? { biosNeeded: true, biosStatus: "ok", biosLabel: "OK" }

--- a/src/utils/gameDetailStore.test.ts
+++ b/src/utils/gameDetailStore.test.ts
@@ -700,6 +700,114 @@ describe("gameDetailStore", () => {
       expect(getGameDetail(nextAppId)).toMatchObject({ romId: 43, romName: "Other version" });
     });
 
+    // #1690 — the BIOS requirement is core-dependent and the core override is
+    // keyed on rom_id, so two versions of one game genuinely can differ here.
+    // The switched-to detail below carries no `stale_fields`, so the cached fold
+    // is the only writer in play.
+    it("clears the BIOS requirement when the switched-to version's core needs none", async () => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(
+        found({
+          bios_status: { platform_slug: "snes", server_count: 3, local_count: 0, all_downloaded: false },
+          bios_level: "missing",
+          bios_label: "0/3",
+        }),
+      );
+      subscribe(nextAppId);
+      await flush();
+      expect(getGameDetail(nextAppId)).toMatchObject({ biosNeeded: true, biosStatus: "missing", biosLabel: "0/3" });
+
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(found({ rom_id: 43 }));
+      await act(async () => {
+        dispatchVersionSwitch(nextAppId);
+        await Promise.resolve();
+      });
+      await flush();
+
+      expect(getGameDetail(nextAppId)).toMatchObject({
+        romId: 43,
+        biosNeeded: false,
+        biosStatus: null,
+        biosLabel: "",
+      });
+    });
+
+    it("keeps the requirement when the switched-to version's core needs BIOS too", async () => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(
+        found({
+          bios_status: { platform_slug: "snes", server_count: 3, local_count: 0, all_downloaded: false },
+          bios_level: "missing",
+          bios_label: "0/3",
+        }),
+      );
+      subscribe(nextAppId);
+      await flush();
+
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(found(switchedDetail));
+      await act(async () => {
+        dispatchVersionSwitch(nextAppId);
+        await Promise.resolve();
+      });
+      await flush();
+
+      expect(getGameDetail(nextAppId)).toMatchObject({
+        romId: 43,
+        biosNeeded: true,
+        biosStatus: "ok",
+        biosLabel: "3/3",
+      });
+    });
+
+    it("clears the requirement when the switched-to version's live BIOS read reports none", async () => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(found());
+      subscribe(nextAppId);
+      await flush();
+      // The switched-to detail still carries the previous version's cached
+      // requirement and marks it stale, so the live re-read is what answers.
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(
+        found({ ...switchedDetail, stale_fields: ["bios"] }),
+      );
+      vi.mocked(backend.getBiosStatus).mockResolvedValue({ bios_status: null, bios_level: null, bios_label: null });
+
+      await act(async () => {
+        dispatchVersionSwitch(nextAppId);
+        await Promise.resolve();
+      });
+      await flush();
+
+      expect(vi.mocked(backend.getBiosStatus)).toHaveBeenCalledWith(43);
+      expect(getGameDetail(nextAppId)).toMatchObject({
+        romId: 43,
+        biosNeeded: false,
+        biosStatus: null,
+        biosLabel: "",
+      });
+    });
+
+    // The over-fix this change invites: a read that FAILED is "we don't know",
+    // not "no BIOS need", so it may not blank the cell (#1690).
+    it("leaves the shown level standing when the switched-to version's BIOS re-read fails", async () => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(found());
+      subscribe(nextAppId);
+      await flush();
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(
+        found({ ...switchedDetail, stale_fields: ["bios"] }),
+      );
+      vi.mocked(backend.getBiosStatus).mockRejectedValue(new Error("offline"));
+
+      await act(async () => {
+        dispatchVersionSwitch(nextAppId);
+        await Promise.resolve();
+      });
+      await flush();
+
+      expect(getGameDetail(nextAppId)).toMatchObject({
+        romId: 43,
+        biosNeeded: true,
+        biosStatus: "ok",
+        biosLabel: "3/3",
+      });
+    });
+
     it("ignores a switch for another appId", async () => {
       vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(found());
       subscribe(nextAppId);

--- a/src/utils/gameDetailStore.ts
+++ b/src/utils/gameDetailStore.ts
@@ -315,12 +315,13 @@ async function loadDetail(appId: number, entry: Entry): Promise<void> {
       refreshAchievementsInBackground(romId, cancelled, writeForRom);
     }
 
-    if (cached.bios_status) {
-      write((prev) => ({
-        ...prev,
-        ...extractBiosInfo(cached.bios_level ?? null, cached.bios_label ?? null),
-      }));
-    }
+    // Folded whether or not the detail reports a requirement: an absent
+    // `bios_status` is the backend answering "this version's core needs none",
+    // and only an unconditional fold can take a shown requirement back (#1690).
+    write((prev) => ({
+      ...prev,
+      ...extractBiosInfo(cached.bios_status, cached.bios_level ?? null, cached.bios_label ?? null),
+    }));
 
     if (staleFields.includes("bios")) {
       refreshBiosInBackground(romId, cancelled, writeForRom);

--- a/src/utils/playSection.test.ts
+++ b/src/utils/playSection.test.ts
@@ -79,8 +79,10 @@ describe("applySaveSyncDisplay", () => {
 });
 
 describe("extractBiosInfo", () => {
+  const requirement = { platform_slug: "snes", server_count: 3, local_count: 3 };
+
   it("projects the pre-computed level/label into the BIOS-only play-section fields (no core fields, #923)", () => {
-    const result = extractBiosInfo("ok", "BIOS OK");
+    const result = extractBiosInfo(requirement, "ok", "BIOS OK");
     expect(result.biosNeeded).toBe(true);
     expect(result.biosStatus).toBe("ok");
     expect(result.biosLabel).toBe("BIOS OK");
@@ -90,9 +92,23 @@ describe("extractBiosInfo", () => {
   });
 
   it("coerces null label to empty string", () => {
-    const result = extractBiosInfo(null, null);
+    const result = extractBiosInfo(requirement, null, null);
     expect(result.biosLabel).toBe("");
     expect(result.biosStatus).toBeNull();
+  });
+
+  it("reports the cleared shape when the answer carries no requirement (#1690)", () => {
+    expect(extractBiosInfo(null, null, null)).toEqual({ biosNeeded: false, biosStatus: null, biosLabel: "" });
+  });
+
+  it("ignores a level and label left over next to an absent requirement (#1690)", () => {
+    // The three fields move together — a cleared requirement never leaves a
+    // level or label behind for the row to render against nothing.
+    expect(extractBiosInfo(undefined, "missing", "0/3")).toEqual({
+      biosNeeded: false,
+      biosStatus: null,
+      biosLabel: "",
+    });
   });
 });
 

--- a/src/utils/playSection.test.ts
+++ b/src/utils/playSection.test.ts
@@ -79,7 +79,9 @@ describe("applySaveSyncDisplay", () => {
 });
 
 describe("extractBiosInfo", () => {
-  const requirement = { platform_slug: "snes", server_count: 3, local_count: 3 };
+  // Only the PRESENCE of this object is read, never its contents — but it is
+  // typed as the real payload, so it has to be one.
+  const requirement = { platform_slug: "snes", server_count: 3, local_count: 3, all_downloaded: true };
 
   it("projects the pre-computed level/label into the BIOS-only play-section fields (no core fields, #923)", () => {
     const result = extractBiosInfo(requirement, "ok", "BIOS OK");

--- a/src/utils/playSection.ts
+++ b/src/utils/playSection.ts
@@ -7,6 +7,7 @@
  * sectionRefresh.ts. Anything stateful belongs in the component itself.
  */
 
+import type { CachedGameDetail } from "../api/backend";
 import type { CoreInfo, EmulatorOption, SaveStatus, SaveSyncDisplay } from "../types";
 import { hasAnySaveConflict } from "./saveStatus";
 import { formatTimeAgo } from "./formatters";
@@ -72,7 +73,7 @@ export function applySaveSyncDisplay(
  *  standing. Core data is sourced separately via `extractCoreInfo` (the BIOS
  *  payload no longer carries it, #923). */
 export function extractBiosInfo(
-  status: Record<string, unknown> | null | undefined,
+  status: CachedGameDetail["bios_status"],
   level: "ok" | "partial" | "missing" | "unmanaged" | null,
   label: string | null,
 ): BiosInfoFields {

--- a/src/utils/playSection.ts
+++ b/src/utils/playSection.ts
@@ -62,16 +62,21 @@ export function applySaveSyncDisplay(
   return { status: "none", label: "No saves" };
 }
 
-/** Project the backend's pre-computed BIOS level/label into the BIOS-only fields
- *  the play-section row needs. `level` and `label` are computed by the backend
- *  so the frontend never re-derives them. Callers only reach this when the
- *  backend reported a BIOS need (a truthy `bios_status`), so `biosNeeded` is
- *  always `true` here. Core data is sourced separately via `extractCoreInfo`
- *  (the BIOS payload no longer carries it, #923). */
+/** Project a whole BIOS answer — the backend's `bios_status` plus the level and
+ *  label it pre-computed for it — into the BIOS-only fields the play-section row
+ *  needs. `level` and `label` are never re-derived here. Only the PRESENCE of
+ *  `status` is read: its absence is the backend answering "this core needs no
+ *  BIOS", which clears all three fields, so a requirement can be taken back off
+ *  the page (#1690). A read that FAILED is not that answer and must never be
+ *  funnelled in as one — the caller drops it and leaves the shown level
+ *  standing. Core data is sourced separately via `extractCoreInfo` (the BIOS
+ *  payload no longer carries it, #923). */
 export function extractBiosInfo(
+  status: Record<string, unknown> | null | undefined,
   level: "ok" | "partial" | "missing" | "unmanaged" | null,
   label: string | null,
 ): BiosInfoFields {
+  if (!status) return { biosNeeded: false, biosStatus: null, biosLabel: "" };
   return {
     biosNeeded: true,
     biosStatus: level,

--- a/src/utils/sectionRefresh.test.ts
+++ b/src/utils/sectionRefresh.test.ts
@@ -117,19 +117,33 @@ describe("refreshBiosInBackground", () => {
     expect(setter).not.toHaveBeenCalled();
   });
 
-  it("skips the setter when bios_status is null", async () => {
+  it("clears the shown requirement when the read reports none", async () => {
+    // A read that ANSWERS "no BIOS need" is the only thing that may take a shown
+    // requirement back — the core the answer was read for may genuinely need
+    // none (#1690).
     vi.mocked(backend.getBiosStatus).mockResolvedValueOnce({
       bios_status: null,
       bios_level: null,
       bios_label: null,
     } as unknown as Awaited<ReturnType<typeof backend.getBiosStatus>>);
-    const setter = vi.fn();
-    refreshBiosInBackground(1, () => false, setter);
+
+    const setter = vi.fn<(updater: (prev: BiosState) => BiosState) => void>();
+    refreshBiosInBackground(1, () => false, setter as unknown as Dispatch<SetStateAction<BiosState>>);
     await flushMicrotasks();
-    expect(setter).not.toHaveBeenCalled();
+
+    expect(setter).toHaveBeenCalledOnce();
+    const next = setter.mock.calls[0]![0]({
+      biosNeeded: true,
+      biosStatus: "missing",
+      biosLabel: "0/3",
+      unrelated: "keep",
+    });
+    expect(next).toEqual({ biosNeeded: false, biosStatus: null, biosLabel: "", unrelated: "keep" });
   });
 
   it("logs the error and skips the setter when the fetch rejects", async () => {
+    // The counterpart to the clear above: a FAILED read is "we don't know", not
+    // "no BIOS need", so the shown level stands (#1690).
     vi.mocked(backend.getBiosStatus).mockRejectedValueOnce(new Error("network"));
     vi.mocked(backend.debugLog).mockResolvedValue(undefined);
     const setter = vi.fn();

--- a/src/utils/sectionRefresh.test.ts
+++ b/src/utils/sectionRefresh.test.ts
@@ -119,15 +119,14 @@ describe("refreshBiosInBackground", () => {
 
   it("clears the shown requirement when the read reports none", async () => {
     // A read that ANSWERS "no BIOS need" is the only thing that may take a shown
-    // requirement back — the core the answer was read for may genuinely need
-    // none (#1690).
-    //
-    // This case asserted the opposite until #1690: a resolved read reporting no
-    // requirement wrote nothing, which is the defect itself — the BIOS fields
-    // could only ever move one way, so a version switch to a core needing no
-    // BIOS left the previous level standing. The assertion that must NOT be
-    // relaxed is the rejection case below: a read that FAILED still writes
-    // nothing, because that one is "we don't know", not an answer.
+    // requirement back — the core it was read for may genuinely need none. This
+    // case asserted the opposite until #1690, and that expectation was the
+    // defect: the fields could only ever move one way, so a version switch to a
+    // core needing no BIOS left the previous level standing (both writers on the
+    // load path had to move, this one and the cached fold in gameDetailStore).
+    // The assertion that must NOT be relaxed is the rejection case below: a read
+    // that FAILED still writes nothing, because that one is "we don't know",
+    // not an answer.
     vi.mocked(backend.getBiosStatus).mockResolvedValueOnce({
       bios_status: null,
       bios_level: null,

--- a/src/utils/sectionRefresh.test.ts
+++ b/src/utils/sectionRefresh.test.ts
@@ -121,6 +121,13 @@ describe("refreshBiosInBackground", () => {
     // A read that ANSWERS "no BIOS need" is the only thing that may take a shown
     // requirement back — the core the answer was read for may genuinely need
     // none (#1690).
+    //
+    // This case asserted the opposite until #1690: a resolved read reporting no
+    // requirement wrote nothing, which is the defect itself — the BIOS fields
+    // could only ever move one way, so a version switch to a core needing no
+    // BIOS left the previous level standing. The assertion that must NOT be
+    // relaxed is the rejection case below: a read that FAILED still writes
+    // nothing, because that one is "we don't know", not an answer.
     vi.mocked(backend.getBiosStatus).mockResolvedValueOnce({
       bios_status: null,
       bios_level: null,

--- a/src/utils/sectionRefresh.ts
+++ b/src/utils/sectionRefresh.ts
@@ -16,6 +16,10 @@ interface AchievementFields {
   achievementTotal: number;
 }
 
+/** Re-read this ROM's BIOS status and fold the answer in — including an answer
+ *  reporting no requirement, which clears the shown one (#1690). A read that
+ *  FAILS writes nothing at all, so the shown level stands: a failure is "we
+ *  don't know", not "no BIOS need". */
 export function refreshBiosInBackground<S extends BiosInfoFields>(
   romId: number,
   cancelled: () => boolean,
@@ -23,13 +27,11 @@ export function refreshBiosInBackground<S extends BiosInfoFields>(
 ): void {
   getBiosStatus(romId)
     .then((result) => {
-      const b = result.bios_status;
-      if (!cancelled() && b) {
-        setter((prev) => ({
-          ...prev,
-          ...extractBiosInfo(result.bios_level, result.bios_label),
-        }));
-      }
+      if (cancelled()) return;
+      setter((prev) => ({
+        ...prev,
+        ...extractBiosInfo(result.bios_status, result.bios_level, result.bios_label),
+      }));
     })
     .catch((e) => debugLog(`Background BIOS status fetch error: ${e}`));
 }


### PR DESCRIPTION
Two halves of one symptom: after switching to another version of a game, the BIOS information
described the version the page had left.

**The store could not take a requirement back.** `extractBiosInfo` hardcoded `biosNeeded: true`, and
both writers on the load path only wrote when the payload carried a requirement — so no load could
ever clear one. Only the core-change paths could, and a version switch does not go through them.
Switching to a version whose core needs no BIOS therefore left the play row's BIOS cell standing with
the previous version's level. The projection now takes the BIOS answer itself and reports the cleared
shape when it carries none, which makes that case impossible to forget at a call site rather than an
else-branch nobody wrote.

**The info panel never re-keyed core and BIOS.** Its version-switch handler re-keys identity, install
state, regions, languages, save status, achievements, slots and cover, but left `coreInfo`,
`biosStatus` and `biosLevel` to the core-change handler and the initial load. So the BIOS tab kept
the previous version's active core and level until the page was re-entered, while the SAVES tab
followed correctly. It now re-keys all three and re-issues the core read for the new rom.

Clearing the requirement removes the BIOS tab's button, so the panel now leaves that tab for GAME
INFO when it happens underneath the user — otherwise the button vanishes while `activeTab` still
points at it and the body resolves to nothing.

**A failed read is not an answer.** The whole change rests on that distinction: a read that failed
means "we don't know" and must leave the shown level standing, while a read reporting no requirement
is a positive answer and must clear. Every path that writes BIOS fields keeps the two apart, and a
test guards each direction, because the obvious over-fix is to treat any empty result as a negative.

docs: N/A — no page stated the old behaviour.

Closes #1681
Closes #1690
