### PR TITLE
fix(saves): fall back to srm when the server sends an empty or null file_extension

### DIFF
--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -1166,6 +1166,13 @@ slot switch — writes content to a path of the form:
 `Mario Golf - Advance Tour (USA).gba`); `<server_save.file_extension>` is the `file_extension` field on the chosen RomM
 save (e.g. `srm`).
 
+An unusable `file_extension` never reaches the filesystem, and the four cases are deliberately not equivalent. An
+**absent** field is the benign default: `srm`, silently. A field that is **present but empty or `null`** also falls back
+to `srm` but is reported to the caller, which logs it — a server that sent one is saying something, and the joined name
+(`<rom_basename>.` / `<rom_basename>.None`) would otherwise be a perfectly valid filename for a save no emulator ever
+writes. A value carrying **path separators** is reduced to its basename and reported as sanitized. A value that leaves
+**no usable component at all** (trailing separator, NUL byte) falls back to `srm` and is reported.
+
 This is the **only** path used for local writes. The server's stored `file_name` (which may carry a timestamp tag like
 `[2026-03-24_15-18-50]` or come from a different client with an unrelated naming convention) and the server's
 `file_name_no_tags` are **not** consulted. RetroArch identifies SRAM purely by `<rom_basename>.<ext>` filename match —

--- a/py_modules/domain/save_path.py
+++ b/py_modules/domain/save_path.py
@@ -140,6 +140,14 @@ def compute_local_save_target(server_save: dict[str, Any], rom_name: str) -> Loc
     path and silently break the sync.
     """
     ext = server_save.get("file_extension", "srm")
+    if not ext:
+        # ``None`` and ``""`` both join into a syntactically valid filename
+        # (``<rom_name>.None`` / ``<rom_name>.``), so the sanitizer below has no
+        # reason to reject them — and RetroArch, which finds SRAM only by
+        # ``<rom_basename>.<ext>`` match, would then look under a name no
+        # emulator writes. An ABSENT key is the benign default and stays silent;
+        # a present-but-unusable value is reported like any other fallback.
+        return LocalSaveTarget(f"{rom_name}.srm", fallback_extension=str(ext))
     target = f"{rom_name}.{ext}"
     try:
         sanitized = sanitize_save_filename(target)

--- a/tests/domain/test_save_path.py
+++ b/tests/domain/test_save_path.py
@@ -239,17 +239,34 @@ class TestComputeLocalSaveTarget:
         assert result.fallback_extension == "srm\x00evil"
         assert result.sanitized_from is None
 
-    def test_empty_string_extension_keeps_trailing_dot(self) -> None:
-        """An empty ``file_extension`` produces ``<rom_name>.``.
+    def test_empty_string_extension_falls_back(self) -> None:
+        """An empty ``file_extension`` falls back to ``srm`` and is reported.
 
         ``sanitize_save_filename`` accepts ``pokemon.`` as a single safe
-        component (its basename is ``pokemon.``), so no diagnostic flag
-        is set.
+        component, so the unusable value has to be caught before the join
+        rather than by the sanitizer.
         """
         result = compute_local_save_target({"file_extension": ""}, "pokemon")
-        assert result.filename == "pokemon."
-        assert result.fallback_extension is None
+        assert result.filename == "pokemon.srm"
+        assert result.fallback_extension == ""
         assert result.sanitized_from is None
+
+    def test_null_extension_falls_back(self) -> None:
+        """A ``file_extension: null`` falls back to ``srm`` and is reported.
+
+        Without the guard the join yields ``pokemon.None`` — a valid filename
+        for a save RetroArch will never look for.
+        """
+        result = compute_local_save_target({"file_extension": None}, "pokemon")
+        assert result.filename == "pokemon.srm"
+        assert result.fallback_extension == "None"
+        assert result.sanitized_from is None
+
+    def test_absent_extension_is_not_reported_as_a_fallback(self) -> None:
+        """A missing key is the benign default, not an unusable server value."""
+        result = compute_local_save_target({}, "pokemon")
+        assert result.filename == "pokemon.srm"
+        assert result.fallback_extension is None
 
     def test_dotdot_extension_survives_untouched(self) -> None:
         """``..`` as an extension is accepted: ``pokemon...`` is a valid basename.


### PR DESCRIPTION
`compute_local_save_target` derives the canonical local name as `<rom_name>.<file_extension>`, defaulting the extension via `server_save.get("file_extension", "srm")`. That default only fires when the key is **missing**. A key that is present and carries `null` or `""` joins into `pokemon.None` / `pokemon.` — both syntactically valid filenames, so `sanitize_save_filename` has no reason to reject them, and RetroArch, which finds SRAM only by `<rom_basename>.<ext>` match, would look for a save no emulator writes.

Catch the unusable value before the join. The four cases stay deliberately distinct: an absent field is the benign default and stays silent, while a present-but-unusable one falls back to `srm` and sets `fallback_extension`, so `_helpers.local_save_target` logs it — a server that sends an empty extension is saying something worth seeing once. Separator and NUL handling are unchanged.

`test_empty_string_extension_keeps_trailing_dot` pinned the old outcome, down to a docstring explaining why `pokemon.` was accepted. It is rewritten rather than removed: the sanitizer does still accept that name, which is exactly why the value has to be caught earlier. Added alongside it are the `null` case and one asserting that an absent key is *not* reported as a fallback, so the distinction between the two silences cannot erode.

Not covered, and out of scope: a server sending the literal string `"None"`. It is truthy, so it still joins through — that would be a RomM-side serialization bug rather than a missing value, and guessing at it here would mean rejecting an extension a client could legitimately use.

`compute_local_save_target` is held to the emu-atlas `machines` vectors; they still pass unchanged.

Closes #1727
