### PR TITLE
fix(saves): correct the get_save_slots active_slot type and record the setup-path divergence

### DIFF
--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -858,7 +858,7 @@ export const getSaveSyncSettings = callable<[], SaveSyncSettings>("get_save_sync
 export const updateSaveSyncSettings = callable<[SaveSyncSettings], { success: boolean }>("update_save_sync_settings");
 export const getSaveSlots = callable<
   [number],
-  { success: boolean; slots: SaveSlotSummary[]; active_slot: string; reason?: string; message?: string }
+  { success: boolean; slots: SaveSlotSummary[]; active_slot: string | null; reason?: string; message?: string }
 >("get_save_slots");
 export const getSlotSaves = callable<[number, string], SlotSavesResponse>("get_slot_saves");
 export const switchSlot = callable<[number, string], SwitchSlotResponse>("switch_slot");

--- a/src/utils/saveSetup.ts
+++ b/src/utils/saveSetup.ts
@@ -36,9 +36,15 @@ export function resolveSaveSetupOutcome(info: SaveSetupInfo): SaveSetupOutcome {
   if (info.recommended_action === "auto_confirm_default") {
     return { kind: "auto_confirm", slot: info.default_slot };
   }
-  // Mirrors CustomPlayButton's pre-extraction branches: local-only or
-  // empty-everywhere can still auto-confirm; only "server has saves" forces
-  // the wizard.
+  // Reached with nothing local AND nothing on the server — the one state the
+  // backend routes to the wizard (`recommended_action` is `auto_confirm_default`
+  // only when local saves exist) and the launch path settles itself. The
+  // divergence is deliberate: pressing Play means "play", so an empty slate
+  // takes the default slot instead of a dialog, while opening the SAVES tab
+  // means "configure", so `applyWizardInitialSetupResult` below offers the same
+  // slate as a choice. Nothing is at stake on either route — both sides are
+  // empty and the slot stays changeable — so consistency here would only buy a
+  // launch-time prompt for a decision that costs nothing to defer.
   if (info.server_slots.length === 0) {
     return { kind: "auto_confirm", slot: info.default_slot };
   }


### PR DESCRIPTION
`get_save_slots` declares `active_slot: string`, but the backend returns `null` for a ROM tracked in legacy mode — `services/saves/slots/listing.py` keeps `active_slot=None` deliberately, and #1276 retired legacy only as a confirmation *target*, so existing tracked ROMs still carry it. The consumers were already correct (`slotState.ts` and the panel state both type it `string | null`); only the callable declaration was wrong, and structural typing kept that from surfacing.

The two other findings #1063 collected are struck rather than fixed.

**The post-exit save-sort gate rests on a wrong premise.** The finding reads that `post_exit_sync` uploads from the new layout while old-layout files await migration. It does not: while a migration is pending, `get_rom_save_info` resolves `saves_dir` to the *previous* layout on purpose, because RetroArch caches its runtime save-path at game-load time and the session that just ended therefore wrote to the old directory. Post-exit reads exactly where that session wrote. Adding the gate turns `test_post_exit_sync_new_from_start_skips_stale_download` red — the #238 regression test that pins post-exit as a benign success during a pending migration. The asymmetry with `pre_launch_sync` follows the same difference: the *upcoming* session's layout is ambiguous, so refusing before launch is right; the *finished* session's is not, and refusing after it would strand that session's progress locally behind a migration prompt the user may not act on.

**The zero-saves divergence is intended.** With no local save and nothing on the server, the launch path settles on the default slot while the SAVES tab offers the choice. Pressing Play means "play"; opening the tab means "configure". Nothing is at stake either way — both sides are empty and the slot stays changeable — so making the two agree would only buy a launch-time prompt for a decision that costs nothing to defer. Recorded at the divergence point in `saveSetup.ts`, where both paths sit side by side and the next reader would otherwise reconcile them.

docs: N/A — a callable type declaration and a code comment; no behaviour, flow or UI change.

Closes #1063
