### PR TITLE
feat(brand): rename the plugin to Tender

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -32,7 +32,7 @@ body:
       label: Repro steps
       description: Numbered steps that reproduce the bug from a known-good state. Even a one-line description of what you were doing helps.
       placeholder: |
-        1. Open QAM > Decky > RomM Sync
+        1. Open QAM > Decky > Tender
         2. Click "Sync Library"
         3. ...
     validations:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: Documentation
-    url: https://danielcopper.github.io/decky-romm-sync/
+    url: https://danielcopper.github.io/romm-tender/
     about: Architecture, file structure, user guide, and contributing docs
   - name: Discussions
-    url: https://github.com/danielcopper/decky-romm-sync/discussions
+    url: https://github.com/danielcopper/romm-tender/discussions
     about: Questions, ideas, and general conversation that aren't bug reports or specific feature requests

--- a/README.md
+++ b/README.md
@@ -1,24 +1,25 @@
 <div align="center">
 
-<img src="assets/logo-animated.gif" alt="" width="200">
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="assets/lockup-dark.png">
+  <img src="assets/lockup.png" alt="Tender" width="300">
+</picture>
 
-# decky-romm-sync
+<h3>Your RomM library, running native in Steam</h3>
 
-<h3>Your self-hosted RomM library, in your Steam library</h3>
+[Getting Started](https://danielcopper.github.io/romm-tender/user-guide/getting-started/) ·
+[Configuration](https://danielcopper.github.io/romm-tender/user-guide/configuration/) ·
+[Syncing](https://danielcopper.github.io/romm-tender/user-guide/syncing-your-library/) ·
+[Managing Games](https://danielcopper.github.io/romm-tender/user-guide/managing-games/)
 
-[Getting Started](https://danielcopper.github.io/decky-romm-sync/user-guide/getting-started/) ·
-[Configuration](https://danielcopper.github.io/decky-romm-sync/user-guide/configuration/) ·
-[Syncing](https://danielcopper.github.io/decky-romm-sync/user-guide/syncing-your-library/) ·
-[Managing Games](https://danielcopper.github.io/decky-romm-sync/user-guide/managing-games/)
+[BIOS &amp; Cores](https://danielcopper.github.io/romm-tender/user-guide/bios-management/) ·
+[Save Sync](https://danielcopper.github.io/romm-tender/user-guide/save-sync/) ·
+[Troubleshooting](https://danielcopper.github.io/romm-tender/user-guide/troubleshooting/)
 
-[BIOS &amp; Cores](https://danielcopper.github.io/decky-romm-sync/user-guide/bios-management/) ·
-[Save Sync](https://danielcopper.github.io/decky-romm-sync/user-guide/save-sync/) ·
-[Troubleshooting](https://danielcopper.github.io/decky-romm-sync/user-guide/troubleshooting/)
-
-<a href="https://danielcopper.github.io/decky-romm-sync/"><img alt="Documentation" src="https://img.shields.io/badge/user%20guide-read-4795c9?style=for-the-badge&labelColor=16202c"></a>
-<a href="https://github.com/danielcopper/decky-romm-sync/releases/latest"><img alt="Release" src="https://img.shields.io/github/package-json/v/danielcopper/decky-romm-sync?style=for-the-badge&label=release&color=4795c9&labelColor=16202c"></a>
-<a href="https://github.com/danielcopper/decky-romm-sync/stargazers"><img alt="Stars" src="https://img.shields.io/github/stars/danielcopper/decky-romm-sync?style=for-the-badge&color=4795c9&labelColor=16202c"></a>
-<a href="https://github.com/danielcopper/decky-romm-sync/releases"><img alt="Downloads" src="https://img.shields.io/github/downloads/danielcopper/decky-romm-sync/total?style=for-the-badge&color=4795c9&labelColor=16202c"></a>
+<a href="https://danielcopper.github.io/romm-tender/"><img alt="Documentation" src="https://img.shields.io/badge/user%20guide-read-4795c9?style=for-the-badge&labelColor=16202c"></a>
+<a href="https://github.com/danielcopper/romm-tender/releases/latest"><img alt="Release" src="https://img.shields.io/github/package-json/v/danielcopper/romm-tender?style=for-the-badge&label=release&color=4795c9&labelColor=16202c"></a>
+<a href="https://github.com/danielcopper/romm-tender/stargazers"><img alt="Stars" src="https://img.shields.io/github/stars/danielcopper/romm-tender?style=for-the-badge&color=4795c9&labelColor=16202c"></a>
+<a href="https://github.com/danielcopper/romm-tender/releases"><img alt="Downloads" src="https://img.shields.io/github/downloads/danielcopper/romm-tender/total?style=for-the-badge&color=4795c9&labelColor=16202c"></a>
 <a href="https://github.com/rommapp/romm/releases"><img alt="Requires RomM 4.9.0 or newer" src="https://img.shields.io/badge/RomM-%E2%89%A5%204.9.0-4795c9?style=for-the-badge&labelColor=16202c"></a>
 
 </div>
@@ -31,11 +32,12 @@ A [Decky Loader](https://decky.xyz/) plugin that syncs your self-hosted [RomM](h
 into Steam as non-steam shortcuts. Games appear directly in your Steam library, launch through
 [RetroDECK](https://retrodeck.net/), and can keep their saves in sync across devices through your RomM server.
 
+_Named after the railway car behind a steam locomotive, or the boat that shuttles out to a ship at anchor._
+
 > **Pre-1.0 (v0.x).** The feature set isn't complete yet. Save sync covers standard cartridge saves; the memory-card
 > systems — PlayStation, PS2, Dreamcast, GameCube, PSP, 3DS — don't sync their saves yet, and the
-> [support matrix](https://danielcopper.github.io/decky-romm-sync/user-guide/save-sync-support-matrix/) has the
-> per-system detail. The [Decky Store](https://plugins.deckbrew.xyz/) listing comes with v1.0; until then it's a manual
-> install.
+> [support matrix](https://danielcopper.github.io/romm-tender/user-guide/save-sync-support-matrix/) has the per-system
+> detail. The [Decky Store](https://plugins.deckbrew.xyz/) listing comes with v1.0; until then it's a manual install.
 
 ## Features
 
@@ -45,7 +47,7 @@ into Steam as non-steam shortcuts. Games appear directly in your Steam library, 
   capsules and custom icons, with a manual picker for games that don't match automatically
 - **Save sync** — Opt-in save syncing across devices through your RomM server, automatically before launch and after you
   quit; identical saves resolve silently, and if both sides genuinely changed you decide which one wins
-  ([not every system syncs yet](https://danielcopper.github.io/decky-romm-sync/user-guide/save-sync-support-matrix/))
+  ([not every system syncs yet](https://danielcopper.github.io/romm-tender/user-guide/save-sync-support-matrix/))
 - **Save slots & version history** — Multiple named save profiles per game, plus per-file version history with restore
 - **ROM downloads** — Download on demand with progress, pause/resume/cancel, and a managed queue
 - **BIOS management** — Per-platform BIOS status, download all or only what your active core requires, hash-verified
@@ -88,7 +90,7 @@ into Steam as non-steam shortcuts. Games appear directly in your Steam library, 
 > **v1.0** release. Until then, use the manual install below.
 
 Once published, install it straight from Decky's built-in store — open the Quick Access Menu → **Decky** → store icon,
-search for **RomM Sync**, and install. No Developer Mode required.
+search for **Tender**, and install. No Developer Mode required.
 
 </details>
 
@@ -99,36 +101,36 @@ This is the current method while v1.0 is in progress. It requires **Developer Mo
 gear icon → toggle **Developer Mode**).
 
 1. Download the latest `decky-romm-sync.zip` from the
-   [releases page](https://github.com/danielcopper/decky-romm-sync/releases)
+   [releases page](https://github.com/danielcopper/romm-tender/releases)
 2. In Decky settings → **Developer** tab → **Install Plugin from ZIP** (or **from URL** with the
-   [latest release link](https://github.com/danielcopper/decky-romm-sync/releases/latest/download/decky-romm-sync.zip))
+   [latest release link](https://github.com/danielcopper/romm-tender/releases/latest/download/decky-romm-sync.zip))
 
 </details>
 
 > Full step-by-step instructions, including first-time setup, are in
-> [Getting Started](https://danielcopper.github.io/decky-romm-sync/user-guide/getting-started/).
+> [Getting Started](https://danielcopper.github.io/romm-tender/user-guide/getting-started/).
 
 ## Quick start
 
-1. Open the Quick Access Menu and select **RomM Sync**
+1. Open the Quick Access Menu and select **Tender**
 2. In **Settings**, enter your RomM server URL and credentials, then hit **Test Connection**
 3. In **Platforms**, enable the platforms you want to sync
 4. Hit **Sync Library** — your ROMs appear as non-steam shortcuts
 
-See the [User Guide](https://danielcopper.github.io/decky-romm-sync/user-guide/syncing-your-library/) for syncing
-details, [save sync](https://danielcopper.github.io/decky-romm-sync/user-guide/save-sync/), and
-[BIOS management](https://danielcopper.github.io/decky-romm-sync/user-guide/bios-management/).
+See the [User Guide](https://danielcopper.github.io/romm-tender/user-guide/syncing-your-library/) for syncing details,
+[save sync](https://danielcopper.github.io/romm-tender/user-guide/save-sync/), and
+[BIOS management](https://danielcopper.github.io/romm-tender/user-guide/bios-management/).
 
 ## Contributing
 
 Build from source, run the tests, and read the architecture reference on the documentation site:
 
-- [Development setup](https://danielcopper.github.io/decky-romm-sync/contributing/development/)
-- [Frontend dev loop](https://danielcopper.github.io/decky-romm-sync/contributing/frontend-dev-loop/) — live-reload the
-  UI into a windowed Big Picture on the Deck, no Game Mode switching
-- [Backend architecture](https://danielcopper.github.io/decky-romm-sync/architecture/backend-architecture/)
+- [Development setup](https://danielcopper.github.io/romm-tender/contributing/development/)
+- [Frontend dev loop](https://danielcopper.github.io/romm-tender/contributing/frontend-dev-loop/) — live-reload the UI
+  into a windowed Big Picture on the Deck, no Game Mode switching
+- [Backend architecture](https://danielcopper.github.io/romm-tender/architecture/backend-architecture/)
 
-[![CI](https://github.com/danielcopper/decky-romm-sync/actions/workflows/ci.yml/badge.svg)](https://github.com/danielcopper/decky-romm-sync/actions/workflows/ci.yml)
+[![CI](https://github.com/danielcopper/romm-tender/actions/workflows/ci.yml/badge.svg)](https://github.com/danielcopper/romm-tender/actions/workflows/ci.yml)
 [![Quality Gate](https://sonarcloud.io/api/project_badges/measure?project=danielcopper_decky-romm-sync&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=danielcopper_decky-romm-sync)
 [![Coverage](https://img.shields.io/sonar/coverage/danielcopper_decky-romm-sync?server=https%3A%2F%2Fsonarcloud.io)](https://sonarcloud.io/summary/new_code?id=danielcopper_decky-romm-sync)
 [![Maintainability](https://sonarcloud.io/api/project_badges/measure?project=danielcopper_decky-romm-sync&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=danielcopper_decky-romm-sync)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,7 @@ Only the latest release receives security fixes.
 If you discover a security vulnerability in decky-romm-sync, please report it responsibly:
 
 1. **Do NOT open a public GitHub issue.**
-2. Use [GitHub Security Advisories](https://github.com/danielcopper/decky-romm-sync/security/advisories/new) to report
+2. Use [GitHub Security Advisories](https://github.com/danielcopper/romm-tender/security/advisories/new) to report
    privately.
 3. Include:
    - Description of the vulnerability

--- a/bin/rom-launcher
+++ b/bin/rom-launcher
@@ -1,5 +1,5 @@
 #!/bin/bash
-# rom-launcher — Steam shortcut launcher for the RomM Sync plugin.
+# rom-launcher — Steam shortcut launcher for the Tender plugin.
 # Steam invokes it with the full launch command (emulator invocation + ROM
 # path) in the shortcut's launch options. Pure exec wrapper: it runs exactly
 # what it is handed and owns no state, no path resolution, no emulator knowledge.

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -1,6 +1,6 @@
 # Development
 
-Guide for setting up a development environment and contributing to decky-romm-sync.
+Guide for setting up a development environment and contributing to Tender.
 
 ## Prerequisites
 
@@ -16,8 +16,8 @@ Guide for setting up a development environment and contributing to decky-romm-sy
 ## Setup
 
 ```bash
-git clone https://github.com/danielcopper/decky-romm-sync.git
-cd decky-romm-sync
+git clone https://github.com/danielcopper/romm-tender.git
+cd romm-tender
 mise install          # installs Node LTS, pnpm, Python
 mise run setup        # installs JS + Python dependencies
 ```

--- a/docs/contributing/frontend-dev-loop.md
+++ b/docs/contributing/frontend-dev-loop.md
@@ -57,7 +57,7 @@ What happens:
 
 The reload is bundle-level, not component-level hot module replacement: the plugin is unmounted and re-imported, so
 component state resets and whatever is currently on screen keeps showing the **old** render until it is mounted again.
-Concretely: after a save, leave the plugin's QAM panel and re-enter it (back out of _RomM Sync_, open it again) — or
+Concretely: after a save, leave the plugin's QAM panel and re-enter it (back out of _Tender_, open it again) — or
 re-navigate to a patched game-detail page — to see the change. Keyboard shortcuts in the BPM window: **Ctrl+2** opens
 the Quick Access Menu, **Ctrl+1** the main menu.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# decky-romm-sync { .hero-title }
+# Tender { .hero-title }
 
 A [Decky Loader](https://decky.xyz/) plugin that syncs your self-hosted [RomM](https://github.com/rommapp/romm) ROM
 library into Steam as Non-Steam shortcuts. Games launch through [RetroDECK](https://retrodeck.net/).
@@ -8,7 +8,7 @@ library into Steam as Non-Steam shortcuts. Games launch through [RetroDECK](http
 - Manage BIOS files for systems that require them
 - Sync save files between devices through your RomM server
 
-![A RomM game's detail page in Steam showing the injected RomM Sync panel](assets/screenshot-game-detail.jpg)
+![A RomM game's detail page in Steam showing the injected Tender panel](assets/screenshot-game-detail.jpg)
 
 !!! note "Pre-1.0 (v0.x)"
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -1,7 +1,7 @@
 # Configuration
 
 All settings are accessible from the plugin's QAM panel. Open the Quick Access Menu (**...** button) and navigate to the
-decky-romm-sync plugin.
+Tender plugin.
 
 ## Connection Settings
 

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -1,8 +1,8 @@
 # Getting Started
 
-## What is decky-romm-sync?
+## What is Tender?
 
-decky-romm-sync is a [Decky Loader](https://decky.xyz/) plugin that connects your self-hosted
+Tender is a [Decky Loader](https://decky.xyz/) plugin that connects your self-hosted
 [RomM](https://github.com/rommapp/romm) ROM library to Steam. Every game in your RomM library appears as a Non-Steam
 shortcut in the Steam Library, complete with cover art, metadata, and collections. Games launch through
 [RetroDECK](https://retrodeck.net/).
@@ -38,27 +38,27 @@ Before installing the plugin, you need:
    The URL for the latest release follows this pattern:
 
    ```text
-   https://github.com/danielcopper/decky-romm-sync/releases/download/decky-romm-sync-v{VERSION}/decky-romm-sync.zip
+   https://github.com/danielcopper/romm-tender/releases/download/decky-romm-sync-v{VERSION}/decky-romm-sync.zip
    ```
 
    For example, for v0.9.3:
 
    ```text
-   https://github.com/danielcopper/decky-romm-sync/releases/download/decky-romm-sync-v0.9.3/decky-romm-sync.zip
+   https://github.com/danielcopper/romm-tender/releases/download/decky-romm-sync-v0.9.3/decky-romm-sync.zip
    ```
 
 6. Decky downloads and installs the plugin automatically — no restart needed
 
-**Tip:** You can also open the [releases page](https://github.com/danielcopper/decky-romm-sync/releases) in Steam's
-built-in browser (Gaming Mode → long-press the Steam button → Web Browser), long-press the zip download link, and copy
-the URL from there.
+**Tip:** You can also open the [releases page](https://github.com/danielcopper/romm-tender/releases) in Steam's built-in
+browser (Gaming Mode → long-press the Steam button → Web Browser), long-press the zip download link, and copy the URL
+from there.
 
 Any direct URL to the zip file works (GitHub releases, a self-hosted mirror, etc.) as long as it points to a valid
 `.zip` containing the plugin.
 
 ### Manual installation (alternative)
 
-1. Download `decky-romm-sync.zip` from the [releases page](https://github.com/danielcopper/decky-romm-sync/releases)
+1. Download `decky-romm-sync.zip` from the [releases page](https://github.com/danielcopper/romm-tender/releases)
 2. Extract the zip to `~/homebrew/plugins/` on your device (via SSH, file manager, or USB)
 3. Restart Decky Loader — either reboot, or run `sudo systemctl restart plugin_loader` via SSH
 4. The plugin appears in your QAM under the Decky tab
@@ -67,7 +67,7 @@ Any direct URL to the zip file works (GitHub releases, a self-hosted mirror, etc
 
 After installation, you need to connect the plugin to your RomM server:
 
-1. Open the QAM and find **decky-romm-sync**
+1. Open the QAM and find **Tender**
 2. Tap **Connection Settings**
 3. Enter your RomM server URL (e.g. `http://192.168.1.100:8080`) — this saves automatically
 4. Tap **Sign in**, enter your RomM username and password once, and confirm

--- a/docs/user-guide/managing-games.md
+++ b/docs/user-guide/managing-games.md
@@ -1,12 +1,11 @@
 # Managing Games
 
-After syncing, each game in your Steam Library that came from RomM has an injected **RomM Sync** panel on its detail
-page. This panel handles downloads, artwork, BIOS status, save sync, and more.
+After syncing, each game in your Steam Library that came from RomM has an injected **Tender** panel on its detail page.
+This panel handles downloads, artwork, BIOS status, save sync, and more.
 
 ## The Game Detail Panel
 
-When you open a RomM game in the Steam Library, you'll see the RomM Sync panel below the standard Steam content. It
-shows:
+When you open a RomM game in the Steam Library, you'll see the Tender panel below the standard Steam content. It shows:
 
 - **Status badge** — "Installed", "Downloading", or "Not Installed"
 - **Platform name** — which system the game belongs to (e.g. "Game Boy Advance")
@@ -20,7 +19,7 @@ shows:
   installed games); it's also omitted when RomM doesn't report the size.
 - **Action buttons** — Download, Pause/Resume, Uninstall, Cancel, or Refresh Metadata depending on state
 
-![Game detail page showing the RomM Sync panel for an installed game](../assets/screenshot-game-detail.jpg)
+![Game detail page showing the Tender panel for an installed game](../assets/screenshot-game-detail.jpg)
 
 ## Versions
 
@@ -199,7 +198,7 @@ Games appear as shortcuts in your library even before the ROM file is downloaded
 **Space Required** cell next to the Play button so you know how much disk space the ROM needs. To download:
 
 1. Open the game's detail page in the Steam Library
-2. In the RomM Sync panel, tap **Download**
+2. In the Tender panel, tap **Download**
 3. A progress bar shows download status with bytes transferred
 4. When complete, the status changes to "Installed" and the game is ready to play
 
@@ -343,7 +342,7 @@ the plugin doesn't manage.
 To remove a downloaded ROM file:
 
 1. Open the game's detail page
-2. Tap **Uninstall** in the RomM Sync panel
+2. Tap **Uninstall** in the Tender panel
 3. The ROM file is deleted from disk
 4. The shortcut remains in your library so you can re-download later
 

--- a/docs/user-guide/save-file-extensions.md
+++ b/docs/user-guide/save-file-extensions.md
@@ -135,7 +135,7 @@ Again, standalone emulator formats that don't apply to RetroDECK's RetroArch-bas
 
 ## Implementation Decision
 
-For decky-romm-sync (RetroDECK-only):
+For Tender (RetroDECK-only):
 
 | Extension                      | Include?                          | Reason                                                       |
 | ------------------------------ | --------------------------------- | ------------------------------------------------------------ |

--- a/docs/user-guide/syncing-your-library.md
+++ b/docs/user-guide/syncing-your-library.md
@@ -22,7 +22,7 @@ games appear in the Steam Library with cover art, metadata, and organized into c
    number of shortcuts added and/or removed this run (e.g. "Sync complete — 42 added, 3 removed."), omitting a part that
    is zero. If nothing changed, it reads "Library up to date."
 
-![RomM Sync QAM panel with connection status and the Sync Library button](../assets/screenshot-qam.jpg)
+![Tender QAM panel with connection status and the Sync Library button](../assets/screenshot-qam.jpg)
 
 <!-- Screenshot: Sync in progress with progress bar -->
 

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -6,14 +6,14 @@ Common issues and how to fix them.
 
 ### Connection shows "Backend error"
 
-**Symptom**: The RomM Sync QAM panel's **Connection** row shows a "Backend error" badge with the note "Plugin backend
+**Symptom**: The Tender QAM panel's **Connection** row shows a "Backend error" badge with the note "Plugin backend
 failed to start — check Decky logs", and the Sync buttons are disabled. This state means the plugin's own Python backend
 process never started — it is **not** the same as an unreachable RomM server, which shows **Not connected** instead.
 
 **Fix**: The backend aborted during startup — most often a failed data migration after an update — so the UI can't reach
-it. Open the Decky plugin log to find the underlying error, then reload RomM Sync from the Decky plugin list. If it
-still fails after a reload, restart Steam (or the Steam Deck); if the error persists, include the log output when you
-report it.
+it. Open the Decky plugin log to find the underlying error, then reload Tender from the Decky plugin list. If it still
+fails after a reload, restart Steam (or the Steam Deck); if the error persists, include the log output when you report
+it.
 
 ## Games Won't Launch
 
@@ -30,7 +30,7 @@ for details.
 
 **Symptom**: Pressing Play does nothing, or you get a toast saying the ROM needs to be downloaded.
 
-**Fix**: Open the game's detail page and tap **Download** in the RomM Sync panel. The game will be playable once the
+**Fix**: Open the game's detail page and tap **Download** in the Tender panel. The game will be playable once the
 download completes.
 
 ### The download has no launchable file
@@ -198,8 +198,8 @@ shortcut's tile image and does not always refresh it right away. A tile that is 
 the first time you open that game's detail page, scroll it back into view, or the next time Steam restarts — the cover
 is already on disk; Steam just hasn't re-rendered the tile yet.
 
-**Fix**: If a tile stays blank after that, open the game's detail page and tap **Refresh Metadata** in the RomM Sync
-panel. This re-fetches all artwork and metadata. (Hero banners, logos, and wide grid images additionally need a
+**Fix**: If a tile stays blank after that, open the game's detail page and tap **Refresh Metadata** in the Tender panel.
+This re-fetches all artwork and metadata. (Hero banners, logos, and wide grid images additionally need a
 [SteamGridDB API key](configuration.md#steamgriddb-api-key) — see above.)
 
 ## Shortcuts Appear on Other Devices

--- a/main.py
+++ b/main.py
@@ -201,7 +201,7 @@ class Plugin:
 
         # ── 6. Background tasks ─────────────────────────────────────────────
         self._migration_service.detect_save_sort_change()
-        decky.logger.info("RomM Sync plugin loaded")
+        decky.logger.info("Tender pluginloaded")
 
     async def _unload(self):  # Decky lifecycle — must be async
         self._sync_service.shutdown()
@@ -210,7 +210,7 @@ class Plugin:
         await self._migration_service.shutdown()
         await self._session_lifecycle_service.shutdown()
         await self._cancel_playtime_flush_tasks()
-        decky.logger.info("RomM Sync plugin unloaded")
+        decky.logger.info("Tender pluginunloaded")
 
     async def _cancel_playtime_flush_tasks(self):
         """Cancel and await any in-flight play-session flush tasks on unload.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
-site_name: decky-romm-sync
+site_name: Tender
 site_description: A Decky Loader plugin that syncs your self-hosted RomM library into Steam
-site_url: https://danielcopper.github.io/decky-romm-sync/
+site_url: https://danielcopper.github.io/romm-tender/
 
 # Architectural Decision Records (`docs/adr/`) are kept in the repo for
 # contributors and AI agents — they're internal design history, not user
@@ -9,8 +9,8 @@ site_url: https://danielcopper.github.io/decky-romm-sync/
 exclude_docs: |
   adr/
 
-repo_url: https://github.com/danielcopper/decky-romm-sync
-repo_name: danielcopper/decky-romm-sync
+repo_url: https://github.com/danielcopper/romm-tender
+repo_name: danielcopper/romm-tender
 edit_uri: edit/main/docs/
 
 theme:

--- a/plugin.json
+++ b/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "RomM Sync",
+  "name": "Tender",
   "version": "0.30.1",
   "author": "danielcopper",
   "flags": [],
@@ -12,6 +12,6 @@
       "emulation"
     ],
     "description": "Sync your self-hosted RomM library to Steam. Games appear as native shortcuts with cover art, metadata, and launch via RetroDECK. Includes ROM downloads, BIOS management, save file sync, and SteamGridDB artwork.",
-    "image": "https://raw.githubusercontent.com/danielcopper/decky-romm-sync/main/assets/store_image.png"
+    "image": "https://raw.githubusercontent.com/danielcopper/romm-tender/main/assets/store_image.png"
   }
 }

--- a/py_modules/adapters/recovery_bundle.py
+++ b/py_modules/adapters/recovery_bundle.py
@@ -35,10 +35,10 @@ if TYPE_CHECKING:
 
 _SAFE_BUNDLE_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*_\d{4}-\d{2}-\d{2}_[A-Za-z0-9]{4,32}$", re.ASCII)
 _ROOT_README_NAME = "README.txt"
-_ROOT_README_TEXT = """decky-romm-sync recovery bundles
-================================
+_ROOT_README_TEXT = """Tender recovery bundles
+=======================
 
-This folder holds snapshots the RomM Sync plugin took immediately BEFORE it
+This folder holds snapshots the Tender plugin took immediately BEFORE it
 deleted a game's local data, during "Clean Up Removed RomM Games".
 
   bundles/   one folder per cleaned-up game, named <game>_<date>_<id>.

--- a/py_modules/services/launch_gate.py
+++ b/py_modules/services/launch_gate.py
@@ -28,11 +28,12 @@ if TYPE_CHECKING:
     from services.protocols.files import SaveFileStore
 
 
-_TOAST_TITLE_NOT_INSTALLED = "RomM Sync"
+# Every notice comes from the same plugin, so they all carry the same sender and
+# the body is what tells them apart. Must match the frontend's ``PLUGIN_NAME``
+# and ``plugin.json``; nothing checks that the three agree.
+_TOAST_TITLE = "Tender"
 _TOAST_BODY_NOT_INSTALLED = "ROM not downloaded. Open the game page to download it first."
-_TOAST_TITLE_SAVE_CONFLICT = "RomM Save Sync"
 _TOAST_BODY_SAVE_CONFLICT = "Save conflict detected — open game page to resolve before playing"
-_TOAST_TITLE_SAVE_STATUS_FAILED = "RomM Save Sync"
 _TOAST_BODY_SAVE_STATUS_FAILED = "Save-status check failed — retry?"
 
 
@@ -142,7 +143,7 @@ class LaunchGateService:
             return LaunchVerdict(
                 action="block",
                 reason="not_installed",
-                toast_title=_TOAST_TITLE_NOT_INSTALLED,
+                toast_title=_TOAST_TITLE,
                 toast_body=_TOAST_BODY_NOT_INSTALLED,
             )
 
@@ -167,7 +168,7 @@ class LaunchGateService:
                 return LaunchVerdict(
                     action="warn",
                     reason="save_status_failed",
-                    toast_title=_TOAST_TITLE_SAVE_STATUS_FAILED,
+                    toast_title=_TOAST_TITLE,
                     toast_body=_TOAST_BODY_SAVE_STATUS_FAILED,
                 )
             return LaunchVerdict(action="allow")
@@ -176,7 +177,7 @@ class LaunchGateService:
             return LaunchVerdict(
                 action="block",
                 reason="save_conflict",
-                toast_title=_TOAST_TITLE_SAVE_CONFLICT,
+                toast_title=_TOAST_TITLE,
                 toast_body=_TOAST_BODY_SAVE_CONFLICT,
             )
 

--- a/src/components/CustomPlayButton.test.tsx
+++ b/src/components/CustomPlayButton.test.tsx
@@ -1075,7 +1075,7 @@ describe("CustomPlayButton — uninstall is visible and single-shot (#1664)", ()
 
     await findByText("Play");
     expect(vi.mocked(toaster.toast)).toHaveBeenCalledWith({
-      title: "RomM Sync",
+      title: "Tender",
       body: "This ROM is already being uninstalled",
     });
   });
@@ -1555,7 +1555,7 @@ describe("CustomPlayButton — resolve conflict reads the known conflict (#1276)
     });
 
     expect(vi.mocked(handleConflicts)).not.toHaveBeenCalled();
-    expect(toaster.toast).toHaveBeenCalledWith({ title: "RomM Sync", body: "Cleanup is active." });
+    expect(toaster.toast).toHaveBeenCalledWith({ title: "Tender", body: "Cleanup is active." });
     await utils.findByText("Resolve Conflict");
   });
 });
@@ -1653,7 +1653,7 @@ describe("CustomPlayButton — shared launch gate (ADR-0015)", () => {
     await clickPlay();
 
     expect(toaster.toast).toHaveBeenCalledWith({
-      title: "RomM Sync",
+      title: "Tender",
       body: "This download has no file the emulator can launch. The files are on disk — see the game page.",
     });
     expect(vi.mocked(SteamClient.Apps.RunGame)).not.toHaveBeenCalled();
@@ -2636,7 +2636,7 @@ describe("CustomPlayButton — Stop Game", () => {
     // action that cannot be carried out.
     expect(showStopGameModal).not.toHaveBeenCalled();
     expect(vi.mocked(toaster.toast)).toHaveBeenCalledWith({
-      title: "RomM Sync",
+      title: "Tender",
       body: "Couldn't stop the game — still loading its details",
     });
     // Nothing was stopped, so Resume must stay reachable.
@@ -2663,7 +2663,7 @@ describe("CustomPlayButton — Stop Game", () => {
     });
 
     expect(vi.mocked(toaster.toast)).toHaveBeenCalledWith({
-      title: "RomM Sync",
+      title: "Tender",
       body: "RetroDECK is running, but not this game — nothing was stopped.",
     });
     expect(vi.mocked(backend.debugLog)).toHaveBeenCalledWith(
@@ -2759,7 +2759,7 @@ describe("CustomPlayButton — Stop Game", () => {
     });
 
     expect(vi.mocked(toaster.toast)).toHaveBeenCalledWith({
-      title: "RomM Sync",
+      title: "Tender",
       body: "Couldn't signal the emulator",
     });
     // The game may well still be running — Resume must stay reachable.
@@ -2782,7 +2782,7 @@ describe("CustomPlayButton — Stop Game", () => {
     // logged, and the overlay is deliberately NOT cleared (no verdict was
     // reached, so the game may still be running).
     expect(vi.mocked(toaster.toast)).toHaveBeenCalledWith({
-      title: "RomM Sync",
+      title: "Tender",
       body: "Couldn't stop the game",
     });
     expect(vi.mocked(backend.debugLog)).toHaveBeenCalledWith(

--- a/src/components/CustomPlayButton.tsx
+++ b/src/components/CustomPlayButton.tsx
@@ -11,7 +11,7 @@
 
 import { useState, useEffect, useRef, FC, ReactElement } from "react";
 import { addEventListener, removeEventListener } from "@decky/api";
-import { showToast, SAVE_SYNC_TOAST_TITLE } from "../utils/toast";
+import { showToast } from "../utils/toast";
 import { Focusable, DialogButton, Menu, MenuItem, Navigation, showContextMenu } from "@decky/ui";
 import { appActionButtonClasses, basicAppDetailsSectionStylerClasses } from "../utils/deckyUiInternals";
 import { hideNativePlaySection, showNativePlaySection } from "../utils/styleInjector";
@@ -485,7 +485,7 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
     return applyLaunchGateSetupOutcome(resolveSaveSetupOutcome(setupInfo), {
       rid,
       confirmSlotChoice,
-      toast: (body) => showToast(body, { title: SAVE_SYNC_TOAST_TITLE }),
+      toast: (body) => showToast(body),
       dispatchSavesTab: () =>
         globalThis.dispatchEvent(new CustomEvent("romm_tab_switch", { detail: { tab: "saves" } })),
     });
@@ -566,7 +566,7 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
 
     const toastBody = saveSyncToastBody(result.uploaded, result.downloaded);
     if (toastBody) {
-      showToast(toastBody, { title: SAVE_SYNC_TOAST_TITLE });
+      showToast(toastBody);
     }
     return { success: true, message: result.message };
   };

--- a/src/components/DiscSelector.test.tsx
+++ b/src/components/DiscSelector.test.tsx
@@ -261,7 +261,7 @@ describe("DiscSelector — selecting a disc", () => {
 
     // Non-vacuous: the exact backend message is toasted, and no shortcut write.
     expect(toaster.toast).toHaveBeenCalledWith({
-      title: "RomM Sync",
+      title: "Tender",
       body: "Disc not found in the install directory",
     });
     expect(setLaunchOptionsConfirmed).not.toHaveBeenCalled();
@@ -280,7 +280,7 @@ describe("DiscSelector — selecting a disc", () => {
     });
 
     // Observable catch effect: a fallback toast, and no confirm-set.
-    expect(toaster.toast).toHaveBeenCalledWith({ title: "RomM Sync", body: "Failed to select disc" });
+    expect(toaster.toast).toHaveBeenCalledWith({ title: "Tender", body: "Failed to select disc" });
     expect(setLaunchOptionsConfirmed).not.toHaveBeenCalled();
   });
 });

--- a/src/components/MigrationBlockedPage.test.tsx
+++ b/src/components/MigrationBlockedPage.test.tsx
@@ -133,7 +133,7 @@ describe("MigrationBlockedPage component", () => {
       // clearMigration() was invoked → store is { pending: false }.
       expect(getMigrationState()).toEqual({ pending: false });
       expect(toaster.toast).toHaveBeenCalledWith({
-        title: "RomM Sync",
+        title: "Tender",
         body: "Migrated 3 ROMs",
       });
       // Field now visible with the result message.
@@ -152,7 +152,7 @@ describe("MigrationBlockedPage component", () => {
         await flushAsync();
       });
       expect(toaster.toast).toHaveBeenCalledWith({
-        title: "RomM Sync",
+        title: "Tender",
         body: "Migration complete.",
       });
     });
@@ -210,7 +210,7 @@ describe("MigrationBlockedPage component", () => {
       expect(backend.migrateRetroDeckFiles).toHaveBeenNthCalledWith(2, "overwrite");
       // Second call's success path fired the toast.
       expect(toaster.toast).toHaveBeenCalledWith({
-        title: "RomM Sync",
+        title: "Tender",
         body: "Done after overwrite",
       });
     });
@@ -321,7 +321,7 @@ describe("MigrationBlockedPage component", () => {
       expect(backend.dismissRetrodeckMigration).toHaveBeenCalled();
       expect(getMigrationState()).toEqual({ pending: false });
       expect(toaster.toast).toHaveBeenCalledWith({
-        title: "RomM Sync",
+        title: "Tender",
         body: "Migration dismissed.",
       });
     });

--- a/src/components/RemovedGamesCleanup.test.tsx
+++ b/src/components/RemovedGamesCleanup.test.tsx
@@ -316,7 +316,7 @@ describe("RemovedGamesCleanup", () => {
     fireEvent.click(button);
     await waitFor(() =>
       expect(toaster.toast).toHaveBeenCalledWith({
-        title: "RomM Sync",
+        title: "Tender",
         body: "Could not scan removed RomM games.",
       }),
     );

--- a/src/components/RomMPlaySection.tsx
+++ b/src/components/RomMPlaySection.tsx
@@ -11,7 +11,7 @@
  */
 
 import { useState, useEffect, FC, Fragment, createElement } from "react";
-import { showToast, SAVE_SYNC_TOAST_TITLE } from "../utils/toast";
+import { showToast } from "../utils/toast";
 import {
   ConfirmModal,
   DialogButton,
@@ -537,20 +537,20 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
         const directionalBody = saveSyncToastBody(result.uploaded, result.downloaded);
         const c = result.conflicts?.length ?? 0;
         if (directionalBody) {
-          showToast(directionalBody, { title: SAVE_SYNC_TOAST_TITLE });
+          showToast(directionalBody);
         } else if (c === 0) {
           // Manual surface only (#1486): an explicit per-game "Sync Saves" click
           // that moved nothing and hit no conflicts gets a short acknowledgement,
           // so the click doesn't read as a no-op. The automatic surfaces
           // (pre-launch, post-exit) stay silent on this zero-case.
-          showToast("Saves already up to date", { title: SAVE_SYNC_TOAST_TITLE });
+          showToast("Saves already up to date");
         }
         // Preserve the conflict signal as its own additive toast (mirroring the
         // post-exit conflicts_toast) — it must stay visible even when nothing
         // transferred. Gated above so "up to date" never contradicts pending
         // conflicts.
         if (c > 0) {
-          showToast(`${c} conflict(s) need resolution`, { title: SAVE_SYNC_TOAST_TITLE });
+          showToast(`${c} conflict(s) need resolution`);
         }
         globalThis.dispatchEvent(
           new CustomEvent("romm_data_changed", { detail: { type: "save_sync", rom_id: detail.romId } }),

--- a/src/components/SettingsPage.test.tsx
+++ b/src/components/SettingsPage.test.tsx
@@ -1248,7 +1248,7 @@ describe("SettingsPage", () => {
       expect(vi.mocked(showModal)).not.toHaveBeenCalled();
       expect(vi.mocked(toaster.toast)).toHaveBeenCalledWith(
         expect.objectContaining({
-          title: "RomM Sync",
+          title: "Tender",
           body: 'Default save slot reset to "default".',
         }),
       );
@@ -1267,7 +1267,7 @@ describe("SettingsPage", () => {
       );
       expect(vi.mocked(toaster.toast)).toHaveBeenCalledWith(
         expect.objectContaining({
-          title: "RomM Sync",
+          title: "Tender",
           body: 'Default save slot reset to "default".',
         }),
       );
@@ -1590,7 +1590,7 @@ describe("SettingsPage", () => {
       expect(vi.mocked(clearSaveSortMigration)).toHaveBeenCalled();
       expect(vi.mocked(toaster.toast)).toHaveBeenCalledWith(
         expect.objectContaining({
-          title: "RomM Sync",
+          title: "Tender",
           body: "Moved 2 files",
         }),
       );

--- a/src/components/SettingsResetBanner.tsx
+++ b/src/components/SettingsResetBanner.tsx
@@ -27,7 +27,7 @@ export function settingsResetCardMessage(backedUpTo: string | null): string {
   const backup = backedUpTo
     ? `A backup of your old settings was saved to ${backedUpTo}.`
     : "A backup of your old settings was saved.";
-  return `Your settings file was corrupt and has been reset. Re-enter your server URL and sign in again. ${backup} Open the RomM Sync menu (QAM) to dismiss this.`;
+  return `Your settings file was corrupt and has been reset. Re-enter your server URL and sign in again. ${backup} Open the Tender menu (QAM) to dismiss this.`;
 }
 
 interface SettingsResetBannerProps {

--- a/src/components/SettingsResetCard.test.tsx
+++ b/src/components/SettingsResetCard.test.tsx
@@ -30,7 +30,7 @@ describe("SettingsResetCard", () => {
     });
     expect(capturedWarningCard[0]?.message).toContain("settings.json.corrupt-9");
     // Informational only — the copy points the user to the QAM to dismiss.
-    expect(capturedWarningCard[0]?.message).toContain("Open the RomM Sync menu (QAM) to dismiss this.");
+    expect(capturedWarningCard[0]?.message).toContain("Open the Tender menu (QAM) to dismiss this.");
   });
 
   it("forwards compact=true and the generic message when backup path is null", () => {
@@ -38,7 +38,7 @@ describe("SettingsResetCard", () => {
     render(<SettingsResetCard backedUpTo={null} compact />);
     expect(capturedWarningCard[0]?.compact).toBe(true);
     expect(capturedWarningCard[0]?.message).toContain("A backup of your old settings was saved.");
-    expect(capturedWarningCard[0]?.message).toContain("Open the RomM Sync menu (QAM) to dismiss this.");
+    expect(capturedWarningCard[0]?.message).toContain("Open the Tender menu (QAM) to dismiss this.");
   });
 
   it("renders NO dismiss button — it delegates only to the (button-less) WarningCard", () => {

--- a/src/components/SlotSetupWizard.test.tsx
+++ b/src/components/SlotSetupWizard.test.tsx
@@ -657,7 +657,7 @@ describe("SlotSetupWizard", () => {
 
       expect(vi.mocked(backend.confirmSlotChoice)).toHaveBeenCalledWith(5, "default", true, null, false);
       expect(vi.mocked(toaster.toast)).toHaveBeenCalledWith({
-        title: "RomM Sync",
+        title: "Tender",
         body: "Migrated 1 save into ‘default’. The legacy save stays in the read-only legacy bucket.",
       });
       expect(onComplete).toHaveBeenCalledOnce();

--- a/src/components/SyncConflictModal.test.tsx
+++ b/src/components/SyncConflictModal.test.tsx
@@ -216,7 +216,7 @@ describe("SyncConflictModal", () => {
       await flushAsync();
 
       expect(vi.mocked(toaster.toast)).toHaveBeenCalledWith({
-        title: "RomM Sync",
+        title: "Tender",
         body: "Conflict resolved — kept your local save (uploaded to server).",
       });
     });
@@ -232,7 +232,7 @@ describe("SyncConflictModal", () => {
       await flushAsync();
 
       expect(vi.mocked(toaster.toast)).toHaveBeenCalledWith({
-        title: "RomM Sync",
+        title: "Tender",
         body: "Conflict resolved — used the server save · your local was backed up.",
       });
     });

--- a/src/components/SystemPage.tsx
+++ b/src/components/SystemPage.tsx
@@ -415,7 +415,7 @@ export const SystemPage: FC<SystemPageProps> = ({ onBack }) => {
               <PanelSectionRow>
                 <Field
                   label={`${unknownFiles.length} file(s) not recognized`}
-                  description="Report at github.com/danielcopper/decky-romm-sync/issues if needed."
+                  description="Report at github.com/danielcopper/romm-tender/issues if needed."
                   bottomSeparator="none"
                 />
               </PanelSectionRow>

--- a/src/components/VersionPicker.test.tsx
+++ b/src/components/VersionPicker.test.tsx
@@ -516,7 +516,7 @@ describe("VersionPicker — vanished retained rows (#1570)", () => {
     });
 
     expect(log).toHaveBeenCalledWith(expect.stringContaining("offline"));
-    expect(toaster.toast).toHaveBeenCalledWith({ title: "RomM Sync", body: "Could not prepare local cleanup." });
+    expect(toaster.toast).toHaveBeenCalledWith({ title: "Tender", body: "Could not prepare local cleanup." });
   });
 });
 
@@ -920,7 +920,7 @@ describe("VersionPicker — switching", () => {
       await clickRow(menu.container, "Game (Japan)");
     });
 
-    expect(toaster.toast).toHaveBeenCalledWith({ title: "RomM Sync", body: "Switched — re-switch if launch fails" });
+    expect(toaster.toast).toHaveBeenCalledWith({ title: "Tender", body: "Switched — re-switch if launch fails" });
     expect(invalidateCachedGameDetail).toHaveBeenCalledWith(APP_ID);
     expect(dispatched.some((e) => e.detail?.type === "version_switched")).toBe(true);
   });
@@ -945,7 +945,7 @@ describe("VersionPicker — switching", () => {
 
       // A throw is treated like a failed confirm: warn + still complete the switch.
       expect(logErrorSpy).toHaveBeenCalledWith(expect.stringContaining("launch-options confirm threw"));
-      expect(toaster.toast).toHaveBeenCalledWith({ title: "RomM Sync", body: "Switched — re-switch if launch fails" });
+      expect(toaster.toast).toHaveBeenCalledWith({ title: "Tender", body: "Switched — re-switch if launch fails" });
       expect(invalidateCachedGameDetail).toHaveBeenCalledWith(APP_ID);
       expect(dispatched.some((e) => e.detail?.type === "version_switched")).toBe(true);
     } finally {
@@ -978,7 +978,7 @@ describe("VersionPicker — switching", () => {
 
     // Short body (Steam truncates it to one line), backend detail in subtext (#1359).
     expect(toaster.toast).toHaveBeenCalledWith({
-      title: "RomM Sync",
+      title: "Tender",
       body: "Could not switch version",
       subtext: "That version is bound to another shortcut.",
     });
@@ -993,7 +993,7 @@ describe("VersionPicker — switching", () => {
     const { menu } = await renderAndOpen();
     await clickRow(menu.container, "Game (Japan)");
 
-    expect(toaster.toast).toHaveBeenCalledWith({ title: "RomM Sync", body: "Could not switch version" });
+    expect(toaster.toast).toHaveBeenCalledWith({ title: "Tender", body: "Could not switch version" });
     expect(invalidateCachedGameDetail).not.toHaveBeenCalled();
   });
 
@@ -1067,7 +1067,7 @@ describe("VersionPicker — switch target liveness (#1570)", () => {
     const dispatched = await captureDataChanged(() => clickRow(menu.container, "Game (Japan)"));
 
     expect(toaster.toast).toHaveBeenCalledWith({
-      title: "RomM Sync",
+      title: "Tender",
       body: "Could not switch version",
       subtext: vanishedFailure.message,
     });
@@ -1291,7 +1291,7 @@ describe("VersionPicker — switch target liveness (#1570)", () => {
       const dispatched = await captureDataChanged(() => clickRow(menu.container, "Game (Japan)"));
 
       expect(toaster.toast).toHaveBeenCalledWith({
-        title: "RomM Sync",
+        title: "Tender",
         body: "Could not switch version",
         subtext: vanishedFailure.message,
       });
@@ -1390,7 +1390,7 @@ describe("VersionPicker — unsynced-saves soft-block", () => {
 
     expect(backend.switchVersion).toHaveBeenNthCalledWith(2, APP_ID, 2, true);
     expect(toaster.toast).toHaveBeenCalledWith({
-      title: "RomM Sync",
+      title: "Tender",
       body: "Could not switch version",
       subtext: "That version is bound to another shortcut.",
     });
@@ -1520,7 +1520,7 @@ describe("VersionPicker — unsynced-saves soft-block", () => {
 
     expect(backend.switchVersion).toHaveBeenNthCalledWith(2, APP_ID, 2, true);
     expect(toaster.toast).toHaveBeenCalledWith({
-      title: "RomM Sync",
+      title: "Tender",
       body: "Could not switch version",
       subtext: vanished.message,
     });
@@ -1572,7 +1572,7 @@ describe("VersionPicker — unsynced-saves soft-block", () => {
 
     expect(backend.switchVersion).toHaveBeenNthCalledWith(2, APP_ID, 2, false);
     expect(toaster.toast).toHaveBeenCalledWith({
-      title: "RomM Sync",
+      title: "Tender",
       body: "Could not switch version",
       subtext: vanished.message,
     });
@@ -1606,7 +1606,7 @@ describe("VersionPicker — unsynced-saves soft-block", () => {
     expect(backend.refreshSaveStatus).toHaveBeenCalledWith(block.unsynced_rom_id);
     // The refusal toast still fires — the refresh is additive, not a replacement.
     expect(toaster.toast).toHaveBeenCalledWith({
-      title: "RomM Sync",
+      title: "Tender",
       body: "Could not switch version",
       subtext: refused.message,
     });
@@ -1639,7 +1639,7 @@ describe("VersionPicker — unsynced-saves soft-block", () => {
       await clickRow(menu.container, "Game (Japan)");
     });
 
-    expect(toaster.toast).toHaveBeenCalledWith({ title: "RomM Sync", body: "Couldn't sync saves — try again" });
+    expect(toaster.toast).toHaveBeenCalledWith({ title: "Tender", body: "Couldn't sync saves — try again" });
     // The stranded version's status is refreshed so the conflict UI can surface.
     expect(backend.refreshSaveStatus).toHaveBeenCalledWith(1);
     expect(dispatched.some((e) => e.detail?.type === "version_switched")).toBe(false);
@@ -1659,7 +1659,7 @@ describe("VersionPicker — unsynced-saves soft-block", () => {
     const { menu } = await renderAndOpen();
     await clickRow(menu.container, "Game (Japan)");
 
-    expect(toaster.toast).toHaveBeenCalledWith({ title: "RomM Sync", body: "Resolve save conflicts first" });
+    expect(toaster.toast).toHaveBeenCalledWith({ title: "Tender", body: "Resolve save conflicts first" });
     expect(backend.refreshSaveStatus).toHaveBeenCalledWith(1);
     expect(backend.switchVersion).toHaveBeenCalledTimes(1);
   });
@@ -1677,7 +1677,7 @@ describe("VersionPicker — unsynced-saves soft-block", () => {
       await clickRow(menu.container, "Game (Japan)");
     });
 
-    expect(toaster.toast).toHaveBeenCalledWith({ title: "RomM Sync", body: "Saves still unsynced — try again" });
+    expect(toaster.toast).toHaveBeenCalledWith({ title: "Tender", body: "Saves still unsynced — try again" });
     expect(backend.refreshSaveStatus).toHaveBeenCalledWith(1);
     expect(dispatched.some((e) => e.detail?.type === "version_switched")).toBe(false);
   });
@@ -1694,7 +1694,7 @@ describe("VersionPicker — unsynced-saves soft-block", () => {
       await clickRow(menu.container, "Game (Japan)");
 
       // The abort toast still fires, and the rejected refresh is warned (not swallowed silently).
-      expect(toaster.toast).toHaveBeenCalledWith({ title: "RomM Sync", body: "Couldn't sync saves — try again" });
+      expect(toaster.toast).toHaveBeenCalledWith({ title: "Tender", body: "Couldn't sync saves — try again" });
       expect(logWarnSpy).toHaveBeenCalledWith(expect.stringContaining("post-abort save-status refresh failed"));
     } finally {
       logWarnSpy.mockRestore();

--- a/src/components/saves/VersionHistoryPanel.test.tsx
+++ b/src/components/saves/VersionHistoryPanel.test.tsx
@@ -253,7 +253,7 @@ describe("VersionHistoryPanel", () => {
       await flushAsync();
       await flushAsync();
       expect(vi.mocked(toaster.toast)).toHaveBeenCalledWith(
-        expect.objectContaining({ title: "RomM Sync", body: expect.stringContaining("Save restored") }),
+        expect.objectContaining({ title: "Tender", body: expect.stringContaining("Save restored") }),
       );
       expect(onRestored).toHaveBeenCalledTimes(1);
       // Collapsed again — chevron is ▸

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -207,7 +207,7 @@ describe("index.tsx — persistent prune listeners", () => {
     expect(invalidateCachedGameDetail).toHaveBeenCalledWith(9001);
     expect(unregisterRomMAppId).toHaveBeenCalledWith(9001);
     expect(changed).toHaveBeenCalledTimes(1);
-    expect(toaster.toast).toHaveBeenCalledWith({ title: "RomM Sync", body: "Removed 1 local entry." });
+    expect(toaster.toast).toHaveBeenCalledWith({ title: "Tender", body: "Removed 1 local entry." });
 
     globalThis.removeEventListener("romm_data_changed", changed);
     plugin.onDismount();
@@ -274,7 +274,7 @@ describe("index.tsx — persistent prune listeners", () => {
     });
 
     expect(toaster.toast).toHaveBeenCalledWith({
-      title: "RomM Sync",
+      title: "Tender",
       body: "Shortcut removal committed; local cleanup incomplete.",
       subtext: "Steam removed the shortcut, but local cleanup was retained.",
     });
@@ -383,7 +383,7 @@ describe("index.tsx — persistent prune listeners", () => {
 
     expect(publishCommittedVersionSwitch).not.toHaveBeenCalled();
     expect(toaster.toast).toHaveBeenCalledWith({
-      title: "RomM Sync",
+      title: "Tender",
       body: "Shortcut repoint outcome is uncertain; source data was retained.",
       subtext: "The repoint outcome is unknown.",
     });

--- a/src/utils/downloadFailure.test.ts
+++ b/src/utils/downloadFailure.test.ts
@@ -53,7 +53,7 @@ describe("handleGlobalDownloadFailure", () => {
     });
     expect(toast.toast).toHaveBeenCalledOnce();
     expect(toast.toast).toHaveBeenCalledWith({
-      title: "RomM Sync",
+      title: "Tender",
       body: "Download failed: Super Mario 64 — disk full",
     });
   });
@@ -91,7 +91,7 @@ describe("handleGlobalDownloadFailure", () => {
     handleGlobalDownloadFailure(makeEvent({ error_message: "" }), store, toast);
 
     expect(toast.toast).toHaveBeenCalledWith({
-      title: "RomM Sync",
+      title: "Tender",
       body: "Download failed: Super Mario 64 — ",
     });
     const [updatedCall] = (store.updateDownload as unknown as { mock: { calls: [DownloadItem][] } }).mock.calls;

--- a/src/utils/launchInterceptor.test.ts
+++ b/src/utils/launchInterceptor.test.ts
@@ -325,7 +325,7 @@ describe("launchInterceptor — full funnel watcher", () => {
 
       expect(SteamClient.Apps.CancelGameAction).toHaveBeenCalledWith(77);
       expect(toaster.toast).toHaveBeenCalledWith({
-        title: "RomM Sync",
+        title: "Tender",
         body: "ROM not downloaded. Open the plugin to download it first.",
       });
       expect(launchGate.runLaunchGate).not.toHaveBeenCalled();
@@ -369,7 +369,7 @@ describe("launchInterceptor — full funnel watcher", () => {
       await flush();
 
       expect(toaster.toast).toHaveBeenCalledWith({
-        title: "RomM Sync",
+        title: "Tender",
         body: "ROM not downloaded. Open the plugin to download it first.",
       });
       expect(launchGate.runLaunchGate).not.toHaveBeenCalled();
@@ -515,7 +515,7 @@ describe("launchInterceptor — full funnel watcher", () => {
       await flush();
 
       expect(toaster.toast).toHaveBeenCalledWith({
-        title: "RomM Sync",
+        title: "Tender",
         body: "Pending RetroDECK migration. Open the plugin QAM to migrate or dismiss.",
       });
       expect(runGameMock()).not.toHaveBeenCalled();
@@ -530,7 +530,7 @@ describe("launchInterceptor — full funnel watcher", () => {
       await flush();
 
       expect(toaster.toast).toHaveBeenCalledWith({
-        title: "RomM Sync",
+        title: "Tender",
         body: "This download has no file the emulator can launch. The files are on disk — see the game page.",
       });
       expect(runGameMock()).not.toHaveBeenCalled();
@@ -652,7 +652,7 @@ describe("launchInterceptor — full funnel watcher", () => {
         expect(steamShortcuts.setLaunchOptionsConfirmed).not.toHaveBeenCalled();
         expect(runGameMock()).not.toHaveBeenCalled();
         // The watcher owns no UI, so without this toast the press dies silently.
-        expect(toaster.toast).toHaveBeenCalledWith({ title: "RomM Sync", body: "Launch cancelled — try again" });
+        expect(toaster.toast).toHaveBeenCalledWith({ title: "Tender", body: "Launch cancelled — try again" });
       } finally {
         vi.useRealTimers();
       }

--- a/src/utils/pruneActions.ts
+++ b/src/utils/pruneActions.ts
@@ -86,7 +86,7 @@ async function captureShortcutSnapshot(appId: number): Promise<PruneSteamSnapsho
   if (!liveApps) throw new Error("Steam shortcut store was unavailable");
   if (!liveApps.has(appId)) throw new Error("Steam shortcut is absent");
   const details = await getAppDetails(appId);
-  if (!isRomMShortcutDetails(details)) throw new Error("The live shortcut is not owned by RomM Sync");
+  if (!isRomMShortcutDetails(details)) throw new Error("The live shortcut is not owned by Tender");
   const overview = appStore.GetAppOverviewByAppID(appId);
   if (!overview) throw new Error("Steam shortcut playtime state was unavailable");
   const collections = collectionStore.userCollections
@@ -190,7 +190,7 @@ async function repointShortcutReport(
   attempt: SteamMutationAttempt,
 ): Promise<CompletePruneActionRequest> {
   const details = await getAppDetails(action.app_id);
-  if (!isRomMShortcutDetails(details)) throw new Error("The live shortcut is not owned by RomM Sync");
+  if (!isRomMShortcutDetails(details)) throw new Error("The live shortcut is not owned by Tender");
   assertCurrent(generation);
   const result: SwitchVersionSuccess = {
     success: true,

--- a/src/utils/scrollHelpers.ts
+++ b/src/utils/scrollHelpers.ts
@@ -98,7 +98,7 @@ export function scrollToTop(e: FocusLike): void {
 
 // Resolution-relative top clearance for scrollElementToTop, derived from the
 // scroll parent's clientHeight so it scales with the viewport. The QAM's fixed
-// "RomM Sync" header sits over the scroll parent's top:0, and its height scales
+// "Tender" header sits over the scroll parent's top:0, and its height scales
 // with resolution / UI scale (Deck 1280x800 vs Big Picture 1080p/1440p/4K), so
 // a fixed px clears the header on only one display. `fraction * clientHeight`
 // lands ~64px on the Deck QAM (on-device-tuned so the heading sits just clear of

--- a/src/utils/sessionManager.test.ts
+++ b/src/utils/sessionManager.test.ts
@@ -435,7 +435,7 @@ describe("sessionManager post-exit save-sync toast (#1481)", () => {
     finalizeWithSync({ success: true, uploaded: 2, downloaded: 0 });
     await runStop();
     expect(vi.mocked(toaster.toast)).toHaveBeenCalledWith(
-      expect.objectContaining({ title: "RomM Save Sync", body: "Saves uploaded to RomM" }),
+      expect.objectContaining({ title: "Tender", body: "Saves uploaded to RomM" }),
     );
   });
 
@@ -451,7 +451,7 @@ describe("sessionManager post-exit save-sync toast (#1481)", () => {
     finalizeWithSync({ success: false, uploaded: 0, downloaded: 0, failure_toast: "Failed to sync saves after exit" });
     await runStop();
     expect(vi.mocked(toaster.toast)).toHaveBeenCalledWith(
-      expect.objectContaining({ title: "RomM Save Sync", body: "Failed to sync saves after exit" }),
+      expect.objectContaining({ title: "Tender", body: "Failed to sync saves after exit" }),
     );
   });
 

--- a/src/utils/sessionManager.ts
+++ b/src/utils/sessionManager.ts
@@ -8,7 +8,7 @@
  * used only for LIVENESS at reload-adoption, never to identify a launching app.
  */
 
-import { showToast, SAVE_SYNC_TOAST_TITLE } from "./toast";
+import { showToast } from "./toast";
 import { recordSessionStart, getAppIdRomIdMap, finalizeGameSession, logInfo, logError, debugLog } from "../api/backend";
 import { saveSyncToastBody } from "./saveSyncToast";
 import { setMigrationStatus } from "./migrationStore";
@@ -278,9 +278,9 @@ async function handleGameStop(stoppedAppId: number): Promise<void> {
       ? saveSyncToastBody(result.sync.uploaded, result.sync.downloaded)
       : null;
     if (directionalBody) {
-      showToast(directionalBody, { title: SAVE_SYNC_TOAST_TITLE });
+      showToast(directionalBody);
     } else if (result.sync.failure_toast) {
-      showToast(result.sync.failure_toast, { title: SAVE_SYNC_TOAST_TITLE });
+      showToast(result.sync.failure_toast);
     }
 
     // Save-sync event dispatch — fires unconditionally so open surfaces refresh
@@ -291,7 +291,7 @@ async function handleGameStop(stoppedAppId: number): Promise<void> {
 
     // Additive conflicts toast — backend renders the count string.
     if (result.sync.conflicts_toast) {
-      showToast(result.sync.conflicts_toast, { title: SAVE_SYNC_TOAST_TITLE });
+      showToast(result.sync.conflicts_toast);
     }
 
     // Migration store updates — backend ran refresh_state, frontend just

--- a/src/utils/toast.test.ts
+++ b/src/utils/toast.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { toaster } from "@decky/api";
 import type { ToastNotification } from "@decky/api";
-import { showToast, PLUGIN_NAME, SAVE_SYNC_TOAST_TITLE } from "./toast";
+import { showToast, PLUGIN_NAME } from "./toast";
 
 describe("showToast", () => {
   beforeEach(() => {
@@ -26,13 +26,8 @@ describe("showToast", () => {
     });
   });
 
-  it("lets a caller override the title", () => {
-    showToast("Saves uploaded to RomM", { title: SAVE_SYNC_TOAST_TITLE });
-
-    expect(toaster.toast).toHaveBeenCalledWith({
-      title: SAVE_SYNC_TOAST_TITLE,
-      body: "Saves uploaded to RomM",
-    });
+  it("names the plugin the same way the manifest does", () => {
+    expect(PLUGIN_NAME).toBe("Tender");
   });
 
   it("returns the notification so a caller can dismiss it", () => {

--- a/src/utils/toast.ts
+++ b/src/utils/toast.ts
@@ -5,17 +5,14 @@ import type { ReactNode } from "react";
 // Must match `plugin.json`'s `name` and the `name` returned from `definePlugin`
 // — Decky reads those two for the plugin list and the QAM header, and nothing
 // checks that the three agree.
-export const PLUGIN_NAME = "RomM Sync";
-
-// Save-sync notices carry their own title so the user can tell an automatic
-// save operation from everything else the plugin reports.
-export const SAVE_SYNC_TOAST_TITLE = "RomM Save Sync";
+export const PLUGIN_NAME = "Tender";
 
 /**
  * Raise a toast under the plugin's name.
  *
- * *options* passes through to `toaster.toast` and may override the title —
- * save-sync call sites do, via {@link SAVE_SYNC_TOAST_TITLE}.
+ * *options* passes through to `toaster.toast` and may override the title, which
+ * no call site currently needs: every notice comes from the same plugin, so a
+ * second sender would only make the user work out that they are the same thing.
  */
 export function showToast(body: ReactNode, options?: Partial<Omit<ToastData, "body">>): ToastNotification {
   return toaster.toast({ title: PLUGIN_NAME, body, ...options });

--- a/tests/services/library/test_sync_orchestrator.py
+++ b/tests/services/library/test_sync_orchestrator.py
@@ -268,7 +268,12 @@ class TestShortcutDataFormat:
         result = build_shortcuts_data([{"id": 1, "name": "Game"}], decky.DECKY_PLUGIN_DIR, {}, {})
         exe = result[0]["exe"]
         assert exe.endswith("/bin/rom-launcher"), f"Exe path should end with /bin/rom-launcher, got: {exe}"
-        assert "decky-romm-sync" in exe, f"Exe path should contain plugin name, got: {exe}"
+        # Anchored to the directory it was handed, not to a name: DECKY_PLUGIN_DIR
+        # is the checkout root under test, so asserting a literal name here pins
+        # whatever the working copy happens to be called.
+        assert exe.startswith(f"{decky.DECKY_PLUGIN_DIR}/"), (
+            f"Exe path should sit inside the plugin directory it was given, got: {exe}"
+        )
 
     def test_installed_rom_gets_launch_command(self, plugin):
         """An installed ROM's launch_options is the full RetroDECK launch command."""

--- a/tests/services/test_launch_gate.py
+++ b/tests/services/test_launch_gate.py
@@ -253,7 +253,7 @@ class TestEvaluateBlock:
 
         assert verdict.action == "block"
         assert verdict.reason == "not_installed"
-        assert verdict.toast_title == "RomM Sync"
+        assert verdict.toast_title == "Tender"
         assert verdict.toast_body == "ROM not downloaded. Open the game page to download it first."
         # Save-status reader must not be consulted when the ROM is not installed.
         assert save_status_reader.calls == []
@@ -285,7 +285,7 @@ class TestEvaluateBlock:
 
         assert verdict.action == "block"
         assert verdict.reason == "save_conflict"
-        assert verdict.toast_title == "RomM Save Sync"
+        assert verdict.toast_title == "Tender"
         assert verdict.toast_body == "Save conflict detected — open game page to resolve before playing"
 
 
@@ -310,7 +310,7 @@ class TestEvaluateWarn:
 
         assert verdict.action == "warn"
         assert verdict.reason == "save_status_failed"
-        assert verdict.toast_title == "RomM Save Sync"
+        assert verdict.toast_title == "Tender"
         assert verdict.toast_body == "Save-status check failed — retry?"
         assert save_status_reader.calls == [99]
         assert save_status_reader.tracked_calls == [99]


### PR DESCRIPTION
The plugin's user-facing name becomes Tender: `plugin.json`, the QAM header, every toast, the docs site and the user
guide. The package name is unchanged, so settings, the database and existing shortcuts are untouched.

Save-sync notices lose their separate sender. They shared a handler with notices titled "RomM Sync" three lines apart,
so the same operation announced itself under two names depending on whether it succeeded — and the body already says the
notice is about saves.

The banner carries the lockup, and the tagline names what the plugin actually claims: the games are real Steam entries
and they launch.

Repository URLs follow the rename to `romm-tender`. Two things deliberately do not:

- **The SonarCloud project key.** `danielcopper_decky-romm-sync` identifies the project on SonarCloud's side, not on
  GitHub's. Changing it here would point the scanner at a project that does not exist and lose the history and gate
  configuration with it.
- **Install paths, the release tag prefix and the zip name.** Those follow the package name, which is staying
  `decky-romm-sync` (#1536).

Issue and ADR links elsewhere in the docs are left alone — GitHub redirects them, and rewriting 165 links is churn with
a real chance of putting a typo into one nobody would notice was broken.

Closes #1548. Part of #1536.
