### PR TITLE
fix(ui): re-read the installed rom on a version switch and drop the saves pane with its tab

### DIFF
--- a/src/components/RomMGameInfoPanel.test.tsx
+++ b/src/components/RomMGameInfoPanel.test.tsx
@@ -937,6 +937,73 @@ describe("RomMGameInfoPanel", () => {
       expect(container.textContent).not.toContain("SAVES");
     });
 
+    // #1748 — the tab strip asks whether save sync is still on, the pane below
+    // it only asks which tab is active. Switching the setting off under an open
+    // SAVES tab is where the two disagree.
+    it("save_sync_settings enabled=false while the SAVES tab is open → falls back to the info tab (#1748)", async () => {
+      // configured=true so the open tab is SavesTab itself, not the setup wizard.
+      vi.mocked(backend.isSaveTrackingConfigured).mockResolvedValue({
+        configured: true,
+        active_slot: "main",
+      });
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
+        found: true,
+        rom_id: 55,
+        rom_name: "Game (USA)",
+        save_sync_enabled: true,
+        metadata: makeMetadata(),
+        stale_fields: [],
+      });
+      const { container, queryByTestId } = render(<RomMGameInfoPanel appId={testAppId} />);
+      await flushAsync();
+      await act(async () => {
+        globalThis.dispatchEvent(new CustomEvent("romm_tab_switch", { detail: { tab: "saves" } }));
+      });
+      await flushAsync();
+      expect(queryByTestId("saves-tab")).not.toBeNull();
+
+      await act(async () => {
+        globalThis.dispatchEvent(
+          new CustomEvent("romm_data_changed", {
+            detail: { type: "save_sync_settings", save_sync_enabled: false },
+          }),
+        );
+        await Promise.resolve();
+      });
+
+      // The button went with the setting; the pane must go with the button,
+      // leaving the tab every ROM has — asserted on the info tab's BODY (the
+      // RomM game name), not on its button, which is present either way.
+      expect(container.textContent).not.toContain("SAVES");
+      expect(queryByTestId("saves-tab")).toBeNull();
+      expect(container.textContent).toContain("Game (USA)");
+    });
+
+    it("save_sync_settings enabled=false leaves a user standing on another tab where they are", async () => {
+      // The over-fix this invites: only the SAVES tab loses its button, so
+      // nobody else may be moved.
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(biosNeedingDetail());
+      const { container } = render(<RomMGameInfoPanel appId={testAppId} />);
+      await flushAsync();
+      await act(async () => {
+        globalThis.dispatchEvent(new CustomEvent("romm_tab_switch", { detail: { tab: "bios" } }));
+      });
+      await flushAsync();
+      expect(container.textContent).toContain("1/2 files ready");
+
+      await act(async () => {
+        globalThis.dispatchEvent(
+          new CustomEvent("romm_data_changed", {
+            detail: { type: "save_sync_settings", save_sync_enabled: false },
+          }),
+        );
+        await Promise.resolve();
+      });
+
+      expect(container.textContent).not.toContain("SAVES");
+      expect(container.textContent).toContain("1/2 files ready");
+    });
+
     it("save_sync_settings enabled=true with getSaveStatus rejection → falls back to null updatedStatus (non-vacuous .catch)", async () => {
       // Configure save tracking so SavesTab (not SlotSetupWizard) renders
       // after we switch tabs — gives us a captured-props observable on the
@@ -3528,6 +3595,194 @@ describe("RomMGameInfoPanel", () => {
       await flushAsync();
       expect(vi.mocked(backend.getAchievements)).toHaveBeenCalledWith(2);
       expect(vi.mocked(backend.getAchievementProgress)).toHaveBeenCalledWith(2);
+    });
+
+    // #1742 — the ROM File row and the launch-target note under it are decided
+    // by the installed-rom record, which describes ONE version. The switch
+    // writes `installed` from the fresh detail, so the record has to follow it.
+    describe("ROM File row across a version switch (#1742)", () => {
+      const installedRomFor = (romId: number, fileName: string, launchable = true): InstalledRom => ({
+        rom_id: romId,
+        file_name: fileName,
+        file_path: `/roms/snes/${fileName}`,
+        system: "snes",
+        platform_slug: "snes",
+        installed_at: "2026-01-01",
+        launchable,
+      });
+
+      const detailFor = (romId: number, installed: boolean): CachedGameDetail => ({
+        found: true,
+        rom_id: romId,
+        rom_name: romId === 1 ? "Game (USA)" : "Game (Japan)",
+        platform_slug: "snes",
+        installed,
+        metadata: makeMetadata(),
+        stale_fields: [],
+      });
+
+      const switchToRom2 = async (installed: boolean) => {
+        vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(detailFor(2, installed));
+        await act(async () => {
+          globalThis.dispatchEvent(
+            new CustomEvent("romm_data_changed", {
+              detail: { type: "version_switched", app_id: testAppId, rom_id: 2 },
+            }),
+          );
+        });
+        await flushAsync();
+      };
+
+      it("shows the switched-to version's ROM File row when it is the installed one", async () => {
+        // The page was opened on a version that is not installed, so there is
+        // no record yet — only the switch can fetch one.
+        vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(detailFor(1, false));
+        vi.mocked(backend.getInstalledRom).mockResolvedValue(installedRomFor(2, "Game (Japan).sfc"));
+        const { container } = render(<RomMGameInfoPanel appId={testAppId} />);
+        await flushAsync();
+        expect(container.textContent).not.toContain("ROM File");
+
+        await switchToRom2(true);
+
+        expect(vi.mocked(backend.getInstalledRom)).toHaveBeenCalledWith(2);
+        expect(container.textContent).toContain("ROM File");
+        expect(container.textContent).toContain("Game (Japan).sfc");
+      });
+
+      it("decides the launch-target note from the switched-to version's record", async () => {
+        // The version left behind launches; the one switched to is a sealed
+        // package that does not. The previous version's record would withhold
+        // the note that says so.
+        vi.mocked(backend.getInstalledRom).mockImplementation((romId: number) =>
+          Promise.resolve(
+            romId === 1 ? installedRomFor(1, "Game (USA).sfc") : installedRomFor(2, "Game (Japan).pkg", false),
+          ),
+        );
+        vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(detailFor(1, true));
+        const { container } = render(<RomMGameInfoPanel appId={testAppId} />);
+        await flushAsync();
+        expect(container.textContent).not.toContain("nothing here is a format");
+
+        await switchToRom2(true);
+
+        expect(container.textContent).toContain("nothing here is a format snes can launch");
+      });
+
+      it("issues no installed-rom read when the switched-to version is not installed", async () => {
+        vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(detailFor(1, false));
+        const { container } = render(<RomMGameInfoPanel appId={testAppId} />);
+        await flushAsync();
+        vi.mocked(backend.getInstalledRom).mockClear();
+
+        await switchToRom2(false);
+
+        expect(vi.mocked(backend.getInstalledRom)).not.toHaveBeenCalled();
+        expect(container.textContent).not.toContain("ROM File");
+      });
+
+      it("drops the previous version's row while the switched-to version's record is in flight", async () => {
+        // Downloading a sibling supersedes the install this record describes and
+        // the panel never hears about it, so the previous version's file name
+        // can stand under a true `installed` for the version that replaced it.
+        let releaseRom2!: (rom: InstalledRom) => void;
+        const heldRom2 = new Promise<InstalledRom>((resolve) => {
+          releaseRom2 = resolve;
+        });
+        vi.mocked(backend.getInstalledRom).mockImplementation((romId: number) =>
+          romId === 2 ? heldRom2 : Promise.resolve(installedRomFor(1, "Game (USA).sfc")),
+        );
+        vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(detailFor(1, true));
+        const { container } = render(<RomMGameInfoPanel appId={testAppId} />);
+        await flushAsync();
+        expect(container.textContent).toContain("Game (USA).sfc");
+
+        await switchToRom2(true);
+
+        expect(container.textContent).not.toContain("Game (USA).sfc");
+        expect(container.textContent).not.toContain("ROM File");
+
+        await act(async () => {
+          releaseRom2(installedRomFor(2, "Game (Japan).sfc"));
+        });
+        await flushAsync();
+
+        expect(container.textContent).toContain("Game (Japan).sfc");
+      });
+    });
+
+    // #1748 — the switch writes `saveSyncEnabled` from the fresh detail, so it
+    // can take the SAVES button away exactly as it can the BIOS one. The flag is
+    // global, so this needs the settings event and the switch to disagree: an
+    // event dropped by the load-window guard, with a stale cached detail then
+    // re-showing the button. Rare, but the dead end is the same one.
+    describe("SAVES tab across a version switch (#1748)", () => {
+      const detailFor = (romId: number, saveSyncEnabled: boolean): CachedGameDetail => ({
+        found: true,
+        rom_id: romId,
+        rom_name: romId === 1 ? "Game (USA)" : "Game (Japan)",
+        platform_slug: "snes",
+        save_sync_enabled: saveSyncEnabled,
+        metadata: makeMetadata(),
+        stale_fields: [],
+      });
+
+      const mountOnSavesTab = async (overrides: Partial<CachedGameDetail> = {}) => {
+        // configured=true so the open tab is SavesTab itself, not the wizard.
+        vi.mocked(backend.isSaveTrackingConfigured).mockResolvedValue({
+          configured: true,
+          active_slot: "main",
+        });
+        vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({ ...detailFor(1, true), ...overrides });
+        const view = render(<RomMGameInfoPanel appId={testAppId} />);
+        await flushAsync();
+        await act(async () => {
+          globalThis.dispatchEvent(new CustomEvent("romm_tab_switch", { detail: { tab: "saves" } }));
+        });
+        await flushAsync();
+        expect(view.queryByTestId("saves-tab")).not.toBeNull();
+        return view;
+      };
+
+      const switchToRom2 = async (overrides: Partial<CachedGameDetail> = {}) => {
+        vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({ ...detailFor(2, false), ...overrides });
+        await act(async () => {
+          globalThis.dispatchEvent(
+            new CustomEvent("romm_data_changed", {
+              detail: { type: "version_switched", app_id: testAppId, rom_id: 2 },
+            }),
+          );
+        });
+        await flushAsync();
+      };
+
+      it("leaves the SAVES tab for the info tab when the switched-to detail says save sync is off", async () => {
+        const { container, queryByTestId } = await mountOnSavesTab();
+
+        await switchToRom2();
+
+        // Asserted on the info tab's BODY (the new version's RomM name), not on
+        // its button, which is present either way.
+        expect(container.textContent).not.toContain("SAVES");
+        expect(queryByTestId("saves-tab")).toBeNull();
+        expect(container.textContent).toContain("Game (Japan)");
+      });
+
+      it("lands on the info tab when the switch clears the BIOS answer as well", async () => {
+        // Both gated tabs lose their button at once. The user is on SAVES, so
+        // that is the dead end that has to be caught — a fallback that answers
+        // for BIOS first would leave them there.
+        const { container, queryByTestId } = await mountOnSavesTab({
+          bios_status: { platform_slug: "snes", server_count: 2, local_count: 1, all_downloaded: false },
+          bios_level: "partial",
+        });
+        expect(container.textContent).toContain("BIOS");
+
+        await switchToRom2();
+
+        expect(container.textContent).not.toContain("BIOS");
+        expect(queryByTestId("saves-tab")).toBeNull();
+        expect(container.textContent).toContain("Game (Japan)");
+      });
     });
 
     // #1681 — BIOS is the third per-rom tab. The requirement is core-dependent

--- a/src/components/panelEvents.ts
+++ b/src/components/panelEvents.ts
@@ -74,7 +74,15 @@ async function handleSaveSyncSettingsChange(
     // sequence's next ticket: a status read an earlier event left in flight
     // would otherwise land afterwards and put the SAVES tab back.
     takeReadTicket(ctx.readSeqs, "saveStatus");
-    ctx.setState((prev) => ({ ...prev, saveSyncEnabled: false }));
+    ctx.setState((prev) => ({
+      ...prev,
+      saveSyncEnabled: false,
+      // The SAVES tab's button is gated on the same flag, so switching it off
+      // under a user standing on that tab would take the button away and leave
+      // its pane below an unmarked strip. Send them back to the tab every ROM
+      // has — the move `handleVersionSwitched` makes for BIOS.
+      activeTab: prev.activeTab === "saves" ? "info" : prev.activeTab,
+    }));
     return;
   }
   // Switching save sync ON is a fact about the setting, not an answer about this
@@ -209,17 +217,31 @@ async function handleVersionSwitched(
   // A detail carrying no BIOS answer keeps the shown status: the switched-to
   // version's requirement is unread, not absent (#1693).
   const biosFields = biosFieldsFromCache(cached);
+  const saveSyncEnabled = cached.save_sync_enabled ?? false;
   ctx.setState((prev) => {
     const biosStatus = biosFields ? biosFields.biosStatus : prev.biosStatus;
+    // Both gated tabs can lose their button to this switch, and a user standing
+    // on one is then looking at a body with nothing marked in the strip above
+    // it. Asked as one question because the answer is the same either way and
+    // only one tab is active: back to the tab every version has.
+    const activeTabGone =
+      (prev.activeTab === "bios" && !biosStatus) || (prev.activeTab === "saves" && !saveSyncEnabled);
     return {
       ...prev,
       romId: newRomId,
       romName: cached.rom_name || prev.romName,
       installed: cached.installed ?? false,
+      // Cleared rather than overwritten: `refreshInstalledRomInBackground`
+      // writes only on a truthy answer, so a failed or empty read would leave
+      // the previous version's file name standing under this version's
+      // `installed` until a remount. The record describes ONE version, and a
+      // sibling download supersedes the install it names without the panel
+      // hearing about it (#1742). Re-read below.
+      installedRom: null,
       regions: cached.regions ?? [],
       languages: cached.languages ?? [],
       // Re-key per-rom tab state so nothing lingers from the previous version.
-      saveSyncEnabled: cached.save_sync_enabled ?? false,
+      saveSyncEnabled,
       saveStatus,
       conflicts: cached.save_status?.conflicts ?? [],
       raId: cached.ra_id ?? null,
@@ -227,29 +249,30 @@ async function handleVersionSwitched(
       availableSlots: [],
       slotsLoading: false,
       ...biosFields,
-      // The BIOS tab's button is gated on `biosStatus`, so clearing it while
-      // the user stands on that tab would hide the button and leave the body
-      // empty with nothing selected. Send them back to the tab every version
-      // has.
-      activeTab: !biosStatus && prev.activeTab === "bios" ? "info" : prev.activeTab,
+      activeTab: activeTabGone ? "info" : prev.activeTab,
     };
   });
   // Re-fetch slot configuration (slotConfirmed) + slots for the new rom_id,
   // mirroring loadData's save-sync branch — this is the authority that keeps
   // the SlotSetupWizard-vs-SavesTab gate correct across the switch.
-  if (cached.save_sync_enabled && newRomId != null) {
+  if (saveSyncEnabled && newRomId != null) {
     refreshSlotState(bindCurrentRom(ctx, newRomId), ctx.readSeqs);
   }
   if (newRomId) {
     const binding = bindCurrentRom(ctx, newRomId);
-    await Promise.all([
+    const reads = [
       refreshCoverArtInBackground(binding),
       // The BIOS tab's "Active Core" row and its per-file core lines come
       // from the dedicated core-info path (#923), keyed on rom_id so a
       // per-game override follows the switch. A failed read keeps the
       // previous reading rather than blanking it.
       refreshPanelCoreInfo(binding),
-    ]);
+    ];
+    // Read only when this version has an install to describe, mirroring the
+    // mount load — the ROM File row and its launch-target note are hidden
+    // either way, and an uninstalled version has no record to fetch.
+    if (cached.installed) reads.push(refreshInstalledRomInBackground(binding));
+    await Promise.all(reads);
   }
 }
 


### PR DESCRIPTION
Two gaps in the game-detail panel's event handlers, each one a handler not doing what its sibling
does.

**The ROM File row (#1742).** A version switch re-keyed the per-rom state but never touched the
installed-rom record, and its background reads covered the cover and the core info but not that one.
The row is gated on `installed && installedRom`, and `installed` comes from the switched-TO version
while the record describes the one being left — so the two are read together and have to be re-keyed
together. Switching to a version that is installed showed no row at all; a narrower path left the
previous version's filename standing under the new version's name, with the launch-target note
decided against the wrong ROM.

The record is now cleared as part of the switch and re-read, not only re-read. That distinction
carries the fix: `refreshInstalledRomInBackground` writes only on a truthy answer and never clears,
so a rejected call — or an install that vanished between the detail read and the record read — would
otherwise leave the stale filename standing until a remount. Clearing degrades to a missing row,
which is an honest gap; not clearing degrades to a confident wrong answer that nothing withdraws.

**The SAVES pane (#1748).** Switching save sync off while the pane was open removed the tab from the
strip and left the pane rendered beneath it, with nothing marked active above. The panel already
solves this for BIOS by sending the user back to the tab every version has; save sync now does the
same.

Applying that pattern turned up the sibling site it was already missing: the version-switch handler
writes the save-sync flag from the fresh detail and applied the BIOS fallback but not the save-sync
one. Both dead ends are now asked as a single question rather than a chain — only one tab is active
at a time and the answer is the same either way, so there is no ordering between them to get wrong,
and a switch that clears both cannot strand the user on the one that lost second.

docs: N/A — both defects were the UI failing to match behaviour the user guide already describes;
nothing documented changes.

Closes #1742
Closes #1748
