### PR TITLE
fix(ci): copy the release zip somewhere writable before uploading

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,11 +141,13 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.tag.outputs.tag }}
         run: |
+          # The asset takes its name from the file uploaded, and the Decky CLI
+          # names its output after the package. Renaming therefore means copying
+          # — into RUNNER_TEMP, because /tmp/output belongs to the container that
+          # produced the zip and is not writable here.
           BUILT_ZIP=$(ls /tmp/output/*.zip | head -1)
-          DEST="/tmp/output/tender.zip"
-          if [ "$BUILT_ZIP" != "$DEST" ]; then
-            cp "$BUILT_ZIP" "$DEST"
-          fi
+          DEST="$RUNNER_TEMP/tender.zip"
+          cp "$BUILT_ZIP" "$DEST"
           gh release upload "$TAG" \
             "$DEST" \
             --clobber


### PR DESCRIPTION
Renaming the asset to `tender.zip` made the copy step run for the first time: while source and destination shared a
name, the guard skipped it. It then failed, because `/tmp/output` belongs to the container that produced the zip and the
runner cannot write there.

```
cp: cannot create regular file '/tmp/output/tender.zip': Permission denied
```

The copy now lands in `RUNNER_TEMP`, and the guard goes with it — the two paths always differ now, so a conditional
would only hide the intent.

Caught by a manual release-please dispatch. On a real release it would have built the plugin and then failed to attach
it.

docs: N/A — CI-only fix, no user-visible change.
