### PR TITLE
fix(bios): tell a check that could not answer apart from one reporting no requirement

### DIFF
--- a/docs/user-guide/bios-management.md
+++ b/docs/user-guide/bios-management.md
@@ -33,11 +33,16 @@ ok/partial/missing classification used everywhere in the plugin:
 The classification is computed against the **active core** for that game — so switching to a core that needs no BIOS (or
 that treats a file as optional) clears the warning, while switching to a core that requires a missing file surfaces it.
 
-A BIOS warning only ever disappears on an **answer**. When the plugin cannot work out the requirement — your RomM server
-is unreachable while it checks, or the BIOS state has not been re-read yet after a download or a delete — it keeps
-showing the last status it knew rather than reporting "no BIOS needed". So a check that failed never quietly clears a
-missing-BIOS warning and lets the game launch without its files; it just leaves the warning where it was until a check
-gets through.
+A BIOS warning only ever disappears on an **answer**. When the plugin cannot work out the requirement — most often right
+after a BIOS download or delete, before the state has been read again — it keeps showing the last status it knew rather
+than reporting "no BIOS needed". So a check that could not be completed never quietly clears a missing-BIOS warning and
+lets the game launch without its files; it leaves the warning where it was until a check gets through.
+
+An unreachable RomM server usually does **not** put the plugin in that position: it falls back to its built-in registry
+of known BIOS files and still tells you what the platform needs. Only a platform that registry does not cover depends
+entirely on the server — see
+[Platforms Without Plugin Coverage](#platforms-without-plugin-coverage-not-managed-by-the-plugin) — and that is where an
+unreachable server leaves the requirement unknown.
 
 Tap the BIOS status indicator to see a detailed list of individual files and which ones are present or missing. Each
 file lists the cores that use it (e.g. _Beetle PSX HW (required)_, _SwanStation (optional)_); the **active core**'s line

--- a/docs/user-guide/bios-management.md
+++ b/docs/user-guide/bios-management.md
@@ -33,6 +33,12 @@ ok/partial/missing classification used everywhere in the plugin:
 The classification is computed against the **active core** for that game — so switching to a core that needs no BIOS (or
 that treats a file as optional) clears the warning, while switching to a core that requires a missing file surfaces it.
 
+A BIOS warning only ever disappears on an **answer**. When the plugin cannot work out the requirement — your RomM server
+is unreachable while it checks, or the BIOS state has not been re-read yet after a download or a delete — it keeps
+showing the last status it knew rather than reporting "no BIOS needed". So a check that failed never quietly clears a
+missing-BIOS warning and lets the game launch without its files; it just leaves the warning where it was until a check
+gets through.
+
 Tap the BIOS status indicator to see a detailed list of individual files and which ones are present or missing. Each
 file lists the cores that use it (e.g. _Beetle PSX HW (required)_, _SwanStation (optional)_); the **active core**'s line
 is highlighted in amber so you can spot at a glance which core's requirements the file applies to.

--- a/py_modules/services/firmware.py
+++ b/py_modules/services/firmware.py
@@ -745,6 +745,12 @@ class FirmwareService:
         per-game game-detail path passes the ROM's resolved ``.so``. Core info
         reaches the frontend through the dedicated ``get_platform_core_info``
         path, not this payload (#923).
+
+        A failed firmware fetch degrades to the local registry, which still
+        answers the requirement for a covered platform. An uncovered platform has
+        nothing to degrade to, so the ``needs_bios: False`` that comes back then
+        carries ``bios_status_unknown: True`` — no consumer may read that one as
+        "this platform needs none" (#1693).
         """
         system = self._resolve_system(platform_slug)
         fw_slugs = firmware_paths.resolve_firmware_slugs(platform_slug)
@@ -763,8 +769,14 @@ class FirmwareService:
             files = collect_firmware_status(items, registry_platform, active_core_so)
         except Exception:
             if not registry_platform:
+                # Nothing left to answer from: the server list is the only source
+                # of the requirement for a platform the registry does not cover,
+                # so this is "we don't know", not "needs none" (#1693). Reporting
+                # it as a negative would clear the "unmanaged" state a successful
+                # check had shown.
                 return {
                     "needs_bios": False,
+                    "bios_status_unknown": True,
                 }
             registry_items = []
             for file_name, reg_entry in registry_platform.items():

--- a/py_modules/services/firmware.py
+++ b/py_modules/services/firmware.py
@@ -299,7 +299,12 @@ class FirmwareService:
 
         TTL is checked against the wall-clock cache epoch so a cache
         restored from disk after a plugin restart still expires.
-        On HTTP error, falls back to cached data (if any) or empty list.
+
+        On HTTP error, falls back to cached data if there is any and RAISES
+        otherwise. Returning an empty list instead would be indistinguishable
+        from a server that genuinely holds no firmware, and ``check_platform_bios``
+        answers a confident "needs none" for that — so the raise is what lets a
+        failed fetch be reported as unknown rather than as a negative (#1693).
         """
         now = self._clock.time()
         if self._firmware_cache is not None and (now - self._firmware_cache_epoch) < _FIRMWARE_CACHE_TTL:

--- a/py_modules/services/game_detail.py
+++ b/py_modules/services/game_detail.py
@@ -91,6 +91,29 @@ class GameDetailService:
         return rom.fs_name
 
     @staticmethod
+    def _bios_answer(
+        bios_status: dict[str, Any] | None = None,
+        bios_level: str | None = None,
+        bios_label: str | None = None,
+        *,
+        unknown: bool = False,
+    ) -> dict[str, Any]:
+        """Build the BIOS half of a game-detail payload.
+
+        ``unknown`` marks a payload that carries no BIOS answer — the check
+        raised, or answered from a source that could not see the requirement —
+        as opposed to the answer "the active core needs no BIOS". The two ship
+        the same absent ``bios_status``, and only the latter may take a shown
+        requirement off the frontend, so the flag is what separates them.
+        """
+        return {
+            "bios_status": bios_status,
+            "bios_level": bios_level,
+            "bios_label": bios_label,
+            "bios_status_unknown": unknown,
+        }
+
+    @staticmethod
     def _build_save_status(save_state: RomSaveSyncState | None) -> dict[str, Any] | None:
         """Build cached save-sync status from the ROM's save state, or None."""
         if save_state is None:
@@ -233,10 +256,15 @@ class GameDetailService:
         bios_status = None
         bios_level = None
         bios_label = None
+        # A cold firmware cache answers None — this payload then carries no BIOS
+        # answer at all, which is not the same as "the active core needs none".
+        bios_status_unknown = False
         if platform_slug:
             active_core_so, _ = self._active_core.active_core_for_rom(rom_id)
             cached_bios = self._bios_checker.check_platform_bios_cached(platform_slug, active_core_so=active_core_so)
-            if cached_bios and cached_bios.get("needs_bios"):
+            if cached_bios is None:
+                bios_status_unknown = True
+            elif cached_bios.get("needs_bios"):
                 bios_obj = format_bios_status(cached_bios, platform_slug, cached_at=cached_bios.get("cached_at", 0.0))
                 bios_status = asdict(bios_obj)
                 bios_level = compute_bios_level(bios_obj)
@@ -268,6 +296,7 @@ class GameDetailService:
             "bios_status": bios_status,
             "bios_level": bios_level,
             "bios_label": bios_label,
+            "bios_status_unknown": bios_status_unknown,
             "rom_file": rom_file,
             "ra_id": ra_id,
             "achievement_summary": achievement_summary,
@@ -289,9 +318,12 @@ class GameDetailService:
         """Return BIOS status for a ROM by looking up platform/rom_file from SQLite.
 
         Response always includes ``bios_status`` (dict or ``None``), ``bios_level``
-        (``"ok"`` / ``"partial"`` / ``"missing"`` or ``None``), and ``bios_label``
-        (str or ``None``). The pre-computed level + label match what the cached
-        ``get_cached_game_detail`` ships so the frontend never re-derives them.
+        (``"ok"`` / ``"partial"`` / ``"missing"`` or ``None``), ``bios_label``
+        (str or ``None``), and ``bios_status_unknown`` (bool). The pre-computed
+        level + label match what the cached ``get_cached_game_detail`` ships so
+        the frontend never re-derives them; the flag separates a check that could
+        not answer from the answer "this core needs no BIOS", which is the only
+        one of the two that clears a shown requirement.
         """
         rom_id = int(rom_id)
 
@@ -301,11 +333,11 @@ class GameDetailService:
             rom = uow.roms.get(rom_id)
 
         if rom is None:
-            return {"bios_status": None, "bios_level": None, "bios_label": None}
+            return self._bios_answer()
 
         platform_slug = rom.platform_slug
         if not platform_slug:
-            return {"bios_status": None, "bios_level": None, "bios_label": None}
+            return self._bios_answer()
 
         # The core-aware BIOS filter keys off the per-game active core (the pin
         # over the system default), resolved by rom_id from the shared seam.
@@ -315,12 +347,15 @@ class GameDetailService:
             bios = await self._bios_checker.check_platform_bios(platform_slug, active_core_so=active_core_so)
             if bios.get("needs_bios"):
                 bios_obj = format_bios_status(bios, platform_slug)
-                return {
-                    "bios_status": asdict(bios_obj),
-                    "bios_level": compute_bios_level(bios_obj),
-                    "bios_label": compute_bios_label(bios_obj),
-                }
+                return self._bios_answer(
+                    asdict(bios_obj),
+                    compute_bios_level(bios_obj),
+                    compute_bios_label(bios_obj),
+                )
         except Exception as e:
             self._logger.warning(f"BIOS status check failed for {platform_slug}: {e}")
+            return self._bios_answer(unknown=True)
 
-        return {"bios_status": None, "bios_level": None, "bios_label": None}
+        # No requirement — but a check that itself degraded to a source blind to
+        # the requirement reports that, and its verdict travels on unchanged.
+        return self._bios_answer(unknown=bool(bios.get("bios_status_unknown")))

--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -66,7 +66,37 @@ export function isCallableFailure(value: object): value is CallableFailure {
   return "success" in value && value.success === false;
 }
 
-export interface CachedGameDetail {
+/**
+ * The BIOS half of a backend answer: the requirement, plus the level and label
+ * the backend pre-computed for it. Shipped by `get_bios_status` and, under the
+ * same keys, inside a cached game detail — so one projection
+ * (`utils/playSection.extractBiosInfo`) reads both.
+ *
+ * An absent `bios_status` means the active core needs no BIOS and clears a shown
+ * requirement (#1690). `bios_status_unknown` marks the payload that carries no
+ * answer at all — the check raised, or the firmware cache it would have been
+ * read from is cold — and it ships the identical absent `bios_status`, so the
+ * flag is the only thing keeping a failed check from taking a missing-BIOS
+ * warning off the page (#1693).
+ */
+export interface BiosAnswer {
+  bios_status?: {
+    needs_bios?: boolean;
+    platform_slug: string;
+    server_count: number;
+    local_count: number;
+    all_downloaded: boolean;
+    required_count?: number;
+    required_downloaded?: number;
+    cached_at?: number;
+    files?: BiosFileStatus[];
+  } | null;
+  bios_level?: "ok" | "partial" | "missing" | "unmanaged" | null;
+  bios_label?: string | null;
+  bios_status_unknown?: boolean;
+}
+
+export interface CachedGameDetail extends BiosAnswer {
   found: boolean;
   rom_id?: number;
   rom_name?: string;
@@ -81,22 +111,9 @@ export interface CachedGameDetail {
   } | null;
 
   metadata?: Record<string, unknown> | null;
-  bios_status?: {
-    needs_bios?: boolean;
-    platform_slug: string;
-    server_count: number;
-    local_count: number;
-    all_downloaded: boolean;
-    required_count?: number;
-    required_downloaded?: number;
-    cached_at?: number;
-    files?: BiosFileStatus[];
-  } | null;
   rom_file?: string;
   ra_id?: number | null;
   achievement_summary?: AchievementSummary | null;
-  bios_level?: "ok" | "partial" | "missing" | "unmanaged" | null;
-  bios_label?: string | null;
   save_sync_display?: SaveSyncDisplay | null;
   stale_fields?: string[];
   // Version metadata (ADR-0021) — the RomM sibling-group dimensions of the
@@ -364,14 +381,7 @@ export const getFirmwareStatus = callable<[], FirmwareStatus>("get_firmware_stat
 export const downloadAllFirmware = callable<[string], FirmwareDownloadResult>("download_all_firmware");
 export const downloadRequiredFirmware = callable<[string], FirmwareDownloadResult>("download_required_firmware");
 export const checkPlatformBios = callable<[string], BiosStatus>("check_platform_bios");
-export const getBiosStatus = callable<
-  [number],
-  {
-    bios_status: CachedGameDetail["bios_status"];
-    bios_level: "ok" | "partial" | "missing" | "unmanaged" | null;
-    bios_label: string | null;
-  }
->("get_bios_status");
+export const getBiosStatus = callable<[number], BiosAnswer>("get_bios_status");
 /**
  * A single shortcut whose baked `launch_options` must be confirm-set after a
  * per-platform core change. The backend returns one entry per installed + bound

--- a/src/components/RomMGameInfoPanel.test.tsx
+++ b/src/components/RomMGameInfoPanel.test.tsx
@@ -15,6 +15,7 @@ import { render, act } from "@testing-library/react";
 import { createElement, type ComponentProps } from "react";
 import { RomMGameInfoPanel } from "./RomMGameInfoPanel";
 import * as backend from "../api/backend";
+import type { CachedGameDetail } from "../api/backend";
 import * as cachedStore from "../utils/cachedGameDetailStore";
 import * as slotState from "../utils/slotState";
 import {
@@ -173,6 +174,28 @@ function makeMetadata(overrides: Partial<RomMetadata> = {}): RomMetadata & Recor
     player_count: "",
     cached_at: 0,
     steam_categories: [],
+    ...overrides,
+  };
+}
+
+/** A cached detail on the snes platform (so the #1082 guard lets a matching
+ *  `bios` event through) that carries a BIOS requirement — the panel mounts with
+ *  its BIOS tab visible, which is what a later BIOS answer can take away. */
+function biosNeedingDetail(overrides: Partial<CachedGameDetail> = {}): CachedGameDetail {
+  return {
+    found: true,
+    rom_id: 60,
+    platform_slug: "snes",
+    save_sync_enabled: true,
+    metadata: makeMetadata(),
+    stale_fields: [],
+    bios_status: {
+      platform_slug: "snes",
+      server_count: 2,
+      local_count: 1,
+      all_downloaded: false,
+    },
+    bios_level: "partial",
     ...overrides,
   };
 }
@@ -1217,22 +1240,15 @@ describe("RomMGameInfoPanel", () => {
       expect(vi.mocked(backend.checkPlatformBios)).not.toHaveBeenCalled();
     });
 
-    it("bios: checkPlatformBios rejection → falls back to { needs_bios: false } (non-vacuous .catch)", async () => {
-      // Mount on the snes platform (so the #1082 guard lets the matching
-      // event through) without bios_status, so biosStatus starts null and
-      // the BIOS tab is NOT visible — the assertion that it STAYS hidden
-      // after the rejection is the fallback-state observable.
-      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
-        found: true,
-        rom_id: 60,
-        platform_slug: "snes",
-        save_sync_enabled: true,
-        metadata: makeMetadata(),
-        stale_fields: [],
-      });
+    it("bios: checkPlatformBios rejection → the shown requirement stands (#1693, non-vacuous .catch)", async () => {
+      // Trigger: "Download BIOS" from the gear menu where the follow-up check
+      // fails. Rewriting the rejection into { needs_bios: false } dropped the
+      // whole BIOS tab while the play row above correctly kept its level, so the
+      // panel mounts WITH a requirement and it has to survive.
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(biosNeedingDetail());
       const { container } = render(<RomMGameInfoPanel appId={testAppId} />);
       await flushAsync();
-      expect(container.textContent).not.toContain("BIOS");
+      expect(container.textContent).toContain("BIOS");
       vi.mocked(backend.checkPlatformBios).mockRejectedValue(new Error("net"));
       await act(async () => {
         globalThis.dispatchEvent(
@@ -1243,11 +1259,51 @@ describe("RomMGameInfoPanel", () => {
         await Promise.resolve();
         await Promise.resolve();
       });
-      // The outer try/catch did not fire — inline .catch swallowed and
-      // produced { needs_bios: false }, which means biosStatus stays null
-      // (the handler's setState resolves the ternary to null) and the
-      // BIOS tab remains hidden.
+      // The outer try/catch did not fire — the inline .catch swallowed the
+      // rejection and wrote nothing, so the BIOS tab is still there.
       expect(vi.mocked(backend.debugLog)).not.toHaveBeenCalledWith(expect.stringContaining("onDataChanged error"));
+      expect(container.textContent).toContain("BIOS");
+    });
+
+    it("bios: a check that could not determine the requirement keeps the tab (#1693)", async () => {
+      // The check answered without raising — an uncovered platform whose
+      // firmware fetch failed — and says so with the flag. Same absent
+      // requirement on the wire as the clear below; only the flag separates them.
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(biosNeedingDetail());
+      const { container } = render(<RomMGameInfoPanel appId={testAppId} />);
+      await flushAsync();
+      expect(container.textContent).toContain("BIOS");
+      vi.mocked(backend.checkPlatformBios).mockResolvedValue({ needs_bios: false, bios_status_unknown: true });
+      await act(async () => {
+        globalThis.dispatchEvent(
+          new CustomEvent("romm_data_changed", {
+            detail: { type: "bios", platform_slug: "snes" },
+          }),
+        );
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(container.textContent).toContain("BIOS");
+    });
+
+    it("bios: a real 'needs none' answer still clears the tab", async () => {
+      // The other direction — an ANSWER carrying no requirement takes the tab
+      // away, which is what makes the flag above load-bearing rather than a
+      // blanket "never clear".
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(biosNeedingDetail());
+      const { container } = render(<RomMGameInfoPanel appId={testAppId} />);
+      await flushAsync();
+      expect(container.textContent).toContain("BIOS");
+      vi.mocked(backend.checkPlatformBios).mockResolvedValue({ needs_bios: false });
+      await act(async () => {
+        globalThis.dispatchEvent(
+          new CustomEvent("romm_data_changed", {
+            detail: { type: "bios", platform_slug: "snes" },
+          }),
+        );
+        await Promise.resolve();
+        await Promise.resolve();
+      });
       expect(container.textContent).not.toContain("BIOS");
     });
 
@@ -1414,6 +1470,54 @@ describe("RomMGameInfoPanel", () => {
         await Promise.resolve();
       });
       expect(container.textContent).toContain("FROM_CORE_CHANGED");
+    });
+
+    it("core_changed: a cached detail with no BIOS answer keeps the tab (#1693)", async () => {
+      // The firmware cache is invalidated by every BIOS download and delete, and
+      // a detail derived while it is cold carries no BIOS answer. Reading that
+      // as "needs none" hid the tab until something else refreshed it.
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(biosNeedingDetail());
+      const { container } = render(<RomMGameInfoPanel appId={testAppId} />);
+      await flushAsync();
+      expect(container.textContent).toContain("BIOS");
+
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(
+        biosNeedingDetail({ bios_status: null, bios_level: null, bios_status_unknown: true }),
+      );
+      await act(async () => {
+        globalThis.dispatchEvent(
+          new CustomEvent("romm_data_changed", {
+            detail: { type: "core_changed", platform_slug: "snes" },
+          }),
+        );
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(container.textContent).toContain("BIOS");
+    });
+
+    it("core_changed: an answered detail without a requirement clears the tab", async () => {
+      // The counterpart: the new core genuinely needs no BIOS, so the tab goes.
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(biosNeedingDetail());
+      const { container } = render(<RomMGameInfoPanel appId={testAppId} />);
+      await flushAsync();
+      expect(container.textContent).toContain("BIOS");
+
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(
+        biosNeedingDetail({ bios_status: null, bios_level: null }),
+      );
+      await act(async () => {
+        globalThis.dispatchEvent(
+          new CustomEvent("romm_data_changed", {
+            detail: { type: "core_changed", platform_slug: "snes" },
+          }),
+        );
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(container.textContent).not.toContain("BIOS");
     });
 
     it("core_changed: cache returns found=false → no state mutation", async () => {
@@ -3485,6 +3589,29 @@ describe("RomMGameInfoPanel", () => {
         await switchVersion();
 
         expect(container.textContent).not.toContain("BIOS");
+      });
+
+      it("leaves the shown level standing when the switched-to detail carries no BIOS answer (#1693)", async () => {
+        vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(detailNeedingBios(1, 1));
+        const { container } = render(<RomMGameInfoPanel appId={testAppId} />);
+        await flushAsync();
+        await openBiosTab();
+        expect(container.textContent).toContain("1/3 files ready");
+
+        // The switch lands inside the window a BIOS download or delete opens:
+        // the firmware cache is cold, so the detail carries no BIOS answer — the
+        // same absent `bios_status` as the clear above.
+        vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
+          found: true,
+          rom_id: 2,
+          platform_slug: "snes",
+          metadata: makeMetadata(),
+          stale_fields: ["bios"],
+          bios_status_unknown: true,
+        });
+        await switchVersion();
+
+        expect(container.textContent).toContain("1/3 files ready");
       });
 
       it("leaves the BIOS tab for the info tab when the requirement is cleared under it", async () => {

--- a/src/components/RomMGameInfoPanel.tsx
+++ b/src/components/RomMGameInfoPanel.tsx
@@ -37,6 +37,7 @@ import {
   refreshMigrationState,
   logError,
 } from "../api/backend";
+import type { BiosAnswer } from "../api/backend";
 import { SlotSetupWizard } from "./SlotSetupWizard";
 import { SavesTab } from "./SavesTab";
 import { ConnectingIndicator } from "./saves/ConnectingIndicator";
@@ -177,12 +178,21 @@ function refreshMetadataInBackground(
     .catch(() => {});
 }
 
-/** Build a `BiosStatus` from a cached game detail's `bios_status` field. */
-function biosStatusFromCache(cachedBios: Record<string, unknown> | null | undefined): BiosStatus | null {
-  if (!cachedBios) return null;
+/** The panel's two BIOS fields as a cached game detail answers them, or `null`
+ *  when the payload carries no BIOS answer — a detail derived while the firmware
+ *  cache was cold, which every BIOS download and delete makes it. The caller then
+ *  leaves the shown status standing instead of hiding the BIOS tab on a
+ *  non-answer (#1693).
+ *
+ *  `bios_level` is computed by the backend (`compute_bios_level`) and threaded
+ *  straight through, never re-derived; it is null whenever there is no
+ *  requirement. */
+function biosFieldsFromCache(cached: BiosAnswer): Pick<PanelState, "biosStatus" | "biosLevel"> | null {
+  if (cached.bios_status_unknown) return null;
+  if (!cached.bios_status) return { biosStatus: null, biosLevel: null };
   return {
-    needs_bios: true,
-    ...cachedBios,
+    biosStatus: { needs_bios: true, ...cached.bios_status },
+    biosLevel: cached.bios_level ?? null,
   };
 }
 
@@ -323,10 +333,9 @@ async function loadData(
     romIdRef.current = romId;
     platformSlugRef.current = platformSlug;
 
-    const biosStatus = biosStatusFromCache(cached.bios_status);
-    // bios_level is computed by the backend (`compute_bios_level`) and shipped on
-    // the cached payload — thread it straight through, never re-derive here.
-    const biosLevel = biosStatus ? (cached.bios_level ?? null) : null;
+    // Nothing is shown yet on a first render, so a payload carrying no BIOS
+    // answer starts the panel out with none either.
+    const { biosStatus, biosLevel } = biosFieldsFromCache(cached) ?? { biosStatus: null, biosLevel: null };
     const saveStatus = saveStatusFromCache(romId, cached.save_status);
     const conflicts: SyncConflict[] = cached.save_status?.conflicts ?? [];
     const raId = cached.ra_id ?? null;
@@ -531,8 +540,12 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => { //
       // and to skip the wasted checkPlatformBios fetch (#1082). Read via ref
       // to avoid a stale closure.
       if (!detail.platform_slug || detail.platform_slug !== platformSlugRef.current) return;
-      const updated = await checkPlatformBios(detail.platform_slug).catch((): BiosStatus => ({ needs_bios: false }));
-      if (cancelled) return;
+      // A rejected check and one that could not determine the requirement are
+      // both "we don't know" — writing either would drop the whole BIOS tab
+      // while the play row above keeps its level (#1693). Only an ANSWER moves
+      // the tab, in either direction.
+      const updated = await checkPlatformBios(detail.platform_slug).catch((): BiosStatus | null => null);
+      if (cancelled || !updated || updated.bios_status_unknown) return;
       const biosLevel = updated.needs_bios ? (updated.bios_level ?? null) : null;
       setState((prev) => ({ ...prev, biosStatus: updated.needs_bios ? updated : null, biosLevel }));
     };
@@ -551,17 +564,11 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => { //
         getCachedGameDetail(appId),
       ]);
       if (cancelled || !cached.found) return;
-      let biosStatus: BiosStatus | null = null;
-      if (cached.bios_status) {
-        biosStatus = {
-          needs_bios: true,
-          ...cached.bios_status,
-        };
-      }
-      // bios_level comes from the backend cache (compute_bios_level) — thread it
-      // through, never re-derive. null when there's no BIOS need.
-      const biosLevel = biosStatus ? (cached.bios_level ?? null) : null;
-      setState((prev) => ({ ...prev, biosStatus, biosLevel, coreInfo: coreInfo ?? prev.coreInfo }));
+      // A detail carrying no BIOS answer leaves the shown status alone — the
+      // core switch invalidated the cached detail, but a cold firmware cache
+      // makes the re-read a non-answer rather than a "needs none" (#1693).
+      const biosFields = biosFieldsFromCache(cached);
+      setState((prev) => ({ ...prev, ...biosFields, coreInfo: coreInfo ?? prev.coreInfo }));
     };
 
     const handleVersionSwitched = async (detail: Extract<RommDataChangedDetail, { type: "version_switched" }>) => {
@@ -589,36 +596,37 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => { //
       achievementsLoadedRef.current = false;
       slotsLoadedRef.current = false;
       const saveStatus = newRomId != null ? saveStatusFromCache(newRomId, cached.save_status) : null;
-      const biosStatus = biosStatusFromCache(cached.bios_status);
-      // bios_level comes from the backend cache (compute_bios_level) — thread it
-      // through, never re-derive. null when there's no BIOS need.
-      const biosLevel = biosStatus ? (cached.bios_level ?? null) : null;
-      setState((prev) => ({
-        ...prev,
-        romId: newRomId,
-        romName: cached.rom_name || prev.romName,
-        installed: cached.installed ?? false,
-        regions: cached.regions ?? [],
-        languages: cached.languages ?? [],
-        // Re-key per-rom tab state so nothing lingers from the previous version.
-        saveSyncEnabled: cached.save_sync_enabled ?? false,
-        saveStatus,
-        conflicts: cached.save_status?.conflicts ?? [],
-        raId: cached.ra_id ?? null,
-        activeSlot: "default",
-        availableSlots: [],
-        slotsLoading: false,
-        achievements: [],
-        achievementProgress: null,
-        achievementsLoading: false,
-        biosStatus,
-        biosLevel,
-        // The BIOS tab's button is gated on `biosStatus`, so clearing it while
-        // the user stands on that tab would hide the button and leave the body
-        // empty with nothing selected. Send them back to the tab every version
-        // has.
-        activeTab: !biosStatus && prev.activeTab === "bios" ? "info" : prev.activeTab,
-      }));
+      // A detail carrying no BIOS answer keeps the shown status: the switched-to
+      // version's requirement is unread, not absent (#1693).
+      const biosFields = biosFieldsFromCache(cached);
+      setState((prev) => {
+        const biosStatus = biosFields ? biosFields.biosStatus : prev.biosStatus;
+        return {
+          ...prev,
+          romId: newRomId,
+          romName: cached.rom_name || prev.romName,
+          installed: cached.installed ?? false,
+          regions: cached.regions ?? [],
+          languages: cached.languages ?? [],
+          // Re-key per-rom tab state so nothing lingers from the previous version.
+          saveSyncEnabled: cached.save_sync_enabled ?? false,
+          saveStatus,
+          conflicts: cached.save_status?.conflicts ?? [],
+          raId: cached.ra_id ?? null,
+          activeSlot: "default",
+          availableSlots: [],
+          slotsLoading: false,
+          achievements: [],
+          achievementProgress: null,
+          achievementsLoading: false,
+          ...biosFields,
+          // The BIOS tab's button is gated on `biosStatus`, so clearing it while
+          // the user stands on that tab would hide the button and leave the body
+          // empty with nothing selected. Send them back to the tab every version
+          // has.
+          activeTab: !biosStatus && prev.activeTab === "bios" ? "info" : prev.activeTab,
+        };
+      });
       // Re-fetch slot configuration (slotConfirmed) + slots for the new rom_id,
       // mirroring loadData's save-sync branch — this is the authority that keeps
       // the SlotSetupWizard-vs-SavesTab gate correct across the switch.

--- a/src/components/RomMPlaySection.test.tsx
+++ b/src/components/RomMPlaySection.test.tsx
@@ -300,18 +300,20 @@ describe("RomMPlaySection", () => {
       status: "synced",
       label: "synced label",
     });
-    // MUST honour the requirement argument, the way the real helper does: an
+    // MUST honour the answer it is handed, the way the real helper does: an
     // absent `bios_status` is the answer "no BIOS need" and yields the cleared
-    // shape (#1690). The store folds this in unconditionally, so a fixed return
-    // here would fold a BIOS need into EVERY mount — including the cached
-    // details below that carry no `bios_status` — and every test in this file
-    // that renders one would then be asserting against a row state production
-    // never produces.
-    vi.mocked(playSectionUtils.extractBiosInfo).mockImplementation((status) =>
-      status
+    // shape (#1690), while a payload flagged as carrying no answer yields null
+    // and the caller writes nothing (#1693). The store folds the result in, so a
+    // fixed return here would fold a BIOS need into EVERY mount — including the
+    // cached details below that carry no `bios_status` — and every test in this
+    // file that renders one would then be asserting against a row state
+    // production never produces.
+    vi.mocked(playSectionUtils.extractBiosInfo).mockImplementation((answer) => {
+      if (answer.bios_status_unknown) return null;
+      return answer.bios_status
         ? { biosNeeded: true, biosStatus: "ok", biosLabel: "OK" }
-        : { biosNeeded: false, biosStatus: null, biosLabel: "" },
-    );
+        : { biosNeeded: false, biosStatus: null, biosLabel: "" };
+    });
     vi.mocked(playSectionUtils.extractCoreInfo).mockReturnValue({
       activeCoreLabel: null,
       activeCoreIsDefault: true,
@@ -519,15 +521,17 @@ describe("RomMPlaySection", () => {
         expect.any(Function),
         expect.any(Function),
       );
-      // Assert exact arg shape: (cached.bios_status, cached.bios_level,
-      // cached.bios_label). The requirement itself leads, so its absence can
-      // clear the row (#1690); the level and label stay pre-computed by the
-      // backend (#923). Catches arg-order regressions that a bare
-      // .toHaveBeenCalled() would miss.
+      // Assert exact arg shape: the WHOLE BIOS answer, not three hand-picked
+      // fields. The requirement drives the clear (#1690) and the level/label
+      // stay pre-computed by the backend (#923) — and `bios_status_unknown`
+      // rides on the same payload, so a call site that unpacked the answer
+      // itself could leave it behind (#1693).
       expect(playSectionUtils.extractBiosInfo).toHaveBeenCalledWith(
-        expect.objectContaining({ platform_slug: "snes" }),
-        "ok",
-        "OK",
+        expect.objectContaining({
+          bios_status: expect.objectContaining({ platform_slug: "snes" }),
+          bios_level: "ok",
+          bios_label: "OK",
+        }),
       );
       // resolveSaveSyncLabel is called with the cached save_sync_display.
       expect(playSectionUtils.resolveSaveSyncLabel).toHaveBeenCalledWith(
@@ -2033,16 +2037,17 @@ describe("RomMPlaySection", () => {
 
     it("dispatch handler throw → onDataChanged outer try/catch fires debugLog", async () => {
       // Drive the outer try/catch in onDataChanged by routing through the
-      // core_changed branch (no inline .catch on getBiosStatus) and making
-      // getBiosStatus reject. The throw escapes handleCoreChange, propagates
-      // to onDataChanged's catch, and surfaces via debugLog.
+      // core_changed branch (no inline .catch on getPlatformCoreInfo) and making
+      // getPlatformCoreInfo reject. The throw escapes handleCoreChange,
+      // propagates to onDataChanged's catch, and surfaces via debugLog. The
+      // sibling BIOS read has its own catch (#1693), so it cannot drive this.
       vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
         found: true,
         rom_id: 33,
       });
       render(<RomMPlaySection appId={testAppId} />);
       await flushAsync();
-      vi.mocked(backend.getBiosStatus).mockRejectedValue(new Error("handler-boom"));
+      vi.mocked(backend.getPlatformCoreInfo).mockRejectedValue(new Error("handler-boom"));
       vi.mocked(backend.debugLog).mockClear();
       await act(async () => {
         globalThis.dispatchEvent(

--- a/src/types/firmware.ts
+++ b/src/types/firmware.ts
@@ -114,6 +114,11 @@ export interface BiosStatus {
   // files but none map to a registry entry (no coverage). Present only when
   // needs_bios is true.
   bios_level?: "ok" | "partial" | "missing" | "unmanaged" | null;
+  // Set when the check could not determine the requirement: the firmware fetch
+  // failed and the platform has no registry coverage to fall back on. The
+  // `needs_bios: false` it rides on is ignorance, not an answer, so no consumer
+  // may clear a shown requirement on it (#1693).
+  bios_status_unknown?: boolean;
 }
 
 export interface FirmwareDownloadResult {

--- a/src/utils/gameDetailStore.test.ts
+++ b/src/utils/gameDetailStore.test.ts
@@ -671,7 +671,7 @@ describe("gameDetailStore", () => {
       vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(found());
       subscribe(nextAppId);
       await flush();
-      vi.mocked(backend.getBiosStatus).mockRejectedValue(new Error("handler-boom"));
+      vi.mocked(backend.getPlatformCoreInfo).mockRejectedValue(new Error("handler-boom"));
       vi.mocked(backend.debugLog).mockClear();
 
       await act(async () => {
@@ -681,6 +681,92 @@ describe("gameDetailStore", () => {
       await flush();
 
       expect(vi.mocked(backend.debugLog)).toHaveBeenCalledWith(expect.stringContaining("onDataChanged error"));
+    });
+
+    // The same user action as refreshCoreAndBios, and it has to answer the same
+    // way: a failed BIOS read is "we don't know", and the core answer that DID
+    // land is still worth showing (#1693).
+    it("folds the core answer and keeps the shown BIOS need when the BIOS read fails", async () => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(
+        found({
+          bios_status: { platform_slug: "snes", server_count: 3, local_count: 0, all_downloaded: false },
+          bios_level: "missing",
+          bios_label: "0/3",
+        }),
+      );
+      subscribe(nextAppId);
+      await flush();
+      vi.mocked(backend.getPlatformCoreInfo).mockResolvedValue(laterCoreInfo);
+      vi.mocked(backend.getBiosStatus).mockRejectedValue(new Error("offline"));
+      vi.mocked(backend.debugLog).mockClear();
+
+      await act(async () => {
+        dispatchCoreChanged();
+        await Promise.resolve();
+      });
+      await flush();
+
+      expect(getGameDetail(nextAppId)).toMatchObject({
+        activeCoreLabel: "Genesis Plus GX",
+        biosNeeded: true,
+        biosStatus: "missing",
+        biosLabel: "0/3",
+      });
+      // Non-vacuous: the BIOS read's own catch handled it, so the handler-level
+      // catch never fired.
+      expect(vi.mocked(backend.debugLog)).not.toHaveBeenCalledWith(expect.stringContaining("onDataChanged error"));
+    });
+
+    it("keeps the shown BIOS need when the BIOS read carries no answer", async () => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(
+        found({
+          bios_status: { platform_slug: "snes", server_count: 3, local_count: 0, all_downloaded: false },
+          bios_level: "missing",
+          bios_label: "0/3",
+        }),
+      );
+      subscribe(nextAppId);
+      await flush();
+      vi.mocked(backend.getBiosStatus).mockResolvedValue({
+        bios_status: null,
+        bios_level: null,
+        bios_label: null,
+        bios_status_unknown: true,
+      });
+
+      await act(async () => {
+        dispatchCoreChanged();
+        await Promise.resolve();
+      });
+      await flush();
+
+      expect(getGameDetail(nextAppId)).toMatchObject({
+        activeCoreLabel: "Snes9x",
+        biosNeeded: true,
+        biosStatus: "missing",
+        biosLabel: "0/3",
+      });
+    });
+
+    it("clears the BIOS need when the re-read reports the new core needs none", async () => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(
+        found({
+          bios_status: { platform_slug: "snes", server_count: 3, local_count: 0, all_downloaded: false },
+          bios_level: "missing",
+          bios_label: "0/3",
+        }),
+      );
+      subscribe(nextAppId);
+      await flush();
+      vi.mocked(backend.getBiosStatus).mockResolvedValue({ bios_status: null, bios_level: null, bios_label: null });
+
+      await act(async () => {
+        dispatchCoreChanged();
+        await Promise.resolve();
+      });
+      await flush();
+
+      expect(getGameDetail(nextAppId)).toMatchObject({ biosNeeded: false, biosStatus: null, biosLabel: "" });
     });
   });
 
@@ -754,6 +840,38 @@ describe("gameDetailStore", () => {
         biosNeeded: true,
         biosStatus: "ok",
         biosLabel: "3/3",
+      });
+    });
+
+    // The cold-cache window (#1693): every firmware download and every platform
+    // BIOS delete invalidates the in-memory firmware cache, and a detail derived
+    // while it is cold carries no BIOS answer at all. It ships the same absent
+    // `bios_status` as the clear above, so only the flag keeps the badge on.
+    it("keeps the shown requirement when the re-derived detail carries no BIOS answer", async () => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(
+        found({
+          bios_status: { platform_slug: "snes", server_count: 3, local_count: 0, all_downloaded: false },
+          bios_level: "missing",
+          bios_label: "0/3",
+        }),
+      );
+      subscribe(nextAppId);
+      await flush();
+
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(
+        found({ rom_id: 43, bios_status_unknown: true, stale_fields: [] }),
+      );
+      await act(async () => {
+        dispatchVersionSwitch(nextAppId);
+        await Promise.resolve();
+      });
+      await flush();
+
+      expect(getGameDetail(nextAppId)).toMatchObject({
+        romId: 43,
+        biosNeeded: true,
+        biosStatus: "missing",
+        biosLabel: "0/3",
       });
     });
 
@@ -1215,14 +1333,81 @@ describe("gameDetailStore", () => {
       expect(vi.mocked(cachedStore.invalidateCachedGameDetail)).toHaveBeenCalledWith(nextAppId);
     });
 
-    it("refreshCoreAndBios clears the BIOS need when the refreshed read fails", async () => {
+    it("refreshCoreAndBios clears the BIOS need when the refreshed read reports none", async () => {
+      // The core just changed, so the new core may genuinely need no BIOS — an
+      // ANSWER saying so still takes the requirement off the row (#1690).
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(
+        found({
+          bios_status: { platform_slug: "snes", server_count: 3, local_count: 0, all_downloaded: false },
+          bios_level: "missing",
+          bios_label: "0/3",
+        }),
+      );
+      subscribe(nextAppId);
+      await flush();
+      vi.mocked(backend.getBiosStatus).mockResolvedValue({ bios_status: null, bios_level: null, bios_label: null });
+
+      await refreshCoreAndBios(nextAppId);
+
+      expect(getGameDetail(nextAppId)).toMatchObject({
+        activeCoreLabel: "Snes9x",
+        biosNeeded: false,
+        biosStatus: null,
+        biosLabel: "",
+      });
+    });
+
+    it("refreshCoreAndBios keeps the shown BIOS need when the refreshed read fails (#1693)", async () => {
+      // The gear-menu core switch: the core read is local and succeeds, the BIOS
+      // read goes over HTTP and fails. Clearing here launched the game without
+      // its required BIOS and said nothing.
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(
+        found({
+          bios_status: { platform_slug: "snes", server_count: 3, local_count: 0, all_downloaded: false },
+          bios_level: "missing",
+          bios_label: "0/3",
+        }),
+      );
       subscribe(nextAppId);
       await flush();
       vi.mocked(backend.getBiosStatus).mockRejectedValue(new Error("offline"));
 
       await refreshCoreAndBios(nextAppId);
 
-      expect(getGameDetail(nextAppId)).toMatchObject({ activeCoreLabel: "Snes9x", biosNeeded: false });
+      expect(getGameDetail(nextAppId)).toMatchObject({
+        // The core answer still lands — only the BIOS half is missing.
+        activeCoreLabel: "Snes9x",
+        biosNeeded: true,
+        biosStatus: "missing",
+        biosLabel: "0/3",
+      });
+    });
+
+    it("refreshCoreAndBios keeps the shown BIOS need when the read carries no answer (#1693)", async () => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(
+        found({
+          bios_status: { platform_slug: "snes", server_count: 3, local_count: 0, all_downloaded: false },
+          bios_level: "missing",
+          bios_label: "0/3",
+        }),
+      );
+      subscribe(nextAppId);
+      await flush();
+      vi.mocked(backend.getBiosStatus).mockResolvedValue({
+        bios_status: null,
+        bios_level: null,
+        bios_label: null,
+        bios_status_unknown: true,
+      });
+
+      await refreshCoreAndBios(nextAppId);
+
+      expect(getGameDetail(nextAppId)).toMatchObject({
+        activeCoreLabel: "Snes9x",
+        biosNeeded: true,
+        biosStatus: "missing",
+        biosLabel: "0/3",
+      });
     });
 
     it("does nothing for an appId nobody is subscribed to", async () => {

--- a/src/utils/gameDetailStore.ts
+++ b/src/utils/gameDetailStore.ts
@@ -111,11 +111,16 @@ const DEFAULT_STATE: GameDetailState = {
 
 type BiosStatusResult = Awaited<ReturnType<typeof getBiosStatus>>;
 
-/** Stand-in for a BIOS read that failed, read as "no BIOS need known".
- *  {@link refreshBiosStatus} leaves the shown level standing on it;
- *  {@link refreshCoreAndBios} re-derives from it, because a core switch may
- *  genuinely have removed the requirement. */
-const NO_BIOS_STATUS: BiosStatusResult = { bios_status: null, bios_level: null, bios_label: null };
+/** Stand-in for a BIOS read that failed, carrying the backend's own "no answer"
+ *  flag. Every reader routes it through `extractBiosInfo`, which refuses to
+ *  project it — so a failed read leaves the shown level exactly where it was,
+ *  the same as an answer the backend itself could not determine (#1693). */
+const UNKNOWN_BIOS_STATUS: BiosStatusResult = {
+  bios_status: null,
+  bios_level: null,
+  bios_label: null,
+  bios_status_unknown: true,
+};
 
 /** A save-status read still in flight, together with the rom identity it was
  *  issued for. A version switch re-keys the entry to a new rom_id without
@@ -318,10 +323,11 @@ async function loadDetail(appId: number, entry: Entry): Promise<void> {
     // Folded whether or not the detail reports a requirement: an absent
     // `bios_status` is the backend answering "this version's core needs none",
     // and only an unconditional fold can take a shown requirement back (#1690).
-    write((prev) => ({
-      ...prev,
-      ...extractBiosInfo(cached.bios_status, cached.bios_level ?? null, cached.bios_label ?? null),
-    }));
+    // A detail derived while the firmware cache was cold carries no answer at
+    // all and is refused here instead (#1693) — the `bios` stale field below
+    // then brings the live one.
+    const cachedBios = extractBiosInfo(cached);
+    if (cachedBios) write((prev) => ({ ...prev, ...cachedBios }));
 
     if (staleFields.includes("bios")) {
       refreshBiosInBackground(romId, cancelled, writeForRom);
@@ -429,32 +435,30 @@ export function noteSaveSyncDisplay(appId: number, display: SaveSyncDisplay): vo
 
 /** Re-read the BIOS level after a firmware download. Leaves the shown level
  *  alone when the read fails, when it reports no BIOS need, or when a version
- *  switch re-keyed the entry while the read was open. */
+ *  switch re-keyed the entry while the read was open. Downloading firmware
+ *  cannot remove a requirement — it only fills it — so this path adopts a
+ *  refreshed level and nothing else. */
 export async function refreshBiosStatus(appId: number): Promise<void> {
   const entry = _entries.get(appId);
   const romId = entry?.state.romId;
   if (!entry || !romId) return;
   const generation = entry.generation;
-  const refreshed = await getBiosStatus(romId).catch(() => NO_BIOS_STATUS);
-  if (!refreshed.bios_status) return;
-  writerForRom(
-    entry,
-    generation,
-    romId,
-  )((prev) => ({
-    ...prev,
-    biosStatus: refreshed.bios_level,
-    biosLabel: refreshed.bios_label ?? "",
-  }));
+  const refreshed = await getBiosStatus(romId).catch(() => UNKNOWN_BIOS_STATUS);
+  const biosInfo = extractBiosInfo(refreshed);
+  if (!biosInfo?.biosNeeded) return;
+  writerForRom(entry, generation, romId)((prev) => ({ ...prev, ...biosInfo }));
 }
 
 /**
  * Re-read core selection and BIOS after an override was pinned or cleared, and
  * drop the cached detail so the next read sees the new core.
  *
- * `biosNeeded` is re-derived from the refreshed status rather than kept: the
- * active core just changed, so the BIOS requirement may have changed with it
- * (#923).
+ * The BIOS fields are re-derived from an ANSWER rather than kept: the active
+ * core just changed, so the requirement may have changed with it (#923). A read
+ * that could not answer is not that — it leaves the shown level standing while
+ * the core half of the fold still lands, which is the difference between a core
+ * switch that reports its new BIOS state and one that silently drops a
+ * missing-BIOS warning off a game that still needs it (#1693).
  *
  * A version switch landing while the two reads are open re-keys the entry, and
  * the answers are then about the ROM it moved off — so the fold is refused. The
@@ -469,8 +473,9 @@ export async function refreshCoreAndBios(appId: number): Promise<void> {
   const generation = entry.generation;
   const [coreInfo, refreshed] = await Promise.all([
     getPlatformCoreInfo(romId),
-    getBiosStatus(romId).catch(() => NO_BIOS_STATUS),
+    getBiosStatus(romId).catch(() => UNKNOWN_BIOS_STATUS),
   ]);
+  const biosInfo = extractBiosInfo(refreshed);
   writerForRom(
     entry,
     generation,
@@ -478,9 +483,7 @@ export async function refreshCoreAndBios(appId: number): Promise<void> {
   )((prev) => ({
     ...prev,
     ...extractCoreInfo(coreInfo),
-    biosNeeded: !!refreshed.bios_status,
-    biosStatus: refreshed.bios_level,
-    biosLabel: refreshed.bios_label ?? "",
+    ...biosInfo,
   }));
   invalidateCachedGameDetail(appId);
 }
@@ -547,7 +550,15 @@ async function handleCoreChange(entry: Entry): Promise<void> {
   // the active core reflects a per-game DB override (epic #945). BIOS
   // level/label still come from the (now core-free) BIOS status — the active
   // core just switched, so the BIOS requirements may have changed.
-  const [coreInfo, biosResult] = await Promise.all([getPlatformCoreInfo(romId), getBiosStatus(romId)]);
+  //
+  // Same user action as refreshCoreAndBios, so the same answer to a BIOS read
+  // that failed: the core half still folds, and the shown level stands rather
+  // than the whole fold being lost to the handler's catch (#1693).
+  const [coreInfo, biosResult] = await Promise.all([
+    getPlatformCoreInfo(romId),
+    getBiosStatus(romId).catch(() => UNKNOWN_BIOS_STATUS),
+  ]);
+  const biosInfo = extractBiosInfo(biosResult);
   writerForRom(
     entry,
     generation,
@@ -555,9 +566,7 @@ async function handleCoreChange(entry: Entry): Promise<void> {
   )((prev) => ({
     ...prev,
     ...extractCoreInfo(coreInfo),
-    biosNeeded: !!biosResult.bios_status,
-    biosStatus: biosResult.bios_level,
-    biosLabel: biosResult.bios_label ?? "",
+    ...biosInfo,
   }));
 }
 

--- a/src/utils/gameDetailStore.ts
+++ b/src/utils/gameDetailStore.ts
@@ -433,11 +433,11 @@ export function noteSaveSyncDisplay(appId: number, display: SaveSyncDisplay): vo
   }));
 }
 
-/** Re-read the BIOS level after a firmware download. Leaves the shown level
+/** Re-read the BIOS answer after a firmware download. Leaves what is shown
  *  alone when the read fails, when it reports no BIOS need, or when a version
  *  switch re-keyed the entry while the read was open. Downloading firmware
- *  cannot remove a requirement — it only fills it — so this path adopts a
- *  refreshed level and nothing else. */
+ *  cannot remove a requirement — it only fills one, or reveals one the cache had
+ *  not seen — so this path adopts a refreshed answer and never clears one. */
 export async function refreshBiosStatus(appId: number): Promise<void> {
   const entry = _entries.get(appId);
   const romId = entry?.state.romId;

--- a/src/utils/playSection.test.ts
+++ b/src/utils/playSection.test.ts
@@ -84,33 +84,59 @@ describe("extractBiosInfo", () => {
   const requirement = { platform_slug: "snes", server_count: 3, local_count: 3, all_downloaded: true };
 
   it("projects the pre-computed level/label into the BIOS-only play-section fields (no core fields, #923)", () => {
-    const result = extractBiosInfo(requirement, "ok", "BIOS OK");
-    expect(result.biosNeeded).toBe(true);
-    expect(result.biosStatus).toBe("ok");
-    expect(result.biosLabel).toBe("BIOS OK");
+    const result = extractBiosInfo({ bios_status: requirement, bios_level: "ok", bios_label: "BIOS OK" });
+    expect(result).not.toBeNull();
+    expect(result!.biosNeeded).toBe(true);
+    expect(result!.biosStatus).toBe("ok");
+    expect(result!.biosLabel).toBe("BIOS OK");
     // Core fields no longer ride the BIOS payload — they come from extractCoreInfo.
     expect(result).not.toHaveProperty("activeCoreLabel");
     expect(result).not.toHaveProperty("availableCores");
   });
 
   it("coerces null label to empty string", () => {
-    const result = extractBiosInfo(requirement, null, null);
-    expect(result.biosLabel).toBe("");
-    expect(result.biosStatus).toBeNull();
+    const result = extractBiosInfo({ bios_status: requirement, bios_level: null, bios_label: null });
+    expect(result!.biosLabel).toBe("");
+    expect(result!.biosStatus).toBeNull();
   });
 
   it("reports the cleared shape when the answer carries no requirement (#1690)", () => {
-    expect(extractBiosInfo(null, null, null)).toEqual({ biosNeeded: false, biosStatus: null, biosLabel: "" });
+    expect(extractBiosInfo({ bios_status: null, bios_level: null, bios_label: null })).toEqual({
+      biosNeeded: false,
+      biosStatus: null,
+      biosLabel: "",
+    });
   });
 
   it("ignores a level and label left over next to an absent requirement (#1690)", () => {
     // The three fields move together — a cleared requirement never leaves a
     // level or label behind for the row to render against nothing.
-    expect(extractBiosInfo(undefined, "missing", "0/3")).toEqual({
+    expect(extractBiosInfo({ bios_level: "missing", bios_label: "0/3" })).toEqual({
       biosNeeded: false,
       biosStatus: null,
       biosLabel: "",
     });
+  });
+
+  it("returns null when the payload carries no BIOS answer (#1693)", () => {
+    // The same absent requirement as the clear above — the flag is the only
+    // thing separating them, and it is what stops a check that could not answer
+    // from taking a shown requirement off the page.
+    expect(
+      extractBiosInfo({ bios_status: null, bios_level: null, bios_label: null, bios_status_unknown: true }),
+    ).toBeNull();
+  });
+
+  it("refuses an unknown payload whatever level and label ride along (#1693)", () => {
+    expect(
+      extractBiosInfo({ bios_status: null, bios_level: "missing", bios_label: "0/3", bios_status_unknown: true }),
+    ).toBeNull();
+  });
+
+  it("treats an explicit bios_status_unknown: false as the answer it is", () => {
+    expect(
+      extractBiosInfo({ bios_status: null, bios_level: null, bios_label: null, bios_status_unknown: false }),
+    ).toEqual({ biosNeeded: false, biosStatus: null, biosLabel: "" });
   });
 });
 

--- a/src/utils/playSection.ts
+++ b/src/utils/playSection.ts
@@ -7,7 +7,7 @@
  * sectionRefresh.ts. Anything stateful belongs in the component itself.
  */
 
-import type { CachedGameDetail } from "../api/backend";
+import type { BiosAnswer } from "../api/backend";
 import type { CoreInfo, EmulatorOption, SaveStatus, SaveSyncDisplay } from "../types";
 import { hasAnySaveConflict } from "./saveStatus";
 import { formatTimeAgo } from "./formatters";
@@ -65,23 +65,27 @@ export function applySaveSyncDisplay(
 
 /** Project a whole BIOS answer — the backend's `bios_status` plus the level and
  *  label it pre-computed for it — into the BIOS-only fields the play-section row
- *  needs. `level` and `label` are never re-derived here. Only the PRESENCE of
- *  `status` is read: its absence is the backend answering "this core needs no
- *  BIOS", which clears all three fields, so a requirement can be taken back off
- *  the page (#1690). A read that FAILED is not that answer and must never be
- *  funnelled in as one — the caller drops it and leaves the shown level
- *  standing. Core data is sourced separately via `extractCoreInfo` (the BIOS
- *  payload no longer carries it, #923). */
-export function extractBiosInfo(
-  status: CachedGameDetail["bios_status"],
-  level: "ok" | "partial" | "missing" | "unmanaged" | null,
-  label: string | null,
-): BiosInfoFields {
-  if (!status) return { biosNeeded: false, biosStatus: null, biosLabel: "" };
+ *  needs, or `null` when the payload carries no answer at all. The level and
+ *  label are never re-derived here.
+ *
+ *  Three payloads, three outcomes. `bios_status` present: the requirement, with
+ *  its level and label. `bios_status` absent: the backend answering "this core
+ *  needs no BIOS", which clears all three fields so a requirement can be taken
+ *  back off the page (#1690). `bios_status_unknown` set: the check could not
+ *  answer — the same absent `bios_status` as the clear, and folding it would
+ *  take a real requirement off the page, so the caller writes nothing and the
+ *  shown level stands (#1693). The flag decides before the requirement is even
+ *  looked at, so an unknown payload is never partially adopted.
+ *
+ *  Core data is sourced separately via `extractCoreInfo` (the BIOS payload no
+ *  longer carries it, #923). */
+export function extractBiosInfo(answer: BiosAnswer): BiosInfoFields | null {
+  if (answer.bios_status_unknown) return null;
+  if (!answer.bios_status) return { biosNeeded: false, biosStatus: null, biosLabel: "" };
   return {
     biosNeeded: true,
-    biosStatus: level,
-    biosLabel: label ?? "",
+    biosStatus: answer.bios_level ?? null,
+    biosLabel: answer.bios_label ?? "",
   };
 }
 

--- a/src/utils/sectionRefresh.test.ts
+++ b/src/utils/sectionRefresh.test.ts
@@ -147,6 +147,24 @@ describe("refreshBiosInBackground", () => {
     expect(next).toEqual({ biosNeeded: false, biosStatus: null, biosLabel: "", unrelated: "keep" });
   });
 
+  it("writes nothing when the read carries no BIOS answer (#1693)", async () => {
+    // The backend flags a check it could not answer — a cold firmware cache, a
+    // platform check that failed — and it ships the same absent `bios_status` as
+    // a real negative. Folding it would clear the shown requirement.
+    vi.mocked(backend.getBiosStatus).mockResolvedValueOnce({
+      bios_status: null,
+      bios_level: null,
+      bios_label: null,
+      bios_status_unknown: true,
+    } as unknown as Awaited<ReturnType<typeof backend.getBiosStatus>>);
+
+    const setter = vi.fn();
+    refreshBiosInBackground(1, () => false, setter);
+    await flushMicrotasks();
+
+    expect(setter).not.toHaveBeenCalled();
+  });
+
   it("logs the error and skips the setter when the fetch rejects", async () => {
     // The counterpart to the clear above: a FAILED read is "we don't know", not
     // "no BIOS need", so the shown level stands (#1690).

--- a/src/utils/sectionRefresh.ts
+++ b/src/utils/sectionRefresh.ts
@@ -17,9 +17,9 @@ interface AchievementFields {
 }
 
 /** Re-read this ROM's BIOS status and fold the answer in — including an answer
- *  reporting no requirement, which clears the shown one (#1690). A read that
- *  FAILS writes nothing at all, so the shown level stands: a failure is "we
- *  don't know", not "no BIOS need". */
+ *  reporting no requirement, which clears the shown one (#1690). Nothing is
+ *  written when the read fails or comes back carrying no answer, so the shown
+ *  level stands: neither is "no BIOS need", both are "we don't know" (#1693). */
 export function refreshBiosInBackground<S extends BiosInfoFields>(
   romId: number,
   cancelled: () => boolean,
@@ -28,10 +28,9 @@ export function refreshBiosInBackground<S extends BiosInfoFields>(
   getBiosStatus(romId)
     .then((result) => {
       if (cancelled()) return;
-      setter((prev) => ({
-        ...prev,
-        ...extractBiosInfo(result.bios_status, result.bios_level, result.bios_label),
-      }));
+      const biosInfo = extractBiosInfo(result);
+      if (!biosInfo) return;
+      setter((prev) => ({ ...prev, ...biosInfo }));
     })
     .catch((e) => debugLog(`Background BIOS status fetch error: ${e}`));
 }

--- a/tests/contract/test_game_detail_read.py
+++ b/tests/contract/test_game_detail_read.py
@@ -1,10 +1,10 @@
-"""Contract tests for ``get_cached_game_detail`` over the real nesting.
+"""Contract tests for the game-detail read callables over the real nesting.
 
-Drives the real ``main.py`` callable through the real ``bootstrap()`` + SQLite,
-pinning the response shape the frontend consumes — including the version-metadata
-keys added in #1295 (ADR-0019). The version dimensions are server-derived facts
-persisted on the ``Rom`` aggregate and surfaced read-only in the play-section
-"Version" row.
+Drives the real ``main.py`` callables through the real ``bootstrap()`` + SQLite,
+pinning the response shapes the frontend consumes — the version-metadata keys
+added in #1295 (ADR-0019), and the BIOS answer both game-detail reads ship. The
+version dimensions are server-derived facts persisted on the ``Rom`` aggregate
+and surfaced read-only in the play-section "Version" row.
 """
 
 from __future__ import annotations
@@ -20,7 +20,7 @@ def _seed_versioned_rom(harness, **overrides):
         uow.roms.save(
             Rom.synced(
                 rom_id=42,
-                platform_slug="snes",
+                platform_slug=overrides.get("platform_slug", "snes"),
                 name="Chrono Trigger",
                 fs_name="ct.sfc",
                 shortcut_app_id=app_id,
@@ -97,3 +97,57 @@ async def test_cached_game_detail_unknown_app_id_is_not_found(harness):
     result = await harness.plugin.get_cached_game_detail(999999)
 
     assert result == {"found": False}
+
+
+# ── The BIOS answer both reads ship (#1693) ──────────────────────────────────
+# An absent ``bios_status`` means "the active core needs no BIOS" and clears a
+# shown requirement (#1690); ``bios_status_unknown`` marks the payload that has
+# no answer at all, which must not. Both callables are pinned in both directions.
+# The uncovered platform (psvita) is the one where the BIOS registry cannot stand
+# in for a failed firmware fetch.
+
+
+async def test_cached_game_detail_cold_firmware_cache_is_unknown(harness):
+    """A never-filled firmware cache carries no BIOS answer and says so."""
+    app_id = _seed_versioned_rom(harness, platform_slug="psvita")
+
+    result = await harness.plugin.get_cached_game_detail(app_id)
+
+    assert result["bios_status"] is None
+    assert result["bios_status_unknown"] is True
+
+
+async def test_cached_game_detail_warm_cache_without_firmware_is_answered(harness):
+    """A warm cache finding no firmware is the real negative — unflagged."""
+    app_id = _seed_versioned_rom(harness, platform_slug="psvita")
+    # The System-page read fills the in-memory firmware cache the game-detail
+    # path reads; the fake server has no firmware files.
+    await harness.plugin.get_firmware_status()
+
+    result = await harness.plugin.get_cached_game_detail(app_id)
+
+    assert result["bios_status"] is None
+    assert result["bios_status_unknown"] is False
+
+
+async def test_bios_status_unreachable_server_is_unknown(harness):
+    """A failed firmware fetch with no registry coverage answers "unknown"."""
+    _seed_versioned_rom(harness, platform_slug="psvita")
+    harness.romm.list_firmware_side_effect = RuntimeError("offline")
+
+    result = await harness.plugin.get_bios_status(42)
+
+    assert result["bios_status"] is None
+    assert result["bios_level"] is None
+    assert result["bios_label"] is None
+    assert result["bios_status_unknown"] is True
+
+
+async def test_bios_status_reachable_server_without_firmware_is_answered(harness):
+    """A reachable server with no firmware for the platform is the real negative."""
+    _seed_versioned_rom(harness, platform_slug="psvita")
+
+    result = await harness.plugin.get_bios_status(42)
+
+    assert result["bios_status"] is None
+    assert result["bios_status_unknown"] is False

--- a/tests/services/test_firmware.py
+++ b/tests/services/test_firmware.py
@@ -1648,7 +1648,9 @@ class TestCheckPlatformBiosNoCoreFields:
         with patch.object(plugin._romm_api, "list_firmware", side_effect=Exception("offline")):
             result = await fw.check_platform_bios("sms")
 
-        assert result == {"needs_bios": False}
+        # Uncovered platform with the fetch failed — the answer is "we don't
+        # know" (#1693), and it still carries no core fields.
+        assert result == {"needs_bios": False, "bios_status_unknown": True}
         assert "active_core" not in result
         assert "available_cores" not in result
         assert core_info.emulator_options_calls == []
@@ -1927,10 +1929,20 @@ class TestCheckPlatformBiosOffline:
         assert result["required_count"] == 2
         assert result["required_downloaded"] == 1
         assert len(result["files"]) == 3
+        # The registry knows what this platform needs, so the degraded answer is
+        # a real one — nothing to flag (#1693).
+        assert "bios_status_unknown" not in result
 
     @pytest.mark.asyncio
     async def test_offline_no_registry_entries(self, plugin, fw, tmp_path):
-        """API fails and no registry entries — returns needs_bios False."""
+        """API fails and no registry entries — needs_bios False, flagged unknown (#1693).
+
+        For a platform the BIOS registry does not cover, the server list is the
+        only source of the requirement. With the fetch failed there is nothing
+        left to answer from, so the payload says it does not know instead of
+        reporting a confident "needs none" — which would clear the "Not managed
+        by the plugin" state a successful check had shown.
+        """
 
         fw._bios_registry = {"platforms": {}}
         fw._bios_files_index = {}
@@ -1942,6 +1954,27 @@ class TestCheckPlatformBiosOffline:
             result = await fw.check_platform_bios("n64")
 
         assert result["needs_bios"] is False
+        assert result["bios_status_unknown"] is True
+
+    @pytest.mark.asyncio
+    async def test_online_no_firmware_is_a_real_negative(self, plugin, fw, tmp_path):
+        """A successful fetch finding no firmware answers needs_bios False, unflagged.
+
+        The counterpart to the offline case above: this negative IS an answer, so
+        it stays unflagged and consumers may clear a shown requirement on it.
+        """
+
+        fw._bios_registry = {"platforms": {}}
+        fw._bios_files_index = {}
+
+        with (
+            patch.object(plugin._romm_api, "list_firmware", return_value=[]),
+            patch.object(fw, "_retrodeck_paths", FakeRetroDeckPaths(bios=str(tmp_path / "bios"))),
+        ):
+            result = await fw.check_platform_bios("n64")
+
+        assert result["needs_bios"] is False
+        assert "bios_status_unknown" not in result
 
     @pytest.mark.asyncio
     async def test_offline_all_required_downloaded(self, plugin, fw, tmp_path):

--- a/tests/services/test_game_detail.py
+++ b/tests/services/test_game_detail.py
@@ -508,13 +508,21 @@ class TestGetCachedGameDetailBiosFromCache:
     """Test that get_cached_game_detail returns bios_status from firmware cache."""
 
     @pytest.mark.asyncio
-    async def test_bios_status_none_when_cache_empty(self, plugin, game_detail_service):
-        """No firmware cache → bios_status is None."""
+    async def test_cold_cache_flags_bios_status_unknown(self, plugin, game_detail_service):
+        """A cold firmware cache carries NO BIOS answer, and says so (#1693).
+
+        ``check_platform_bios_cached`` answers ``None`` whenever the in-memory
+        firmware cache has never been filled — and every firmware download and
+        every platform BIOS delete invalidates it. The frontend clears a shown
+        requirement on an absent ``bios_status``, so the payload has to separate
+        "not known here" from "this core needs none".
+        """
         _seed_rom(plugin, 42, app_id=50000, name="Pokemon", platform_slug="gba")
         # firmware cache is empty by default (None)
         result = game_detail_service.get_cached_game_detail(50000)
         assert result["found"] is True
         assert result["bios_status"] is None
+        assert result["bios_status_unknown"] is True
 
     @pytest.mark.asyncio
     async def test_bios_status_from_populated_cache(self, plugin, game_detail_service, tmp_path):
@@ -546,6 +554,7 @@ class TestGetCachedGameDetailBiosFromCache:
         assert bs["cached_at"] == pytest.approx(99.0)
         assert bs["server_count"] == 1
         assert bs["local_count"] == 0
+        assert result["bios_status_unknown"] is False
 
     @pytest.mark.asyncio
     async def test_bios_status_none_when_no_platform_slug(self, plugin, game_detail_service):
@@ -553,10 +562,17 @@ class TestGetCachedGameDetailBiosFromCache:
         _seed_rom(plugin, 42, app_id=50000, name="Game", platform_slug="")
         result = game_detail_service.get_cached_game_detail(50000)
         assert result["bios_status"] is None
+        # Nothing to check against, which is an answer rather than a gap.
+        assert result["bios_status_unknown"] is False
 
     @pytest.mark.asyncio
     async def test_bios_status_none_when_needs_bios_false(self, plugin, game_detail_service):
-        """Cache populated but no firmware for platform → bios_status is None."""
+        """Cache populated but no firmware for platform → bios_status is None.
+
+        A warm cache that finds no files for the platform is the real negative,
+        so it is NOT flagged unknown — this is the answer that still clears a
+        shown requirement (#1690).
+        """
         _seed_rom(plugin, 42, app_id=50000, name="Tetris", platform_slug="gb")
         plugin._firmware_service._firmware_cache = []
         plugin._firmware_service._firmware_cache_epoch = 50.0
@@ -565,6 +581,7 @@ class TestGetCachedGameDetailBiosFromCache:
         result = game_detail_service.get_cached_game_detail(50000)
 
         assert result["bios_status"] is None
+        assert result["bios_status_unknown"] is False
 
 
 # ============================================================================
@@ -609,6 +626,7 @@ class TestGetBiosStatusFound:
         # counts (core-aware badge) by the BIOS checker, NOT a platform default.
         assert result["bios_level"] == "partial"
         assert result["bios_label"] == "1/2 required"
+        assert result["bios_status_unknown"] is False
 
     @pytest.mark.asyncio
     async def test_badge_keys_off_active_core(self, plugin, game_detail_service):
@@ -653,7 +671,11 @@ class TestGetBiosStatusFound:
 
     @pytest.mark.asyncio
     async def test_returns_none_when_no_bios_needed(self, plugin, game_detail_service):
-        """ROM with needs_bios=False returns bios_status / level / label all None."""
+        """ROM with needs_bios=False returns bios_status / level / label all None.
+
+        This is the real negative — the answer the frontend is allowed to clear a
+        shown requirement on, so it must NOT be flagged unknown (#1693).
+        """
         _seed_rom(plugin, 42, app_id=50000, name="Game", platform_slug="gba")
         game_detail_service._bios_checker.check_platform_bios = AsyncMock(return_value={"needs_bios": False})
 
@@ -661,6 +683,7 @@ class TestGetBiosStatusFound:
         assert result["bios_status"] is None
         assert result["bios_level"] is None
         assert result["bios_label"] is None
+        assert result["bios_status_unknown"] is False
 
     @pytest.mark.asyncio
     async def test_passes_resolved_per_game_core_to_bios_check(self, plugin, game_detail_service, active_core_resolver):
@@ -729,25 +752,63 @@ class TestGetBiosStatusNotFound:
 
     @pytest.mark.asyncio
     async def test_unknown_rom_id(self, game_detail_service):
-        """Unknown rom_id returns bios_status / level / label all None."""
+        """Unknown rom_id returns bios_status / level / label all None, answered."""
         result = await game_detail_service.get_bios_status(999)
-        assert result == {"bios_status": None, "bios_level": None, "bios_label": None}
+        assert result == {
+            "bios_status": None,
+            "bios_level": None,
+            "bios_label": None,
+            "bios_status_unknown": False,
+        }
 
     @pytest.mark.asyncio
     async def test_no_platform_slug(self, plugin, game_detail_service):
-        """ROM without platform_slug returns bios_status / level / label all None."""
+        """ROM without platform_slug returns bios_status / level / label all None, answered."""
         _seed_rom(plugin, 42, app_id=50000, name="Game", platform_slug="")
         result = await game_detail_service.get_bios_status(42)
-        assert result == {"bios_status": None, "bios_level": None, "bios_label": None}
+        assert result == {
+            "bios_status": None,
+            "bios_level": None,
+            "bios_label": None,
+            "bios_status_unknown": False,
+        }
 
     @pytest.mark.asyncio
-    async def test_firmware_error_returns_none(self, plugin, game_detail_service):
-        """Firmware service exception returns bios_status / level / label all None."""
+    async def test_firmware_error_flags_unknown(self, plugin, game_detail_service):
+        """A raising BIOS check answers ``bios_status_unknown`` — not "no BIOS need" (#1693).
+
+        The frontend clears a shown requirement on an absent ``bios_status``, so
+        a failed check that shipped the same payload as a real negative took the
+        missing-BIOS warning off the page.
+        """
         _seed_rom(plugin, 42, app_id=50000, name="Game", platform_slug="gba")
         game_detail_service._bios_checker.check_platform_bios = AsyncMock(side_effect=Exception("fail"))
 
         result = await game_detail_service.get_bios_status(42)
-        assert result == {"bios_status": None, "bios_level": None, "bios_label": None}
+        assert result == {
+            "bios_status": None,
+            "bios_level": None,
+            "bios_label": None,
+            "bios_status_unknown": True,
+        }
+
+    @pytest.mark.asyncio
+    async def test_checker_unknown_verdict_is_passed_through(self, plugin, game_detail_service):
+        """A check that answered "unknown" itself keeps that verdict on the wire (#1693).
+
+        ``check_platform_bios`` handles a failed firmware fetch internally and
+        flags the answer when it had no registry coverage to degrade to — no
+        exception reaches here, so the flag is the only thing separating it from
+        a platform that genuinely needs nothing.
+        """
+        _seed_rom(plugin, 42, app_id=50000, name="Game", platform_slug="gba")
+        game_detail_service._bios_checker.check_platform_bios = AsyncMock(
+            return_value={"needs_bios": False, "bios_status_unknown": True}
+        )
+
+        result = await game_detail_service.get_bios_status(42)
+        assert result["bios_status"] is None
+        assert result["bios_status_unknown"] is True
 
 
 class TestGetCachedGameDetailSaveStatusConflicts:


### PR DESCRIPTION
A BIOS check that failed and a check reporting "this platform needs none" were the same answer on the
wire. `get_bios_status` caught every exception, logged it, and returned the same all-null payload as
the no-requirement path; a cold firmware cache produced that shape again. Three frontend paths then
read it as a negative and cleared a requirement that was still real.

The worst of the three: on a platform showing a missing-BIOS warning, picking a different core from
the gear menu issues a local core read that succeeds and a BIOS read over HTTP that can fail. The
warning disappeared and the game launched without its required files, with nothing on screen saying
so, until the page was re-entered.

The answer now carries `bios_status_unknown`. One flag and no reason field: the cause is already
determined by which callable produced the payload, and every consumer does the same single thing with
it, so a reason would be a field nobody branches on. The shape follows what the repo already uses for
a payload carrying its own partial failure.

`extractBiosInfo` now takes the whole answer instead of three unpacked arguments and checks the flag
before the requirement, so a call site cannot adopt half of an unanswerable payload — the mistake is
unrepresentable rather than a convention.

One branch beyond the issue: for a platform the built-in BIOS registry does not cover, a failed
firmware fetch had nothing to answer from and returned a confident `needs_bios: False`. That negative
cleared the real "not managed by the plugin" state, so it carries the flag too. A covered platform
still degrades to the registry and answers a genuine requirement; that path was already honest and is
unchanged.

`_get_firmware_list`'s docstring claimed it falls back to an empty list when the fetch fails and there
is no cache. It raises instead, and that raise is load-bearing — an empty list is indistinguishable
from a server holding no firmware, which the check answers as a confident negative. The docstring now
says so.

Both directions are tested on every writer: a check that could not answer never clears a shown
requirement, and a genuine "needs none" still does.

docs: `docs/user-guide/bios-management.md` states the guarantee in user language, with the
qualification that an unreachable server does not blind the plugin about the platforms its registry
covers.

Closes #1693
