### PR TITLE
refactor(ui): centralize the toast title behind a showToast helper

### DIFF
--- a/src/components/CustomPlayButton.tsx
+++ b/src/components/CustomPlayButton.tsx
@@ -10,7 +10,8 @@
  */
 
 import { useState, useEffect, useRef, FC, ReactElement } from "react";
-import { addEventListener, removeEventListener, toaster } from "@decky/api";
+import { addEventListener, removeEventListener } from "@decky/api";
+import { showToast, SAVE_SYNC_TOAST_TITLE } from "../utils/toast";
 import { Focusable, DialogButton, Menu, MenuItem, Navigation, showContextMenu } from "@decky/ui";
 import { appActionButtonClasses, basicAppDetailsSectionStylerClasses } from "../utils/deckyUiInternals";
 import { hideNativePlaySection, showNativePlaySection } from "../utils/styleInjector";
@@ -484,7 +485,7 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
     return applyLaunchGateSetupOutcome(resolveSaveSetupOutcome(setupInfo), {
       rid,
       confirmSlotChoice,
-      toast: (body) => toaster.toast({ title: "RomM Save Sync", body }),
+      toast: (body) => showToast(body, { title: SAVE_SYNC_TOAST_TITLE }),
       dispatchSavesTab: () =>
         globalThis.dispatchEvent(new CustomEvent("romm_tab_switch", { detail: { tab: "saves" } })),
     });
@@ -565,7 +566,7 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
 
     const toastBody = saveSyncToastBody(result.uploaded, result.downloaded);
     if (toastBody) {
-      toaster.toast({ title: "RomM Save Sync", body: toastBody });
+      showToast(toastBody, { title: SAVE_SYNC_TOAST_TITLE });
     }
     return { success: true, message: result.message };
   };
@@ -700,7 +701,7 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
         // block/no_launch_target has no such standing surface at the moment of the
         // press — the page states it, but the press must not read as a dead button.
         if (verdict.decision === "block" && verdict.reason === "no_launch_target") {
-          toaster.toast({ title: "RomM Sync", body: NO_LAUNCH_TARGET_TOAST_BODY });
+          showToast(NO_LAUNCH_TARGET_TOAST_BODY);
         }
         setState("play");
         return "done";
@@ -846,7 +847,7 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
     // leave the overlay up so Resume stays reachable.
     if (romId == null) {
       detach(debugLog(`CustomPlayButton: Stop on appId=${appId} but the rom id is not resolved yet — not stopping`));
-      toaster.toast({ title: "RomM Sync", body: "Couldn't stop the game — still loading its details" });
+      showToast("Couldn't stop the game — still loading its details");
       return;
     }
 
@@ -883,12 +884,12 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
       detach(
         debugLog(`CustomPlayButton: stop_running_game refused for appId=${appId} — reason=${result.reason ?? "none"}`),
       );
-      toaster.toast({ title: "RomM Sync", body: result.message || "Couldn't stop the game" });
+      showToast(result.message || "Couldn't stop the game");
     } catch (e) {
       // The overlay deliberately stays up: the call never reached a verdict, so
       // the game may well still be running and Resume must stay reachable.
       detach(debugLog(`CustomPlayButton: stop_running_game threw for appId=${appId}: ${e}`));
-      toaster.toast({ title: "RomM Sync", body: "Couldn't stop the game" });
+      showToast("Couldn't stop the game");
     } finally {
       // Released on every path, so a failed stop can be retried deliberately
       // (the backend, not this flag, is what makes a retry safe).
@@ -930,7 +931,7 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
 
       if (isCallableFailure(result)) {
         detach(debugLog(`CustomPlayButton: resolve conflict deferred: ${result.message}`));
-        toaster.toast({ title: "RomM Sync", body: result.message });
+        showToast(result.message);
         setState("conflict");
         return;
       }
@@ -948,12 +949,11 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
           reportServerReachable(false);
         }
         detach(debugLog(`CustomPlayButton: resolve conflict — server query failed for rom ${romId}`));
-        toaster.toast({
-          title: "RomM Sync",
-          body: unreachable
+        showToast(
+          unreachable
             ? "Couldn't reach server to resolve conflict"
             : "RomM couldn't find this game's save data — conflict left unresolved",
-        });
+        );
         setState("conflict");
         return;
       }
@@ -973,7 +973,7 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
       setState("play");
     } catch (e) {
       detach(debugLog(`CustomPlayButton: resolve conflict failed: ${e}`));
-      toaster.toast({ title: "RomM Sync", body: "Couldn't reach server to resolve conflict" });
+      showToast("Couldn't reach server to resolve conflict");
       setState("conflict");
     }
   };
@@ -984,11 +984,11 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
     try {
       const result = await startDownload(romId);
       if (!result.success) {
-        toaster.toast({ title: "RomM Sync", body: result.message || "Download failed" });
+        showToast(result.message || "Download failed");
         setActionPending(false);
       }
     } catch {
-      toaster.toast({ title: "RomM Sync", body: "Download failed — is RomM server running?" });
+      showToast("Download failed — is RomM server running?");
       setActionPending(false);
     }
   };
@@ -1046,17 +1046,17 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
           admission,
         );
         globalThis.dispatchEvent(new CustomEvent("romm_rom_uninstalled", { detail: { rom_id: romId } }));
-        toaster.toast({ title: "RomM Sync", body: `${romName || "ROM"} uninstalled` });
+        showToast(`${romName || "ROM"} uninstalled`);
         // Dark pulse transition before showing Download button
         setState("uninstalling");
         transitionTimerRef.current = setTimeout(() => setState("download"), 500);
         return;
       } else {
-        toaster.toast({ title: "RomM Sync", body: result.message || "Uninstall failed" });
+        showToast(result.message || "Uninstall failed");
         setState(stateBeforeUninstall);
       }
     } catch {
-      toaster.toast({ title: "RomM Sync", body: "Uninstall failed" });
+      showToast("Uninstall failed");
       setState(stateBeforeUninstall);
     } finally {
       uninstallPendingRef.current = false;

--- a/src/components/DiscSelector.tsx
+++ b/src/components/DiscSelector.tsx
@@ -16,7 +16,7 @@
  */
 
 import { useState, useEffect, useRef, FC, ReactNode } from "react";
-import { addEventListener, removeEventListener, toaster } from "@decky/api";
+import { addEventListener, removeEventListener } from "@decky/api";
 import { Menu, MenuItem, showContextMenu, DialogButton } from "@decky/ui";
 import { FaCompactDisc, FaChevronDown } from "react-icons/fa";
 import { getCachedGameDetail, getDiscSelection, selectDisc, logError, logWarn } from "../api/backend";
@@ -24,6 +24,7 @@ import type { DiscSelection } from "../api/backend";
 import { setLaunchOptionsConfirmed } from "../utils/steamShortcuts";
 import { getEventTarget } from "../utils/events";
 import { detach } from "../utils/detach";
+import { showToast } from "../utils/toast";
 import type { DownloadCompleteEvent } from "../types";
 import {
   capturePruneLeaseAdmission,
@@ -152,7 +153,7 @@ export const DiscSelector: FC<DiscSelectorProps> = ({ appId }) => {
             if (signal.aborted) return;
             setSelected(result.selected ?? null);
           } else {
-            toaster.toast({ title: "RomM Sync", body: result.message || "Failed to select disc" });
+            showToast(result.message || "Failed to select disc");
           }
         },
         leaseOwner,
@@ -168,7 +169,7 @@ export const DiscSelector: FC<DiscSelectorProps> = ({ appId }) => {
       // Observable catch effect: surface the failure so the user knows the pick
       // didn't take, and leave `selected` unchanged (revert to the prior pin).
       logError(`DiscSelector: selectDisc failed: ${e}`);
-      toaster.toast({ title: "RomM Sync", body: "Failed to select disc" });
+      showToast("Failed to select disc");
     }
   };
 

--- a/src/components/DownloadQueue.tsx
+++ b/src/components/DownloadQueue.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, FC, Fragment } from "react";
 import { PanelSection, PanelSectionRow, ButtonItem, Field } from "@decky/ui";
-import { toaster } from "@decky/api";
+import { showToast } from "../utils/toast";
 import {
   getDownloadQueue,
   cancelDownload,
@@ -74,10 +74,10 @@ export const DownloadQueue: FC<DownloadQueueProps> = ({ onBack }) => {
     try {
       const result = await cancelDownload(romId);
       if (!result.success) {
-        toaster.toast({ title: "RomM Sync", body: result.message || "Could not cancel the download" });
+        showToast(result.message || "Could not cancel the download");
       }
     } catch {
-      toaster.toast({ title: "RomM Sync", body: "Could not cancel the download" });
+      showToast("Could not cancel the download");
     }
   };
 

--- a/src/components/MigrationBlockedPage.tsx
+++ b/src/components/MigrationBlockedPage.tsx
@@ -1,6 +1,6 @@
 import { FC, useEffect, useState } from "react";
 import { PanelSection, PanelSectionRow, ButtonItem, Field, ConfirmModal, showModal } from "@decky/ui";
-import { toaster } from "@decky/api";
+import { showToast } from "../utils/toast";
 import { migrateRetroDeckFiles, dismissRetrodeckMigration } from "../api/backend";
 import type { MigrationStatus } from "../types";
 import { getMigrationState, onMigrationChange, clearMigration } from "../utils/migrationStore";
@@ -46,10 +46,7 @@ export const MigrationBlockedPage: FC<MigrationBlockedPageProps> = ({ migration 
       setMigrateResult(result.message);
       if (result.success) {
         clearMigration();
-        toaster.toast({
-          title: "RomM Sync",
-          body: result.message || "Migration complete.",
-        });
+        showToast(result.message || "Migration complete.");
       }
     } catch {
       setMigrateResult("Migration failed");
@@ -79,10 +76,7 @@ export const MigrationBlockedPage: FC<MigrationBlockedPageProps> = ({ migration 
                 const result = await dismissRetrodeckMigration();
                 if (result.success) {
                   clearMigration();
-                  toaster.toast({
-                    title: "RomM Sync",
-                    body: "Migration dismissed.",
-                  });
+                  showToast("Migration dismissed.");
                 }
               } catch {
                 setMigrateResult("Dismiss failed");

--- a/src/components/RemovedGamesCleanup.tsx
+++ b/src/components/RemovedGamesCleanup.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, FC, Fragment } from "react";
-import { toaster } from "@decky/api";
+import { showToast } from "../utils/toast";
 import {
   ButtonItem,
   DialogButton,
@@ -790,11 +790,11 @@ export const RemovedGamesCleanupSection: FC = () => {
     setScanning(true);
     try {
       if (!(await openRemovedGamesCleanupModal())) {
-        toaster.toast({ title: "RomM Sync", body: "No removed RomM entries were found." });
+        showToast("No removed RomM entries were found.");
       }
     } catch (e) {
       logError(`Removed-game cleanup scan failed: ${e}`);
-      toaster.toast({ title: "RomM Sync", body: "Could not scan removed RomM games." });
+      showToast("Could not scan removed RomM games.");
     } finally {
       setScanning(false);
     }

--- a/src/components/RomMPlaySection.tsx
+++ b/src/components/RomMPlaySection.tsx
@@ -11,7 +11,7 @@
  */
 
 import { useState, useEffect, FC, Fragment, createElement } from "react";
-import { toaster } from "@decky/api";
+import { showToast, SAVE_SYNC_TOAST_TITLE } from "../utils/toast";
 import {
   ConfirmModal,
   DialogButton,
@@ -432,7 +432,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
   const handleRefreshArtwork = async () => {
     if (actionPending) return;
     if (!detail.romId) {
-      toaster.toast({ title: "RomM Sync", body: "ROM info not loaded yet" });
+      showToast("ROM info not loaded yet");
       return;
     }
     const romId = detail.romId;
@@ -466,22 +466,22 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
         return null;
       });
       if (!resolution) {
-        toaster.toast({ title: "RomM Sync", body: "Failed to refresh artwork" });
+        showToast("Failed to refresh artwork");
         return;
       }
 
       switch (resolution.decision) {
         case "no_api_key":
-          toaster.toast({ title: "RomM Sync", body: "Set a SteamGridDB API key in settings first" });
+          showToast("Set a SteamGridDB API key in settings first");
           break;
         case "resolved": {
           const applied = await applyArtwork(romId, appId);
           if (applied === -1) {
-            toaster.toast({ title: "RomM Sync", body: "Set a SteamGridDB API key in settings first" });
+            showToast("Set a SteamGridDB API key in settings first");
           } else if (applied > 0) {
-            toaster.toast({ title: "RomM Sync", body: `Artwork refreshed (${applied}/4 images applied)` });
+            showToast(`Artwork refreshed (${applied}/4 images applied)`);
           } else {
-            toaster.toast({ title: "RomM Sync", body: "No artwork available for this game" });
+            showToast("No artwork available for this game");
           }
           break;
         }
@@ -504,7 +504,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
         detach(debugLog(`handleRefreshArtwork: continuation was cancelled: ${e}`));
         return;
       }
-      toaster.toast({ title: "RomM Sync", body: "Failed to refresh artwork" });
+      showToast("Failed to refresh artwork");
     } finally {
       setActionPending(null);
     }
@@ -515,12 +515,12 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
     setActionPending("metadata");
     try {
       await getRomMetadata(detail.romId);
-      toaster.toast({ title: "RomM Sync", body: "Metadata refreshed" });
+      showToast("Metadata refreshed");
       globalThis.dispatchEvent(
         new CustomEvent("romm_data_changed", { detail: { type: "metadata", rom_id: detail.romId } }),
       );
     } catch {
-      toaster.toast({ title: "RomM Sync", body: "Failed to refresh metadata" });
+      showToast("Failed to refresh metadata");
     } finally {
       setActionPending(null);
     }
@@ -537,20 +537,20 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
         const directionalBody = saveSyncToastBody(result.uploaded, result.downloaded);
         const c = result.conflicts?.length ?? 0;
         if (directionalBody) {
-          toaster.toast({ title: "RomM Save Sync", body: directionalBody });
+          showToast(directionalBody, { title: SAVE_SYNC_TOAST_TITLE });
         } else if (c === 0) {
           // Manual surface only (#1486): an explicit per-game "Sync Saves" click
           // that moved nothing and hit no conflicts gets a short acknowledgement,
           // so the click doesn't read as a no-op. The automatic surfaces
           // (pre-launch, post-exit) stay silent on this zero-case.
-          toaster.toast({ title: "RomM Save Sync", body: "Saves already up to date" });
+          showToast("Saves already up to date", { title: SAVE_SYNC_TOAST_TITLE });
         }
         // Preserve the conflict signal as its own additive toast (mirroring the
         // post-exit conflicts_toast) — it must stay visible even when nothing
         // transferred. Gated above so "up to date" never contradicts pending
         // conflicts.
         if (c > 0) {
-          toaster.toast({ title: "RomM Save Sync", body: `${c} conflict(s) need resolution` });
+          showToast(`${c} conflict(s) need resolution`, { title: SAVE_SYNC_TOAST_TITLE });
         }
         globalThis.dispatchEvent(
           new CustomEvent("romm_data_changed", { detail: { type: "save_sync", rom_id: detail.romId } }),
@@ -558,10 +558,10 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
         // Refresh save sync status — last_sync_check_at was just set by the backend
         noteSaveSyncDisplay(appId, { status: "synced", label: "Just now", last_sync_check_at: null });
       } else {
-        toaster.toast({ title: "RomM Sync", body: result.message || "Save sync failed" });
+        showToast(result.message || "Save sync failed");
       }
     } catch {
-      toaster.toast({ title: "RomM Sync", body: "Save sync failed" });
+      showToast("Save sync failed");
     } finally {
       setActionPending(null);
     }
@@ -573,17 +573,17 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
     try {
       const result = await downloadAllFirmware(detail.platformSlug);
       if (result.success) {
-        toaster.toast({ title: "RomM Sync", body: `BIOS downloaded (${result.downloaded ?? 0} files)` });
+        showToast(`BIOS downloaded (${result.downloaded ?? 0} files)`);
         globalThis.dispatchEvent(
           new CustomEvent("romm_data_changed", { detail: { type: "bios", platform_slug: detail.platformSlug } }),
         );
         // Refresh BIOS status — getBiosStatus ships pre-computed level/label so we don't re-derive.
         await refreshBiosStatus(appId);
       } else {
-        toaster.toast({ title: "RomM Sync", body: result.message || "BIOS download failed" });
+        showToast(result.message || "BIOS download failed");
       }
     } catch {
-      toaster.toast({ title: "RomM Sync", body: "BIOS download failed" });
+      showToast("BIOS download failed");
     } finally {
       setActionPending(null);
     }
@@ -608,9 +608,9 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
           `game-detail:${appId}`,
           admission,
         );
-        toaster.toast({ title: "RomM Sync", body: `${detail.romName || "ROM"} uninstalled` });
+        showToast(`${detail.romName || "ROM"} uninstalled`);
       } else {
-        toaster.toast({ title: "RomM Sync", body: result.message || "Uninstall failed" });
+        showToast(result.message || "Uninstall failed");
       }
     } catch (e) {
       // The backend uninstall already committed before the continuation was torn
@@ -619,7 +619,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
         detach(debugLog(`handleUninstall: continuation was cancelled: ${e}`));
         return;
       }
-      toaster.toast({ title: "RomM Sync", body: "Uninstall failed" });
+      showToast("Uninstall failed");
     } finally {
       setActionPending(null);
     }
@@ -642,17 +642,17 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
               try {
                 const result = await deleteLocalSaves(romId);
                 if (result.success) {
-                  toaster.toast({ title: "RomM Sync", body: result.message });
+                  showToast(result.message);
                   // Directly update the shown status — no local saves remain
                   noteSaveSyncDisplay(appId, { status: "none", label: "No saves", last_sync_check_at: null });
                   globalThis.dispatchEvent(
                     new CustomEvent("romm_data_changed", { detail: { type: "save_sync", rom_id: romId } }),
                   );
                 } else {
-                  toaster.toast({ title: "RomM Sync", body: result.message || "Failed to delete saves" });
+                  showToast(result.message || "Failed to delete saves");
                 }
               } catch {
-                toaster.toast({ title: "RomM Sync", body: "Failed to delete saves" });
+                showToast("Failed to delete saves");
               } finally {
                 setActionPending(null);
               }
@@ -686,7 +686,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
   ) => {
     await withPruneLease(result.prune_lease_token, "Core selection", async (signal) => {
       if (!result.success) {
-        toaster.toast({ title: "RomM Sync", body: result.message || "Failed to set core" });
+        showToast(result.message || "Failed to set core");
         return;
       }
       // Installed + bound: confirm the re-baked launch_options landed before
@@ -698,12 +698,12 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
         if (!confirmed) {
           // Never toast success on an unconfirmed bake. Keep the DB row — a Steam
           // restart (or the next migration/re-sync) re-bakes from the override.
-          toaster.toast({ title: "RomM Sync", body: "Core saved — restart Steam to apply" });
+          showToast("Core saved — restart Steam to apply");
           return;
         }
       }
       // Confirmed (or uninstalled/unbound: nothing to confirm) → success.
-      toaster.toast({ title: "RomM Sync", body: successBody });
+      showToast(successBody);
       await refreshCoreDisplay(platformSlug);
     }, `game-detail:${appId}`, admission);
   };
@@ -725,7 +725,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
         detach(debugLog(`handleChangeGameCore: continuation was cancelled: ${e}`));
         return;
       }
-      toaster.toast({ title: "RomM Sync", body: "Failed to set core" });
+      showToast("Failed to set core");
     }
   };
 
@@ -744,7 +744,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
         detach(debugLog(`handleResetGameCore: continuation was cancelled: ${e}`));
         return;
       }
-      toaster.toast({ title: "RomM Sync", body: "Failed to reset core" });
+      showToast("Failed to reset core");
     }
   };
 

--- a/src/components/SessionBudgetBanner.tsx
+++ b/src/components/SessionBudgetBanner.tsx
@@ -1,6 +1,6 @@
 import { FC, ReactNode } from "react";
 import { PanelSectionRow, ButtonItem, Focusable } from "@decky/ui";
-import { toaster } from "@decky/api";
+import { showToast } from "../utils/toast";
 import { isAnyAppRunning } from "../utils/runningApps";
 
 /**
@@ -52,7 +52,7 @@ export function memoryLevelColor(rssKb: number, warnKb: number, ceilingKb: numbe
  */
 function restartSteam(): void {
   if (isAnyAppRunning()) {
-    toaster.toast({ title: "RomM Sync", body: "Close your running game before restarting Steam." });
+    showToast("Close your running game before restarting Steam.");
     return;
   }
   SteamClient.User.StartRestart(false);

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, FC } from "react";
 import { PanelSection, PanelSectionRow, ButtonItem, ConfirmModal, showModal } from "@decky/ui";
-import { toaster } from "@decky/api";
+import { showToast } from "../utils/toast";
 import {
   getSettings,
   saveServerUrl,
@@ -375,10 +375,7 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
   const handleResetDefaultSlot = () => {
     setSaveSyncSettings((prev) => (prev ? { ...prev, default_slot: "default" } : prev));
     detach(handleSaveSyncSettingChange({ default_slot: "default" }));
-    toaster.toast({
-      title: "RomM Sync",
-      body: 'Default save slot reset to "default".',
-    });
+    showToast('Default save slot reset to "default".');
   };
   const handleDefaultSlotSubmit = (value: string) => {
     const trimmed = value.trim();
@@ -481,10 +478,7 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
       setSaveSortResult(result.message);
       if (result.success) {
         clearSaveSortMigration();
-        toaster.toast({
-          title: "RomM Sync",
-          body: result.message || "Migration complete.",
-        });
+        showToast(result.message || "Migration complete.");
       }
     } catch {
       setSaveSortResult("Migration failed");

--- a/src/components/SgdbGamePickerModal.tsx
+++ b/src/components/SgdbGamePickerModal.tsx
@@ -20,7 +20,7 @@
 
 import { FC, useState, KeyboardEvent } from "react";
 import { ConfirmModal, DialogButton, Focusable, GamepadButton, TextField, Spinner, type GamepadEvent } from "@decky/ui";
-import { toaster } from "@decky/api";
+import { showToast } from "../utils/toast";
 import { searchSgdbGames, applySgdbGameId, debugLog, type SgdbCandidate } from "../api/backend";
 import { applyArtwork } from "../utils/artwork";
 import { scrollToTop, scrollFocusedToCenter } from "../utils/scrollHelpers";
@@ -136,7 +136,7 @@ export const SgdbGamePickerModalContent: FC<SgdbGamePickerModalProps> = ({
         return { success: false };
       });
       if (!result.success) {
-        toaster.toast({ title: "RomM Sync", body: "Failed to apply artwork selection" });
+        showToast("Failed to apply artwork selection");
         return;
       }
       const applied = await applyArtwork(romId, appId).catch((e): number => {
@@ -144,11 +144,11 @@ export const SgdbGamePickerModalContent: FC<SgdbGamePickerModalProps> = ({
         return 0;
       });
       if (applied === -1) {
-        toaster.toast({ title: "RomM Sync", body: "Set a SteamGridDB API key in settings first" });
+        showToast("Set a SteamGridDB API key in settings first");
       } else if (applied > 0) {
-        toaster.toast({ title: "RomM Sync", body: `Artwork refreshed (${applied}/4 images applied)` });
+        showToast(`Artwork refreshed (${applied}/4 images applied)`);
       } else {
-        toaster.toast({ title: "RomM Sync", body: "No artwork available for this game" });
+        showToast("No artwork available for this game");
       }
       onApplied(applied);
       closeModal?.();

--- a/src/components/SlotSetupWizard.tsx
+++ b/src/components/SlotSetupWizard.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, FC, createElement, ChangeEvent, KeyboardEvent } from "react";
-import { toaster } from "@decky/api";
+import { showToast } from "../utils/toast";
 import { DialogButton, ConfirmModal, ModalRoot, TextField, showModal } from "@decky/ui";
 import { getSaveSetupInfo, confirmSlotChoice, logError } from "../api/backend";
 import { scrollFocusedToCenter } from "../utils/scrollHelpers";
@@ -258,7 +258,7 @@ function createConfirmHandler({ romId, setConfirming, setError, onComplete }: Co
       // never log-only. Only a migration reports counts; a plain confirm doesn't.
       if (migrate) {
         const body = wizardMigrationOutcomeToastBody(result.migrated ?? 0, result.failed ?? 0, slot);
-        if (body) toaster.toast({ title: "RomM Sync", body });
+        if (body) showToast(body);
       }
       onComplete();
     } catch (e) {

--- a/src/components/SyncConflictModal.tsx
+++ b/src/components/SyncConflictModal.tsx
@@ -1,5 +1,5 @@
 import { FC, useState } from "react";
-import { toaster } from "@decky/api";
+import { showToast } from "../utils/toast";
 import { ModalRoot, DialogButton, showModal } from "@decky/ui";
 import { resolveSyncConflict, logError } from "../api/backend";
 import type { SyncConflict } from "../types";
@@ -184,7 +184,7 @@ const SyncConflictModalHost: FC<SyncConflictModalHostProps> = ({ conflict, close
         action === "keep_local"
           ? "Conflict resolved — kept your local save (uploaded to server)."
           : "Conflict resolved — used the server save · your local was backed up.";
-      toaster.toast({ title: "RomM Sync", body: successBody });
+      showToast(successBody);
       closeModal?.();
       onDone(action);
     } catch (e) {

--- a/src/components/VersionPicker.tsx
+++ b/src/components/VersionPicker.tsx
@@ -28,7 +28,8 @@
  */
 
 import { useState, useEffect, useRef, FC, ReactNode } from "react";
-import { toaster, addEventListener, removeEventListener } from "@decky/api";
+import { addEventListener, removeEventListener } from "@decky/api";
+import { showToast } from "../utils/toast";
 import { Menu, MenuItem, showContextMenu, DialogButton } from "@decky/ui";
 import { FaChevronDown, FaCompactDisc, FaLayerGroup, FaTrash } from "react-icons/fa";
 import {
@@ -287,7 +288,7 @@ export const VersionPicker: FC<VersionPickerProps> = ({ appId }) => {
       admission,
     );
     if (!confirmed) {
-      toaster.toast({ title: "RomM Sync", body: "Switched — re-switch if launch fails" });
+      showToast("Switched — re-switch if launch fails");
     }
   };
 
@@ -300,7 +301,7 @@ export const VersionPicker: FC<VersionPickerProps> = ({ appId }) => {
   const handleSwitchFailure = (result: SwitchVersionFailure | SwitchVersionUnsyncedSaves): void => {
     if (result.reason === "server_unreachable") reportServerReachable(false);
     setSwitching(false);
-    toaster.toast({ title: "RomM Sync", body: "Could not switch version", subtext: result.message });
+    showToast("Could not switch version", { subtext: result.message });
     if (result.reason === "version_vanished") detach(refreshAfterVanishedRefusal());
   };
 
@@ -328,7 +329,7 @@ export const VersionPicker: FC<VersionPickerProps> = ({ appId }) => {
       // Every sync-then-switch failure is terminal for this attempt — release the
       // in-flight guard so the trigger re-enables (it never reaches a reload).
       setSwitching(false);
-      toaster.toast({ title: "RomM Sync", body });
+      showToast(body);
       refreshStrandedSaveStatus();
     };
     if (!isPruneLeaseAdmissionCurrent(admission)) return;
@@ -435,7 +436,7 @@ export const VersionPicker: FC<VersionPickerProps> = ({ appId }) => {
       }
       setSwitching(false);
       logError(`VersionPicker: switchVersion failed: ${e}`);
-      toaster.toast({ title: "RomM Sync", body: "Could not switch version" });
+      showToast("Could not switch version");
     }
   };
 
@@ -443,11 +444,11 @@ export const VersionPicker: FC<VersionPickerProps> = ({ appId }) => {
     detach(
       openRemovedGamesCleanupModal(romId)
         .then((opened) => {
-          if (!opened) toaster.toast({ title: "RomM Sync", body: "This local entry already changed." });
+          if (!opened) showToast("This local entry already changed.");
         })
         .catch((error) => {
           logError(`VersionPicker: cleanup preview failed for rom ${romId}: ${error}`);
-          toaster.toast({ title: "RomM Sync", body: "Could not prepare local cleanup." });
+          showToast("Could not prepare local cleanup.");
         }),
     );
   };

--- a/src/components/saves/SlotPanel.tsx
+++ b/src/components/saves/SlotPanel.tsx
@@ -6,7 +6,7 @@
 
 import { useState, useRef, useEffect, createElement, FC } from "react";
 import { ConfirmModal, DialogButton, showModal } from "@decky/ui";
-import { toaster } from "@decky/api";
+import { showToast } from "../../utils/toast";
 import { getSlotSaves, switchSlot, debugLog, getSlotDeleteInfo, deleteSlot } from "../../api/backend";
 import type {
   SaveStatus,
@@ -242,7 +242,7 @@ export const SlotPanel: FC<SlotPanelProps> = ({
     try {
       const info: SlotDeleteInfo = await getSlotDeleteInfo(romId, slotName);
       if (!info.success) {
-        toaster.toast({ title: "RomM Sync", body: slotDeleteFailureToast(info) });
+        showToast(slotDeleteFailureToast(info));
         return;
       }
 
@@ -274,14 +274,14 @@ export const SlotPanel: FC<SlotPanelProps> = ({
                 try {
                   const result = await deleteSlot(romId, slotName);
                   if (result.success) {
-                    toaster.toast({ title: "RomM Sync", body: `Slot '${slotName}' deleted` });
+                    showToast(`Slot '${slotName}' deleted`);
                     onSlotDeleted();
                   } else {
-                    toaster.toast({ title: "RomM Sync", body: result.message ?? "Failed to delete slot" });
+                    showToast(result.message ?? "Failed to delete slot");
                   }
                 } catch (e) {
                   detach(debugLog(`SavesTab: deleteSlot error: ${e}`));
-                  toaster.toast({ title: "RomM Sync", body: "An error occurred while deleting the slot" });
+                  showToast("An error occurred while deleting the slot");
                 }
               })(),
             );
@@ -290,7 +290,7 @@ export const SlotPanel: FC<SlotPanelProps> = ({
       );
     } catch (e) {
       detach(debugLog(`SavesTab: getSlotDeleteInfo error: ${e}`));
-      toaster.toast({ title: "RomM Sync", body: "Failed to load slot info" });
+      showToast("Failed to load slot info");
     } finally {
       setDeleting(false);
     }

--- a/src/components/saves/VersionHistoryPanel.tsx
+++ b/src/components/saves/VersionHistoryPanel.tsx
@@ -6,7 +6,7 @@
 
 import { useState, useEffect, createElement, FC } from "react";
 import { DialogButton } from "@decky/ui";
-import { toaster } from "@decky/api";
+import { showToast } from "../../utils/toast";
 import { debugLog, savesListFileVersions, savesRollbackToVersion } from "../../api/backend";
 import type { SaveVersionEntry, RollbackStatus, ListFileVersionsResult } from "../../types";
 import { showSyncConflictModal } from "../SyncConflictModal";
@@ -103,7 +103,7 @@ export const VersionHistoryPanel: FC<VersionHistoryPanelProps> = ({
     try {
       const result: RollbackStatus = await savesRollbackToVersion(romId, slot, version.id);
       if (result.status === "ok") {
-        toaster.toast({ title: "RomM Sync", body: `Save restored from ${formatRelativeTime(version.updated_at)}` });
+        showToast(`Save restored from ${formatRelativeTime(version.updated_at)}`);
         setVersions(null);
         setExpanded(false);
         onRestored();
@@ -123,21 +123,17 @@ export const VersionHistoryPanel: FC<VersionHistoryPanelProps> = ({
           // Degenerate: the server blocked on a conflict but sent none to
           // show, so there is no modal to surface it — nudge the user directly
           // instead of failing silently.
-          toaster.toast({
-            title: "RomM Sync",
-            body: "Restore blocked by a sync conflict. Sync this save, then try again.",
-          });
+          showToast("Restore blocked by a sync conflict. Sync this save, then try again.");
         }
       } else if (result.status === "preflight_failed") {
         const detail = result.errors[0] ?? "preflight error";
-        toaster.toast({ title: "RomM Sync", body: `Sync failed before restore: ${detail}` });
+        showToast(`Sync failed before restore: ${detail}`);
       } else if (result.status === "put_failed") {
         // Local download succeeded but the server-side bump didn't — switch
         // is locally complete, just won't propagate to other devices yet.
-        toaster.toast({
-          title: "RomM Sync",
-          body: "Restored locally, but the server didn't update. Other devices will see the previous version until you retry.",
-        });
+        showToast(
+          "Restored locally, but the server didn't update. Other devices will see the previous version until you retry.",
+        );
         setVersions(null);
         setExpanded(false);
         onRestored();
@@ -145,20 +141,20 @@ export const VersionHistoryPanel: FC<VersionHistoryPanelProps> = ({
         // Distinct from ``version_deleted``: the chosen version may well
         // still exist on the server; the local ROM install is what's gone
         // (uninstalled between version-list load and restore tap).
-        toaster.toast({ title: "RomM Sync", body: "ROM is no longer installed locally. Reinstall and try again." });
+        showToast("ROM is no longer installed locally. Reinstall and try again.");
       } else if (result.status === "version_deleted") {
-        toaster.toast({ title: "RomM Sync", body: "This version no longer exists on the server" });
+        showToast("This version no longer exists on the server");
       } else if (result.status === "server_unreachable") {
         // Distinct from ``not_found``: the version may well still exist;
         // we just couldn't reach the server to confirm. Prompt for retry
         // instead of telling the user the version is gone.
-        toaster.toast({ title: "RomM Sync", body: "Couldn't reach RomM. Check your connection and try again." });
+        showToast("Couldn't reach RomM. Check your connection and try again.");
       } else if (result.status === "not_found") {
         // Mirror of the branch above: RomM answered, so a retry cannot help.
-        toaster.toast({ title: "RomM Sync", body: "RomM couldn't find this game's save data — nothing was restored." });
+        showToast("RomM couldn't find this game's save data — nothing was restored.");
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- exhaustive final branch of the 9-member RollbackStatus union; an explicit check (vs. plain `else`) keeps the per-status symmetry and leaves any future-added status unhandled instead of silently routing it to the "unsupported" toast
       } else if (result.status === "unsupported") {
-        toaster.toast({ title: "RomM Sync", body: "Version history requires RomM 4.7+" });
+        showToast("Version history requires RomM 4.7+");
       }
     } catch (e) {
       detach(debugLog(`VersionHistoryPanel: restore error for save ${version.id}: ${e}`));

--- a/src/components/saves/useCopyToSlot.ts
+++ b/src/components/saves/useCopyToSlot.ts
@@ -9,7 +9,7 @@
 
 import { useCallback, createElement } from "react";
 import { showModal } from "@decky/ui";
-import { toaster } from "@decky/api";
+import { showToast } from "../../utils/toast";
 import { copySaveToSlot, debugLog } from "../../api/backend";
 import type { CopySaveToSlotStatus, SaveSlotSummary } from "../../types";
 import { showSyncConflictModal } from "../SyncConflictModal";
@@ -17,8 +17,6 @@ import { detach } from "../../utils/detach";
 import { displaySlot } from "./helpers";
 import { CopyToSlotModal } from "./CopyToSlotModal";
 import type { CopyToSlotHandler } from "./CopyToSlotButton";
-
-const TITLE = "RomM Sync";
 
 /** Refresh both the source and target slot views after a successful copy. */
 function dispatchDataChanged(romId: number): void {
@@ -28,13 +26,13 @@ function dispatchDataChanged(romId: number): void {
 async function handleResult(result: CopySaveToSlotStatus, target: string, romId: number): Promise<void> {
   switch (result.status) {
     case "ok":
-      toaster.toast({ title: TITLE, body: `Save copied to slot '${displaySlot(target)}'` });
+      showToast(`Save copied to slot '${displaySlot(target)}'`);
       dispatchDataChanged(romId);
       return;
     case "already_present":
       // Content-identical to a save already in the target slot — nothing was
       // copied (no churn), so no refresh either.
-      toaster.toast({ title: TITLE, body: `Already in slot '${displaySlot(target)}' as #${result.existing_id}` });
+      showToast(`Already in slot '${displaySlot(target)}' as #${result.existing_id}`);
       return;
     case "conflict_blocked": {
       // A real conflict on the ROM's current slot must be resolved first. The
@@ -44,52 +42,47 @@ async function handleResult(result: CopySaveToSlotStatus, target: string, romId:
       if (first) {
         await showSyncConflictModal(first);
       } else {
-        toaster.toast({ title: TITLE, body: "Copy blocked by a sync conflict. Sync this save, then try again." });
+        showToast("Copy blocked by a sync conflict. Sync this save, then try again.");
       }
       return;
     }
     case "target_slot_busy":
-      toaster.toast({
-        title: TITLE,
-        body: `Slot '${displaySlot(target)}' has newer changes on another device — sync it first, then copy again.`,
-      });
+      showToast(`Slot '${displaySlot(target)}' has newer changes on another device — sync it first, then copy again.`);
       return;
     case "preflight_failed":
-      toaster.toast({ title: TITLE, body: `Sync failed before copy: ${result.errors[0] ?? "preflight error"}` });
+      showToast(`Sync failed before copy: ${result.errors[0] ?? "preflight error"}`);
       return;
     case "server_unreachable":
-      toaster.toast({ title: TITLE, body: "Couldn't reach RomM. Check your connection and try again." });
+      showToast("Couldn't reach RomM. Check your connection and try again.");
       return;
     case "not_found":
       // The server answered — it has no such ROM or device id (#1560 family).
       // A retry can't help, so the copy must not send the user to check their
       // connection, and must not claim the saves are gone: the 404 can be the
       // device registration rather than the ROM (#1570).
-      toaster.toast({ title: TITLE, body: "RomM couldn't find this game's save data — nothing was copied." });
+      showToast("RomM couldn't find this game's save data — nothing was copied.");
       return;
     case "version_deleted":
-      toaster.toast({ title: TITLE, body: "This save no longer exists on the server." });
+      showToast("This save no longer exists on the server.");
       return;
     case "rom_not_installed":
-      toaster.toast({ title: TITLE, body: "ROM is no longer installed locally. Reinstall and try again." });
+      showToast("ROM is no longer installed locally. Reinstall and try again.");
       return;
     case "unsupported":
-      toaster.toast({
-        title: TITLE,
-        body:
-          result.reason === "savefiles_in_content_dir"
-            ? "Save sync is off for this game (RetroArch writes saves next to the ROM)."
-            : "Copying isn't available for multi-file saves yet.",
-      });
+      showToast(
+        result.reason === "savefiles_in_content_dir"
+          ? "Save sync is off for this game (RetroArch writes saves next to the ROM)."
+          : "Copying isn't available for multi-file saves yet.",
+      );
       return;
     case "not_configured":
-      toaster.toast({ title: TITLE, body: "Set up save slots for this game first, then copy." });
+      showToast("Set up save slots for this game first, then copy.");
       return;
     case "copy_failed":
-      toaster.toast({ title: TITLE, body: `Couldn't copy the save: ${result.message}` });
+      showToast(`Couldn't copy the save: ${result.message}`);
       return;
     case "invalid_slot_name":
-      toaster.toast({ title: TITLE, body: "Enter a valid slot name." });
+      showToast("Enter a valid slot name.");
       return;
   }
 }
@@ -104,7 +97,7 @@ export function useCopyToSlot(romId: number, availableSlots: SaveSlotSummary[]):
           await handleResult(result, target, romId);
         } catch (e) {
           detach(debugLog(`useCopyToSlot: copy failed for save ${saveId} into '${target}': ${e}`));
-          toaster.toast({ title: TITLE, body: "Couldn't copy the save. Check your connection and try again." });
+          showToast("Couldn't copy the save. Check your connection and try again.");
         }
       };
       showModal(

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,5 @@
 import { definePlugin, addEventListener, removeEventListener, toaster } from "@decky/api";
+import { showToast, PLUGIN_NAME } from "./utils/toast";
 import { useState, useRef, useEffect, FC, type ReactNode } from "react";
 import { FaGamepad } from "react-icons/fa";
 import { MainPage } from "./components/MainPage";
@@ -447,10 +448,7 @@ export default definePlugin(() => {
         const status = await getSaveSortMigrationStatus();
         if (status.pending) {
           setSaveSortMigrationStatus(status);
-          toaster.toast({
-            title: "RomM Sync",
-            body: "RetroArch save sorting changed. Go to Settings to migrate save files.",
-          });
+          showToast("RetroArch save sorting changed. Go to Settings to migrate save files.");
         }
       } catch (e) {
         logError(`Failed to check save sort migration status: ${e}`);
@@ -519,7 +517,7 @@ export default definePlugin(() => {
     logInfo(`sync_complete received: ${data.total_games} games, cancelled=${data.cancelled ?? false}`);
 
     const { body, duration } = buildSyncCompleteToast(data, getSyncDelta());
-    toaster.toast({ title: "RomM Sync", body, ...(duration !== undefined ? { duration } : {}) });
+    showToast(body, duration !== undefined ? { duration } : undefined);
 
     // Drive the terminal UI teardown from ``sync_complete`` — the guaranteed
     // terminal signal. The backend ALSO emits a separate stage:"done"/"cancelled"
@@ -821,10 +819,7 @@ export default definePlugin(() => {
         total_bytes: prev?.total_bytes ?? 0,
         resumable: data.resumable ?? prev?.resumable ?? false,
       });
-      toaster.toast({
-        title: "RomM Sync",
-        body: `Downloaded ${data.rom_name}`,
-      });
+      showToast(`Downloaded ${data.rom_name}`);
 
       // The ROM is now installed — its shortcut's launch options must carry the
       // full launch command (was "" while uninstalled). The backend resolved
@@ -883,10 +878,7 @@ export default definePlugin(() => {
       },
     ]
   >("save_sort_changed", () => {
-    toaster.toast({
-      title: "RomM Sync",
-      body: "RetroArch save sorting changed. Go to Settings to migrate save files.",
-    });
+    showToast("RetroArch save sorting changed. Go to Settings to migrate save files.");
   });
 
   const saveStatusListener = addEventListener<[SaveStatus]>("save_status_updated", (data: SaveStatus) => {
@@ -1007,11 +999,12 @@ export default definePlugin(() => {
       // every conflicting callable in the meantime (#1570 F13).
       detach(releasePruneLease(completed.prune_lease_token, "Cleanup completion with nothing to publish"));
     }
-    toaster.toast({ title: "RomM Sync", ...buildPruneCompleteToast(completed) });
+    const { body, subtext } = buildPruneCompleteToast(completed);
+    showToast(body, { subtext });
   });
 
   return {
-    name: "RomM Sync",
+    name: PLUGIN_NAME,
     icon: <FaGamepad />,
     content: <QAMPanel />,
     alwaysRender: true,

--- a/src/utils/downloadFailure.ts
+++ b/src/utils/downloadFailure.ts
@@ -12,6 +12,7 @@
  */
 
 import type { DownloadFailedEvent, DownloadItem } from "../types";
+import { PLUGIN_NAME } from "./toast";
 
 export interface ToasterLike {
   toast: (msg: { title: string; body: string }) => void;
@@ -47,7 +48,7 @@ export function handleGlobalDownloadFailure(
     error: event.error_message,
   });
   toast.toast({
-    title: "RomM Sync",
+    title: PLUGIN_NAME,
     body: `Download failed: ${event.rom_name} — ${event.error_message}`,
   });
 }

--- a/src/utils/launchInterceptor.ts
+++ b/src/utils/launchInterceptor.ts
@@ -15,7 +15,7 @@
  * Registered on plugin load, unregistered on unload.
  */
 
-import { toaster } from "@decky/api";
+import { showToast } from "./toast";
 import { isRomMAppId } from "../patches/gameDetailPatch";
 import {
   refreshMigrationState,
@@ -220,7 +220,7 @@ async function relaunch(appId: number, romId: number, admission: PruneLeaseAdmis
     // The watcher has no game-page UI to fall back to, so the refusal would
     // otherwise be a silently dead Play press — say it out loud instead
     // (CustomPlayButton's twin path returns its trigger to "Play").
-    toaster.toast({ title: "RomM Sync", body: "Launch cancelled — try again" });
+    showToast("Launch cancelled — try again");
     return;
   }
   bareRelaunch(appId);
@@ -251,9 +251,9 @@ async function handleWatcherVerdict(
       return "done";
     case "block":
       if (verdict.reason === "migration_pending") {
-        toaster.toast({ title: "RomM Sync", body: MIGRATION_TOAST_BODY });
+        showToast(MIGRATION_TOAST_BODY);
       } else if (verdict.reason === "no_launch_target") {
-        toaster.toast({ title: "RomM Sync", body: NO_LAUNCH_TARGET_TOAST_BODY });
+        showToast(NO_LAUNCH_TARGET_TOAST_BODY);
       }
       return "done";
     case "conflict": {
@@ -381,10 +381,7 @@ export function registerLaunchInterceptor(prompts: LaunchPrompts): void {
             // (no relaunch): the ROM is gone.
             if (!(await isRomInstalled(appId, romId))) {
               if (!isPruneLeaseAdmissionCurrent(admission)) return;
-              toaster.toast({
-                title: "RomM Sync",
-                body: "ROM not downloaded. Open the plugin to download it first.",
-              });
+              showToast("ROM not downloaded. Open the plugin to download it first.");
               return;
             }
 

--- a/src/utils/sessionManager.ts
+++ b/src/utils/sessionManager.ts
@@ -8,7 +8,7 @@
  * used only for LIVENESS at reload-adoption, never to identify a launching app.
  */
 
-import { toaster } from "@decky/api";
+import { showToast, SAVE_SYNC_TOAST_TITLE } from "./toast";
 import { recordSessionStart, getAppIdRomIdMap, finalizeGameSession, logInfo, logError, debugLog } from "../api/backend";
 import { saveSyncToastBody } from "./saveSyncToast";
 import { setMigrationStatus } from "./migrationStore";
@@ -278,9 +278,9 @@ async function handleGameStop(stoppedAppId: number): Promise<void> {
       ? saveSyncToastBody(result.sync.uploaded, result.sync.downloaded)
       : null;
     if (directionalBody) {
-      toaster.toast({ title: "RomM Save Sync", body: directionalBody });
+      showToast(directionalBody, { title: SAVE_SYNC_TOAST_TITLE });
     } else if (result.sync.failure_toast) {
-      toaster.toast({ title: "RomM Save Sync", body: result.sync.failure_toast });
+      showToast(result.sync.failure_toast, { title: SAVE_SYNC_TOAST_TITLE });
     }
 
     // Save-sync event dispatch — fires unconditionally so open surfaces refresh
@@ -291,7 +291,7 @@ async function handleGameStop(stoppedAppId: number): Promise<void> {
 
     // Additive conflicts toast — backend renders the count string.
     if (result.sync.conflicts_toast) {
-      toaster.toast({ title: "RomM Save Sync", body: result.sync.conflicts_toast });
+      showToast(result.sync.conflicts_toast, { title: SAVE_SYNC_TOAST_TITLE });
     }
 
     // Migration store updates — backend ran refresh_state, frontend just

--- a/src/utils/toast.test.ts
+++ b/src/utils/toast.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { toaster } from "@decky/api";
+import type { ToastNotification } from "@decky/api";
+import { showToast, PLUGIN_NAME, SAVE_SYNC_TOAST_TITLE } from "./toast";
+
+describe("showToast", () => {
+  beforeEach(() => {
+    vi.mocked(toaster.toast).mockReset();
+  });
+
+  it("titles the toast with the plugin name", () => {
+    showToast("Sync complete");
+
+    expect(toaster.toast).toHaveBeenCalledOnce();
+    expect(toaster.toast).toHaveBeenCalledWith({ title: PLUGIN_NAME, body: "Sync complete" });
+  });
+
+  it("passes options through alongside the body", () => {
+    showToast("12 games added", { duration: 8000, subtext: "3 skipped" });
+
+    expect(toaster.toast).toHaveBeenCalledWith({
+      title: PLUGIN_NAME,
+      body: "12 games added",
+      duration: 8000,
+      subtext: "3 skipped",
+    });
+  });
+
+  it("lets a caller override the title", () => {
+    showToast("Saves uploaded to RomM", { title: SAVE_SYNC_TOAST_TITLE });
+
+    expect(toaster.toast).toHaveBeenCalledWith({
+      title: SAVE_SYNC_TOAST_TITLE,
+      body: "Saves uploaded to RomM",
+    });
+  });
+
+  it("returns the notification so a caller can dismiss it", () => {
+    const notification = { data: { title: PLUGIN_NAME, body: "Downloading" }, dismiss: vi.fn() };
+    vi.mocked(toaster.toast).mockReturnValue(notification as ToastNotification);
+
+    expect(showToast("Downloading")).toBe(notification);
+  });
+});

--- a/src/utils/toast.ts
+++ b/src/utils/toast.ts
@@ -1,0 +1,22 @@
+import { toaster } from "@decky/api";
+import type { ToastData, ToastNotification } from "@decky/api";
+import type { ReactNode } from "react";
+
+// Must match `plugin.json`'s `name` and the `name` returned from `definePlugin`
+// — Decky reads those two for the plugin list and the QAM header, and nothing
+// checks that the three agree.
+export const PLUGIN_NAME = "RomM Sync";
+
+// Save-sync notices carry their own title so the user can tell an automatic
+// save operation from everything else the plugin reports.
+export const SAVE_SYNC_TOAST_TITLE = "RomM Save Sync";
+
+/**
+ * Raise a toast under the plugin's name.
+ *
+ * *options* passes through to `toaster.toast` and may override the title —
+ * save-sync call sites do, via {@link SAVE_SYNC_TOAST_TITLE}.
+ */
+export function showToast(body: ReactNode, options?: Partial<Omit<ToastData, "body">>): ToastNotification {
+  return toaster.toast({ title: PLUGIN_NAME, body, ...options });
+}


### PR DESCRIPTION
The plugin's display name was duplicated at 87 call sites across 19 modules. Changing it — a rename, or any per-toast
policy such as an icon or log mirroring — meant touching every one of them.

`showToast(body, options?)` in `src/utils/toast.ts` owns the title and passes everything else through to
`toaster.toast`. It returns the notification, because one call site hands it back to its caller, and it takes an options
bag rather than the `(body, title)` pair the issue sketched, because three sites need `duration` or `subtext`. It is
named `showToast` rather than `rommToast`: the display name is about to change, and new code should not carry the old
one.

Two constants come with it — `PLUGIN_NAME`, which the QAM panel header now reads as well, and `SAVE_SYNC_TOAST_TITLE`,
which keeps the save-sync toasts on their existing separate title. Whether that second title survives is a user-visible
question, so it is not decided here.

`downloadFailure.ts` keeps its injected toaster — that injection exists for testability — and takes only the title
constant.

The `"RomM Sync"` literals in the test files stay literals. Reading them from the constant would let a wrong display
name pass unnoticed; a rename should have to update those assertions deliberately.

Closes #1176.

docs: N/A — internal refactor, no user-visible change.
