### PR TITLE
fix(ui): bind the save-sync display note to the rom it describes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -276,6 +276,15 @@ Format: **invariant** — tier — enforced by.
 - **Every destructive RomM proof is bound to one canonical server-origin/token-origin/user namespace from preview
   through every exact-ID request; a namespace change is uncertainty, never a 404 deletion authority** — test +
   prompt-only — prune service namespace-race tests; new destructive RomM proof paths are prompt-only
+- **Every write into the per-appId game-detail store's state (`src/utils/gameDetailStore.ts`) that crosses an `await` is
+  bound to a rom identity — via `writerForRom` to the rom the read was issued for, or in `applySaveStatus` to the
+  answer's own `rom_id`. Two writes are exempt by construction: the identity write in `loadDetail`, which installs the
+  identity a binding would compare against, and the `cached.bios_status` fold in the same synchronous run. A version
+  switch re-keys the entry without closing it, so the generation counter cannot see this class at all. The game-detail
+  panel and the play button keep their own per-rom state and are NOT covered (#1713, #1714)** — prompt-only — a checker
+  scoped to the store's own function bodies would be green on the case this rule was written for, because the write
+  happens in a synchronous function the caller reaches after its own await; a caller-side checker cannot tell a binding
+  store function from an unbound one syntactically
 
 When a change applies a guard / sanitize / backup / grouping pattern, sweep for sibling sites of the same pattern — the
 register is what that sweep checks against.

--- a/src/components/RomMPlaySection.test.tsx
+++ b/src/components/RomMPlaySection.test.tsx
@@ -2468,6 +2468,37 @@ describe("RomMPlaySection", () => {
       });
       expect(vi.mocked(toaster.toast)).toHaveBeenCalledWith(expect.objectContaining({ body: "Save sync failed" }));
     });
+
+    // The display write lands after the sync's await, so a version switch
+    // arriving in that window would record "Just now" on the ROM the page moved
+    // TO — a display it never earned (#1673).
+    it("a version switch landing before the sync answers leaves the switched-to rom's display alone", async () => {
+      const items = await setupSavesAction();
+      let settleSync: (result: Awaited<ReturnType<typeof backend.syncRomSaves>>) => void = () => {};
+      vi.mocked(backend.syncRomSaves).mockReturnValue(
+        new Promise((resolve) => {
+          settleSync = resolve;
+        }),
+      );
+      act(() => {
+        items[2]!.props.onClick?.();
+      });
+
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({ found: true, rom_id: 43 });
+      await act(async () => {
+        globalThis.dispatchEvent(
+          new CustomEvent("romm_data_changed", { detail: { type: "version_switched", app_id: testAppId, rom_id: 43 } }),
+        );
+        await Promise.resolve();
+      });
+      await flushAsync();
+      expect(getGameDetail(testAppId).romId).toBe(43);
+
+      settleSync({ success: true, message: "", synced: 1, uploaded: 1, downloaded: 0, conflicts: [] });
+      await flushAsync();
+
+      expect(getGameDetail(testAppId)).toMatchObject({ saveSyncStatus: null, saveSyncLabel: "" });
+    });
   });
 
   // ------------------------------------------------------------------

--- a/src/components/RomMPlaySection.tsx
+++ b/src/components/RomMPlaySection.tsx
@@ -528,9 +528,10 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
 
   const handleSyncSaves = async () => {
     if (actionPending || !detail.romId) return;
+    const romId = detail.romId;
     setActionPending("savesync");
     try {
-      const result = await syncRomSaves(detail.romId);
+      const result = await syncRomSaves(romId);
       if (result.success) {
         // Directional completion toast via the shared helper — the single source
         // of that copy across every save-sync surface (#1481).
@@ -552,11 +553,9 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
         if (c > 0) {
           showToast(`${c} conflict(s) need resolution`);
         }
-        globalThis.dispatchEvent(
-          new CustomEvent("romm_data_changed", { detail: { type: "save_sync", rom_id: detail.romId } }),
-        );
+        globalThis.dispatchEvent(new CustomEvent("romm_data_changed", { detail: { type: "save_sync", rom_id: romId } }));
         // Refresh save sync status — last_sync_check_at was just set by the backend
-        noteSaveSyncDisplay(appId, { status: "synced", label: "Just now", last_sync_check_at: null });
+        noteSaveSyncDisplay(appId, romId, { status: "synced", label: "Just now", last_sync_check_at: null });
       } else {
         showToast(result.message || "Save sync failed");
       }
@@ -644,7 +643,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
                 if (result.success) {
                   showToast(result.message);
                   // Directly update the shown status — no local saves remain
-                  noteSaveSyncDisplay(appId, { status: "none", label: "No saves", last_sync_check_at: null });
+                  noteSaveSyncDisplay(appId, romId, { status: "none", label: "No saves", last_sync_check_at: null });
                   globalThis.dispatchEvent(
                     new CustomEvent("romm_data_changed", { detail: { type: "save_sync", rom_id: romId } }),
                   );

--- a/src/utils/gameDetailStore.test.ts
+++ b/src/utils/gameDetailStore.test.ts
@@ -288,7 +288,7 @@ describe("gameDetailStore", () => {
       expect(result.current).toMatchObject({ romId: 42, installed: true });
 
       act(() => {
-        noteSaveSyncDisplay(nextAppId, { status: "none", label: "No saves", last_sync_check_at: null });
+        noteSaveSyncDisplay(nextAppId, 42, { status: "none", label: "No saves", last_sync_check_at: null });
       });
       expect(result.current.saveSyncLabel).toBe("No saves");
 
@@ -1242,8 +1242,29 @@ describe("gameDetailStore", () => {
       subscribe(nextAppId);
       await flush();
 
-      noteSaveSyncDisplay(nextAppId, { status: "synced", label: "Just now", last_sync_check_at: null });
+      noteSaveSyncDisplay(nextAppId, 42, { status: "synced", label: "Just now", last_sync_check_at: null });
 
+      expect(getGameDetail(nextAppId)).toMatchObject({ saveSyncStatus: "synced", saveSyncLabel: "Just now" });
+    });
+
+    it("noteSaveSyncDisplay does not record a display for the rom the entry has since left", async () => {
+      subscribe(nextAppId);
+      await flush();
+      expect(getGameDetail(nextAppId)).toMatchObject({ romId: 42 });
+
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(found({ rom_id: 43 }));
+      await act(async () => {
+        dispatchVersionSwitch(nextAppId);
+        await Promise.resolve();
+      });
+      await flush();
+
+      noteSaveSyncDisplay(nextAppId, 42, { status: "synced", label: "Just now", last_sync_check_at: null });
+      expect(getGameDetail(nextAppId)).toMatchObject({ romId: 43, saveSyncStatus: null, saveSyncLabel: "" });
+
+      // The refusal is about whose display it is, not about the note being
+      // inert: the same display for the rom the entry now holds still lands.
+      noteSaveSyncDisplay(nextAppId, 43, { status: "synced", label: "Just now", last_sync_check_at: null });
       expect(getGameDetail(nextAppId)).toMatchObject({ saveSyncStatus: "synced", saveSyncLabel: "Just now" });
     });
 
@@ -1432,7 +1453,7 @@ describe("gameDetailStore", () => {
     });
 
     it("does nothing for an appId nobody is subscribed to", async () => {
-      noteSaveSyncDisplay(nextAppId, { status: "none", label: "No saves", last_sync_check_at: null });
+      noteSaveSyncDisplay(nextAppId, 42, { status: "none", label: "No saves", last_sync_check_at: null });
       await refreshBiosStatus(nextAppId);
       await refreshCoreAndBios(nextAppId);
 

--- a/src/utils/gameDetailStore.ts
+++ b/src/utils/gameDetailStore.ts
@@ -417,15 +417,19 @@ function applySaveStatus(entry: Entry, generation: number, status: SaveStatus): 
   }));
 }
 
-/** Record a save-sync display a surface already knows to be true — the "Just
- *  now" after a manual sync, the "No saves" after a local delete — without
- *  waiting for a round-trip to confirm it. */
-export function noteSaveSyncDisplay(appId: number, display: SaveSyncDisplay): void {
+/** Record a save-sync display a surface already knows to be true about `romId` —
+ *  the "Just now" after a manual sync, the "No saves" after a local delete —
+ *  without waiting for a round-trip to confirm it. Refused once the entry has
+ *  moved on to another ROM: every caller reaches this after an await, so a
+ *  version switch landing in that window would otherwise put a display on the
+ *  page of a ROM that never earned it (#1673). */
+export function noteSaveSyncDisplay(appId: number, romId: number, display: SaveSyncDisplay): void {
   const entry = _entries.get(appId);
   if (!entry) return;
-  writerFor(
+  writerForRom(
     entry,
     entry.generation,
+    romId,
   )((prev) => ({
     ...prev,
     saveSyncStatus: display.status,


### PR DESCRIPTION
`noteSaveSyncDisplay` wrote the sync display into the entry without binding it to a rom, while both
callers reach it after an await — after the sync call, and after deleting local saves. A version
switch landing in that window recorded "Just now / synced", or "No saves" after a delete, onto the
version the user switched to: a display that version never earned.

The asymmetry was the tell. On the adjacent line each caller dispatches a `save_sync` event that does
carry `rom_id`, and the store checks it before folding. Two writes out of one block, one guarded and
one not. It now takes the rom it describes and refuses the write once the entry has moved on, in the
same shape as the store's other bound writers.

With this the store's rom-binding is exhaustive, so the rule behind it goes into the invariant
register. `entry.state` is assigned in exactly one place, which makes that an audit rather than a
sample: every write crossing an await is bound — via `writerForRom` to the rom its read was issued
for, or in `applySaveStatus` to the answer's own `rom_id` — and two writes are exempt by
construction.

The entry names what it does **not** cover. The info panel and the play button keep their own per-rom
state and have unbound sites of their own; both now have issues (#1713, #1714). Wording the rule as if
it covered them would have made it false.

It stays `prompt-only` deliberately. A checker scoped to the store's own function bodies would have
been green on this very bug — `noteSaveSyncDisplay` has no await of its own, the await belongs to its
caller. A caller-side checker cannot separate a store function that binds internally from one that
does not.

docs: N/A — no page describes the store's fold behaviour; the register in CLAUDE.md is updated in this
change.

Closes #1673
