### PR TITLE
fix(saves): name no slot until one has been answered

### DIFF
--- a/docs/user-guide/save-sync.md
+++ b/docs/user-guide/save-sync.md
@@ -184,6 +184,11 @@ If the RomM server is unreachable when a sync is attempted:
   outcome — typically pushing your changes once the server is reachable again.
 - No save data is ever lost due to a failed sync.
 
+The slot list comes from the server, so while RomM is unreachable the SAVES tab has no confirmed slot to show — and it
+names none rather than guessing. Your locally tracked save files are still listed, just not filed under a slot panel,
+and the offline banner at the top of the tab explains why slot switching is unavailable. The slots, and the active one
+among them, reappear as soon as the server is reachable again.
+
 "Server offline" is reported **only** for a genuine reachability failure (the server can't be reached or times out). A
 sync that fails for another reason — for example an expired or revoked login token, or an SSL certificate problem —
 shows that specific reason instead (such as "Authentication failed — check your username and password"), so a working

--- a/src/components/RomMGameInfoPanel.test.tsx
+++ b/src/components/RomMGameInfoPanel.test.tsx
@@ -2323,7 +2323,7 @@ describe("RomMGameInfoPanel", () => {
 
       // Activate the saves tab while offline: the fast path must NOT run the
       // server slot fetch (no "Loading slots…" hang through the retry ladder) and
-      // the SavesTab still renders (its degraded per-slot notices).
+      // the SavesTab still renders its degraded view.
       await act(async () => {
         globalThis.dispatchEvent(new CustomEvent("romm_tab_switch", { detail: { tab: "saves" } }));
         await Promise.resolve();
@@ -2339,6 +2339,35 @@ describe("RomMGameInfoPanel", () => {
         await Promise.resolve();
       });
       expect(vi.mocked(backend.getSaveSlots)).toHaveBeenCalledWith(55);
+    });
+
+    it("hands the saves tab an unanswered active slot while no slot answer has landed (#1747)", async () => {
+      // The fast path above skips the fetch, so nothing has answered what the
+      // active slot is. The panel's placeholder is still the shown value — the
+      // tab must be told it is a placeholder, or it renders `default` as a fact.
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
+        found: true,
+        rom_id: 55,
+        save_sync_enabled: true,
+        metadata: makeMetadata(),
+        stale_fields: [],
+      });
+      vi.mocked(backend.isSaveTrackingConfigured).mockResolvedValue({
+        configured: true,
+        active_slot: "main",
+      });
+      setRommConnectionState("offline");
+      render(<RomMGameInfoPanel appId={testAppId} />);
+      await flushAsync();
+      capturedSavesTab.length = 0;
+      await act(async () => {
+        globalThis.dispatchEvent(new CustomEvent("romm_tab_switch", { detail: { tab: "saves" } }));
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      const latest = capturedSavesTab[capturedSavesTab.length - 1];
+      expect(latest?.activeSlot).toBe("default");
+      expect(latest?.activeSlotKnown).toBe(false);
     });
 
     it("saves tab: a mid-flight offline flip does not wedge the connecting indicator; reconnect reloads (#1345 F2)", async () => {
@@ -3499,6 +3528,67 @@ describe("RomMGameInfoPanel", () => {
       const latest = capturedSavesTab[capturedSavesTab.length - 1];
       expect(latest?.romId).toBe(2);
       expect(latest?.saveStatus?.files[0]?.filename).toBe("NEW_VERSION.srm");
+    });
+
+    it("re-marks the active slot unanswered on a version switch (#1747)", async () => {
+      // The switch re-keys activeSlot back to the placeholder, so whatever
+      // answered for the previous version must not vouch for the new one.
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
+        found: true,
+        rom_id: 1,
+        save_sync_enabled: true,
+        metadata: makeMetadata(),
+        stale_fields: [],
+      });
+      vi.mocked(backend.isSaveTrackingConfigured).mockResolvedValue({
+        configured: true,
+        active_slot: "main",
+      });
+      render(<RomMGameInfoPanel appId={testAppId} />);
+      await flushAsync();
+      await act(async () => {
+        globalThis.dispatchEvent(new CustomEvent("romm_tab_switch", { detail: { tab: "saves" } }));
+      });
+      await flushAsync();
+      // A completed slot switch is an answer about rom 1's active slot.
+      await act(async () => {
+        capturedSavesTab[capturedSavesTab.length - 1]?.onSlotSwitched("main", {
+          rom_id: 1,
+          files: [],
+          playtime: {
+            total_seconds: 0,
+            session_count: 0,
+            last_session_start: null,
+            last_session_duration_sec: null,
+            last_played: null,
+          },
+          device_id: "d",
+          last_sync_check_at: null,
+        });
+      });
+      await flushAsync();
+      expect(capturedSavesTab[capturedSavesTab.length - 1]?.activeSlotKnown).toBe(true);
+
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
+        found: true,
+        rom_id: 2,
+        save_sync_enabled: true,
+        metadata: makeMetadata(),
+        stale_fields: [],
+      });
+      capturedSavesTab.length = 0;
+      await act(async () => {
+        globalThis.dispatchEvent(
+          new CustomEvent("romm_data_changed", {
+            detail: { type: "version_switched", app_id: testAppId, rom_id: 2 },
+          }),
+        );
+      });
+      await flushAsync();
+      const latest = capturedSavesTab[capturedSavesTab.length - 1];
+      expect(latest?.romId).toBe(2);
+      expect(latest?.activeSlot).toBe("default");
+      expect(latest?.activeSlotKnown).toBe(false);
     });
 
     it("reloads SAVES tab data on the next activation after a switch (slotsLoadedRef reset, #1297)", async () => {

--- a/src/components/RomMGameInfoPanel.tsx
+++ b/src/components/RomMGameInfoPanel.tsx
@@ -67,6 +67,7 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => {
     raId: null,
     slotConfirmed: false,
     activeSlot: "default",
+    activeSlotKnown: false,
     availableSlots: [],
     slotsLoading: false,
     regions: [],

--- a/src/components/SavesTab.test.tsx
+++ b/src/components/SavesTab.test.tsx
@@ -110,6 +110,7 @@ function defaultProps(
     saveStatus: null,
     conflicts: [],
     activeSlot: "default",
+    activeSlotKnown: true,
     availableSlots: [],
     slotsLoading: false,
     onSlotSwitched: vi.fn(),
@@ -355,6 +356,7 @@ describe("SavesTab", () => {
         <SavesTab
           {...defaultProps({
             activeSlot: "ghost",
+            activeSlotKnown: true,
             availableSlots: [makeSlot({ slot: "alpha" })],
           })}
         />,
@@ -379,6 +381,56 @@ describe("SavesTab", () => {
       );
       const order = capturedSlotPanelProps.map((p) => p.slot.slot);
       expect(order).toEqual(["alpha"]);
+    });
+  });
+
+  describe("unanswered slot list (#1747)", () => {
+    it("names no slot while no slot answer has landed, even with the server unreachable", () => {
+      setRommConnectionState("offline");
+      const { queryByTestId, container } = render(
+        <SavesTab {...defaultProps({ activeSlot: "default", activeSlotKnown: false, availableSlots: [] })} />,
+      );
+      expect(capturedSlotPanelProps).toEqual([]);
+      expect(queryByTestId("slot-panel-default")).toBeNull();
+      // The offline banner is the one and only word on reachability here.
+      expect(container.textContent).toContain("RomM is offline");
+    });
+
+    it("keeps the locally tracked save files on screen while no slot answer has landed", () => {
+      const { queryByTestId } = render(
+        <SavesTab
+          {...defaultProps({
+            activeSlotKnown: false,
+            saveStatus: makeSaveStatus({ files: [makeSaveFile({ filename: "zelda.srm" })] }),
+          })}
+        />,
+      );
+      expect(queryByTestId("save-file-row-zelda.srm")).not.toBeNull();
+      expect(capturedSlotPanelProps).toEqual([]);
+    });
+
+    it("shows the tracked-files empty state without claiming legacy mode", () => {
+      const { container } = render(<SavesTab {...defaultProps({ activeSlotKnown: false, saveStatus: null })} />);
+      expect(container.textContent).toContain("No save files tracked yet");
+      expect(container.textContent).not.toContain("legacy mode");
+    });
+
+    it("files go back under the active slot panel once a slot answer has landed", () => {
+      const status = makeSaveStatus({ files: [makeSaveFile({ filename: "zelda.srm" })] });
+      const { queryByTestId } = render(
+        <SavesTab
+          {...defaultProps({
+            activeSlot: "main",
+            activeSlotKnown: true,
+            availableSlots: [makeSlot({ slot: "main" })],
+            saveStatus: status,
+          })}
+        />,
+      );
+      // Under the panel, and only there — a bare row alongside it would show
+      // the same file twice.
+      expect(capturedSlotPanelProps[0]?.saveStatus).toBe(status);
+      expect(queryByTestId("save-file-row-zelda.srm")).toBeNull();
     });
   });
 

--- a/src/components/SavesTab.tsx
+++ b/src/components/SavesTab.tsx
@@ -31,6 +31,10 @@ interface SavesTabProps {
   saveStatus: SaveStatus | null;
   conflicts: SyncConflict[];
   activeSlot: string | null;
+  /** Whether `activeSlot` is an answer for this ROM. False while none has
+   *  landed — the panel starts every ROM on a placeholder slot name, and this
+   *  tab is what would otherwise render it as a fact (#1747). */
+  activeSlotKnown: boolean;
   availableSlots: SaveSlotSummary[];
   slotsLoading: boolean;
   onSlotSwitched: (newSlot: string, newStatus: SaveStatus) => void;
@@ -42,6 +46,7 @@ export const SavesTab: FC<SavesTabProps> = ({
   saveStatus,
   conflicts,
   activeSlot,
+  activeSlotKnown,
   availableSlots,
   slotsLoading,
   onSlotSwitched,
@@ -220,9 +225,12 @@ export const SavesTab: FC<SavesTabProps> = ({
     return a.slot.localeCompare(b.slot);
   });
 
-  // If active slot not in list yet, synthesize a placeholder entry
+  // An active slot the list doesn't carry still gets a panel — it is a slot the
+  // user is on. Only for a slot something ANSWERED, though: synthesised off the
+  // panel's placeholder it puts a slot name on screen that nothing ever said
+  // (#1747), and `default` is a real name here, so it reads as a fact.
   const slotInList = sorted.some((s) => s.slot === activeSlot);
-  if (!slotInList && activeSlot) {
+  if (!slotInList && activeSlot && activeSlotKnown) {
     sorted.unshift({ slot: activeSlot, source: "local", count: 0, latest_updated_at: null });
   }
 
@@ -269,20 +277,23 @@ export const SavesTab: FC<SavesTabProps> = ({
     );
   };
 
-  // --- Legacy mode: show save files directly (not in a slot panel) ---
-  let legacyFilesSection: ReturnType<typeof createElement> | null = null;
-  if (activeSlot === null) {
+  // --- Save files with no slot panel to live under ---
+  // Legacy mode has no slot; an unanswered active slot has none this tab may
+  // name (#1747). Either way the locally tracked files are still what the user
+  // has, so they are shown — just not filed under a slot.
+  let unslottedFilesSection: ReturnType<typeof createElement> | null = null;
+  if (activeSlot === null || !activeSlotKnown) {
     if (saveStatus && saveStatus.files.length > 0) {
-      legacyFilesSection = createElement(
+      unslottedFilesSection = createElement(
         "div",
-        { key: "legacy-files", style: { marginBottom: "12px" } },
+        { key: "unslotted-files", style: { marginBottom: "12px" } },
         ...saveStatus.files.map((f) => {
           const conflict = conflicts.find((c) => c.filename === f.filename);
           return renderSaveFileRow(f, conflict, saveStatus.last_sync_check_at);
         }),
       );
     } else {
-      legacyFilesSection = createElement(
+      unslottedFilesSection = createElement(
         "div",
         {
           key: "no-files",
@@ -303,8 +314,8 @@ export const SavesTab: FC<SavesTabProps> = ({
     strandedBanner,
     legacyWarning,
 
-    // Legacy mode: show save files directly above slot panels
-    legacyFilesSection,
+    // Save files that belong to no slot panel — above the panels, if any.
+    unslottedFilesSection,
 
     // Slot panels — skip the "" (legacy) panel when already in legacy mode
     ...sorted

--- a/src/components/panelEvents.ts
+++ b/src/components/panelEvents.ts
@@ -246,6 +246,7 @@ async function handleVersionSwitched(
       conflicts: cached.save_status?.conflicts ?? [],
       raId: cached.ra_id ?? null,
       activeSlot: "default",
+      activeSlotKnown: false,
       availableSlots: [],
       slotsLoading: false,
       ...biosFields,

--- a/src/components/panelSlotsLoad.ts
+++ b/src/components/panelSlotsLoad.ts
@@ -121,10 +121,13 @@ export function useSaveSlotsLoad(
 
     // Known-offline fast path (#1345): the server slot fetch runs through the
     // retry+backoff ladder, so on a known-unreachable server it would hang
-    // "Loading slots…" for tens of seconds before the local degraded view (the
-    // per-slot "Server unreachable" notices) renders. Skip the fetch entirely —
-    // slotsLoading is still false here (the slotsLoadedRef guard above means the
-    // connected path never set it), so SavesTab renders the degraded view now.
+    // "Loading slots…" for tens of seconds before the local degraded view
+    // renders. Skip the fetch entirely — slotsLoading is still false here (the
+    // slotsLoadedRef guard above means the connected path never set it), so
+    // SavesTab renders that view now: the slots an earlier answer left behind,
+    // the active one carrying its offline summary — or, with nothing answered
+    // for this ROM yet, the locally tracked save files under no slot at all,
+    // since the only slot name on hand is the panel's placeholder (#1747).
     // slotsLoadedRef stays false, so a flip back to connected re-runs this effect
     // (isOffline dep) and loads.
     if (isOffline) return;

--- a/src/components/panelState.test.ts
+++ b/src/components/panelState.test.ts
@@ -47,7 +47,10 @@ function basePanelState(): PanelState {
     activeTab: "saves",
     raId: null,
     slotConfirmed: false,
-    activeSlot: null,
+    // The pair a freshly-mounted panel holds: the placeholder slot name, and
+    // nothing having answered what the active slot actually is.
+    activeSlot: "default",
+    activeSlotKnown: false,
     availableSlots: [],
     slotsLoading: false,
     regions: [],
@@ -98,6 +101,9 @@ describe("refreshSlotState", () => {
     await flush();
 
     expect(state.activeSlot).toBe("main");
+    // The name arrived with an answer, so it is one — the placeholder it
+    // replaced was not (#1747).
+    expect(state.activeSlotKnown).toBe(true);
     expect(state.availableSlots.map((s) => s.slot)).toEqual(["main"]);
     expect(state.slotConfirmed).toBe(true);
   });

--- a/src/components/panelState.ts
+++ b/src/components/panelState.ts
@@ -61,7 +61,14 @@ export interface PanelState {
   activeTab: string;
   raId: number | null;
   slotConfirmed: boolean;
+  // The slot the saves surfaces attribute this ROM's saves to. `null` is the
+  // legacy web-player bucket — a real answer with its own rendering, never a
+  // stand-in for "we don't know". What carries "we don't know" is the flag
+  // below: until it is set, `activeSlot` holds the placeholder every panel
+  // starts on, and `default` is a real slot name in this system, so a reader
+  // cannot tell the two apart (#1747).
   activeSlot: string | null;
+  activeSlotKnown: boolean;
   availableSlots: SaveSlotSummary[];
   slotsLoading: boolean;
   // Region / Languages of the ACTIVE version (ADR-0021), rendered as GAME INFO
@@ -342,6 +349,7 @@ export async function loadData(
       raId,
       slotConfirmed: false,
       activeSlot: "default",
+      activeSlotKnown: false,
       availableSlots: [],
       slotsLoading: false,
       regions: cached.regions ?? [],

--- a/src/components/panelTabContent.ts
+++ b/src/components/panelTabContent.ts
@@ -71,12 +71,17 @@ export function buildTabContent({
     saveStatus: state.saveStatus,
     conflicts: state.conflicts,
     activeSlot: state.activeSlot,
+    activeSlotKnown: state.activeSlotKnown,
     availableSlots: state.availableSlots,
     slotsLoading: state.slotsLoading,
     onSlotSwitched: (newSlot, newStatus) => {
       setState((prev) => ({
         ...prev,
         activeSlot: newSlot === "" ? null : newSlot,
+        // A completed switch is an answer about the active slot in its own
+        // right — the announce below re-reads the list, but the tab must not
+        // fall back to "unknown" for the round trip in between (#1747).
+        activeSlotKnown: true,
         saveStatus: newStatus,
         conflicts: newStatus.conflicts ?? [],
       }));

--- a/src/utils/slotState.test.ts
+++ b/src/utils/slotState.test.ts
@@ -26,6 +26,7 @@ interface LoadState extends LoadSlotsFields {
 
 const refreshState = (overrides: Partial<RefreshState> = {}): RefreshState => ({
   activeSlot: null,
+  activeSlotKnown: false,
   availableSlots: [],
   unrelated: 0,
   ...overrides,
@@ -33,6 +34,7 @@ const refreshState = (overrides: Partial<RefreshState> = {}): RefreshState => ({
 
 const loadState = (overrides: Partial<LoadState> = {}): LoadState => ({
   activeSlot: null,
+  activeSlotKnown: false,
   availableSlots: [],
   slotsLoading: false,
   unrelated: "",
@@ -74,6 +76,7 @@ describe("applyRefreshSlotResult", () => {
     const next = lastUpdater(setter)(refreshState({ unrelated: 7 }));
     expect(next).toEqual({
       activeSlot: "a",
+      activeSlotKnown: true,
       availableSlots: [slot("a"), slot("b")],
       unrelated: 7,
     });
@@ -87,11 +90,27 @@ describe("applyRefreshSlotResult", () => {
     expect(next.availableSlots).toEqual([slot("x")]);
   });
 
+  it("leaves the active slot unanswered when a success carries no active_slot (#1747)", () => {
+    const setter = makeSetter<RefreshState>();
+    applyRefreshSlotResult<RefreshState>({ success: true, slots: [slot("x")] }, setter);
+    const next = lastUpdater(setter)(refreshState({ activeSlot: "placeholder" }));
+    expect(next.activeSlotKnown).toBe(false);
+  });
+
+  it("keeps an already-answered active slot answered when a success carries no active_slot (#1747)", () => {
+    const setter = makeSetter<RefreshState>();
+    applyRefreshSlotResult<RefreshState>({ success: true, slots: [slot("x")] }, setter);
+    const next = lastUpdater(setter)(refreshState({ activeSlot: "a", activeSlotKnown: true }));
+    expect(next.activeSlotKnown).toBe(true);
+  });
+
   it("treats explicit null active_slot as the new value (does not preserve prev)", () => {
     const setter = makeSetter<RefreshState>();
     applyRefreshSlotResult<RefreshState>({ success: true, slots: [], active_slot: null }, setter);
     const next = lastUpdater(setter)(refreshState({ activeSlot: "previous" }));
     expect(next.activeSlot).toBeNull();
+    // The legacy bucket is an answer like any other name (#1747).
+    expect(next.activeSlotKnown).toBe(true);
   });
 });
 
@@ -115,6 +134,9 @@ describe("applyLoadSlotsResult", () => {
     const next = lastUpdater(setter)(prev);
     expect(next).toEqual({
       activeSlot: "keep",
+      // A failed load answered nothing — the shown active slot stays as
+      // unanswered as it was (#1747).
+      activeSlotKnown: false,
       availableSlots: [slot("keep")],
       slotsLoading: false,
       unrelated: "keep",
@@ -148,6 +170,7 @@ describe("applyLoadSlotsResult", () => {
     const next = lastUpdater(setter)(loadState({ slotsLoading: true, unrelated: "x" }));
     expect(next).toEqual({
       activeSlot: "a",
+      activeSlotKnown: true,
       availableSlots: [slot("a")],
       slotsLoading: false,
       unrelated: "x",
@@ -159,6 +182,20 @@ describe("applyLoadSlotsResult", () => {
     applyLoadSlotsResult<LoadState>({ success: true, slots: [slot("x")] }, setter, { current: true }, vi.fn());
     const next = lastUpdater(setter)(loadState({ activeSlot: "previous" }));
     expect(next.activeSlot).toBe("previous");
+  });
+
+  it("on success with no active_slot: leaves the active slot unanswered (#1747)", () => {
+    const setter = makeSetter<LoadState>();
+    applyLoadSlotsResult<LoadState>({ success: true, slots: [slot("x")] }, setter, { current: true }, vi.fn());
+    const next = lastUpdater(setter)(loadState({ activeSlot: "placeholder" }));
+    expect(next.activeSlotKnown).toBe(false);
+  });
+
+  it("on success with no active_slot: keeps an already-answered active slot answered (#1747)", () => {
+    const setter = makeSetter<LoadState>();
+    applyLoadSlotsResult<LoadState>({ success: true, slots: [slot("x")] }, setter, { current: true }, vi.fn());
+    const next = lastUpdater(setter)(loadState({ activeSlot: "a", activeSlotKnown: true }));
+    expect(next.activeSlotKnown).toBe(true);
   });
 
   it("on success: treats explicit null active_slot as the new value", () => {

--- a/src/utils/slotState.ts
+++ b/src/utils/slotState.ts
@@ -23,12 +23,16 @@ export interface SlotsResponse {
 
 export interface RefreshSlotFields {
   activeSlot: string | null;
+  /** Whether `activeSlot` is something a response said, or still the caller's
+   *  own initial value. Only a success that CARRIES `active_slot` turns it on:
+   *  a failure says nothing about the slot, and a success that omits the field
+   *  keeps the previous name — so it keeps the previous verdict with it, rather
+   *  than vouching for a value it never mentioned (#1747). */
+  activeSlotKnown: boolean;
   availableSlots: SaveSlotSummary[];
 }
 
-export interface LoadSlotsFields {
-  activeSlot: string | null;
-  availableSlots: SaveSlotSummary[];
+export interface LoadSlotsFields extends RefreshSlotFields {
   slotsLoading: boolean;
 }
 
@@ -43,6 +47,7 @@ export function applyRefreshSlotResult<S extends RefreshSlotFields>(
     ...prev,
     availableSlots: slotResult.slots,
     activeSlot: slotResult.active_slot === undefined ? prev.activeSlot : slotResult.active_slot,
+    activeSlotKnown: slotResult.active_slot !== undefined || prev.activeSlotKnown,
   }));
 }
 
@@ -64,6 +69,7 @@ export function applyLoadSlotsResult<S extends LoadSlotsFields>(
   setter((prev) => ({
     ...prev,
     activeSlot: result.active_slot === undefined ? prev.activeSlot : result.active_slot,
+    activeSlotKnown: result.active_slot !== undefined || prev.activeSlotKnown,
     availableSlots: result.slots,
     slotsLoading: false,
   }));


### PR DESCRIPTION
While RomM was unreachable the SAVES tab showed an active slot named `default`. That was never an
answer — it is the panel's initial placeholder, surfacing because the slot list is the server's and
the known-offline fast path never fetches one. `SavesTab` then hit its fallback for an active slot
missing from the list and synthesised an entry for it, marked local, with the tracked save file
underneath. What made it more than a cosmetic placeholder is that `default` is a real slot name in
this system — the plugin's own standard one — so nothing distinguished the invention from a fact.

`PanelState` now carries whether the shown active slot is something a response said, and `SavesTab`
consults it before inventing anything. While no answer has landed the tab names no slot at all and
lists the tracked save files unfiled; the offline banner above them stays the only word on
reachability. The synthesised entry still does the job it was written for — a known active slot
genuinely absent from the returned list.

The flag is set only by a response that carries the active slot, which keeps two lies out. A failed
slot read carries a locally persisted `active_slot`, and for an untracked ROM that field is itself a
fallback the backend invented; consuming either would put this defect straight back. It is cleared on
a version switch alongside the rest of the per-rom slot state, and set by a completed slot switch, so
a slot the user just created does not vanish for a round trip.

`activeSlot` keeps its type and its meaning: `null` is the legacy web-player bucket, never an alias
for `default` and never a stand-in for "unknown". The legacy warning stays bound to it alone, so an
unanswered tab cannot claim legacy mode — every writer that leaves the slot unanswered writes the
placeholder string, and every writer that can produce `null` answers in the same write.

Closes #1747
