### PR TITLE
chore(docs): correct the sentinel invariant's enforcement note

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,8 +206,9 @@ Format: **invariant** — tier — enforced by.
   `scripts/check_romm_min_version.py` (ADRs excluded: frozen history)
 - **Server-supplied path components pass `safe_join` (`lib/path_safety.py`)** — test + prompt-only — traversal tests per
   path builder; new call sites are prompt-only
-- **No sentinel objects on the wire — explicit JSON-representable tagged values only** — prompt-only — mechanizable once
-  tagged values have replaced the sentinels
+- **No sentinel objects on the wire — explicit JSON-representable tagged values only** — prompt-only — no sentinel
+  survives on the wire today (`NO_MIGRATION` retired with #1004, legacy `slot:null` confirmation with #1276), so the
+  rule now guards reintroduction; nothing mechanical detects a new one
 - **Every destructive op has backup-or-confirm; never delete data that exists nowhere else** — prompt-only — save-file
   removals route through the `.romm-backup` funnel (`MatrixExecutor.quarantine_local_file`; the removed-game cleanup's
   claimed variant is `PruneSaveSupport.quarantine_prune_saves`); every other delete path carries the rule unmechanized.


### PR DESCRIPTION
The register entry still said the rule was "mechanizable once tagged values have replaced the sentinels", describing a state that ended some time ago: `NO_MIGRATION` was retired with #1004 and the legacy `slot:null` confirmation with #1276, so no sentinel crosses the wire today.

State what the rule now does — guard reintroduction — and that nothing mechanical would catch a new one, so the prompt-only tier reads as a standing gap rather than a pending cleanup.

docs: N/A — the change is one line of CLAUDE.md; nothing under `docs/` is affected.