### PR TITLE
chore(ci): point the Sonar project key at the renamed repository

### DIFF
--- a/.sonarlint.json
+++ b/.sonarlint.json
@@ -1,4 +1,4 @@
 {
   "connectionId": "sonarcloud",
-  "projectKey": "danielcopper_decky-romm-sync"
+  "projectKey": "danielcopper_romm-tender"
 }

--- a/README.md
+++ b/README.md
@@ -130,11 +130,11 @@ Build from source, run the tests, and read the architecture reference on the doc
 - [Backend architecture](https://danielcopper.github.io/romm-tender/architecture/backend-architecture/)
 
 [![CI](https://github.com/danielcopper/romm-tender/actions/workflows/ci.yml/badge.svg)](https://github.com/danielcopper/romm-tender/actions/workflows/ci.yml)
-[![Quality Gate](https://sonarcloud.io/api/project_badges/measure?project=danielcopper_decky-romm-sync&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=danielcopper_decky-romm-sync)
-[![Coverage](https://img.shields.io/sonar/coverage/danielcopper_decky-romm-sync?server=https%3A%2F%2Fsonarcloud.io)](https://sonarcloud.io/summary/new_code?id=danielcopper_decky-romm-sync)
-[![Maintainability](https://sonarcloud.io/api/project_badges/measure?project=danielcopper_decky-romm-sync&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=danielcopper_decky-romm-sync)
-[![Reliability](https://sonarcloud.io/api/project_badges/measure?project=danielcopper_decky-romm-sync&metric=reliability_rating)](https://sonarcloud.io/summary/new_code?id=danielcopper_decky-romm-sync)
-[![Security](https://sonarcloud.io/api/project_badges/measure?project=danielcopper_decky-romm-sync&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=danielcopper_decky-romm-sync)
+[![Quality Gate](https://sonarcloud.io/api/project_badges/measure?project=danielcopper_romm-tender&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=danielcopper_romm-tender)
+[![Coverage](https://img.shields.io/sonar/coverage/danielcopper_romm-tender?server=https%3A%2F%2Fsonarcloud.io)](https://sonarcloud.io/summary/new_code?id=danielcopper_romm-tender)
+[![Maintainability](https://sonarcloud.io/api/project_badges/measure?project=danielcopper_romm-tender&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=danielcopper_romm-tender)
+[![Reliability](https://sonarcloud.io/api/project_badges/measure?project=danielcopper_romm-tender&metric=reliability_rating)](https://sonarcloud.io/summary/new_code?id=danielcopper_romm-tender)
+[![Security](https://sonarcloud.io/api/project_badges/measure?project=danielcopper_romm-tender&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=danielcopper_romm-tender)
 
 ## Acknowledgments
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,4 +1,4 @@
-sonar.projectKey=danielcopper_decky-romm-sync
+sonar.projectKey=danielcopper_romm-tender
 sonar.organization=danielcopper
 
 # Quality Gate


### PR DESCRIPTION
The SonarCloud project was re-keyed to `danielcopper_romm-tender` after the repository rename. A scan carrying the old
key no longer finds a project, which fails the `sonarcloud` job and with it the required `sonar-gate` check, so the
scanner configuration and the five badge URLs follow the key.

The key update preserves the analysis history — measures, the new-code period and the quality gate carry over, so this
is a rename rather than a fresh project.

Branches created before this lands still carry the old key and will fail their Sonar job until they are rebased onto
main.

docs: N/A — scanner configuration and badge URLs, no user-visible behavior.