### PR TITLE
fix(ui): order two game-detail reads for the same rom by when they were issued

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -288,12 +288,13 @@ Format: **invariant** — tier — enforced by.
   holds none of these writes) via `RomBinding`; the achievements tab (`src/components/AchievementsTab.tsx`) by
   construction, its React key being the rom id, so its state cannot outlive the identity it was read for. A version
   switch re-keys without closing, so neither the store's generation counter nor the panel's `[appId]` effect sees this
-  class. Four writes are unbound and none of them is safe by construction: the two identity writes install what a
-  binding would compare against (`loadDetail` is ordered by `loadSeq`, `loadData` is not — #1717); the store's
-  `cached.bios_status` fold runs in the same synchronous run as its guard; the event lane's `handleBiosChange` answers
-  for the platform's default core and can overwrite a rom-keyed answer (#1718). The panel's remaining lazy lane writes
-  through the raw setter, discarded by its own per-run `cancelled` — with the commit-time window #1717 records. The play
-  button is NOT covered (#1714)** — test + prompt-only — the panel's ten bound sites each carry a version-switch test
+  class. Binding answers the wrong-rom question only; two answers for the SAME rom are ordered instead, by a sequence
+  taken when the read is issued — the store's `loadSeq`, the panel's `takeReadTicket` (#1717). Four writes are unbound:
+  the two identity writes install what a binding would compare against, so ordering is all they can have, and both have
+  it. The other two have neither — the store's `cached.bios_status` fold runs in the same synchronous run as its guard,
+  and the event lane's `handleBiosChange` answers for the platform's default core and can overwrite a rom-keyed answer
+  (#1718). The panel's remaining lazy lane writes through the raw setter, ordered by the same ticket. The play button is
+  NOT covered (#1714)** — test + prompt-only — the panel's ten bound sites each carry a version-switch test
   (`src/components/RomMGameInfoPanel.test.tsx`); the store side and every new write site on either are prompt-only,
   because a checker scoped to the store's own function bodies would be green on the case this rule was written for. The
   reasons behind the two writer mechanisms live at `writerForRom` and `RomBinding` — do not restate them here

--- a/src/components/RomMGameInfoPanel.test.tsx
+++ b/src/components/RomMGameInfoPanel.test.tsx
@@ -4099,4 +4099,240 @@ describe("RomMGameInfoPanel", () => {
       expect(container.textContent).toContain("RetroArch save sorting changed");
     });
   });
+
+  // ------------------------------------------------------------------
+  // K. Two answers for the SAME rom, ordered by when their reads were issued
+  // ------------------------------------------------------------------
+
+  describe("two answers for the same rom ordered by when their reads were issued (#1717)", () => {
+    /** A read the test answers by hand, so the one issued FIRST can be made to
+     *  land last. Both are about the rom the panel is showing, so the rom
+     *  binding admits both and only the read's own ticket separates them. */
+    function heldRead<T>() {
+      let release!: (value: T) => void;
+      const promise = new Promise<T>((resolve) => {
+        release = resolve;
+      });
+      return { promise, release: (value: T) => release(value) };
+    }
+
+    const detailFor = (
+      romId: number,
+      romName: string,
+      overrides: Partial<CachedGameDetail> = {},
+    ): CachedGameDetail => ({
+      found: true,
+      rom_id: romId,
+      rom_name: romName,
+      platform_slug: "snes",
+      metadata: makeMetadata(),
+      stale_fields: [],
+      ...overrides,
+    });
+
+    const dispatchDataChanged = async (detail: Record<string, unknown>) => {
+      await act(async () => {
+        globalThis.dispatchEvent(new CustomEvent("romm_data_changed", { detail }));
+      });
+    };
+
+    const openSavesTab = async () => {
+      await act(async () => {
+        globalThis.dispatchEvent(new CustomEvent("romm_tab_switch", { detail: { tab: "saves" } }));
+      });
+      await flushAsync();
+    };
+
+    const statusWithFile = (romId: number, filename: string): SaveStatus => ({
+      rom_id: romId,
+      files: [
+        {
+          filename,
+          status: "skip",
+          local_path: null,
+          local_hash: null,
+          local_mtime: null,
+          local_size: null,
+          server_save_id: null,
+          server_file_name: null,
+          server_emulator: null,
+          server_updated_at: null,
+          server_size: null,
+          last_sync_at: null,
+        },
+      ],
+      playtime: {
+        total_seconds: 0,
+        session_count: 0,
+        last_session_start: null,
+        last_session_duration_sec: null,
+        last_played: null,
+      },
+      device_id: "d",
+      last_sync_check_at: null,
+    });
+
+    /** Run the real slot helpers: the module mock writes nothing, and an
+     *  unordered fold would then look exactly like an ordered one. */
+    const useRealSlotHelpers = async () => {
+      const realSlotState = await vi.importActual<typeof slotState>("../utils/slotState");
+      vi.mocked(slotState.applyRefreshSlotResult).mockImplementation(realSlotState.applyRefreshSlotResult);
+      vi.mocked(slotState.applyLoadSlotsResult).mockImplementation(realSlotState.applyLoadSlotsResult);
+    };
+
+    it("keeps the newest version switch's identity when an earlier switch's read lands last", async () => {
+      // Both switches are for this panel's appId and both install an identity,
+      // so the rom binding admits either — the panel would show whichever cache
+      // read happened to finish last.
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(detailFor(1, "Game (USA)", { regions: ["USA"] }));
+      const { container } = render(<RomMGameInfoPanel appId={testAppId} />);
+      await flushAsync();
+
+      const firstSwitch = heldRead<CachedGameDetail>();
+      vi.mocked(cachedStore.getCachedGameDetail).mockImplementationOnce(() => firstSwitch.promise);
+      await dispatchDataChanged({ type: "version_switched", app_id: testAppId, rom_id: 2 });
+
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(
+        detailFor(3, "Game (Europe)", { regions: ["Europe"] }),
+      );
+      await dispatchDataChanged({ type: "version_switched", app_id: testAppId, rom_id: 3 });
+      await flushAsync();
+      expect(container.textContent).toContain("Game (Europe)");
+
+      await act(async () => {
+        firstSwitch.release(detailFor(2, "Game (Japan)", { regions: ["Japan"] }));
+      });
+      await flushAsync();
+
+      expect(container.textContent).toContain("Game (Europe)");
+      expect(container.textContent).toContain("Europe");
+      expect(container.textContent).not.toContain("Game (Japan)");
+    });
+
+    it("keeps the newest save-status answer when an earlier read lands last", async () => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(detailFor(1, "Game", { save_sync_enabled: true }));
+      vi.mocked(backend.isSaveTrackingConfigured).mockResolvedValue({ configured: true, active_slot: "main" });
+      render(<RomMGameInfoPanel appId={testAppId} />);
+      await flushAsync();
+      await openSavesTab();
+
+      const firstRead = heldRead<backend.SaveStatusResult>();
+      vi.mocked(backend.getSaveStatus).mockImplementationOnce(() => firstRead.promise);
+      await dispatchDataChanged({ type: "save_sync", rom_id: 1 });
+
+      vi.mocked(backend.getSaveStatus).mockResolvedValue(statusWithFile(1, "SECOND.srm"));
+      await dispatchDataChanged({ type: "save_sync", rom_id: 1 });
+      await flushAsync();
+      expect(capturedSavesTab[capturedSavesTab.length - 1]?.saveStatus?.files[0]?.filename).toBe("SECOND.srm");
+
+      await act(async () => {
+        firstRead.release(statusWithFile(1, "FIRST.srm"));
+      });
+      await flushAsync();
+
+      expect(capturedSavesTab[capturedSavesTab.length - 1]?.saveStatus?.files[0]?.filename).toBe("SECOND.srm");
+      expect(capturedSavesTab.some((props) => props.saveStatus?.files[0]?.filename === "FIRST.srm")).toBe(false);
+    });
+
+    it("does not let a status read issued before save sync was switched off put the tab back", async () => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(detailFor(1, "Game", { save_sync_enabled: false }));
+      const { container } = render(<RomMGameInfoPanel appId={testAppId} />);
+      await flushAsync();
+
+      const enableRead = heldRead<backend.SaveStatusResult>();
+      vi.mocked(backend.getSaveStatus).mockImplementationOnce(() => enableRead.promise);
+      await dispatchDataChanged({ type: "save_sync_settings", save_sync_enabled: true });
+      await dispatchDataChanged({ type: "save_sync_settings", save_sync_enabled: false });
+
+      await act(async () => {
+        enableRead.release(statusWithFile(1, "ANY.srm"));
+      });
+      await flushAsync();
+
+      expect(container.textContent).not.toContain("SAVES");
+    });
+
+    it("shows the SAVES tab after save sync is switched on even when the status read is overtaken", async () => {
+      // The fence orders the status ANSWER. The setting is not an answer, and
+      // nothing re-issues it — swallowing it here hides the tab until remount.
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(detailFor(1, "Game", { save_sync_enabled: false }));
+      const { container } = render(<RomMGameInfoPanel appId={testAppId} />);
+      await flushAsync();
+
+      const enableRead = heldRead<backend.SaveStatusResult>();
+      vi.mocked(backend.getSaveStatus).mockImplementationOnce(() => enableRead.promise);
+      await dispatchDataChanged({ type: "save_sync_settings", save_sync_enabled: true });
+
+      vi.mocked(backend.getSaveStatus).mockResolvedValue(statusWithFile(1, "NEWER.srm"));
+      await dispatchDataChanged({ type: "save_sync", rom_id: 1 });
+      await flushAsync();
+
+      await act(async () => {
+        enableRead.release(statusWithFile(1, "OVERTAKEN.srm"));
+      });
+      await flushAsync();
+
+      expect(container.textContent).toContain("SAVES");
+    });
+
+    it("keeps the newest slot list when the lazy SAVES load's answer lands last", async () => {
+      // The lazy lane writes through the panel's raw setter, and its own
+      // `cancelled` flag is only set at commit time — the ticket it takes when
+      // the read is issued has no such gap.
+      await useRealSlotHelpers();
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(detailFor(1, "Game", { save_sync_enabled: true }));
+      vi.mocked(backend.isSaveTrackingConfigured).mockResolvedValue({ configured: true, active_slot: "main" });
+      vi.mocked(backend.getSaveSlots).mockResolvedValue({ success: true, slots: [], active_slot: "mount" });
+      render(<RomMGameInfoPanel appId={testAppId} />);
+      await flushAsync();
+
+      const laneRead = heldRead<Awaited<ReturnType<typeof backend.getSaveSlots>>>();
+      vi.mocked(backend.getSaveSlots).mockImplementationOnce(() => laneRead.promise);
+      await openSavesTab();
+
+      // A save-sync event re-reads the slots for the same rom while the lane's
+      // read is still open, and answers first.
+      vi.mocked(backend.getSaveSlots).mockResolvedValue({ success: true, slots: [], active_slot: "fresh" });
+      await dispatchDataChanged({ type: "save_sync", rom_id: 1 });
+      await flushAsync();
+      expect(capturedSavesTab[capturedSavesTab.length - 1]?.activeSlot).toBe("fresh");
+
+      await act(async () => {
+        laneRead.release({ success: true, slots: [], active_slot: "stale" });
+      });
+      await flushAsync();
+
+      expect(capturedSavesTab[capturedSavesTab.length - 1]?.activeSlot).toBe("fresh");
+      expect(capturedSavesTab.some((props) => props.activeSlot === "stale")).toBe(false);
+      // The run that lost the list still clears the spinner it put up — a fence
+      // that swallowed this write would leave "Loading slots…" standing forever.
+      expect(capturedSavesTab[capturedSavesTab.length - 1]?.slotsLoading).toBe(false);
+    });
+
+    it("still applies a slot-configuration answer the lazy SAVES load overtook", async () => {
+      // The lane re-reads the slot LIST and nothing else, so its ticket must not
+      // fence the tracking answer that decides wizard-vs-tab — nothing would
+      // re-issue that read.
+      await useRealSlotHelpers();
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(detailFor(1, "Game", { save_sync_enabled: true }));
+      const tracking = heldRead<{ configured: boolean; active_slot: string | null }>();
+      vi.mocked(backend.isSaveTrackingConfigured).mockImplementation(() => tracking.promise);
+      vi.mocked(backend.getSaveSlots).mockResolvedValue({ success: true, slots: [], active_slot: "main" });
+      const { queryByTestId } = render(<RomMGameInfoPanel appId={testAppId} />);
+      await flushAsync();
+
+      // Opening the tab issues the lane's slot-list read; until the tracking
+      // answer lands the setup wizard is what the tab shows.
+      await openSavesTab();
+      expect(queryByTestId("slot-setup-wizard")).not.toBeNull();
+
+      await act(async () => {
+        tracking.release({ configured: true, active_slot: "main" });
+      });
+      await flushAsync();
+
+      expect(queryByTestId("saves-tab")).not.toBeNull();
+      expect(queryByTestId("slot-setup-wizard")).toBeNull();
+    });
+  });
 });

--- a/src/components/RomMGameInfoPanel.tsx
+++ b/src/components/RomMGameInfoPanel.tsx
@@ -23,7 +23,7 @@ import { AchievementsTab } from "./AchievementsTab";
 import { BiosTab } from "./BiosTab";
 import { PanelTabBar } from "./PanelTabBar";
 import { SaveSortWarning } from "./SaveSortWarning";
-import { loadData, type PanelState } from "./panelState";
+import { loadData, type PanelReadSeqs, type PanelState } from "./panelState";
 import { wirePanelEvents } from "./panelEvents";
 import { useSaveSlotsLoad } from "./panelSlotsLoad";
 import { buildTabContent } from "./panelTabContent";
@@ -80,6 +80,10 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => {
   // Load-once gate for the lazy SAVES tab data; the rule it enforces is stated
   // at `panelSlotsLoad.ts`. It lives here because a version switch resets it.
   const slotsLoadedRef = useRef(false);
+  // Read sequences ordering two answers about the same ROM; the rule they
+  // enforce is stated at `takeReadTicket`. They live here because the loads, the
+  // event lane and the lazy slots lane take tickets from the same counters.
+  const readSeqs = useRef<PanelReadSeqs>({ detail: 0, saveStatus: 0, slots: 0, slotTracking: 0 });
   const [migration, setMigration] = useState(getMigrationState());
   const [settingsReset, setSettingsReset] = useState(getSettingsResetState());
   const [saveSortPending, setSaveSortPending] = useState(getSaveSortMigrationState().pending);
@@ -107,7 +111,7 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => {
   useEffect(() => {
     let cancelled = false;
 
-    detach(loadData(appId, () => cancelled, romIdRef, platformSlugRef, setState));
+    detach(loadData(appId, () => cancelled, romIdRef, platformSlugRef, readSeqs, setState));
 
     const unwire = wirePanelEvents({
       appId,
@@ -115,6 +119,7 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => {
       romIdRef,
       platformSlugRef,
       slotsLoadedRef,
+      readSeqs,
       setState,
     });
 
@@ -124,7 +129,7 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => {
     };
   }, [appId]);
 
-  useSaveSlotsLoad(state, slotsLoadedRef, setState);
+  useSaveSlotsLoad(state, slotsLoadedRef, readSeqs, setState);
 
   // --- Version mismatch — replace entire panel with polished error card ---
   if (versionError) {

--- a/src/components/panelEvents.ts
+++ b/src/components/panelEvents.ts
@@ -32,6 +32,8 @@ import {
   refreshInstalledRomInBackground,
   refreshSlotState,
   saveStatusFromCache,
+  takeReadTicket,
+  type PanelReadSeqs,
   type PanelState,
   type RomBinding,
 } from "./panelState";
@@ -49,6 +51,10 @@ export interface PanelEventContext {
   readonly platformSlugRef: MutableRefObject<string>;
   /** Load-once gate for the lazy SAVES tab data — a version switch releases it. */
   readonly slotsLoadedRef: MutableRefObject<boolean>;
+  /** Orders two answers about the same ROM, which the rom binding admits — see
+   *  `takeReadTicket`. Shared with the panel's loads and its slots lane, which
+   *  race these handlers for the same fields. */
+  readonly readSeqs: MutableRefObject<PanelReadSeqs>;
   readonly setState: Dispatch<SetStateAction<PanelState>>;
 }
 
@@ -64,19 +70,30 @@ async function handleSaveSyncSettingsChange(
 ): Promise<void> {
   const enabled = detail.save_sync_enabled;
   if (!enabled) {
+    // Switching save sync off is itself the newest word on it, so it takes the
+    // sequence's next ticket: a status read an earlier event left in flight
+    // would otherwise land afterwards and put the SAVES tab back.
+    takeReadTicket(ctx.readSeqs, "saveStatus");
     ctx.setState((prev) => ({ ...prev, saveSyncEnabled: false }));
     return;
   }
+  // Switching save sync ON is a fact about the setting, not an answer about this
+  // rom, so it lands before the read and outside its fence. Carried along with
+  // the status it would be lost whenever the read is overtaken or fails — and
+  // the SAVES tab, gated on this flag, would stay hidden with nothing left to
+  // re-issue it.
+  ctx.setState((prev) => ({ ...prev, saveSyncEnabled: true }));
   const romId = ctx.romIdRef.current;
   if (!romId) return;
   const binding = bindCurrentRom(ctx, romId);
+  const overtaken = takeReadTicket(ctx.readSeqs, "saveStatus");
   const result = await getSaveStatus(binding.romId).catch(() => null);
   if (result && isCallableFailure(result)) return;
+  if (overtaken()) return;
   const updatedStatus: SaveStatus | null = result;
   const conflicts: SyncConflict[] = updatedStatus?.conflicts ?? [];
   binding.write((prev) => ({
     ...prev,
-    saveSyncEnabled: true,
     saveStatus: updatedStatus,
     conflicts,
   }));
@@ -90,17 +107,26 @@ async function handleSaveSyncChange(
   const romId = ctx.romIdRef.current;
   if (!romId) return;
   const binding = bindCurrentRom(ctx, romId);
+  // A status carried on the event needs no read, but still takes the ticket: it
+  // is the newer answer, so a read an earlier event left open must not land on
+  // top of it.
+  const overtaken = takeReadTicket(ctx.readSeqs, "saveStatus");
   const result = detail.save_status ?? (await getSaveStatus(binding.romId).catch(() => null));
   if (result && isCallableFailure(result)) return;
   const updatedStatus: SaveStatus | null = result;
   const conflicts: SyncConflict[] = updatedStatus?.conflicts ?? [];
-  binding.write((prev) => ({
-    ...prev,
-    saveStatus: updatedStatus,
-    conflicts,
-  }));
+  // Only the status fold is fenced. The slot refresh below issues its own reads
+  // under their own sequences, so an overtaken run still re-checks them rather
+  // than dropping the re-check on the floor.
+  if (!overtaken()) {
+    binding.write((prev) => ({
+      ...prev,
+      saveStatus: updatedStatus,
+      conflicts,
+    }));
+  }
   // Also re-check slot configuration + refresh slot data
-  refreshSlotState(binding);
+  refreshSlotState(binding, ctx.readSeqs);
 }
 
 async function handleBiosChange(
@@ -169,9 +195,13 @@ async function handleVersionSwitched(
   // BIOS is the third per-rom tab: the requirement is core-dependent and the
   // core override is keyed on rom_id, so the new version's core may need
   // different files — or none, which hides the tab (#1681).
+  //
+  // Two switches in quick succession read the cache twice and can finish in
+  // either order, so this read is ordered like the mount load's — see `loadData`.
   if (detail.app_id !== ctx.appId) return;
+  const overtaken = takeReadTicket(ctx.readSeqs, "detail");
   const cached = await getCachedGameDetail(ctx.appId);
-  if (ctx.cancelled() || !cached.found) return;
+  if (ctx.cancelled() || overtaken() || !cached.found) return;
   const newRomId = cached.rom_id ?? ctx.romIdRef.current;
   ctx.romIdRef.current = newRomId;
   ctx.slotsLoadedRef.current = false;
@@ -208,7 +238,7 @@ async function handleVersionSwitched(
   // mirroring loadData's save-sync branch — this is the authority that keeps
   // the SlotSetupWizard-vs-SavesTab gate correct across the switch.
   if (cached.save_sync_enabled && newRomId != null) {
-    refreshSlotState(bindCurrentRom(ctx, newRomId));
+    refreshSlotState(bindCurrentRom(ctx, newRomId), ctx.readSeqs);
   }
   if (newRomId) {
     const binding = bindCurrentRom(ctx, newRomId);

--- a/src/components/panelSlotsLoad.ts
+++ b/src/components/panelSlotsLoad.ts
@@ -21,7 +21,7 @@ import {
 } from "../utils/connectionState";
 import { applyLoadSlotsResult } from "../utils/slotState";
 import { detach } from "../utils/detach";
-import type { PanelState } from "./panelState";
+import { takeReadTicket, type PanelReadSeqs, type PanelState } from "./panelState";
 
 /** One run of the slot fetch. The effect's cleanup can tear a run down while it
  *  is still in flight, so the two ends share this record rather than a closure
@@ -36,12 +36,18 @@ async function fetchSlots(
   romId: number,
   run: SlotLoadRun,
   slotsLoadedRef: MutableRefObject<boolean>,
+  readSeqs: MutableRefObject<PanelReadSeqs>,
   setState: Dispatch<SetStateAction<PanelState>>,
 ): Promise<void> {
   const load = beginServerLoad();
   // Drop stale retry progress from a prior load so the SavesTab's
   // ConnectingIndicator starts at plain "Connecting to RomM…" (#1345).
   setServerRetryProgress(null);
+  // Taken here rather than in the effect: this is where the read is issued, and
+  // it is what orders this lane against the panel's slot refreshes. `cancelled`
+  // below cannot do it — the effect sets it only when React commits the
+  // teardown, so an answer arriving before that commit still folds in (#1717).
+  const slotsOvertaken = takeReadTicket(readSeqs, "slots");
   setState((prev) => ({ ...prev, slotsLoading: true }));
   try {
     const result = await getSaveSlots(romId);
@@ -57,6 +63,13 @@ async function fetchSlots(
       reportServerReachable(true);
     } else if (result.reason === "server_unreachable") {
       reportServerReachable(false);
+    }
+    if (result.success && slotsOvertaken()) {
+      // A newer slot read owns the list; this run still owes the spinner it put
+      // up. Only the list is fenced — a failure carries no slot data at all, and
+      // its gate reset is what lets a later tab visit retry.
+      setState((prev) => ({ ...prev, slotsLoading: false }));
+      return;
     }
     applyLoadSlotsResult<PanelState>(result, setState, slotsLoadedRef, (msg) => {
       detach(debugLog(msg));
@@ -94,6 +107,7 @@ function releaseUnsettledRun(
 export function useSaveSlotsLoad(
   state: PanelState,
   slotsLoadedRef: MutableRefObject<boolean>,
+  readSeqs: MutableRefObject<PanelReadSeqs>,
   setState: Dispatch<SetStateAction<PanelState>>,
 ): void {
   // The shared connection state lets the fetch take the known-offline fast path
@@ -117,14 +131,14 @@ export function useSaveSlotsLoad(
     slotsLoadedRef.current = true;
 
     const run: SlotLoadRun = { cancelled: false, settled: false };
-    detach(fetchSlots(romId, run, slotsLoadedRef, setState));
+    detach(fetchSlots(romId, run, slotsLoadedRef, readSeqs, setState));
     return () => {
       run.cancelled = true;
       releaseUnsettledRun(run, slotsLoadedRef, setState);
     };
-    // `slotsLoadedRef` and `setState` are stable for the panel's lifetime (a
-    // useRef object and a useState setter) and never re-run this effect; they
-    // are listed only because arriving as parameters puts them out of reach of
-    // exhaustive-deps' stability inference.
-  }, [activeTab, saveSyncEnabled, romId, isOffline, slotsLoadedRef, setState]);
+    // `slotsLoadedRef`, `readSeqs` and `setState` are stable for the panel's
+    // lifetime (two useRef objects and a useState setter) and never re-run this
+    // effect; they are listed only because arriving as parameters puts them out
+    // of reach of exhaustive-deps' stability inference.
+  }, [activeTab, saveSyncEnabled, romId, isOffline, slotsLoadedRef, readSeqs, setState]);
 }

--- a/src/components/panelState.test.ts
+++ b/src/components/panelState.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { MutableRefObject } from "react";
+import { refreshSlotState, takeReadTicket, type PanelReadSeqs, type PanelState, type RomBinding } from "./panelState";
+import * as backend from "../api/backend";
+import type { SaveSlotSummary } from "../types";
+
+/** A promise the test resolves by hand, so two reads of the same callable can be
+ *  made to answer in the opposite order to the one they were issued in. */
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+const flush = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+const seqsRef = (): MutableRefObject<PanelReadSeqs> => ({
+  current: { detail: 0, saveStatus: 0, slots: 0, slotTracking: 0 },
+});
+
+const slot = (name: string): SaveSlotSummary => ({
+  slot: name,
+  source: "server",
+  count: 1,
+  latest_updated_at: null,
+});
+
+function basePanelState(): PanelState {
+  return {
+    loading: false,
+    romId: 7,
+    romName: "Game",
+    platformName: "SNES",
+    installed: false,
+    installedRom: null,
+    metadata: null,
+    coverBase64: null,
+    biosStatus: null,
+    biosLevel: null,
+    coreInfo: null,
+    saveSyncEnabled: true,
+    saveStatus: null,
+    conflicts: [],
+    error: false,
+    activeTab: "saves",
+    raId: null,
+    slotConfirmed: false,
+    activeSlot: null,
+    availableSlots: [],
+    slotsLoading: false,
+    regions: [],
+    languages: [],
+  };
+}
+
+describe("takeReadTicket", () => {
+  it("reports a read overtaken once a later read of the same kind takes a ticket", () => {
+    const seqs = seqsRef();
+    const first = takeReadTicket(seqs, "slots");
+    expect(first()).toBe(false);
+    const second = takeReadTicket(seqs, "slots");
+    expect(first()).toBe(true);
+    expect(second()).toBe(false);
+  });
+
+  it("keeps the kinds apart, so a read is not fenced by another kind's ticket", () => {
+    const seqs = seqsRef();
+    const slots = takeReadTicket(seqs, "slots");
+    takeReadTicket(seqs, "slotTracking");
+    takeReadTicket(seqs, "saveStatus");
+    takeReadTicket(seqs, "detail");
+    expect(slots()).toBe(false);
+  });
+});
+
+describe("refreshSlotState", () => {
+  let state: PanelState;
+  let binding: RomBinding;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    state = basePanelState();
+    binding = {
+      romId: 7,
+      write: (update) => {
+        state = typeof update === "function" ? update(state) : update;
+      },
+    };
+  });
+
+  it("folds a slot list and a tracking answer into the panel state", async () => {
+    vi.mocked(backend.getSaveSlots).mockResolvedValue({ success: true, slots: [slot("main")], active_slot: "main" });
+    vi.mocked(backend.isSaveTrackingConfigured).mockResolvedValue({ configured: true, active_slot: "main" });
+
+    refreshSlotState(binding, seqsRef());
+    await flush();
+
+    expect(state.activeSlot).toBe("main");
+    expect(state.availableSlots.map((s) => s.slot)).toEqual(["main"]);
+    expect(state.slotConfirmed).toBe(true);
+  });
+
+  it("keeps the newer refresh's slot list when the earlier refresh answers last", async () => {
+    const earlier = deferred<Awaited<ReturnType<typeof backend.getSaveSlots>>>();
+    const later = deferred<Awaited<ReturnType<typeof backend.getSaveSlots>>>();
+    vi.mocked(backend.getSaveSlots).mockReturnValueOnce(earlier.promise).mockReturnValueOnce(later.promise);
+    vi.mocked(backend.isSaveTrackingConfigured).mockResolvedValue({ configured: false, active_slot: null });
+    const seqs = seqsRef();
+
+    refreshSlotState(binding, seqs);
+    refreshSlotState(binding, seqs);
+
+    later.resolve({ success: true, slots: [slot("newer")], active_slot: "newer" });
+    await flush();
+    earlier.resolve({ success: true, slots: [slot("older")], active_slot: "older" });
+    await flush();
+
+    expect(state.activeSlot).toBe("newer");
+    expect(state.availableSlots.map((s) => s.slot)).toEqual(["newer"]);
+  });
+
+  it("keeps the newer refresh's tracking answer when the earlier refresh answers last", async () => {
+    const earlier = deferred<Awaited<ReturnType<typeof backend.isSaveTrackingConfigured>>>();
+    const later = deferred<Awaited<ReturnType<typeof backend.isSaveTrackingConfigured>>>();
+    vi.mocked(backend.isSaveTrackingConfigured).mockReturnValueOnce(earlier.promise).mockReturnValueOnce(later.promise);
+    vi.mocked(backend.getSaveSlots).mockResolvedValue({ success: true, slots: [], active_slot: null });
+    const seqs = seqsRef();
+
+    refreshSlotState(binding, seqs);
+    refreshSlotState(binding, seqs);
+
+    later.resolve({ configured: false, active_slot: null });
+    await flush();
+    earlier.resolve({ configured: true, active_slot: "main" });
+    await flush();
+
+    // The wizard-vs-tab gate: the earlier "configured" answer would put the
+    // SAVES tab in front of a version whose slots were never set up.
+    expect(state.slotConfirmed).toBe(false);
+  });
+
+  it("applies a tracking answer a later slot-list read cannot replace", async () => {
+    // The two reads have their own sequences because only one of them is also
+    // issued by the lazy SAVES load: a slot-list read taken after this refresh
+    // must not drop its tracking answer, which nothing else re-issues.
+    const tracking = deferred<Awaited<ReturnType<typeof backend.isSaveTrackingConfigured>>>();
+    vi.mocked(backend.isSaveTrackingConfigured).mockReturnValue(tracking.promise);
+    vi.mocked(backend.getSaveSlots).mockResolvedValue({ success: true, slots: [], active_slot: null });
+    const seqs = seqsRef();
+
+    refreshSlotState(binding, seqs);
+    takeReadTicket(seqs, "slots");
+    tracking.resolve({ configured: true, active_slot: "main" });
+    await flush();
+
+    expect(state.slotConfirmed).toBe(true);
+  });
+});

--- a/src/components/panelState.ts
+++ b/src/components/panelState.ts
@@ -108,13 +108,58 @@ export function bindRom(
   };
 }
 
+/** The panel's read sequences: one counter per set of reads whose answers write
+ *  the same fields.
+ *
+ *  Matching that set is what makes a counter correct. Too wide and a read fences
+ *  answers nobody re-issues — `slots` and `slotTracking` are separate for
+ *  exactly that reason: the lazy SAVES load re-reads the slot list but never the
+ *  tracking flag, so one shared counter would let opening the tab drop a
+ *  `slotConfirmed` answer and leave the setup wizard standing where the tab
+ *  belongs. Too narrow and two answers for one field are unordered again, which
+ *  is the whole point. */
+export interface PanelReadSeqs {
+  /** The cached-detail reads that install the panel's ROM identity. */
+  detail: number;
+  /** `get_save_status`, behind both save-sync events. */
+  saveStatus: number;
+  /** `get_save_slots`, from the slot refresh and the lazy SAVES-tab load. */
+  slots: number;
+  /** `is_save_tracking_configured`, from the slot refresh alone. */
+  slotTracking: number;
+}
+
+/** Take one kind's next ticket for a read being issued now. The returned
+ *  predicate answers true once a later read of that kind has taken one, so an
+ *  older answer folds nothing in when it lands last.
+ *
+ *  The panel's second fence, and it does not replace the first: {@link bindRom}
+ *  separates two ROMs, this separates two reads for the SAME ROM — which a
+ *  binding admits, because the ROM matches (#1717).
+ *
+ *  Where the ticket is taken is the mechanism: at the point the read is ISSUED.
+ *  Taken when the answer lands, every read holds the newest ticket and nothing
+ *  is ordered at all. */
+export function takeReadTicket(seqs: MutableRefObject<PanelReadSeqs>, kind: keyof PanelReadSeqs): () => boolean {
+  const ticket = ++seqs.current[kind];
+  return () => seqs.current[kind] !== ticket;
+}
+
 /** Refresh slot configuration and available slots. */
-export function refreshSlotState(binding: RomBinding): void {
+export function refreshSlotState(binding: RomBinding, readSeqs: MutableRefObject<PanelReadSeqs>): void {
+  const trackingOvertaken = takeReadTicket(readSeqs, "slotTracking");
+  const slotsOvertaken = takeReadTicket(readSeqs, "slots");
   isSaveTrackingConfigured(binding.romId)
-    .then((result) => binding.write((prev) => ({ ...prev, slotConfirmed: result.configured })))
+    .then((result) => {
+      if (trackingOvertaken()) return;
+      binding.write((prev) => ({ ...prev, slotConfirmed: result.configured }));
+    })
     .catch(() => {});
   getSaveSlots(binding.romId)
-    .then((slotResult) => applyRefreshSlotResult<PanelState>(slotResult, binding.write))
+    .then((slotResult) => {
+      if (slotsOvertaken()) return;
+      applyRefreshSlotResult<PanelState>(slotResult, binding.write);
+    })
     .catch(() => {});
 }
 
@@ -244,12 +289,14 @@ export async function loadData(
   cancelled: () => boolean,
   romIdRef: MutableRefObject<number | null>,
   platformSlugRef: MutableRefObject<string>,
+  readSeqs: MutableRefObject<PanelReadSeqs>,
   setter: Dispatch<SetStateAction<PanelState>>,
 ): Promise<void> {
+  const overtaken = takeReadTicket(readSeqs, "detail");
   try {
     // Phase 1: Cache-first — render instantly from cached data
     const cached = await getCachedGameDetail(appId);
-    if (cancelled()) return;
+    if (cancelled() || overtaken()) return;
     if (!cached.found) {
       setter((prev) => ({ ...prev, loading: false, error: true }));
       return;
@@ -271,8 +318,10 @@ export async function loadData(
     const raId = cached.ra_id ?? null;
 
     // Render immediately with cached data (metadata may be null — that's OK).
-    // Unbound by construction: this is the write that INSTALLS the identity every
-    // background fold below compares itself against.
+    // Ordered by this load's ticket and not bound to a ROM: this is the write
+    // that INSTALLS the identity every background fold below compares itself
+    // against, so a binding here would refuse the very switch that re-keys the
+    // panel — `loadDetail` in `utils/gameDetailStore.ts` states the reasoning.
     setter({
       loading: false,
       romId,
@@ -302,13 +351,13 @@ export async function loadData(
     const binding = bindRom(romId, romIdRef, cancelled, setter);
 
     if (cached.save_sync_enabled) {
-      refreshSlotState(binding);
+      refreshSlotState(binding, readSeqs);
     }
 
     // Phase 2: Background fetch for data not available in cache
     await startBackgroundRefreshes(cached, binding);
   } catch (e) {
     detach(debugLog(`RomMGameInfoPanel: loadData error: ${e}`));
-    if (!cancelled()) setter((prev) => ({ ...prev, loading: false, error: true }));
+    if (!cancelled() && !overtaken()) setter((prev) => ({ ...prev, loading: false, error: true }));
   }
 }


### PR DESCRIPTION
The panel binds every background write to the ROM it was issued for, so an answer for the previous
version cannot fold into the new one. That answers the wrong-rom question and only that one. Two
answers for the *same* ROM were admitted by the binding in whatever order they happened to resolve,
so the older one could land last and win.

Reads that can race for the same fields now take a ticket when they are issued and check it when
their answer lands. Three sets get one: the identity write, where two version switches read the cache
twice; the save-status write, where two `save_sync` events issue two reads; and the slot writes,
shared by the eager refresh and the lazy SAVES load. The slot lane's own `cancelled` flag is only set
when React commits the teardown, so an answer arriving in that window still folded in — a ticket
taken at issue time has no such gap.

Two details are load-bearing. The slot-tracking read gets a counter of its own rather than sharing
the slot list's: opening the SAVES tab would otherwise refuse an in-flight tracking answer, and since
nothing re-issues that read, the setup wizard would stand where the SAVES tab belongs. And switching
save sync off takes the save-status sequence's next ticket without issuing a read, because switching
it off is itself the newest word on it — otherwise a status read issued while it was on lands
afterwards and puts the tab back.

Switching save sync **on** writes that fact before the read and outside the fence. Carried along with
the status it would be lost whenever the read is overtaken or fails, and the SAVES tab — gated on
that flag — would stay hidden with nothing left to re-issue it.

Nothing else is fenced. The cover, metadata, installed-rom and core-info refreshes each write a field
nobody else writes, and for the same ROM two reads return the same value; a counter there would be
ballast, and every refusal condition is a place an update can silently fail to appear. The one real
exception is the core-change write, which shares its field set with the BIOS fields and with
`handleBiosChange` — fencing it needs that whole set decided at once, so it gets its own issue rather
than a counter bolted on here.

The invariant register said the panel's identity write was unordered and that its lazy lane carried a
commit-time window. Both are now false, and it says so — along with the distinction that was only
implicit before: binding answers the wrong-rom question, ordering answers the same-rom one.

docs: N/A — no page describes this mechanism; the user-visible effect is the absence of a defect.

Closes #1717
