### PR TITLE
chore(release): name the release artifacts after Tender

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,7 +142,7 @@ jobs:
           TAG: ${{ steps.tag.outputs.tag }}
         run: |
           BUILT_ZIP=$(ls /tmp/output/*.zip | head -1)
-          DEST="/tmp/output/decky-romm-sync.zip"
+          DEST="/tmp/output/tender.zip"
           if [ "$BUILT_ZIP" != "$DEST" ]; then
             cp "$BUILT_ZIP" "$DEST"
           fi

--- a/README.md
+++ b/README.md
@@ -100,10 +100,9 @@ search for **Tender**, and install. No Developer Mode required.
 This is the current method while v1.0 is in progress. It requires **Developer Mode** in Decky Loader (Decky settings →
 gear icon → toggle **Developer Mode**).
 
-1. Download the latest `decky-romm-sync.zip` from the
-   [releases page](https://github.com/danielcopper/romm-tender/releases)
+1. Download the latest `tender.zip` from the [releases page](https://github.com/danielcopper/romm-tender/releases)
 2. In Decky settings → **Developer** tab → **Install Plugin from ZIP** (or **from URL** with the
-   [latest release link](https://github.com/danielcopper/romm-tender/releases/latest/download/decky-romm-sync.zip))
+   [latest release link](https://github.com/danielcopper/romm-tender/releases/latest/download/tender.zip))
 
 </details>
 

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -35,17 +35,20 @@ Before installing the plugin, you need:
 4. Open the **Developer** tab and select **Install Plugin From URL**
 5. Enter the direct URL to the release zip
 
-   The URL for the latest release follows this pattern:
+   This one always points at the newest release, so it needs no version number:
 
    ```text
-   https://github.com/danielcopper/romm-tender/releases/download/decky-romm-sync-v{VERSION}/decky-romm-sync.zip
+   https://github.com/danielcopper/romm-tender/releases/latest/download/tender.zip
    ```
 
-   For example, for v0.9.3:
+   To pin a specific version instead, name its tag:
 
    ```text
-   https://github.com/danielcopper/romm-tender/releases/download/decky-romm-sync-v0.9.3/decky-romm-sync.zip
+   https://github.com/danielcopper/romm-tender/releases/download/tender-v{VERSION}/tender.zip
    ```
+
+   Releases published before the rename use the older `decky-romm-sync-v{VERSION}/decky-romm-sync.zip` form; their links
+   keep working unchanged.
 
 6. Decky downloads and installs the plugin automatically — no restart needed
 
@@ -58,7 +61,7 @@ Any direct URL to the zip file works (GitHub releases, a self-hosted mirror, etc
 
 ### Manual installation (alternative)
 
-1. Download `decky-romm-sync.zip` from the [releases page](https://github.com/danielcopper/romm-tender/releases)
+1. Download `tender.zip` from the [releases page](https://github.com/danielcopper/romm-tender/releases)
 2. Extract the zip to `~/homebrew/plugins/` on your device (via SSH, file manager, or USB)
 3. Restart Decky Loader — either reboot, or run `sudo systemctl restart plugin_loader` via SSH
 4. The plugin appears in your QAM under the Decky tab

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,7 @@
   "release-type": "node",
   "packages": {
     ".": {
-      "package-name": "decky-romm-sync",
+      "package-name": "tender",
       "initial-version": "0.1.0",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,


### PR DESCRIPTION
The two names a user meets on the releases page were the last places the old name showed: the zip is now `tender.zip`
and future tags carry a `tender-v` prefix. Neither is tied to the package name, which stays `decky-romm-sync` along with
the folder inside the zip and the on-device install path.

Existing releases keep their names and their download URLs. release-please takes the current version from
`.release-please-manifest.json` rather than from the tags, so the prefix change does not disturb the version sequence.

The install instructions now lead with the `/releases/latest/` URL, which needs no version number and cannot go stale —
the previous example pinned a version that would have had to be edited on every release.

Part of #1536.

docs: `docs/user-guide/getting-started.md` carries the new URLs.
