### PR TITLE
fix(ui): report a downed plugin backend instead of spinning forever

### DIFF
--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -15,6 +15,24 @@ it. Open the Decky plugin log to find the underlying error, then reload Tender f
 fails after a reload, restart Steam (or the Steam Deck); if the error persists, include the log output when you report
 it.
 
+Reaching that verdict takes up to about a minute and a half, because the check keeps retrying to ride out a backend that
+is merely slow to start rather than calling it dead too early. It runs to its conclusion whether or not the panel is
+open, so you do not have to sit and watch it — close the QAM and reopen it later, and the row shows the answer. While a
+check is running, the row keeps showing the previous result rather than resetting to **Checking…**.
+
+### Sign-in reports "The plugin backend never answered"
+
+**Symptom**: The **Sign in to RomM** dialog sits on **Signing in…** for a minute and then shows "The plugin backend
+never answered. Reload Decky or restart Steam, then try again."
+
+**Fix**: The dialog reached the plugin's backend process and got no reply at all, which normally means the backend is no
+longer running — the panel itself keeps working because its code is already loaded in Steam. Reload Tender from the
+Decky plugin list, or restart Steam, then sign in again. A pairing code is single-use and expires after 60 seconds, so
+generate a fresh one for the retry.
+
+This message is specific to the plugin backend being unreachable. A RomM server that is merely down or misconfigured
+answers with its own message instead — "Server unreachable", "Sign-in rejected", or the RomM version notice.
+
 ## Games Won't Launch
 
 ### BIOS files missing

--- a/src/components/MainPage.test.tsx
+++ b/src/components/MainPage.test.tsx
@@ -53,6 +53,7 @@ import { beginEtaRun, resetEta, liveEtaSeconds } from "../utils/syncEta";
 import * as syncEta from "../utils/syncEta";
 import { NEW_ITEM_SEC, UPDATED_ITEM_SEC, COVER_DOWNLOAD_SEC, FETCH_ALLOWANCE_SEC } from "../utils/syncEstimate";
 import { setDownloads } from "../utils/downloadStore";
+import { resetConnectionProbeForTests } from "../utils/connectionProbe";
 import { showModal } from "@decky/ui";
 import * as syncManager from "../utils/syncManager";
 import * as connectionState from "../utils/connectionState";
@@ -263,6 +264,9 @@ describe("MainPage", () => {
     // Clear the module-level live-ETA estimator so a prior test's run never bleeds
     // into the next (its state persists across renders like the other stores).
     resetEta();
+    // The connection probe outlives the panel by design (#1730), so its verdict
+    // survives unmount and would carry a prior test's answer into the next.
+    resetConnectionProbeForTests();
     setSyncProgress({
       running: false,
       stage: "",

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -14,7 +14,6 @@ import {
 } from "@decky/ui";
 import { FaCheckCircle, FaTimesCircle, FaExclamationTriangle } from "react-icons/fa";
 import {
-  testConnection,
   cancelSync,
   getSyncStats,
   getSettings,
@@ -55,7 +54,8 @@ import {
   setSaveSortMigrationStatus,
 } from "../utils/saveSortMigrationStore";
 import { reconcileStaleShortcuts, requestSyncCancel, isCancelRequested, resetSyncCancel } from "../utils/syncManager";
-import { setVersionError } from "../utils/connectionState";
+import { useConnectionProbe } from "../utils/connectionProbe";
+import type { BackendFailed, ConnectionFailure } from "../utils/connectionProbe";
 import { retroDeckBanner, type RetroDeckBanner } from "../utils/retrodeckHealth";
 import { VersionErrorCard, useVersionError } from "./VersionErrorCard";
 import { WarningCard } from "./WarningCard";
@@ -73,39 +73,14 @@ import type {
   SessionBudgetStatus,
   DownloadItem,
   MigrationStatus,
-  RommErrorCode,
 } from "../types";
 import { detach } from "../utils/detach";
-import { withTimeout } from "../utils/withTimeout";
 import { wrapText } from "../utils/textStyles";
 
 type Page = "settings" | "library" | "data" | "downloads" | "system";
 
 interface MainPageProps {
   onNavigate: (page: Page) => void;
-}
-
-// The connection probe races each `test_connection()` attempt against a deadline
-// (the callable never times out on its own and hangs forever when the backend
-// isn't up yet) and retries across the slow-cold-boot window. A call that
-// resolves — success OR "not connected" — is authoritative and ends the probe;
-// only an exhausted retry budget means the plugin backend never came up
-// (bootstrap aborted), which the connection row surfaces explicitly instead of
-// an eternal "Checking…" spinner (#1045). The schedule mirrors the metadata init
-// loop's tuned window in index.tsx (#1203).
-const CONNECTION_RETRY_DELAYS = [2000, 5000, 10000, 15000, 20000];
-const CONNECTION_CALLABLE_TIMEOUT = 5000;
-
-/** Backend never answered after the retry budget — distinct from `false` ("not connected"). */
-type BackendFailed = "backend_failed";
-
-/** A resolved-but-failed `test_connection()` probe. `reason`/`message` classify
- *  why so the connection row shows a specific label instead of a bare "Not
- *  connected"; both are absent when the probe never resolved (an unreachable
- *  server that hung past every deadline), which reads as the generic label. */
-interface ConnectionFailure {
-  reason: RommErrorCode | undefined;
-  message: string;
 }
 
 /** The connection-row label for a failed probe, mapped from the backend's
@@ -459,11 +434,12 @@ function terminalStatusTone(stage: SyncProgress["stage"]): StatusTone {
 export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
   const [stats, setStats] = useState<SyncStats | null>(null);
   const [budgetStatus, setBudgetStatus] = useState<SessionBudgetStatus | null>(null);
-  const [connected, setConnected] = useState<boolean | null | BackendFailed>(null);
-  // Classifies a resolved-but-failed probe so the connection row can show a
-  // specific label (auth rejected / server unreachable / no URL / not signed
-  // in). Null for every non-failed state and for a probe that never resolved.
-  const [connectionFailure, setConnectionFailure] = useState<ConnectionFailure | null>(null);
+  // `failure` classifies a resolved-but-failed probe so the connection row can
+  // show a specific label (auth rejected / server unreachable / no URL / not
+  // signed in). Null for every non-failed state and for a probe that never
+  // resolved. The probe itself lives outside this component so a QAM close does
+  // not abandon a run that has not reached a verdict yet.
+  const { connected, failure: connectionFailure } = useConnectionProbe();
   const versionError = useVersionError();
   const [syncing, setSyncing] = useState(false);
   // Disarmed "Cancelling…" state during the backend's RUNNING→CANCELLING→IDLE
@@ -506,12 +482,6 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
   };
 
   useEffect(() => {
-    // Guards for the async connection probe below: `cancelled` stops the retry
-    // loop from touching state after unmount; the timer ref lets cleanup clear a
-    // pending backoff delay.
-    let cancelled = false;
-    let connectionRetryTimer: ReturnType<typeof setTimeout> | null = null;
-
     refreshMigrationState()
       .then(({ retrodeck, save_sort }) => {
         setMigrationStatus(retrodeck);
@@ -527,53 +497,6 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
     getSessionBudgetStatus()
       .then(setBudgetStatus)
       .catch((e) => logError(`Failed to load session budget status: ${e}`));
-
-    // Probe the backend for the connection row. Each attempt has a deadline
-    // because the callable hangs (rather than rejects) while the backend is
-    // still starting, and the retries ride out a slow cold boot. A resolved call
-    // ends the probe — "not connected" (success:false) is an authoritative
-    // answer, not a failure. Only an exhausted retry budget means the backend
-    // never came up (bootstrap aborted); surface that explicitly (#1045).
-    const probeConnection = async (isCancelled: () => boolean) => {
-      for (let attempt = 0; !isCancelled(); attempt++) {
-        try {
-          const r = await withTimeout(testConnection(), CONNECTION_CALLABLE_TIMEOUT);
-          if (isCancelled()) return;
-          setConnected(r.success);
-          setConnectionFailure(r.success ? null : { reason: r.reason, message: r.message });
-          setVersionError(r.reason === "version_error" ? r.message : null);
-          return;
-        } catch {
-          if (isCancelled()) return;
-          if (attempt >= CONNECTION_RETRY_DELAYS.length) {
-            // Retry budget exhausted. test_connection() also waits out the
-            // server round-trip — a hanging RomM server keeps the backend's
-            // retrying heartbeat busy for up to ~90s, far past our per-attempt
-            // deadline — so an exhausted budget alone can't tell a dead backend
-            // from an unreachable server. Ping get_settings (a pure in-memory
-            // read that resolves iff the backend RPC bridge is alive) to decide:
-            // alive ⇒ the server is merely unreachable ("Not connected");
-            // dead ⇒ the backend never came up ("Backend error").
-            try {
-              await withTimeout(getSettings(), CONNECTION_CALLABLE_TIMEOUT);
-              if (isCancelled()) return;
-              setConnected(false);
-            } catch (pingErr) {
-              if (isCancelled()) return;
-              setConnected("backend_failed");
-              // logError is itself a callable and would hang against a dead
-              // backend — log to the console instead.
-              console.error("[RomM] backend RPC bridge unreachable (get_settings ping failed):", pingErr);
-            }
-            return;
-          }
-          await new Promise<void>((resolve) => {
-            connectionRetryTimer = setTimeout(resolve, CONNECTION_RETRY_DELAYS[attempt]);
-          });
-        }
-      }
-    };
-    detach(probeConnection(() => cancelled));
 
     getSettings()
       .then((s) => {
@@ -724,8 +647,6 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
     const unsubPlaytimeScope = onPlaytimeScopeChange(() => setPlaytimeScope(getPlaytimeScopeState()));
     const unsubSaveSort = onSaveSortMigrationChange(() => setSaveSortMigration(getSaveSortMigrationState()));
     return () => {
-      cancelled = true;
-      if (connectionRetryTimer) clearTimeout(connectionRetryTimer);
       unsubProgress();
       unsubMigration();
       unsubSettingsReset();

--- a/src/components/settings/ConnectModal.test.tsx
+++ b/src/components/settings/ConnectModal.test.tsx
@@ -581,6 +581,70 @@ describe("ConnectModal", () => {
       expect(getByTestId("signin-error").textContent).toBe("Sign-in failed. Check your connection and try again.");
     });
 
+    // Decky's callable() stays pending forever against a downed backend, so the
+    // never-settling handler here is the real shape of that failure, not a
+    // contrived one.
+    it("shows a backend-never-answered error and re-enables Sign in when the call never settles", async () => {
+      vi.useFakeTimers();
+      try {
+        const closeModal = vi.fn();
+        const onConnectToken = vi.fn().mockReturnValue(new Promise(() => {}));
+        const { getByTestId, getByText } = render(
+          <ConnectModal
+            closeModal={closeModal}
+            onConnect={ok()}
+            onConnectToken={onConnectToken}
+            onConnectPairing={ok()}
+          />,
+        );
+        fireEvent.click(getByTestId("mode-token"));
+        fireEvent.change(getByTestId("field-API Token"), { target: { value: "rmm_pasted" } });
+        fireEvent.click(signInButton(getByText));
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(60_000);
+        });
+        expect(closeModal).not.toHaveBeenCalled();
+        expect(getByTestId("signin-error").textContent).toBe(
+          "The plugin backend never answered. Reload Decky or restart Steam, then try again.",
+        );
+        // Back out of the in-flight state so the deadline is an exit, not a
+        // second dead end.
+        expect(signInButton(getByText)).toBeTruthy();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("still closes on a slow sign-in that answers before the deadline", async () => {
+      vi.useFakeTimers();
+      try {
+        const closeModal = vi.fn();
+        const onConnectToken = vi.fn().mockReturnValue(
+          new Promise((resolve) => {
+            setTimeout(() => resolve({ success: true, message: "Connected!" }), 45_000);
+          }),
+        );
+        const { getByTestId, getByText, queryByTestId } = render(
+          <ConnectModal
+            closeModal={closeModal}
+            onConnect={ok()}
+            onConnectToken={onConnectToken}
+            onConnectPairing={ok()}
+          />,
+        );
+        fireEvent.click(getByTestId("mode-token"));
+        fireEvent.change(getByTestId("field-API Token"), { target: { value: "rmm_pasted" } });
+        fireEvent.click(signInButton(getByText));
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(45_000);
+        });
+        expect(closeModal).toHaveBeenCalled();
+        expect(queryByTestId("signin-error")).toBeNull();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it("clears a stale error when the user edits a field", async () => {
       const onConnectToken = fail("Pairing code is invalid or has expired.");
       const { getByTestId, getByText, queryByTestId } = render(

--- a/src/components/settings/ConnectModal.tsx
+++ b/src/components/settings/ConnectModal.tsx
@@ -10,10 +10,10 @@
  * (an OTP-style input grouped 4 – 4 around a hyphen, auto-advancing as you type)
  * — typability matters more than obscuring a value that expires almost
  * immediately. Sign in is gated until the selected mode's fields are complete,
- * and the sign-in attempt runs to completion inside the modal: on success the
- * parent's matching handler resolved truthy and the modal closes; on failure the
- * modal stays open and shows the returned message so the user can correct and
- * retry. The parent's handlers — `connect_with_credentials` (exchanges the
+ * and the sign-in attempt runs inside the modal until it answers or the deadline
+ * elapses: on success the parent's matching handler resolved truthy and the modal
+ * closes; on failure the modal stays open and shows the returned message so the
+ * user can correct and retry. The parent's handlers — `connect_with_credentials` (exchanges the
  * credentials for a scoped token and discards the password), `connect_with_token`
  * (validates and stores the pasted token), or `connect_with_pairing_code`
  * (exchanges the code for a token) — own token minting/validation, status, and
@@ -23,6 +23,7 @@
 
 import { FC, Fragment, useState, useRef, ChangeEvent, KeyboardEvent } from "react";
 import { TextField, DropdownItem, Focusable } from "@decky/ui";
+import { withTimeout, TimeoutError } from "../../utils/withTimeout";
 import { ValidatingModalShell } from "./ValidatingModalShell";
 
 type SignInMode = "credentials" | "token" | "pairing";
@@ -48,6 +49,23 @@ const CODE_GROUP = 4;
 const CODE_INDICES = Array.from({ length: CODE_LENGTH }, (_unused, i) => i);
 
 const GENERIC_SIGN_IN_ERROR = "Sign-in failed. Check your connection and try again.";
+
+// Decky's callable() never times out on its own, so a plugin backend that is
+// down (or whose RPC bridge died) leaves the sign-in promise pending forever and
+// the modal stuck on "Signing in…" with no way out but Cancel. The deadline is
+// the only thing that turns that into a message.
+//
+// The deadline is set above the backend's own per-request windows rather than at
+// a snappy UI value. A sign-in is a heartbeat (RommHttpClient.with_retry: 3
+// attempts x 30s) + the credential step (30s, never retried) + /api/users/me
+// (3 x 30s), and each of those failures returns a specific message this one
+// cannot match ("Server unreachable", "Sign-in rejected", the version gate). A
+// deadline under the single 30s request window would pre-empt all of them —
+// and, because losing the race abandons the call instead of cancelling it,
+// would report failure for a sign-in that then succeeds and persists its token,
+// with the single-use pairing code already burned.
+const SIGN_IN_TIMEOUT_MS = 60_000;
+const SIGN_IN_TIMEOUT_ERROR = "The plugin backend never answered. Reload Decky or restart Steam, then try again.";
 
 const helperTextStyle = { fontSize: "12px", marginBottom: "12px", color: "rgba(255,255,255,0.6)" } as const;
 const codeLabelStyle = {
@@ -175,29 +193,29 @@ export const ConnectModal: FC<ConnectModalProps> = ({ closeModal, onConnect, onC
   };
   const canSubmit = computeCanSubmit();
 
-  // Run the selected mode's sign-in to completion. Success closes the modal;
-  // failure keeps it open and shows the returned message so the user can retry.
+  const attemptSignIn = (): Promise<SignInResult> => {
+    if (mode === "token") return onConnectToken(token);
+    // Backend normalizes, so the bare eight characters in order are enough.
+    if (mode === "pairing") return onConnectPairing(code.join(""));
+    return onConnect(username, password);
+  };
+
+  // Run the selected mode's sign-in. Success closes the modal; failure — the
+  // backend's own verdict, a rejection, or the deadline — keeps it open and
+  // shows a message so the user can retry.
   const submit = async () => {
     if (!canSubmit || submitting) return;
     setSubmitting(true);
     setError(null);
     try {
-      let result: SignInResult;
-      if (mode === "token") {
-        result = await onConnectToken(token);
-      } else if (mode === "pairing") {
-        // Backend normalizes, so the bare eight characters in order are enough.
-        result = await onConnectPairing(code.join(""));
-      } else {
-        result = await onConnect(username, password);
-      }
+      const result = await withTimeout(attemptSignIn(), SIGN_IN_TIMEOUT_MS);
       if (result.success) {
         closeModal?.();
       } else {
         setError(result.message);
       }
-    } catch {
-      setError(GENERIC_SIGN_IN_ERROR);
+    } catch (e) {
+      setError(e instanceof TimeoutError ? SIGN_IN_TIMEOUT_ERROR : GENERIC_SIGN_IN_ERROR);
     } finally {
       setSubmitting(false);
     }

--- a/src/utils/connectionProbe.test.ts
+++ b/src/utils/connectionProbe.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getSettings, testConnection } from "../api/backend";
+import {
+  ensureConnectionProbe,
+  getConnectionProbeState,
+  onConnectionProbeChange,
+  resetConnectionProbeForTests,
+} from "./connectionProbe";
+
+vi.mock("../api/backend", () => ({
+  testConnection: vi.fn(),
+  getSettings: vi.fn(),
+  debugLog: vi.fn(() => Promise.resolve()),
+}));
+
+// The full ladder: six attempts at a 5s deadline each, with 2+5+10+15+20s of
+// backoff between them, then the liveness ping.
+const FULL_LADDER_MS = 6 * 5000 + 2000 + 5000 + 10000 + 15000 + 20000 + 5000;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  resetConnectionProbeForTests();
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("connectionProbe", () => {
+  it("publishes the verdict of a resolved probe", async () => {
+    vi.mocked(testConnection).mockResolvedValue({ success: true, message: "" });
+    ensureConnectionProbe();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(getConnectionProbeState()).toEqual({ connected: true, failure: null });
+  });
+
+  it("carries a resolved failure's reason and message", async () => {
+    vi.mocked(testConnection).mockResolvedValue({
+      success: false,
+      reason: "config_error",
+      message: "Not signed in — sign in to RomM first",
+    });
+    ensureConnectionProbe();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(getConnectionProbeState()).toEqual({
+      connected: false,
+      failure: { reason: "config_error", message: "Not signed in — sign in to RomM first" },
+    });
+  });
+
+  // The #1730 regression: the probe used to be owned by the QAM panel's effect,
+  // so closing the panel cancelled the run and reopening restarted it at attempt
+  // 0. Nobody holds the QAM open for the ~87s the ladder needs, so the verdict
+  // was unreachable in practice and the row read "Checking…" forever.
+  it("runs to a verdict even when every subscriber unsubscribes mid-run", async () => {
+    vi.mocked(testConnection).mockRejectedValue(new Error("backend down"));
+    vi.mocked(getSettings).mockImplementation(() => new Promise(() => {}));
+    // A dead bridge is reported to the console rather than through logError,
+    // which is itself a callable and would hang.
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const unsubscribe = onConnectionProbeChange(vi.fn());
+    ensureConnectionProbe();
+    // Close the panel a couple of seconds in — long before any verdict.
+    await vi.advanceTimersByTimeAsync(6000);
+    unsubscribe();
+    expect(getConnectionProbeState().connected).toBeNull();
+
+    await vi.advanceTimersByTimeAsync(FULL_LADDER_MS);
+    expect(getConnectionProbeState().connected).toBe("backend_failed");
+    expect(consoleError).toHaveBeenCalledWith(
+      "[RomM] backend RPC bridge unreachable (get_settings ping failed):",
+      expect.anything(),
+    );
+    consoleError.mockRestore();
+  });
+
+  it("hands the stored verdict to a subscriber that arrives after the run ended", async () => {
+    vi.mocked(testConnection).mockResolvedValue({ success: true, message: "" });
+    ensureConnectionProbe();
+    await vi.advanceTimersByTimeAsync(0);
+
+    // A panel mounting now reads the verdict straight out of the store rather
+    // than starting from "Checking…".
+    expect(getConnectionProbeState().connected).toBe(true);
+  });
+
+  it("collapses concurrent asks into the single run in flight", async () => {
+    vi.mocked(testConnection).mockImplementation(() => new Promise(() => {}));
+    ensureConnectionProbe();
+    ensureConnectionProbe();
+    ensureConnectionProbe();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(testConnection).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-probes once a run has ended so a recovered backend updates the verdict", async () => {
+    vi.mocked(testConnection).mockResolvedValue({ success: false, reason: "server_unreachable", message: "down" });
+    ensureConnectionProbe();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(getConnectionProbeState().connected).toBe(false);
+
+    vi.mocked(testConnection).mockResolvedValue({ success: true, message: "" });
+    ensureConnectionProbe();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(testConnection).toHaveBeenCalledTimes(2);
+    expect(getConnectionProbeState()).toEqual({ connected: true, failure: null });
+  });
+
+  it("reports a merely-unreachable server as 'not connected' when the RPC bridge still answers", async () => {
+    vi.mocked(testConnection).mockRejectedValue(new Error("server hung"));
+    vi.mocked(getSettings).mockResolvedValue({} as Awaited<ReturnType<typeof getSettings>>);
+    ensureConnectionProbe();
+    await vi.advanceTimersByTimeAsync(FULL_LADDER_MS);
+    expect(getConnectionProbeState().connected).toBe(false);
+  });
+});

--- a/src/utils/connectionProbe.ts
+++ b/src/utils/connectionProbe.ts
@@ -1,0 +1,145 @@
+/**
+ * The QAM connection row's backend probe, owned at module level so it outlives
+ * the panel that displays it.
+ *
+ * The probe needs up to ~87s to reach a verdict — six `test_connection()`
+ * attempts spread across a backoff ladder, then a liveness ping — because that
+ * window is what lets it ride out a slow cold boot instead of calling a
+ * still-starting backend dead (#1045). Owned by the panel's `useEffect`, that
+ * budget was unreachable in practice: closing the QAM cancelled the run and
+ * reopening restarted it at attempt 0, so anyone who did not hold the panel open
+ * for the full window saw nothing but "Checking…", forever (#1730). Hoisting the
+ * run out of the component decouples the two: the ladder finishes on its own
+ * schedule, and a panel that mounts mid-run adopts the verdict when it lands.
+ *
+ * A mount re-probes rather than trusting what is stored — a backend reloaded
+ * since the last verdict has to be able to recover the row — but it does NOT
+ * clear the stored verdict first. Showing the last answer while the next one is
+ * computed is the whole point; resetting to "Checking…" on every open would
+ * reintroduce the symptom.
+ */
+
+import { useEffect, useState } from "react";
+import type { RommErrorCode } from "../types";
+import { getSettings, testConnection } from "../api/backend";
+import { setVersionError } from "./connectionState";
+import { detach } from "./detach";
+import { withTimeout } from "./withTimeout";
+
+// Each attempt is raced against a deadline because the callable hangs (rather
+// than rejects) while the backend is still starting. The schedule mirrors the
+// metadata init loop's tuned window in index.tsx (#1203).
+const CONNECTION_RETRY_DELAYS = [2000, 5000, 10000, 15000, 20000];
+const CONNECTION_CALLABLE_TIMEOUT = 5000;
+
+/** Backend never answered after the retry budget — distinct from `false` ("not connected"). */
+export type BackendFailed = "backend_failed";
+
+/** A resolved-but-failed `test_connection()` probe. `reason`/`message` classify
+ *  why so the connection row shows a specific label instead of a bare "Not
+ *  connected"; both are absent when the probe never resolved (an unreachable
+ *  server that hung past every deadline), which reads as the generic label. */
+export interface ConnectionFailure {
+  reason: RommErrorCode | undefined;
+  message: string;
+}
+
+export interface ConnectionProbeState {
+  /** `null` until the first verdict lands — the row's "Checking…" state. */
+  connected: boolean | null | BackendFailed;
+  failure: ConnectionFailure | null;
+}
+
+let _state: ConnectionProbeState = { connected: null, failure: null };
+let _running = false;
+const listeners = new Set<(s: ConnectionProbeState) => void>();
+
+function publish(next: ConnectionProbeState): void {
+  _state = next;
+  listeners.forEach((l) => l(next));
+}
+
+export function getConnectionProbeState(): ConnectionProbeState {
+  return _state;
+}
+
+export function onConnectionProbeChange(cb: (s: ConnectionProbeState) => void): () => void {
+  listeners.add(cb);
+  return () => {
+    listeners.delete(cb);
+  };
+}
+
+/** Run the ladder to a verdict. A resolved call ends it — "not connected"
+ *  (success:false) is an authoritative answer, not a failure — so only an
+ *  exhausted budget reaches the liveness ping. */
+async function runProbe(): Promise<void> {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      const r = await withTimeout(testConnection(), CONNECTION_CALLABLE_TIMEOUT);
+      publish({ connected: r.success, failure: r.success ? null : { reason: r.reason, message: r.message } });
+      setVersionError(r.reason === "version_error" ? r.message : null);
+      return;
+    } catch {
+      if (attempt >= CONNECTION_RETRY_DELAYS.length) {
+        // Retry budget exhausted. test_connection() also waits out the server
+        // round-trip — a hanging RomM server keeps the backend's retrying
+        // heartbeat busy for up to ~90s, far past our per-attempt deadline — so
+        // an exhausted budget alone can't tell a dead backend from an
+        // unreachable server. Ping get_settings (a pure in-memory read that
+        // resolves iff the backend RPC bridge is alive) to decide: alive ⇒ the
+        // server is merely unreachable ("Not connected"); dead ⇒ the backend
+        // never came up ("Backend error").
+        try {
+          await withTimeout(getSettings(), CONNECTION_CALLABLE_TIMEOUT);
+          publish({ connected: false, failure: null });
+        } catch (pingErr) {
+          publish({ connected: "backend_failed", failure: null });
+          // logError is itself a callable and would hang against a dead
+          // backend — log to the console instead.
+          console.error("[RomM] backend RPC bridge unreachable (get_settings ping failed):", pingErr);
+        }
+        return;
+      }
+      await new Promise<void>((resolve) => setTimeout(resolve, CONNECTION_RETRY_DELAYS[attempt]));
+    }
+  }
+}
+
+/** Start a probe unless one is already in flight. Re-entrant by design: every
+ *  panel mount asks for a fresh verdict, and the guard collapses the concurrent
+ *  asks into the single run they are all waiting on. */
+export function ensureConnectionProbe(): void {
+  if (_running) return;
+  _running = true;
+  detach(
+    runProbe().finally(() => {
+      _running = false;
+    }),
+  );
+}
+
+/** Subscribe to the probe's verdict and ask for a fresh one. Re-renders the
+ *  caller on every change; cleans up its listener on unmount without disturbing
+ *  a run still in flight.
+ *
+ *  Seeding from the store in the initializer and subscribing in the effect
+ *  covers every verdict without a resync between the two: a publish only ever
+ *  originates from a timer or a settled promise, neither of which can interleave
+ *  with React's synchronous render-to-commit. */
+export function useConnectionProbe(): ConnectionProbeState {
+  const [state, setState] = useState<ConnectionProbeState>(getConnectionProbeState());
+  useEffect(() => {
+    const unsubscribe = onConnectionProbeChange(setState);
+    ensureConnectionProbe();
+    return unsubscribe;
+  }, []);
+  return state;
+}
+
+/** Reset the module state between tests. Not for production use. */
+export function resetConnectionProbeForTests(): void {
+  _state = { connected: null, failure: null };
+  _running = false;
+  listeners.clear();
+}

--- a/src/utils/pruneLease.test.ts
+++ b/src/utils/pruneLease.test.ts
@@ -139,7 +139,7 @@ it("bounds a lost release acknowledgement and logs the failed release", async ()
   await release;
 
   expect(logError).toHaveBeenCalledWith(
-    "Core selection: failed to release prune lease: Error: callable timed out after 5000ms",
+    "Core selection: failed to release prune lease: TimeoutError: callable timed out after 5000ms",
   );
 });
 

--- a/src/utils/withTimeout.test.ts
+++ b/src/utils/withTimeout.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { withTimeout } from "./withTimeout";
+import { withTimeout, TimeoutError } from "./withTimeout";
 
 describe("withTimeout", () => {
   afterEach(() => {
@@ -22,6 +22,18 @@ describe("withTimeout", () => {
     const assertion = expect(withTimeout(pending, 5000)).rejects.toThrow("callable timed out after 5000ms");
     await vi.advanceTimersByTimeAsync(5000);
     await assertion;
+  });
+
+  it("rejects with a TimeoutError on the deadline, and passes a raced rejection through untouched", async () => {
+    vi.useFakeTimers();
+    const pending = new Promise<string>(() => {
+      /* never settles */
+    });
+    const deadline = expect(withTimeout(pending, 5000)).rejects.toBeInstanceOf(TimeoutError);
+    await vi.advanceTimersByTimeAsync(5000);
+    await deadline;
+    // The promise's own failure must stay distinguishable from the deadline's.
+    await expect(withTimeout(Promise.reject(new Error("boom")), 5000)).rejects.not.toBeInstanceOf(TimeoutError);
   });
 
   it("clears the deadline timer once the promise settles — no leaked timer", async () => {

--- a/src/utils/withTimeout.ts
+++ b/src/utils/withTimeout.ts
@@ -1,17 +1,34 @@
 /**
+ * The rejection {@link withTimeout} raises when its deadline wins the race —
+ * distinguishable from the raced promise's own rejection without matching on
+ * message text, for callers that report the two differently.
+ */
+export class TimeoutError extends Error {
+  constructor(ms: number) {
+    super(`callable timed out after ${ms}ms`);
+    this.name = "TimeoutError";
+  }
+}
+
+/**
  * Race a promise against a deadline. Resolves/rejects with `promise` when it
- * settles first; rejects with a timeout error once `ms` elapses. The deadline
- * timer is cleared as soon as the race settles, so a settled call never leaves a
- * pending timer behind.
+ * settles first; rejects with a {@link TimeoutError} once `ms` elapses. The
+ * deadline timer is cleared as soon as the race settles, so a settled call never
+ * leaves a pending timer behind.
  *
  * Decky's `callable()` has no timeout of its own and hangs forever when the
  * backend isn't ready — every callable probe that must stay responsive races
  * through this.
+ *
+ * Losing the race abandons `promise`, it does not cancel it: a backend call that
+ * answers late still runs to completion and still commits whatever it was going
+ * to commit. Only race a call whose late completion is harmless or self-evident
+ * on the next read of the state it wrote.
  */
 export function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
   let timer!: ReturnType<typeof setTimeout>;
   const timeout = new Promise<never>((_, reject) => {
-    timer = setTimeout(() => reject(new Error(`callable timed out after ${ms}ms`)), ms);
+    timer = setTimeout(() => reject(new TimeoutError(ms)), ms);
   });
   return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
 }


### PR DESCRIPTION
Two surfaces spun indefinitely when the plugin's Python backend was not running.
The panel keeps rendering in both cases because its code is already loaded in
Steam, so nothing on screen suggested the backend was gone.

**Sign in to RomM** sat on "Signing in…" with Cancel as the only exit — Decky's
`callable()` has no timeout of its own, so the promise simply never settled. The
attempt now races a 60s deadline and reports "The plugin backend never answered",
distinct from the generic sign-in failure that points at the connection rather
than at the plugin.

The deadline sits above the backend's own per-request windows rather than at a
snappy UI value. A sign-in is a heartbeat (3 attempts × 30s) + the credential
step (30s, never retried) + `/api/users/me` (3 × 30s), and each of those failures
already returns a message this one cannot match. A deadline under the single 30s
request window would pre-empt all of them — and, because losing the race abandons
the call instead of cancelling it, would report failure for a sign-in that then
succeeds and persists its token, with the single-use pairing code already burned.

The **QAM connection row** read "Checking…" indefinitely. Its probe already had a
deadline and a retry ladder, but it was owned by the panel's effect: closing the
QAM cancelled the run, and reopening restarted it at attempt 0. The ladder needs
~87s to reach a verdict — that window is what lets it ride out a slow cold boot
instead of calling a still-starting backend dead — so anyone who did not hold the
panel open for the full window never saw an answer.

The probe now lives in a module-level store that outlives the panel: the ladder
finishes on its own schedule, a panel mounting mid-run adopts the verdict when it
lands, and a mount re-probes without clearing the stored answer first, so
reopening shows the last verdict instead of resetting to "Checking…".

`withTimeout` now rejects with a named `TimeoutError` so callers can tell the
deadline from the raced call's own rejection without matching on message text.

Fixes #1730

