### PR TITLE
refactor(ui): give the game-detail panel's render blocks their own modules

### DIFF
--- a/src/components/GameInfoTab.tsx
+++ b/src/components/GameInfoTab.tsx
@@ -1,0 +1,166 @@
+/**
+ * GameInfoTab — the GAME INFO pane of the RomM game detail panel: the
+ * descriptive rows about the game, and the ROM File section underneath.
+ *
+ * Render only, from props — nothing here fetches. The panel streams state in as
+ * its background reads land, so this pane is routinely open before the cover,
+ * the installed-rom record and a stale metadata refresh arrive.
+ *
+ * Uses createElement (no JSX) to match the panel. CSS classes prefixed with
+ * `romm-panel-` are injected separately by styleInjector.
+ */
+
+import { FC, createElement } from "react";
+import type { InstalledRom, RomMetadata } from "../types";
+import { infoRow, section } from "./panelSection";
+
+interface GameInfoTabProps {
+  /** The RomM game name (distinct from the Steam shortcut hero title, which can differ). */
+  romName: string;
+  /** Region / Languages of the active version (ADR-0021) — an empty list hides its row. */
+  regions: string[];
+  languages: string[];
+  metadata: RomMetadata | null;
+  platformName: string;
+  coverBase64: string | null;
+  installed: boolean;
+  installedRom: InstalledRom | null;
+}
+
+/** Format a Unix timestamp (seconds) as a release date string (e.g. "15 Mar 2003") */
+function formatReleaseDate(timestamp: number | null): string | null {
+  if (!timestamp || timestamp <= 0) return null;
+  const date = new Date(timestamp * 1000);
+  const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+  return `${date.getDate()} ${months[date.getMonth()]} ${date.getFullYear()}`;
+}
+
+/** The rows a RomM metadata record contributes, in display order. */
+function metadataRows(meta: RomMetadata, platformName: string): ReturnType<typeof createElement>[] {
+  const rows: ReturnType<typeof createElement>[] = [];
+
+  if (meta.summary) {
+    rows.push(createElement("div", { key: "summary", className: "romm-panel-summary" }, meta.summary));
+  }
+
+  if (platformName) {
+    rows.push(infoRow("platform", "Platform", platformName));
+  }
+
+  if (meta.companies.length > 0) {
+    rows.push(infoRow("companies", "Developer / Publisher", meta.companies.join(", ")));
+  }
+
+  if (meta.genres.length > 0) {
+    rows.push(
+      createElement(
+        "div",
+        { key: "genres", className: "romm-panel-info-row" },
+        createElement("span", { className: "romm-panel-label" }, "Genres"),
+        createElement(
+          "div",
+          { className: "romm-panel-tags" },
+          ...meta.genres.map((g) => createElement("span", { key: g, className: "romm-panel-tag" }, g)),
+        ),
+      ),
+    );
+  }
+
+  const releaseDate = formatReleaseDate(meta.first_release_date);
+  if (releaseDate) {
+    rows.push(infoRow("release-date", "Release Date", releaseDate));
+  }
+
+  if (meta.game_modes.length > 0) {
+    rows.push(infoRow("game-modes", "Game Modes", meta.game_modes.join(", ")));
+  }
+
+  if (meta.player_count) {
+    rows.push(infoRow("players", "Players", meta.player_count));
+  }
+
+  if (meta.average_rating != null && meta.average_rating > 0) {
+    rows.push(infoRow("rating", "Rating", `${Math.round(meta.average_rating)}%`));
+  }
+
+  return rows;
+}
+
+/** Every descriptive row the pane shows, in display order. */
+function gameInfoRows(props: GameInfoTabProps): ReturnType<typeof createElement>[] {
+  const rows: ReturnType<typeof createElement>[] = [];
+
+  if (props.romName) {
+    rows.push(createElement("div", { key: "rom-name", className: "romm-panel-rom-name" }, props.romName));
+  }
+
+  if (props.regions.length > 0) {
+    rows.push(infoRow("regions", "Region", props.regions.join("/")));
+  }
+  if (props.languages.length > 0) {
+    rows.push(infoRow("languages", "Languages", props.languages.join(", ")));
+  }
+
+  if (props.metadata) {
+    rows.push(...metadataRows(props.metadata, props.platformName));
+  } else if (props.platformName) {
+    // No metadata — still show platform
+    rows.push(infoRow("platform", "Platform", props.platformName));
+  }
+
+  // "No metadata available" fires only when NO descriptive row was added (name,
+  // region/languages, metadata, or platform) — a plain count of the rows above.
+  if (rows.length === 0) {
+    rows.push(createElement("div", { key: "no-meta", className: "romm-panel-muted" }, "No metadata available"));
+  }
+
+  return rows;
+}
+
+/** The ROM File section — present only once the ROM is on disk. */
+function romFileSection(
+  installed: boolean,
+  installedRom: InstalledRom | null,
+): ReturnType<typeof createElement> | null {
+  if (!installed || !installedRom) return null;
+
+  // A downloaded ROM the system cannot launch keeps its files and its row; only
+  // the shortcut's launch command is withheld. This is the one place that says
+  // so — without it the game simply never starts and nothing explains why.
+  const noLaunchTargetNote = installedRom.launchable
+    ? null
+    : createElement(
+        "div",
+        { key: "no-launch-target", className: "romm-panel-muted", style: { marginTop: "4px" } },
+        `Downloaded, but nothing here is a format ${installedRom.system} can launch — no launch ` +
+          `command was set. The files are on disk; install them in the emulator to play.`,
+      );
+
+  return section("rom-file", "ROM File", infoRow("filename", "Filename", installedRom.file_name), noLaunchTargetNote);
+}
+
+export const GameInfoTab: FC<GameInfoTabProps> = (props) => {
+  const rows = gameInfoRows(props);
+
+  const gameInfoSection = props.coverBase64
+    ? section(
+        "game-info",
+        null,
+        createElement(
+          "div",
+          {
+            key: "game-info-row",
+            style: { display: "flex", gap: "16px", alignItems: "flex-start" },
+          },
+          createElement("img", {
+            key: "cover",
+            src: `data:image/png;base64,${props.coverBase64}`,
+            style: { width: "120px", borderRadius: "4px", flexShrink: 0, objectFit: "cover" as const },
+          }),
+          createElement("div", { key: "details", style: { flex: 1 } }, ...rows),
+        ),
+      )
+    : section("game-info", null, ...rows);
+
+  return createElement("div", null, gameInfoSection, romFileSection(props.installed, props.installedRom));
+};

--- a/src/components/PanelTabBar.test.tsx
+++ b/src/components/PanelTabBar.test.tsx
@@ -1,0 +1,42 @@
+// Which tabs exist for a given ROM is decided by the panel and asserted there
+// (RomMGameInfoPanel.test.tsx). What this file exists for are the two contracts
+// that end at this component's own edge: which button carries the active
+// marking, and that a press reports the tab id rather than acting on it — the
+// panel can only observe the pane that follows, which a wrong id would still
+// produce for the wrong tab.
+
+import { describe, it, expect, vi } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import { PanelTabBar } from "./PanelTabBar";
+
+describe("PanelTabBar", () => {
+  it("reports the pressed tab's id", () => {
+    const onSelect = vi.fn();
+    const { getByText } = render(<PanelTabBar activeTab="info" hasAchievements hasSaves hasBios onSelect={onSelect} />);
+    fireEvent.click(getByText("SAVES"));
+    expect(onSelect).toHaveBeenCalledWith("saves");
+  });
+
+  it("marks the active tab and only the active tab", () => {
+    const { getByText } = render(<PanelTabBar activeTab="bios" hasAchievements hasSaves hasBios onSelect={vi.fn()} />);
+    expect(getByText("BIOS").className).toContain("romm-tab-active");
+    expect(getByText("GAME INFO").className).not.toContain("romm-tab-active");
+  });
+
+  it("renders the tabs in their fixed order", () => {
+    const { getAllByRole } = render(
+      <PanelTabBar activeTab="info" hasAchievements hasSaves hasBios onSelect={vi.fn()} />,
+    );
+    expect(getAllByRole("button").map((b) => b.textContent)).toEqual(["GAME INFO", "ACHIEVEMENTS", "SAVES", "BIOS"]);
+  });
+
+  it("drops the tabs whose pane has nothing to show", () => {
+    const { getByText, queryByText } = render(
+      <PanelTabBar activeTab="info" hasAchievements={false} hasSaves={false} hasBios={false} onSelect={vi.fn()} />,
+    );
+    expect(getByText("GAME INFO")).not.toBeNull();
+    expect(queryByText("ACHIEVEMENTS")).toBeNull();
+    expect(queryByText("SAVES")).toBeNull();
+    expect(queryByText("BIOS")).toBeNull();
+  });
+});

--- a/src/components/PanelTabBar.tsx
+++ b/src/components/PanelTabBar.tsx
@@ -1,0 +1,61 @@
+/**
+ * PanelTabBar — the tab strip at the top of the RomM game detail panel.
+ *
+ * A tab exists only when its pane has something to show, which is why the panel
+ * passes the three optional panes' presence rather than the state they are
+ * derived from.
+ *
+ * Uses createElement (no JSX) to match the panel. CSS classes prefixed with
+ * `romm-tab` are injected separately by styleInjector.
+ */
+
+import { FC, createElement } from "react";
+import { DialogButton, Focusable } from "@decky/ui";
+
+interface PanelTabBarProps {
+  activeTab: string;
+  hasAchievements: boolean;
+  hasSaves: boolean;
+  hasBios: boolean;
+  onSelect: (tabId: string) => void;
+}
+
+export const PanelTabBar: FC<PanelTabBarProps> = ({ activeTab, hasAchievements, hasSaves, hasBios, onSelect }) => {
+  const tabs: { id: string; label: string; visible: boolean }[] = [
+    { id: "info", label: "GAME INFO", visible: true },
+    { id: "achievements", label: "ACHIEVEMENTS", visible: hasAchievements },
+    { id: "saves", label: "SAVES", visible: hasSaves },
+    { id: "bios", label: "BIOS", visible: hasBios },
+  ];
+
+  return createElement(
+    Focusable,
+    {
+      className: "romm-tab-bar",
+      "flow-children": "right",
+      "data-romm": "true",
+    },
+    ...tabs
+      .filter((t) => t.visible)
+      .map((t) =>
+        createElement(
+          DialogButton,
+          {
+            key: `tab-${t.id}`,
+            className: `romm-tab ${activeTab === t.id ? "romm-tab-active" : ""}`,
+            onClick: () => onSelect(t.id),
+            style: {
+              background: "transparent",
+              border: "none",
+              borderBottom: activeTab === t.id ? "2px solid #1a9fff" : "2px solid transparent",
+              padding: "10px 16px",
+              minWidth: "auto",
+              width: "auto",
+            },
+            noFocusRing: false,
+          },
+          t.label,
+        ),
+      ),
+  );
+};

--- a/src/components/RomMGameInfoPanel.tsx
+++ b/src/components/RomMGameInfoPanel.tsx
@@ -1,28 +1,32 @@
 /**
- * RomMGameInfoPanel — metadata and actions panel injected below the PlaySection
- * on RomM game detail pages.
+ * RomMGameInfoPanel — the RomM panel injected below the PlaySection on game
+ * detail pages.
  *
- * Layout:
- *   Game Info:    Platform, Description, Developer/Publisher, Genre tags, Release date
- *   ROM File:     Filename (only when installed)
- *   BIOS:         Status (only when platform needs BIOS)
- *   Save Sync:    Status (only when save sync enabled)
- *   Purely informational — all actions live in RomMPlaySection gear menu.
+ * The shell around the GAME INFO / ACHIEVEMENTS / SAVES / BIOS panes: it owns
+ * the panel's ROM identity, its event lane, the tab selection, and the
+ * whole-panel replacements (version mismatch, corrupt-settings reset, pending
+ * RetroDECK migration) that pre-empt all of them.
+ *
+ * The panel body itself takes no ROM-level actions — download, play, uninstall,
+ * version and core selection live in the RomMPlaySection gear menu. The panes
+ * below it are not all passive: the SAVES pane switches slots and rolls back
+ * versions.
  *
  * Uses createElement throughout (no JSX) to match the RomMPlaySection pattern.
  * CSS classes prefixed with `romm-panel-` are injected separately by styleInjector.
  */
 
 import { useState, useEffect, useRef, FC, createElement } from "react";
-import { DialogButton, Focusable } from "@decky/ui";
-import { getSaveSlots, debugLog, refreshMigrationState, logError } from "../api/backend";
-import { SlotSetupWizard } from "./SlotSetupWizard";
-import { SavesTab } from "./SavesTab";
+import { Focusable } from "@decky/ui";
+import { refreshMigrationState, logError } from "../api/backend";
 import { AchievementsTab } from "./AchievementsTab";
 import { BiosTab } from "./BiosTab";
-import { infoRow, section } from "./panelSection";
+import { PanelTabBar } from "./PanelTabBar";
+import { SaveSortWarning } from "./SaveSortWarning";
 import { loadData, type PanelState } from "./panelState";
 import { wirePanelEvents } from "./panelEvents";
+import { useSaveSlotsLoad } from "./panelSlotsLoad";
+import { buildTabContent } from "./panelTabContent";
 import { getMigrationState, onMigrationChange, setMigrationStatus } from "../utils/migrationStore";
 import { getSettingsResetState, onSettingsResetChange } from "../utils/settingsResetStore";
 import {
@@ -30,14 +34,6 @@ import {
   onSaveSortMigrationChange,
   setSaveSortMigrationStatus,
 } from "../utils/saveSortMigrationStore";
-import {
-  beginServerLoad,
-  reportServerReachable,
-  setServerRetryProgress,
-  settleServerLoad,
-  useRommConnectionState,
-} from "../utils/connectionState";
-import { applyLoadSlotsResult } from "../utils/slotState";
 import { VersionErrorCard, useVersionError } from "./VersionErrorCard";
 import { MigrationBlockedCard } from "./MigrationBlockedCard";
 import { SettingsResetCard } from "./SettingsResetCard";
@@ -47,30 +43,15 @@ interface RomMGameInfoPanelProps {
   appId: number;
 }
 
-/** Format a Unix timestamp (seconds) as a release date string (e.g. "15 Mar 2003") */
-function formatReleaseDate(timestamp: number | null): string | null {
-  if (!timestamp || timestamp <= 0) return null;
-  const date = new Date(timestamp * 1000);
-  const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
-  return `${date.getDate()} ${months[date.getMonth()]} ${date.getFullYear()}`;
-}
-
-// S3776 is raised on the declaration line, so its NOSONAR must stay there. prettier-ignore stops
-// Prettier from relocating the trailing comment into the body (which would break the suppression).
-// prettier-ignore
-export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => { // NOSONAR(typescript:S3776) — React FC fan-out; decomposed in #387/#391/Phase 7. Further split scatters handlers.
+export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => {
   // Subscribe to version error — re-renders when global state changes
   const versionError = useVersionError();
-  // Subscribe to the shared connection state so the saves-tab slot load can take
-  // the known-offline fast path and re-load automatically on reconnect (#1345).
-  const isOffline = useRommConnectionState() === "offline";
 
   const [state, setState] = useState<PanelState>({
     loading: true,
     romId: null,
     romName: "",
     platformName: "",
-    platformSlug: "",
     installed: false,
     installedRom: null,
     metadata: null,
@@ -96,9 +77,8 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => { //
   // handler can reject events for other platforms without a stale closure
   // (mirrors romIdRef). bios events fan out to every mounted panel (#1082).
   const platformSlugRef = useRef<string>("");
-  // Load-once gate for the lazy-loaded SAVES tab data. A version switch resets it
-  // (`handleVersionSwitched` in panelEvents.ts) so the slots re-fetch for the
-  // newly-bound rom_id instead of lingering from the previous version.
+  // Load-once gate for the lazy SAVES tab data; the rule it enforces is stated
+  // at `panelSlotsLoad.ts`. It lives here because a version switch resets it.
   const slotsLoadedRef = useRef(false);
   const [migration, setMigration] = useState(getMigrationState());
   const [settingsReset, setSettingsReset] = useState(getSettingsResetState());
@@ -144,76 +124,7 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => { //
     };
   }, [appId]);
 
-  useEffect(() => {
-    if (state.activeTab !== "saves" || !state.saveSyncEnabled || !state.romId) return;
-    if (slotsLoadedRef.current) return;
-
-    // Known-offline fast path (#1345): the server slot fetch runs through the
-    // retry+backoff ladder, so on a known-unreachable server it would hang
-    // "Loading slots…" for tens of seconds before the local degraded view (the
-    // per-slot "Server unreachable" notices) renders. Skip the fetch entirely —
-    // slotsLoading is still false here (the slotsLoadedRef guard above means the
-    // connected path never set it), so SavesTab renders the degraded view now.
-    // slotsLoadedRef stays false, so a flip back to connected re-runs this effect
-    // (isOffline dep) and loads.
-    if (isOffline) return;
-    slotsLoadedRef.current = true;
-
-    const load = beginServerLoad();
-    let cancelled = false;
-    let settled = false;
-
-    async function loadSlots() {
-      // Drop stale retry progress from a prior load so the SavesTab's
-      // ConnectingIndicator starts at plain "Connecting to RomM…" (#1345).
-      setServerRetryProgress(null);
-      setState((prev) => ({ ...prev, slotsLoading: true }));
-      try {
-        if (!state.romId) return;
-        const result = await getSaveSlots(state.romId);
-        if (cancelled) return;
-        settled = true;
-        // A completed slot fetch is a reachability signal (#1345): a success
-        // proves the server is reachable; an unreachable server drives the store
-        // offline (which then renders the fast path above on the next dependent
-        // run). Any OTHER failure reason is a server-side "no" (the server
-        // answered), not a connectivity verdict — leave the store untouched.
-        if (result.success) {
-          reportServerReachable(true);
-        } else if (result.reason === "server_unreachable") {
-          reportServerReachable(false);
-        }
-        applyLoadSlotsResult<PanelState>(result, setState, slotsLoadedRef, (msg) => {
-          detach(debugLog(msg));
-        });
-      } catch (e) {
-        detach(debugLog(`Failed to load save slots: ${e}`));
-        if (!cancelled) {
-          settled = true;
-          slotsLoadedRef.current = false;
-          setState((prev) => ({ ...prev, slotsLoading: false }));
-        }
-      } finally {
-        // Clear-on-settle in addition to clear-on-start (#1345 F2) — refused
-        // when a newer load of any lane already owns the shared frame.
-        settleServerLoad(load);
-      }
-    }
-
-    detach(loadSlots());
-    return () => {
-      cancelled = true;
-      // Torn down mid-flight (e.g. a concurrent call flipped the store offline,
-      // re-running this effect) — release the load-once gate and drop the spinner
-      // so the re-run isn't wedged behind a stuck slotsLoading/slotsLoadedRef, and
-      // a later reconnect reliably reloads (#1345 F2). A settled load already set
-      // its own final state, so leave it alone.
-      if (!settled) {
-        slotsLoadedRef.current = false;
-        setState((prev) => (prev.slotsLoading ? { ...prev, slotsLoading: false } : prev));
-      }
-    };
-  }, [state.activeTab, state.saveSyncEnabled, state.romId, isOffline]);
+  useSaveSlotsLoad(state, slotsLoadedRef, setState);
 
   // --- Version mismatch — replace entire panel with polished error card ---
   if (versionError) {
@@ -255,247 +166,18 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => { //
   }
 
   const romId = state.romId;
-  const meta = state.metadata;
-
-  // --- Game Info section ---
-  const gameInfoChildren: ReturnType<typeof createElement>[] = [];
-
-  // The RomM game name (distinct from the Steam shortcut hero title, which can differ).
-  if (state.romName) {
-    gameInfoChildren.push(createElement("div", { key: "rom-name", className: "romm-panel-rom-name" }, state.romName));
-  }
-
-  // Region / Languages of the active version (ADR-0021) — omitted when empty.
-  if (state.regions.length > 0) {
-    gameInfoChildren.push(infoRow("regions", "Region", state.regions.join("/")));
-  }
-  if (state.languages.length > 0) {
-    gameInfoChildren.push(infoRow("languages", "Languages", state.languages.join(", ")));
-  }
-
-  if (meta) {
-    if (meta.summary) {
-      gameInfoChildren.push(createElement("div", { key: "summary", className: "romm-panel-summary" }, meta.summary));
-    }
-
-    // Platform after description
-    if (state.platformName) {
-      gameInfoChildren.push(infoRow("platform", "Platform", state.platformName));
-    }
-
-    if (meta.companies.length > 0) {
-      gameInfoChildren.push(infoRow("companies", "Developer / Publisher", meta.companies.join(", ")));
-    }
-
-    if (meta.genres.length > 0) {
-      gameInfoChildren.push(
-        createElement(
-          "div",
-          { key: "genres", className: "romm-panel-info-row" },
-          createElement("span", { className: "romm-panel-label" }, "Genres"),
-          createElement(
-            "div",
-            { className: "romm-panel-tags" },
-            ...meta.genres.map((g) => createElement("span", { key: g, className: "romm-panel-tag" }, g)),
-          ),
-        ),
-      );
-    }
-
-    const releaseDate = formatReleaseDate(meta.first_release_date);
-    if (releaseDate) {
-      gameInfoChildren.push(infoRow("release-date", "Release Date", releaseDate));
-    }
-
-    if (meta.game_modes.length > 0) {
-      gameInfoChildren.push(infoRow("game-modes", "Game Modes", meta.game_modes.join(", ")));
-    }
-
-    if (meta.player_count) {
-      gameInfoChildren.push(infoRow("players", "Players", meta.player_count));
-    }
-
-    if (meta.average_rating != null && meta.average_rating > 0) {
-      gameInfoChildren.push(infoRow("rating", "Rating", `${Math.round(meta.average_rating)}%`));
-    }
-  } else if (state.platformName) {
-    // No metadata — still show platform
-    gameInfoChildren.push(infoRow("platform", "Platform", state.platformName));
-  }
-
-  // "No metadata available" fires only when NO descriptive row was added (name,
-  // region/languages, metadata, or platform). The version switcher no longer lives
-  // here — it moved to the play-button section (#1297) — so this is a plain count
-  // of the descriptive rows.
-  if (gameInfoChildren.length === 0) {
-    gameInfoChildren.push(createElement("div", { key: "no-meta", className: "romm-panel-muted" }, "No metadata available"));
-  }
-  const gameInfoContent = gameInfoChildren;
-
-  const gameInfoSection = state.coverBase64
-    ? section(
-        "game-info",
-        null,
-        createElement(
-          "div",
-          {
-            key: "game-info-row",
-            style: { display: "flex", gap: "16px", alignItems: "flex-start" },
-          },
-          createElement("img", {
-            key: "cover",
-            src: `data:image/png;base64,${state.coverBase64}`,
-            style: { width: "120px", borderRadius: "4px", flexShrink: 0, objectFit: "cover" as const },
-          }),
-          createElement("div", { key: "details", style: { flex: 1 } }, ...gameInfoContent),
-        ),
-      )
-    : section("game-info", null, ...gameInfoContent);
-
-  // --- ROM File section (only when installed) ---
-  // A downloaded ROM the system cannot launch keeps its files and its row; only
-  // the shortcut's launch command is withheld. This is the one place that says
-  // so — without it the game simply never starts and nothing explains why.
-  const noLaunchTargetNote =
-    state.installedRom && !state.installedRom.launchable
-      ? createElement(
-          "div",
-          { key: "no-launch-target", className: "romm-panel-muted", style: { marginTop: "4px" } },
-          `Downloaded, but nothing here is a format ${state.installedRom.system} can launch — no launch ` +
-            `command was set. The files are on disk; install them in the emulator to play.`,
-        )
-      : null;
-
-  const romFileSection =
-    state.installed && state.installedRom
-      ? section(
-          "rom-file",
-          "ROM File",
-          infoRow("filename", "Filename", state.installedRom.file_name),
-          noLaunchTargetNote,
-        )
-      : null;
-
-  // --- Tab bar ---
-  const tabs: { id: string; label: string; visible: boolean }[] = [
-    { id: "info", label: "GAME INFO", visible: true },
-    { id: "achievements", label: "ACHIEVEMENTS", visible: !!state.raId },
-    { id: "saves", label: "SAVES", visible: state.saveSyncEnabled },
-    { id: "bios", label: "BIOS", visible: !!state.biosStatus },
-  ];
-
-  const tabBar = createElement(
-    Focusable,
-    {
-      className: "romm-tab-bar",
-      "flow-children": "right",
-      "data-romm": "true",
-    },
-    ...tabs
-      .filter((t) => t.visible)
-      .map((t) =>
-        createElement(
-          DialogButton,
-          {
-            key: `tab-${t.id}`,
-            className: `romm-tab ${state.activeTab === t.id ? "romm-tab-active" : ""}`,
-            onClick: () => setState((prev) => ({ ...prev, activeTab: t.id })),
-            style: {
-              background: "transparent",
-              border: "none",
-              borderBottom: state.activeTab === t.id ? "2px solid #1a9fff" : "2px solid transparent",
-              padding: "10px 16px",
-              minWidth: "auto",
-              width: "auto",
-            },
-            noFocusRing: false,
-          },
-          t.label,
-        ),
-      ),
-  );
-
-  const saveSortWarning = saveSortPending
-    ? createElement(
-        "div",
-        {
-          key: "save-sort-warning",
-          style: {
-            padding: "8px 12px",
-            marginBottom: "12px",
-            backgroundColor: "rgba(212, 167, 44, 0.15)",
-            borderLeft: "3px solid #d4a72c",
-            borderRadius: "4px",
-          },
-        },
-        createElement(
-          "div",
-          {
-            style: { fontSize: "13px", fontWeight: "bold", color: "#d4a72c", marginBottom: "4px" },
-          },
-          "\u26A0\uFE0F RetroArch save sorting changed",
-        ),
-        createElement(
-          "div",
-          {
-            style: { fontSize: "12px", color: "rgba(255, 255, 255, 0.7)" },
-          },
-          "Save file paths may be incorrect. Go to Settings to migrate.",
-        ),
-      )
-    : null;
-
-  // --- Determine active tab content ---
-  // The ACHIEVEMENTS and BIOS panes are not built here: they are mounted below
-  // for every ROM and decide themselves whether to render.
-  let activeTabContent: ReturnType<typeof createElement> | null = null;
-  if (state.activeTab === "info") {
-    activeTabContent = createElement("div", { key: "tab-info" }, gameInfoSection, romFileSection);
-  } else if (state.activeTab === "saves") {
-    if (state.saveSyncEnabled && !state.slotConfirmed) {
-      activeTabContent = createElement(SlotSetupWizard, {
-        romId: state.romId,
-        onComplete: () => {
-          // Refresh: mark as configured and reload save status
-          setState((prev) => ({ ...prev, slotConfirmed: true }));
-          globalThis.dispatchEvent(
-            new CustomEvent("romm_data_changed", {
-              detail: { type: "save_sync", rom_id: state.romId },
-            }),
-          );
-        },
-      });
-    } else {
-      activeTabContent = createElement(SavesTab, {
-        appId,
-        romId,
-        saveStatus: state.saveStatus,
-        conflicts: state.conflicts,
-        activeSlot: state.activeSlot,
-        availableSlots: state.availableSlots,
-        slotsLoading: state.slotsLoading,
-        onSlotSwitched: (newSlot, newStatus) => {
-          setState((prev) => ({
-            ...prev,
-            activeSlot: newSlot === "" ? null : newSlot,
-            saveStatus: newStatus,
-            conflicts: newStatus.conflicts ?? [],
-          }));
-          globalThis.dispatchEvent(
-            new CustomEvent("romm_data_changed", {
-              detail: { type: "save_sync", rom_id: state.romId },
-            }),
-          );
-        },
-      });
-    }
-  }
 
   return createElement(
     "div",
     { "data-romm": "true" },
-    saveSortWarning,
-    tabBar,
+    saveSortPending ? createElement(SaveSortWarning, { key: "save-sort-warning" }) : null,
+    createElement(PanelTabBar, {
+      activeTab: state.activeTab,
+      hasAchievements: !!state.raId,
+      hasSaves: state.saveSyncEnabled,
+      hasBios: !!state.biosStatus,
+      onSelect: (tabId) => setState((prev) => ({ ...prev, activeTab: tabId })),
+    }),
     createElement(
       Focusable,
       {
@@ -503,7 +185,7 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => { //
         className: "romm-tab-content",
         style: { paddingBottom: "48px" },
       },
-      activeTabContent,
+      buildTabContent({ appId, romId, state, setState }),
       // Mounted for every ROM and rendering nothing until their tab is active.
       // For achievements that is load-bearing: the list is fetched by the tab
       // itself, and unmounting it on a tab switch would re-fetch (and re-spinner)

--- a/src/components/SaveSortWarning.tsx
+++ b/src/components/SaveSortWarning.tsx
@@ -1,0 +1,37 @@
+/**
+ * SaveSortWarning — the banner the game detail panel shows while a RetroArch
+ * save-sorting migration is still pending, i.e. while save file paths written
+ * under the old sorting may no longer be where the emulator looks.
+ *
+ * Uses createElement (no JSX) to match the panel.
+ */
+
+import { FC, createElement } from "react";
+
+export const SaveSortWarning: FC = () =>
+  createElement(
+    "div",
+    {
+      style: {
+        padding: "8px 12px",
+        marginBottom: "12px",
+        backgroundColor: "rgba(212, 167, 44, 0.15)",
+        borderLeft: "3px solid #d4a72c",
+        borderRadius: "4px",
+      },
+    },
+    createElement(
+      "div",
+      {
+        style: { fontSize: "13px", fontWeight: "bold", color: "#d4a72c", marginBottom: "4px" },
+      },
+      "\u26A0\uFE0F RetroArch save sorting changed",
+    ),
+    createElement(
+      "div",
+      {
+        style: { fontSize: "12px", color: "rgba(255, 255, 255, 0.7)" },
+      },
+      "Save file paths may be incorrect. Go to Settings to migrate.",
+    ),
+  );

--- a/src/components/panelSlotsLoad.ts
+++ b/src/components/panelSlotsLoad.ts
@@ -1,0 +1,130 @@
+/**
+ * The game-detail panel's lazy SAVES slot load.
+ *
+ * The slot list is fetched on the first activation of the SAVES tab and not
+ * again for the same ROM once it succeeds — `slotsLoadedRef` is that gate. A
+ * fetch that fails, or is torn down mid-flight, reopens it so a reconnect or a
+ * later activation retries. The gate is owned by the panel because a version
+ * switch resets it (`handleVersionSwitched` in `panelEvents.ts`) so the slots
+ * re-fetch for the newly-bound rom_id.
+ */
+
+import { useEffect } from "react";
+import type { Dispatch, MutableRefObject, SetStateAction } from "react";
+import { getSaveSlots, debugLog } from "../api/backend";
+import {
+  beginServerLoad,
+  reportServerReachable,
+  setServerRetryProgress,
+  settleServerLoad,
+  useRommConnectionState,
+} from "../utils/connectionState";
+import { applyLoadSlotsResult } from "../utils/slotState";
+import { detach } from "../utils/detach";
+import type { PanelState } from "./panelState";
+
+/** One run of the slot fetch. The effect's cleanup can tear a run down while it
+ *  is still in flight, so the two ends share this record rather than a closure
+ *  over each other's locals. */
+interface SlotLoadRun {
+  cancelled: boolean;
+  settled: boolean;
+}
+
+/** Fetch the slot list for `romId` and fold it into panel state. */
+async function fetchSlots(
+  romId: number,
+  run: SlotLoadRun,
+  slotsLoadedRef: MutableRefObject<boolean>,
+  setState: Dispatch<SetStateAction<PanelState>>,
+): Promise<void> {
+  const load = beginServerLoad();
+  // Drop stale retry progress from a prior load so the SavesTab's
+  // ConnectingIndicator starts at plain "Connecting to RomM…" (#1345).
+  setServerRetryProgress(null);
+  setState((prev) => ({ ...prev, slotsLoading: true }));
+  try {
+    const result = await getSaveSlots(romId);
+    if (run.cancelled) return;
+    run.settled = true;
+    // A completed slot fetch is a reachability signal (#1345): a success
+    // proves the server is reachable; an unreachable server drives the store
+    // offline (which then renders the known-offline fast path in the effect
+    // below on the next dependent run). Any OTHER failure reason is a
+    // server-side "no" (the server answered), not a connectivity verdict —
+    // leave the store untouched.
+    if (result.success) {
+      reportServerReachable(true);
+    } else if (result.reason === "server_unreachable") {
+      reportServerReachable(false);
+    }
+    applyLoadSlotsResult<PanelState>(result, setState, slotsLoadedRef, (msg) => {
+      detach(debugLog(msg));
+    });
+  } catch (e) {
+    detach(debugLog(`Failed to load save slots: ${e}`));
+    if (!run.cancelled) {
+      run.settled = true;
+      slotsLoadedRef.current = false;
+      setState((prev) => ({ ...prev, slotsLoading: false }));
+    }
+  } finally {
+    // Clear-on-settle in addition to clear-on-start (#1345 F2) — refused
+    // when a newer load of any lane already owns the shared frame.
+    settleServerLoad(load);
+  }
+}
+
+/** Release a run torn down before it settled — e.g. a concurrent call flipped
+ *  the store offline and re-ran the effect. Gives the load-once gate back and
+ *  drops the spinner, so the re-run isn't wedged behind a stuck
+ *  slotsLoading/slotsLoadedRef and a later reconnect reliably reloads (#1345
+ *  F2). A settled run already set its own final state — leave it alone. */
+function releaseUnsettledRun(
+  run: SlotLoadRun,
+  slotsLoadedRef: MutableRefObject<boolean>,
+  setState: Dispatch<SetStateAction<PanelState>>,
+): void {
+  if (run.settled) return;
+  slotsLoadedRef.current = false;
+  setState((prev) => (prev.slotsLoading ? { ...prev, slotsLoading: false } : prev));
+}
+
+/** Load the ROM's save slots once the SAVES tab is first shown. */
+export function useSaveSlotsLoad(
+  state: PanelState,
+  slotsLoadedRef: MutableRefObject<boolean>,
+  setState: Dispatch<SetStateAction<PanelState>>,
+): void {
+  // The shared connection state lets the fetch take the known-offline fast path
+  // below and re-load automatically on reconnect (#1345).
+  const isOffline = useRommConnectionState() === "offline";
+  const { activeTab, saveSyncEnabled, romId } = state;
+
+  useEffect(() => {
+    if (activeTab !== "saves" || !saveSyncEnabled || !romId) return;
+    if (slotsLoadedRef.current) return;
+
+    // Known-offline fast path (#1345): the server slot fetch runs through the
+    // retry+backoff ladder, so on a known-unreachable server it would hang
+    // "Loading slots…" for tens of seconds before the local degraded view (the
+    // per-slot "Server unreachable" notices) renders. Skip the fetch entirely —
+    // slotsLoading is still false here (the slotsLoadedRef guard above means the
+    // connected path never set it), so SavesTab renders the degraded view now.
+    // slotsLoadedRef stays false, so a flip back to connected re-runs this effect
+    // (isOffline dep) and loads.
+    if (isOffline) return;
+    slotsLoadedRef.current = true;
+
+    const run: SlotLoadRun = { cancelled: false, settled: false };
+    detach(fetchSlots(romId, run, slotsLoadedRef, setState));
+    return () => {
+      run.cancelled = true;
+      releaseUnsettledRun(run, slotsLoadedRef, setState);
+    };
+    // `slotsLoadedRef` and `setState` are stable for the panel's lifetime (a
+    // useRef object and a useState setter) and never re-run this effect; they
+    // are listed only because arriving as parameters puts them out of reach of
+    // exhaustive-deps' stability inference.
+  }, [activeTab, saveSyncEnabled, romId, isOffline, slotsLoadedRef, setState]);
+}

--- a/src/components/panelState.ts
+++ b/src/components/panelState.ts
@@ -36,7 +36,6 @@ export interface PanelState {
   romId: number | null;
   romName: string;
   platformName: string;
-  platformSlug: string;
   installed: boolean;
   installedRom: InstalledRom | null;
   metadata: RomMetadata | null;
@@ -279,7 +278,6 @@ export async function loadData(
       romId,
       romName,
       platformName,
-      platformSlug,
       installed: cached.installed ?? false,
       installedRom: null, // Will be filled by background fetch if installed
       metadata: cached.metadata as RomMetadata | null,

--- a/src/components/panelTabContent.ts
+++ b/src/components/panelTabContent.ts
@@ -1,0 +1,86 @@
+/**
+ * The body of the game detail panel's active tab.
+ *
+ * Only the pane the user is looking at is created. That is load-bearing for
+ * SAVES: `SavesTab` fetches on mount, so building it for a tab nobody opened
+ * would fire those requests on every game page.
+ *
+ * The ACHIEVEMENTS and BIOS panes are not built here — the panel mounts them for
+ * every ROM and they decide themselves whether to render.
+ */
+
+import { createElement } from "react";
+import type { Dispatch, SetStateAction } from "react";
+import { GameInfoTab } from "./GameInfoTab";
+import { SavesTab } from "./SavesTab";
+import { SlotSetupWizard } from "./SlotSetupWizard";
+import type { PanelState } from "./panelState";
+
+interface TabContentContext {
+  readonly appId: number;
+  readonly romId: number;
+  readonly state: PanelState;
+  readonly setState: Dispatch<SetStateAction<PanelState>>;
+}
+
+/** Tell every surface showing this ROM that its save-sync facts moved. */
+function announceSaveSyncChange(romId: number): void {
+  globalThis.dispatchEvent(
+    new CustomEvent("romm_data_changed", {
+      detail: { type: "save_sync", rom_id: romId },
+    }),
+  );
+}
+
+/** Build the pane for the active tab, or null when the active tab builds none. */
+export function buildTabContent({
+  appId,
+  romId,
+  state,
+  setState,
+}: TabContentContext): ReturnType<typeof createElement> | null {
+  if (state.activeTab === "info") {
+    return createElement(GameInfoTab, {
+      key: "tab-info",
+      romName: state.romName,
+      regions: state.regions,
+      languages: state.languages,
+      metadata: state.metadata,
+      platformName: state.platformName,
+      coverBase64: state.coverBase64,
+      installed: state.installed,
+      installedRom: state.installedRom,
+    });
+  }
+
+  if (state.activeTab !== "saves") return null;
+
+  if (state.saveSyncEnabled && !state.slotConfirmed) {
+    return createElement(SlotSetupWizard, {
+      romId,
+      onComplete: () => {
+        setState((prev) => ({ ...prev, slotConfirmed: true }));
+        announceSaveSyncChange(romId);
+      },
+    });
+  }
+
+  return createElement(SavesTab, {
+    appId,
+    romId,
+    saveStatus: state.saveStatus,
+    conflicts: state.conflicts,
+    activeSlot: state.activeSlot,
+    availableSlots: state.availableSlots,
+    slotsLoading: state.slotsLoading,
+    onSlotSwitched: (newSlot, newStatus) => {
+      setState((prev) => ({
+        ...prev,
+        activeSlot: newSlot === "" ? null : newSlot,
+        saveStatus: newStatus,
+        conflicts: newStatus.conflicts ?? [],
+      }));
+      announceSaveSyncChange(romId);
+    },
+  });
+}


### PR DESCRIPTION
The panel's cognitive-complexity suppression is gone, which is the point of this change rather than
a side effect of it. What kept the score up was that the component body still held a load lane and
every render builder: the lazy SAVES slot load, the GAME INFO rows, the ROM File section, the tab
bar, the save-sort banner and the tab-content selection. Each is now its own module, and the
component measures 6 against a threshold of 15 — four early-return guards, the error gate, and one
ternary. It is 207 lines, from 527.

Mounting is deliberately not uniform, and the asymmetry is the interesting part. AchievementsTab and
BiosTab stay mounted for every ROM and render nothing until their tab is active, because they fetch
their own data and unmounting them would re-fetch on every visit. Everything else is still created
only while its tab is active: the tab-content selection became a builder function rather than a
component precisely so no new always-mounted layer appears. SavesTab fetches the version list and a
per-sibling drift check on mount, so always-mounting it would fire those on every game page whether
or not the tab is ever opened.

PanelState.platformSlug is deleted. It had no reader anywhere; the value the BIOS event filter reads
is platformSlugRef, which stays.

Three changes go beyond moving code. A guard inside the old slot load could never fire — the effect
had already proven the same field truthy against the same frozen render object — and is gone. The
two places that hand-built the same save-sync event now call one helper; the event name, shape and
value are identical. And the slot-load effect's dependency list grew by the two identities it now
receives as parameters instead of reading from its own component, both stable for the panel's
lifetime, so it cannot re-run more often than before.

RomMGameInfoPanel.test.tsx is unchanged, and its 130 tests pass against the new structure as they
did against the old. The one added test file covers the tab bar, which nothing exercised before
because the tab strip had no edge of its own.

docs: N/A — pure refactor; nothing the user sees changes.

Part of #994; the JSX conversion follows separately.
