### PR TITLE
fix(ui): bind the save tab's two write-backs to the rom they were issued for

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -294,16 +294,16 @@ Format: **invariant** — tier — enforced by.
   state, event and tab-content modules (`src/components/panelState.ts`, `src/components/panelEvents.ts`,
   `src/components/panelTabContent.ts` — the panel component itself holds none of these writes) via `RomBinding`, built
   by `bindRom` for a read a run of the `[appId]` effect issued and by `bindRomInState` for the active tab's panes, whose
-  writer is built during render where a ref cannot reach; the achievements tab (`src/components/AchievementsTab.tsx`) by
-  construction, its React key being the rom id, so its state cannot outlive the identity it was read for. A version
-  switch re-keys without closing, so neither the store's generation counter nor the panel's `[appId]` effect sees this
-  class. Binding answers the wrong-rom question only; two answers for the SAME rom are ordered instead, by a sequence
-  taken when the read is issued — the store's `loadSeq`, the panel's `takeReadTicket` (#1717). Four writes are unbound:
-  the two identity writes install what a binding would compare against, so ordering is all they can have, and both have
-  it. The other two have neither — the store's `cached.bios_status` fold runs in the same synchronous run as its guard,
-  and the event lane's `handleBiosChange` answers for the platform's default core and can overwrite a rom-keyed answer
-  (#1718). The panel's remaining lazy lane writes through the raw setter, ordered by the same ticket. The play button is
-  NOT covered (#1714)** — test + prompt-only — the panel's twelve bound sites each carry a version-switch test
+  writer is built during render; the achievements tab (`src/components/AchievementsTab.tsx`) by construction, its React
+  key being the rom id, so its state cannot outlive the identity it was read for. A version switch re-keys without
+  closing, so neither the store's generation counter nor the panel's `[appId]` effect sees this class. Binding answers
+  the wrong-rom question only; two answers for the SAME rom are ordered instead, by a sequence taken when the read is
+  issued — the store's `loadSeq`, the panel's `takeReadTicket` (#1717). Four writes are unbound: the two identity writes
+  install what a binding would compare against, so ordering is all they can have, and both have it. The other two have
+  neither — the store's `cached.bios_status` fold runs in the same synchronous run as its guard, and the event lane's
+  `handleBiosChange` answers for the platform's default core and can overwrite a rom-keyed answer (#1718). The panel's
+  remaining lazy lane writes through the raw setter, ordered by the same ticket. The play button is NOT covered
+  (#1714)** — test + prompt-only — the panel's twelve bound sites each carry a version-switch test
   (`src/components/RomMGameInfoPanel.test.tsx`); the store side and every new write site on either are prompt-only,
   because a checker scoped to the store's own function bodies would be green on the case this rule was written for. The
   reasons behind the two writer mechanisms live at `writerForRom` and `RomBinding` — do not restate them here

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -303,7 +303,7 @@ Format: **invariant** — tier — enforced by.
   it. The other two have neither — the store's `cached.bios_status` fold runs in the same synchronous run as its guard,
   and the event lane's `handleBiosChange` answers for the platform's default core and can overwrite a rom-keyed answer
   (#1718). The panel's remaining lazy lane writes through the raw setter, ordered by the same ticket. The play button is
-  NOT covered (#1714)** — test + prompt-only — the panel's eleven bound sites each carry a version-switch test
+  NOT covered (#1714)** — test + prompt-only — the panel's twelve bound sites each carry a version-switch test
   (`src/components/RomMGameInfoPanel.test.tsx`); the store side and every new write site on either are prompt-only,
   because a checker scoped to the store's own function bodies would be green on the case this rule was written for. The
   reasons behind the two writer mechanisms live at `writerForRom` and `RomBinding` — do not restate them here

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -291,8 +291,10 @@ Format: **invariant** — tier — enforced by.
   prompt-only — prune service namespace-race tests; new destructive RomM proof paths are prompt-only
 - **Every write into per-rom detail state that crosses an `await` is bound to a rom identity — the store
   (`src/utils/gameDetailStore.ts`) via `writerForRom`, or the answer's own `rom_id` in `applySaveStatus`; the panel's
-  state and event modules (`src/components/panelState.ts`, `src/components/panelEvents.ts` — the panel component itself
-  holds none of these writes) via `RomBinding`; the achievements tab (`src/components/AchievementsTab.tsx`) by
+  state, event and tab-content modules (`src/components/panelState.ts`, `src/components/panelEvents.ts`,
+  `src/components/panelTabContent.ts` — the panel component itself holds none of these writes) via `RomBinding`, built
+  by `bindRom` for a read a run of the `[appId]` effect issued and by `bindRomInState` for the active tab's panes, whose
+  writer is built during render where a ref cannot reach; the achievements tab (`src/components/AchievementsTab.tsx`) by
   construction, its React key being the rom id, so its state cannot outlive the identity it was read for. A version
   switch re-keys without closing, so neither the store's generation counter nor the panel's `[appId]` effect sees this
   class. Binding answers the wrong-rom question only; two answers for the SAME rom are ordered instead, by a sequence
@@ -301,7 +303,7 @@ Format: **invariant** — tier — enforced by.
   it. The other two have neither — the store's `cached.bios_status` fold runs in the same synchronous run as its guard,
   and the event lane's `handleBiosChange` answers for the platform's default core and can overwrite a rom-keyed answer
   (#1718). The panel's remaining lazy lane writes through the raw setter, ordered by the same ticket. The play button is
-  NOT covered (#1714)** — test + prompt-only — the panel's ten bound sites each carry a version-switch test
+  NOT covered (#1714)** — test + prompt-only — the panel's eleven bound sites each carry a version-switch test
   (`src/components/RomMGameInfoPanel.test.tsx`); the store side and every new write site on either are prompt-only,
   because a checker scoped to the store's own function bodies would be green on the case this rule was written for. The
   reasons behind the two writer mechanisms live at `writerForRom` and `RomBinding` — do not restate them here

--- a/src/components/RomMGameInfoPanel.test.tsx
+++ b/src/components/RomMGameInfoPanel.test.tsx
@@ -4460,6 +4460,38 @@ describe("RomMGameInfoPanel", () => {
         expect(container.textContent).toContain("MOUNTED SUMMARY");
         expect(container.textContent).not.toContain("USA SUMMARY");
       });
+
+      it("does not fold a slot switch started on the previous version into the switched-to version", async () => {
+        // The one write here that is not a background read: the SAVES pane hands
+        // this callback to `SavesTab`, which calls it after awaiting the switch.
+        // The tab gets no React key, so it survives the version switch holding
+        // the callback it was rendered with — which still answers for the
+        // previous version's rom (#1754).
+        vi.mocked(backend.isSaveTrackingConfigured).mockResolvedValue({ configured: true, active_slot: "main" });
+        vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(detailFor(1, { save_sync_enabled: true }));
+        render(<RomMGameInfoPanel appId={testAppId} />);
+        await flushAsync();
+        await openSavesTab();
+
+        // The switch the user started while the previous version was showing.
+        const switchedOnRom1 = capturedSavesTab[capturedSavesTab.length - 1]?.onSlotSwitched;
+        expect(switchedOnRom1).toBeDefined();
+
+        await switchToRom2({ save_sync_enabled: true });
+
+        await act(async () => {
+          switchedOnRom1!("japan-only", emptySaveStatus(1));
+        });
+        await flushAsync();
+
+        const latest = capturedSavesTab[capturedSavesTab.length - 1];
+        expect(latest?.activeSlot).toBe("default");
+        // The field the stale write does the most damage to: it is what tells
+        // the tab the slot name above is a fact rather than the placeholder.
+        expect(latest?.activeSlotKnown).toBe(false);
+        expect(latest?.saveStatus).toBeNull();
+        expect(capturedSavesTab.some((props) => props.activeSlot === "japan-only")).toBe(false);
+      });
     });
   });
 

--- a/src/components/RomMGameInfoPanel.test.tsx
+++ b/src/components/RomMGameInfoPanel.test.tsx
@@ -4492,6 +4492,36 @@ describe("RomMGameInfoPanel", () => {
         expect(latest?.saveStatus).toBeNull();
         expect(capturedSavesTab.some((props) => props.activeSlot === "japan-only")).toBe(false);
       });
+
+      it("does not fold a slot confirmation started on the previous version into the switched-to version", async () => {
+        // The pane's other render-scoped write. Its sibling above holds the
+        // previous version's `isSaveTrackingConfigured` READ open; this one lets
+        // the read answer normally and fires the wizard callback instead, which
+        // is the write that reaches `slotConfirmed` without going near a fence.
+        vi.mocked(backend.isSaveTrackingConfigured).mockResolvedValue({ configured: false, active_slot: null });
+        vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(detailFor(1, { save_sync_enabled: true }));
+        const { queryByTestId } = render(<RomMGameInfoPanel appId={testAppId} />);
+        await flushAsync();
+        await openSavesTab();
+        expect(queryByTestId("slot-setup-wizard")).not.toBeNull();
+
+        // The confirm the user started while the previous version was showing.
+        const confirmedOnRom1 = capturedSlotSetupWizard[capturedSlotSetupWizard.length - 1]?.onComplete;
+        expect(confirmedOnRom1).toBeDefined();
+
+        await switchToRom2({ save_sync_enabled: true });
+
+        await act(async () => {
+          confirmedOnRom1!();
+        });
+        await flushAsync();
+
+        // `slotConfirmed` is the gate between the two panes, so the refused
+        // write is the whole difference between the switched-to version's own
+        // wizard and a saves tab it has no configured tracking for.
+        expect(queryByTestId("slot-setup-wizard")).not.toBeNull();
+        expect(queryByTestId("saves-tab")).toBeNull();
+      });
     });
   });
 

--- a/src/components/RomMGameInfoPanel.tsx
+++ b/src/components/RomMGameInfoPanel.tsx
@@ -192,7 +192,7 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => {
         className: "romm-tab-content",
         style: { paddingBottom: "48px" },
       },
-      buildTabContent({ appId, binding: bindRomInState(romId, setState), state, setState }),
+      buildTabContent({ appId, binding: bindRomInState(romId, setState), state }),
       // Mounted for every ROM and rendering nothing until their tab is active.
       // For achievements that is load-bearing: the list is fetched by the tab
       // itself, and unmounting it on a tab switch would re-fetch (and re-spinner)

--- a/src/components/RomMGameInfoPanel.tsx
+++ b/src/components/RomMGameInfoPanel.tsx
@@ -23,7 +23,7 @@ import { AchievementsTab } from "./AchievementsTab";
 import { BiosTab } from "./BiosTab";
 import { PanelTabBar } from "./PanelTabBar";
 import { SaveSortWarning } from "./SaveSortWarning";
-import { loadData, type PanelReadSeqs, type PanelState } from "./panelState";
+import { bindRomInState, loadData, type PanelReadSeqs, type PanelState } from "./panelState";
 import { wirePanelEvents } from "./panelEvents";
 import { useSaveSlotsLoad } from "./panelSlotsLoad";
 import { buildTabContent } from "./panelTabContent";
@@ -192,7 +192,7 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => {
         className: "romm-tab-content",
         style: { paddingBottom: "48px" },
       },
-      buildTabContent({ appId, romId, state, setState }),
+      buildTabContent({ appId, binding: bindRomInState(romId, setState), state, setState }),
       // Mounted for every ROM and rendering nothing until their tab is active.
       // For achievements that is load-bearing: the list is fetched by the tab
       // itself, and unmounting it on a tab switch would re-fetch (and re-spinner)

--- a/src/components/panelState.test.ts
+++ b/src/components/panelState.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import type { MutableRefObject } from "react";
+import type { MutableRefObject, SetStateAction } from "react";
 import {
+  bindRomInState,
   refreshPanelCoreInfo,
   refreshSlotState,
   takeReadTicket,
@@ -86,6 +87,42 @@ describe("takeReadTicket", () => {
     takeReadTicket(seqs, "saveStatus");
     takeReadTicket(seqs, "detail");
     expect(slots()).toBe(false);
+  });
+});
+
+describe("bindRomInState", () => {
+  /** A `useState` setter over a plain value, so a binding's writes can be
+   *  applied and read back without mounting the panel. */
+  function stateSetter(initial: PanelState) {
+    let state = initial;
+    return {
+      setter: (update: SetStateAction<PanelState>) => {
+        state = typeof update === "function" ? update(state) : update;
+      },
+      get current(): PanelState {
+        return state;
+      },
+    };
+  }
+
+  it("folds an answer in while the state still names the bound rom", () => {
+    const store = stateSetter(basePanelState());
+    bindRomInState(7, store.setter).write((prev) => ({ ...prev, activeSlot: "main", activeSlotKnown: true }));
+    expect(store.current.activeSlot).toBe("main");
+    expect(store.current.activeSlotKnown).toBe(true);
+  });
+
+  it("drops an answer for a rom the state has moved off", () => {
+    const store = stateSetter({ ...basePanelState(), romId: 8 });
+    bindRomInState(7, store.setter).write((prev) => ({ ...prev, activeSlot: "main", activeSlotKnown: true }));
+    expect(store.current.activeSlot).toBe("default");
+    expect(store.current.activeSlotKnown).toBe(false);
+  });
+
+  it("takes a whole-state action as well as an updater — the writer's published shape", () => {
+    const store = stateSetter(basePanelState());
+    bindRomInState(7, store.setter).write({ ...basePanelState(), activeSlot: "main" });
+    expect(store.current.activeSlot).toBe("main");
   });
 });
 

--- a/src/components/panelState.ts
+++ b/src/components/panelState.ts
@@ -121,6 +121,33 @@ export function bindRom(
   };
 }
 
+/** Bind a write to `romId` against the identity carried by the state it
+ *  updates — the binding for a writer built during RENDER, which is what the
+ *  active tab's panes get handed.
+ *
+ *  Neither of {@link bindRom}'s two ends is reachable from there, each for its
+ *  own reason. `romIdRef` cannot be passed to a callee during render at all
+ *  (`react-hooks/refs`), and `prev.romId` is the same answer: the panel installs
+ *  it and re-points it in the same synchronous block as the ref, so the two can
+ *  only disagree inside that block — never across the await a stale answer
+ *  arrives from. `cancelled` belongs to a single run of the `[appId]` effect,
+ *  and a render-scoped writer could only reach it through a ref that every new
+ *  run resets — which would answer false again for the PREVIOUS run's load and
+ *  event lane, letting back in exactly the writes `bindRom` exists to refuse.
+ *  What its absence leaves uncovered is the window between an appId change and
+ *  the new load installing its ROM: the state still names the old ROM there, so
+ *  a write lands — into state that same load then replaces whole. */
+export function bindRomInState(romId: number, setter: Dispatch<SetStateAction<PanelState>>): RomBinding {
+  return {
+    romId,
+    write: (update) =>
+      setter((prev) => {
+        if (prev.romId !== romId) return prev;
+        return typeof update === "function" ? update(prev) : update;
+      }),
+  };
+}
+
 /** The panel's read sequences: one counter per set of reads whose answers write
  *  the same fields.
  *

--- a/src/components/panelState.ts
+++ b/src/components/panelState.ts
@@ -86,11 +86,17 @@ export interface PanelState {
 /** A ROM identity paired with the only writer allowed to fold an answer read for
  *  it into panel state.
  *
- *  `write` drops the update when the panel that issued the read is gone, and
- *  when the panel has been re-bound to a different ROM since. Those are two
- *  separate ends, and neither covers the other: a version switch re-binds the
- *  shortcut to a new rom_id without changing the appId, so the `[appId]` effect
- *  never re-runs and its `cancelled` flag never fires for it (#1713).
+ *  What the TYPE promises is one end: `write` drops the update once the panel
+ *  has been re-bound to a different ROM. That is the end a version switch needs,
+ *  because it re-binds the shortcut to a new rom_id without changing the appId,
+ *  so the `[appId]` effect never re-runs and its `cancelled` flag never fires
+ *  for it (#1713).
+ *
+ *  Whether a binding ALSO drops the update once the panel that issued the read
+ *  is gone is the constructor's to decide, and the two ends do not cover each
+ *  other. A read that outlives its effect run needs both, so hand it a
+ *  {@link bindRom} binding — a {@link bindRomInState} one carries the rom end
+ *  alone and would let that run's answer land.
  *
  *  Carrying the ROM alongside its writer is what keeps the two from drifting
  *  apart — a read issued off `binding.romId` cannot be folded in through a

--- a/src/components/panelTabContent.ts
+++ b/src/components/panelTabContent.ts
@@ -14,11 +14,11 @@ import type { Dispatch, SetStateAction } from "react";
 import { GameInfoTab } from "./GameInfoTab";
 import { SavesTab } from "./SavesTab";
 import { SlotSetupWizard } from "./SlotSetupWizard";
-import type { PanelState } from "./panelState";
+import type { PanelState, RomBinding } from "./panelState";
 
 interface TabContentContext {
   readonly appId: number;
-  readonly romId: number;
+  readonly binding: RomBinding;
   readonly state: PanelState;
   readonly setState: Dispatch<SetStateAction<PanelState>>;
 }
@@ -35,10 +35,12 @@ function announceSaveSyncChange(romId: number): void {
 /** Build the pane for the active tab, or null when the active tab builds none. */
 export function buildTabContent({
   appId,
-  romId,
+  binding,
   state,
   setState,
 }: TabContentContext): ReturnType<typeof createElement> | null {
+  const romId = binding.romId;
+
   if (state.activeTab === "info") {
     return createElement(GameInfoTab, {
       key: "tab-info",
@@ -76,7 +78,12 @@ export function buildTabContent({
     lastKnownSlots: state.lastKnownSlots,
     slotsLoading: state.slotsLoading,
     onSlotSwitched: (newSlot, newStatus) => {
-      setState((prev) => ({
+      // `SavesTab` calls this after awaiting the switch, and gets no React key
+      // of its own: it survives the version switch that re-points the panel to
+      // another rom_id under the same appId, still holding the callback it was
+      // rendered with. Only the ROM this pane was built for separates that
+      // answer from one about the version now showing (#1754).
+      binding.write((prev) => ({
         ...prev,
         activeSlot: newSlot === "" ? null : newSlot,
         // A completed switch is an answer about the active slot in its own

--- a/src/components/panelTabContent.ts
+++ b/src/components/panelTabContent.ts
@@ -10,7 +10,6 @@
  */
 
 import { createElement } from "react";
-import type { Dispatch, SetStateAction } from "react";
 import { GameInfoTab } from "./GameInfoTab";
 import { SavesTab } from "./SavesTab";
 import { SlotSetupWizard } from "./SlotSetupWizard";
@@ -20,7 +19,6 @@ interface TabContentContext {
   readonly appId: number;
   readonly binding: RomBinding;
   readonly state: PanelState;
-  readonly setState: Dispatch<SetStateAction<PanelState>>;
 }
 
 /** Tell every surface showing this ROM that its save-sync facts moved. */
@@ -33,12 +31,7 @@ function announceSaveSyncChange(romId: number): void {
 }
 
 /** Build the pane for the active tab, or null when the active tab builds none. */
-export function buildTabContent({
-  appId,
-  binding,
-  state,
-  setState,
-}: TabContentContext): ReturnType<typeof createElement> | null {
+export function buildTabContent({ appId, binding, state }: TabContentContext): ReturnType<typeof createElement> | null {
   const romId = binding.romId;
 
   if (state.activeTab === "info") {
@@ -61,7 +54,12 @@ export function buildTabContent({
     return createElement(SlotSetupWizard, {
       romId,
       onComplete: () => {
-        setState((prev) => ({ ...prev, slotConfirmed: true }));
+        // Bound for the same reason the slot switch below is: the wizard calls
+        // this after awaiting the confirm, and it is unkeyed too. `slotConfirmed`
+        // is the gate deciding which of the two panes this function builds, so a
+        // stale `true` puts a saves tab in front of a version whose tracking is
+        // not configured (#1754).
+        binding.write((prev) => ({ ...prev, slotConfirmed: true }));
         announceSaveSyncChange(romId);
       },
     });


### PR DESCRIPTION
The game detail panel hands its active tab two callbacks that write per-rom
state back into it: one when a slot switch completes, one when the save-setup
wizard confirms a slot. Both wrote through the panel's raw setter, and both are
invoked after an await.

A version switch re-binds the panel to a different rom_id without changing the
appId, so the [appId] effect never re-runs and its cancelled flag never fires.
The saves tab gets no React key either, so it survives the switch instead of
remounting. A slot switch or a confirmation still in flight when the version
changes therefore wrote the previous version's answer into the new one's state.
For the switch that is a wrong slot name, and activeSlotKnown claiming it is a
fact rather than a placeholder. For the confirmation it is worse: slotConfirmed
decides whether the pane shows the wizard or the saves tab, so a stale true puts
a saves tab in front of a version whose tracking is not configured, and nothing
corrects it afterwards — the announcement that follows carries the old rom_id
and every listener drops it.

Both now write through a RomBinding, refusing an answer once the panel names a
different rom. The panel's existing bindRom does not reach here: its ref cannot
be passed to a callee during render, and its cancelled flag belongs to one run
of an effect while these callbacks live as long as the tab does. bindRomInState
checks the rom carried by the state it is updating, which the panel installs and
re-points in the same synchronous block as the ref — so the two cannot disagree
across an await. With the raw setter gone from the module, an unbound write is
no longer expressible there.

Giving the saves tab a key on the rom, as the achievements tab has, was the
other way to fix this. It was rejected: remounting on every version switch
re-fires the tab's stranded-version check — a version list plus one drift check
per installed sibling — and drops the tab's own state, to fix a write the
binding refuses for free.

docs: N/A — no user-visible behaviour change; the stale slot name was already
tracked and the fix only refuses a write. CLAUDE.md's invariant register is
updated: both sites were absent from it, so it read as complete when it was not.

Closes #1754
