### PR TITLE
fix(ui): let the game page go back for a BIOS answer it could not get

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -303,7 +303,7 @@ Format: **invariant** — tier — enforced by.
   neither — the store's `cached.bios_status` fold runs in the same synchronous run as its guard, and the event lane's
   `handleBiosChange` answers for the platform's default core and can overwrite a rom-keyed answer (#1718). The panel's
   remaining lazy lane writes through the raw setter, ordered by the same ticket. The play button is NOT covered
-  (#1714)** — test + prompt-only — the panel's twelve bound sites each carry a version-switch test
+  (#1714)** — test + prompt-only — the panel's thirteen bound sites each carry a version-switch test
   (`src/components/RomMGameInfoPanel.test.tsx`); the store side and every new write site on either are prompt-only,
   because a checker scoped to the store's own function bodies would be green on the case this rule was written for. The
   reasons behind the two writer mechanisms live at `writerForRom` and `RomBinding` — do not restate them here

--- a/docs/user-guide/bios-management.md
+++ b/docs/user-guide/bios-management.md
@@ -39,9 +39,10 @@ than reporting "no BIOS needed". So a check that could not be completed never qu
 lets the game launch without its files; it leaves the warning where it was.
 
 It does not leave it there indefinitely, though: whenever the game detail page is shown a BIOS state it could not work
-out — on opening the page, after switching the emulator core, after switching to another version of the game — it goes
-back for a real answer in the background. The BIOS tab catches up on its own within a moment, so you do not have to
-leave the page and come back to see the state after a download or a delete.
+out — when the page opens, after switching the emulator core, after switching to another version of the game — it asks
+again in the background and fills the answer in a moment later. Opening a game while the requirement is unread used to
+show no BIOS tab at all until something else refreshed it, and switching core or version used to leave the previous
+core's or the previous version's readiness on screen.
 
 An unreachable RomM server usually does **not** put the plugin in that position: it falls back to its built-in registry
 of known BIOS files and still tells you what the platform needs. Only a platform that registry does not cover depends

--- a/docs/user-guide/bios-management.md
+++ b/docs/user-guide/bios-management.md
@@ -36,7 +36,12 @@ that treats a file as optional) clears the warning, while switching to a core th
 A BIOS warning only ever disappears on an **answer**. When the plugin cannot work out the requirement — most often right
 after a BIOS download or delete, before the state has been read again — it keeps showing the last status it knew rather
 than reporting "no BIOS needed". So a check that could not be completed never quietly clears a missing-BIOS warning and
-lets the game launch without its files; it leaves the warning where it was until a check gets through.
+lets the game launch without its files; it leaves the warning where it was.
+
+It does not leave it there indefinitely, though: whenever the game detail page is shown a BIOS state it could not work
+out — on opening the page, after switching the emulator core, after switching to another version of the game — it goes
+back for a real answer in the background. The BIOS tab catches up on its own within a moment, so you do not have to
+leave the page and come back to see the state after a download or a delete.
 
 An unreachable RomM server usually does **not** put the plugin in that position: it falls back to its built-in registry
 of known BIOS files and still tells you what the platform needs. Only a platform that registry does not cover depends

--- a/docs/user-guide/bios-management.md
+++ b/docs/user-guide/bios-management.md
@@ -38,11 +38,11 @@ after a BIOS download or delete, before the state has been read again — it kee
 than reporting "no BIOS needed". So a check that could not be completed never quietly clears a missing-BIOS warning and
 lets the game launch without its files; it leaves the warning where it was.
 
-It does not leave it there indefinitely, though: whenever the game detail page is shown a BIOS state it could not work
+It does not leave it there indefinitely, though. Whenever the game detail page is shown a BIOS state it could not work
 out — when the page opens, after switching the emulator core, after switching to another version of the game — it asks
-again in the background and fills the answer in a moment later. Opening a game while the requirement is unread used to
-show no BIOS tab at all until something else refreshed it, and switching core or version used to leave the previous
-core's or the previous version's readiness on screen.
+again in the background and fills the answer in a moment later. So a game opened while its requirement is still unread
+gets its BIOS tab a beat after the rest of the page, and a core or version switch settles on the new core's or new
+version's readiness rather than the one before it.
 
 An unreachable RomM server usually does **not** put the plugin in that position: it falls back to its built-in registry
 of known BIOS files and still tells you what the platform needs. Only a platform that registry does not cover depends

--- a/src/api/sharedReads.test.ts
+++ b/src/api/sharedReads.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import * as backend from "./backend";
-import { getPlatformCoreInfoShared, getRomMetadataShared, _resetSharedReadsForTests } from "./sharedReads";
+import {
+  getBiosStatusShared,
+  getPlatformCoreInfoShared,
+  getRomMetadataShared,
+  _resetSharedReadsForTests,
+} from "./sharedReads";
+import type { BiosAnswer } from "./backend";
 import type { CoreInfo, RomMetadata } from "../types";
 
 /** A read a test can hold open across a second caller's arrival. */
@@ -133,6 +139,20 @@ describe("sharedReads (#1758)", () => {
     expect(core).toMatchObject({ active_core_label: "Snes9x" });
     expect(vi.mocked(backend.getRomMetadata)).toHaveBeenCalledExactlyOnceWith(42);
     expect(vi.mocked(backend.getPlatformCoreInfo)).toHaveBeenCalledExactlyOnceWith(42);
+  });
+
+  it("collapses two overlapping BIOS callers into ONE backend call", async () => {
+    const open = deferred<BiosAnswer>();
+    vi.mocked(backend.getBiosStatus).mockReturnValue(open.promise);
+
+    const panel = getBiosStatusShared(42);
+    const playRow = getBiosStatusShared(42);
+    const answer: BiosAnswer = { bios_level: "missing" };
+    open.resolve(answer);
+
+    expect(await panel).toBe(answer);
+    expect(await playRow).toBe(answer);
+    expect(vi.mocked(backend.getBiosStatus)).toHaveBeenCalledExactlyOnceWith(42);
   });
 
   it("collapses two overlapping metadata callers into ONE backend call", async () => {

--- a/src/api/sharedReads.ts
+++ b/src/api/sharedReads.ts
@@ -28,12 +28,13 @@
  *   entirely and their duplicate on page open stands.
  *
  * What the rule admits, for the three reads below: both load lanes read them at
- * page open, and the only other paths that re-issue them are the two
- * `reloadDetail` triggers — `download_complete` and `rom_adopted`. Neither can
- * change a ROM's metadata, its active core, or which firmware files are on disk,
- * so the answer they would join is the answer they would get. A version switch
- * re-keys to a different rom_id, which is a different key here and so never
- * shares at all.
+ * page open, and the only other paths that re-issue them are the store's three
+ * re-derive triggers — `download_complete`, `rom_adopted` and
+ * `romm_rom_uninstalled`. None can change a ROM's metadata, its active core, or
+ * which firmware files are on disk, so the answer they would join is the answer
+ * they would get. A version switch re-keys to a different rom_id, which is a
+ * different key here — it shares with the other lane's load for that same new
+ * rom_id, and with nothing else.
  *
  * `get_bios_status` needs that argument made twice over, because a BIOS answer
  * is the one of the three that a user action moves within a single page's

--- a/src/api/sharedReads.ts
+++ b/src/api/sharedReads.ts
@@ -27,15 +27,35 @@
  *   never join a pre-mutation one, so these two are absent from this module
  *   entirely and their duplicate on page open stands.
  *
- * What the rule admits, for the two reads below: both load lanes read them at
+ * What the rule admits, for the three reads below: both load lanes read them at
  * page open, and the only other paths that re-issue them are the two
  * `reloadDetail` triggers — `download_complete` and `rom_adopted`. Neither can
- * change a ROM's metadata or its active core, so the answer they would join is
- * the answer they would get. A version switch re-keys to a different rom_id,
- * which is a different key here and so never shares at all.
+ * change a ROM's metadata, its active core, or which firmware files are on disk,
+ * so the answer they would join is the answer they would get. A version switch
+ * re-keys to a different rom_id, which is a different key here and so never
+ * shares at all.
+ *
+ * `get_bios_status` needs that argument made twice over, because a BIOS answer
+ * is the one of the three that a user action moves within a single page's
+ * lifetime: a firmware download or delete empties the firmware cache, and the
+ * next read answers differently. What admits it anyway is that no such action
+ * ever leads to a read through this module. Every re-read that follows one is
+ * change-driven and calls `api/backend` directly — the play row's post-download
+ * `refreshBiosStatus`, the `bios` event's own `check_platform_bios`, both
+ * stores' core-change handlers, and the info panel's version-switch re-read —
+ * and neither store re-runs a LOAD on a `bios` event, so a shared read is never
+ * issued after a firmware mutation.
+ *
+ * The bound on all three: a request is joinable only while it is open, so what
+ * a joiner can be handed is an answer read at most one open request ago. That is
+ * the page-open pair for the reads below, whose two calls are issued microtasks
+ * apart with no await a user action could land in. A read left hanging long
+ * enough to span one — an unresponsive server — can still be joined by the next
+ * load of the same ROM, which is the residual every entry here carries and the
+ * thing to weigh before adding a fourth.
  */
 
-import { getPlatformCoreInfo, getRomMetadata } from "./backend";
+import { getBiosStatus, getPlatformCoreInfo, getRomMetadata } from "./backend";
 
 /** Every wrapped read's open-request map, so the test reset below can reach all
  *  of them without each read having to register itself. */
@@ -71,6 +91,13 @@ export const getRomMetadataShared = shareInFlight(getRomMetadata);
  *  lanes. Both issue it unconditionally on every page open, so this is the one
  *  read that doubled on every single one. */
 export const getPlatformCoreInfoShared = shareInFlight(getPlatformCoreInfo);
+
+/** `get_bios_status` for one ROM, shared across the page's two load lanes. Both
+ *  issue it off the same `bios` stale mark on the same cached detail, and the
+ *  backend sets that mark whenever the detail carries no BIOS answer — which
+ *  includes every platform whose active core needs none, so the pair of them
+ *  made this read on nearly every page open. */
+export const getBiosStatusShared = shareInFlight(getBiosStatus);
 
 /** Test-only: forget every open request. A request only ever releases itself by
  *  settling, so a test that leaves one pending would otherwise hand it to the

--- a/src/components/RomMGameInfoPanel.test.tsx
+++ b/src/components/RomMGameInfoPanel.test.tsx
@@ -17,7 +17,7 @@ import { RomMGameInfoPanel } from "./RomMGameInfoPanel";
 import * as backend from "../api/backend";
 import type { CachedGameDetail } from "../api/backend";
 import * as cachedStore from "../utils/cachedGameDetailStore";
-import { _resetSharedReadsForTests } from "../api/sharedReads";
+import { getBiosStatusShared, _resetSharedReadsForTests } from "../api/sharedReads";
 import * as slotState from "../utils/slotState";
 import {
   installDomEventListenerSpy,
@@ -3423,6 +3423,30 @@ describe("RomMGameInfoPanel", () => {
       await flushAsync();
 
       expect(vi.mocked(backend.getBiosStatus)).toHaveBeenCalledWith(61);
+      expect(container.textContent).toContain("All ready (3/3)");
+    });
+
+    it("joins the play row's open read rather than opening a second round trip", async () => {
+      // Both lanes reach this read off the same stale mark on the same cached
+      // detail, microtasks apart, on every page open. Standing in for the play
+      // row's load here is a direct call to the shared seam both go through.
+      const open = heldAnswer<backend.BiosAnswer>();
+      vi.mocked(backend.getBiosStatus).mockReturnValue(open.promise);
+      const playRow = getBiosStatusShared(60);
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(staleDetail({ bios_status_unknown: true }));
+
+      const { container } = render(<RomMGameInfoPanel appId={testAppId} />);
+      await flushAsync();
+      await act(async () => {
+        open.release(biosAnswer(3));
+        await playRow;
+      });
+      await flushAsync();
+      await openBiosTab();
+
+      expect(vi.mocked(backend.getBiosStatus)).toHaveBeenCalledExactlyOnceWith(60);
+      // Non-vacuous in the other direction: the JOINED answer is the one folded,
+      // so this is sharing rather than the panel having skipped the read.
       expect(container.textContent).toContain("All ready (3/3)");
     });
 

--- a/src/components/RomMGameInfoPanel.test.tsx
+++ b/src/components/RomMGameInfoPanel.test.tsx
@@ -162,6 +162,17 @@ const flushAsync = () =>
     await Promise.resolve();
   });
 
+/** A read the test answers by hand, so it can still be open while the next event
+ *  runs — which is what lets one read be made to land after another, or a
+ *  request be left open for a later caller to join. */
+function heldRead<T>() {
+  let release!: (value: T) => void;
+  const promise = new Promise<T>((resolve) => {
+    release = resolve;
+  });
+  return { promise, release: (value: T) => release(value) };
+}
+
 let testAppId = 5000;
 
 // Complete RomMetadata fixture. The backend always serializes every field
@@ -3299,16 +3310,6 @@ describe("RomMGameInfoPanel", () => {
       await flushAsync();
     };
 
-    /** An answer the test hands over by hand, so a read can still be open while
-     *  the next event runs. */
-    function heldAnswer<T>() {
-      let release!: (value: T) => void;
-      const promise = new Promise<T>((resolve) => {
-        release = resolve;
-      });
-      return { promise, release: (value: T) => release(value) };
-    }
-
     it("re-reads on mount when the cached detail carries no answer, and the live one brings the tab back", async () => {
       vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(staleDetail({ bios_status_unknown: true }));
       vi.mocked(backend.getBiosStatus).mockResolvedValue(biosAnswer(1));
@@ -3430,7 +3431,7 @@ describe("RomMGameInfoPanel", () => {
       // Both lanes reach this read off the same stale mark on the same cached
       // detail, microtasks apart, on every page open. Standing in for the play
       // row's load here is a direct call to the shared seam both go through.
-      const open = heldAnswer<backend.BiosAnswer>();
+      const open = heldRead<backend.BiosAnswer>();
       vi.mocked(backend.getBiosStatus).mockReturnValue(open.promise);
       const playRow = getBiosStatusShared(60);
       vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(staleDetail({ bios_status_unknown: true }));
@@ -3450,6 +3451,45 @@ describe("RomMGameInfoPanel", () => {
       expect(container.textContent).toContain("All ready (3/3)");
     });
 
+    it("reads the switched-to version directly rather than joining an open read for it", async () => {
+      // A request for the version being switched TO can already be open — the
+      // page showed it earlier — and joining it would hand the switch an answer
+      // read before whatever has changed since. The store's own switch load
+      // reads the same rom_id microtasks away, so there is a real request here
+      // to join; staying direct is the choice, not the absence of one.
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(staleDetail({ ...biosAnswer(1), stale_fields: [] }));
+      const { container } = render(<RomMGameInfoPanel appId={testAppId} />);
+      await flushAsync();
+      await openBiosTab();
+      expect(container.textContent).toContain("1/3 files ready");
+
+      // Left open across the switch: a join lands on this and never answers.
+      const openForNewVersion = heldRead<backend.BiosAnswer>();
+      vi.mocked(backend.getBiosStatus).mockReturnValueOnce(openForNewVersion.promise);
+      const joinable = getBiosStatusShared(61);
+
+      vi.mocked(backend.getBiosStatus).mockResolvedValue(biosAnswer(3));
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(
+        staleDetail({ rom_id: 61, bios_status_unknown: true }),
+      );
+      await act(async () => {
+        globalThis.dispatchEvent(
+          new CustomEvent("romm_data_changed", {
+            detail: { type: "version_switched", app_id: testAppId, rom_id: 61 },
+          }),
+        );
+      });
+      await flushAsync();
+
+      expect(container.textContent).toContain("All ready (3/3)");
+
+      // Settle the seeded request rather than carrying it out of the test.
+      await act(async () => {
+        openForNewVersion.release({ bios_status_unknown: true });
+        await joinable;
+      });
+    });
+
     it("keeps the re-read a version switch issues when a core change is re-keyed under it", async () => {
       // The core change captures its identity before its two reads, so a switch
       // landing in that window leaves it answering for the version the panel
@@ -3463,7 +3503,7 @@ describe("RomMGameInfoPanel", () => {
       expect(container.textContent).toContain("1/3 files ready");
 
       // The core change's cache read stays open...
-      const coreChangeDetail = heldAnswer<CachedGameDetail>();
+      const coreChangeDetail = heldRead<CachedGameDetail>();
       vi.mocked(cachedStore.getCachedGameDetail).mockImplementationOnce(() => coreChangeDetail.promise);
       await act(async () => {
         globalThis.dispatchEvent(
@@ -3473,7 +3513,7 @@ describe("RomMGameInfoPanel", () => {
 
       // ...while a version switch re-keys the panel to rom 61 and issues the
       // re-read its own unreadable detail needs.
-      const switchedBios = heldAnswer<backend.BiosAnswer>();
+      const switchedBios = heldRead<backend.BiosAnswer>();
       vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(
         staleDetail({ rom_id: 61, bios_status_unknown: true }),
       );
@@ -4850,16 +4890,9 @@ describe("RomMGameInfoPanel", () => {
   // ------------------------------------------------------------------
 
   describe("two answers for the same rom ordered by when their reads were issued (#1717)", () => {
-    /** A read the test answers by hand, so the one issued FIRST can be made to
-     *  land last. Both are about the rom the panel is showing, so the rom
-     *  binding admits both and only the read's own ticket separates them. */
-    function heldRead<T>() {
-      let release!: (value: T) => void;
-      const promise = new Promise<T>((resolve) => {
-        release = resolve;
-      });
-      return { promise, release: (value: T) => release(value) };
-    }
+    // Every read held open in this block is about the rom the panel is showing,
+    // so the rom binding admits both answers and only the read's own ticket
+    // separates them.
 
     const detailFor = (
       romId: number,

--- a/src/components/RomMGameInfoPanel.test.tsx
+++ b/src/components/RomMGameInfoPanel.test.tsx
@@ -270,6 +270,10 @@ describe("RomMGameInfoPanel", () => {
     vi.mocked(backend.getInstalledRom).mockResolvedValue(null);
     vi.mocked(backend.getArtworkBase64).mockResolvedValue({ base64: null });
     vi.mocked(backend.checkPlatformBios).mockResolvedValue({ needs_bios: false });
+    // The live re-read a detail marked `bios`-stale triggers. Default: a read
+    // that could not answer, so a fixture carrying the stale mark re-reads
+    // without moving what is shown (#1693). Tests opt into an answer.
+    vi.mocked(backend.getBiosStatus).mockResolvedValue({ bios_status_unknown: true });
     // Core info comes from the dedicated get_platform_core_info path (#923),
     // decoupled from BIOS status. Default: no cores. Tests opt into shapes.
     vi.mocked(backend.getPlatformCoreInfo).mockResolvedValue({
@@ -3256,6 +3260,159 @@ describe("RomMGameInfoPanel", () => {
     });
   });
 
+  // #1752 — a detail that could not answer leaves the shown status standing
+  // (#1693), and nothing used to go back for the real one: the panel waited for
+  // a `bios` event, a core change, a version switch or a remount. The backend
+  // marks exactly that payload's `bios` field stale.
+  describe("BIOS re-read when the detail marks its answer stale (#1752)", () => {
+    /** A BIOS answer — cached or live, one shape — with `localCount` of 3 files
+     *  present. */
+    const biosAnswer = (localCount: number) => ({
+      bios_status: {
+        platform_slug: "snes",
+        server_count: 3,
+        local_count: localCount,
+        all_downloaded: localCount === 3,
+      },
+      bios_level: localCount === 3 ? ("ok" as const) : ("partial" as const),
+    });
+
+    /** A cached detail whose BIOS answer the backend marked stale — what every
+     *  BIOS download and delete leaves behind until something re-reads it. */
+    const staleDetail = (overrides: Partial<CachedGameDetail> = {}): CachedGameDetail => ({
+      found: true,
+      rom_id: 60,
+      platform_slug: "snes",
+      metadata: makeMetadata(),
+      stale_fields: ["bios"],
+      ...overrides,
+    });
+
+    const openBiosTab = async () => {
+      await act(async () => {
+        globalThis.dispatchEvent(new CustomEvent("romm_tab_switch", { detail: { tab: "bios" } }));
+      });
+      await flushAsync();
+    };
+
+    it("re-reads on mount when the cached detail carries no answer, and the live one brings the tab back", async () => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(staleDetail({ bios_status_unknown: true }));
+      vi.mocked(backend.getBiosStatus).mockResolvedValue(biosAnswer(1));
+      const { container } = render(<RomMGameInfoPanel appId={testAppId} />);
+      await flushAsync();
+
+      // Keyed on rom_id — `get_bios_status` resolves the per-game active core
+      // (#945), which is what the requirement is computed against.
+      expect(vi.mocked(backend.getBiosStatus)).toHaveBeenCalledWith(60);
+      expect(container.textContent).toContain("BIOS");
+      await openBiosTab();
+      expect(container.textContent).toContain("1/3 files ready");
+    });
+
+    it("adopts a live answer that has moved on from the stale cached one", async () => {
+      // The cached answer is a real one, just old — a BIOS download since it was
+      // written is exactly why the backend marked it stale.
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(staleDetail(biosAnswer(1)));
+      vi.mocked(backend.getBiosStatus).mockResolvedValue(biosAnswer(3));
+      const { container } = render(<RomMGameInfoPanel appId={testAppId} />);
+      await flushAsync();
+      await openBiosTab();
+
+      expect(container.textContent).toContain("All ready (3/3)");
+      expect(container.textContent).not.toContain("1/3 files ready");
+    });
+
+    it("does not re-read when the cached answer is not marked stale", async () => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(staleDetail({ ...biosAnswer(1), stale_fields: [] }));
+      const { container } = render(<RomMGameInfoPanel appId={testAppId} />);
+      await flushAsync();
+      await openBiosTab();
+
+      expect(vi.mocked(backend.getBiosStatus)).not.toHaveBeenCalled();
+      expect(container.textContent).toContain("1/3 files ready");
+    });
+
+    it("leaves the shown status standing when the re-read cannot answer either (#1693)", async () => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(staleDetail(biosAnswer(1)));
+      vi.mocked(backend.getBiosStatus).mockResolvedValue({ bios_status_unknown: true });
+      const { container } = render(<RomMGameInfoPanel appId={testAppId} />);
+      await flushAsync();
+      await openBiosTab();
+
+      expect(container.textContent).toContain("1/3 files ready");
+    });
+
+    it("leaves the shown status standing when the re-read fails, and says so in the log", async () => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(staleDetail(biosAnswer(1)));
+      vi.mocked(backend.getBiosStatus).mockRejectedValue(new Error("offline"));
+      const { container } = render(<RomMGameInfoPanel appId={testAppId} />);
+      await flushAsync();
+      await openBiosTab();
+
+      expect(container.textContent).toContain("1/3 files ready");
+      expect(vi.mocked(backend.debugLog)).toHaveBeenCalledWith(expect.stringContaining("BIOS status refresh error"));
+    });
+
+    it("clears the requirement when the live answer reports none", async () => {
+      // The other direction has to keep working: a re-read IS an answer, so one
+      // reporting no requirement takes the tab away (#1690).
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(staleDetail(biosAnswer(1)));
+      vi.mocked(backend.getBiosStatus).mockResolvedValue({ bios_status: null, bios_level: null });
+      const { container } = render(<RomMGameInfoPanel appId={testAppId} />);
+      await flushAsync();
+
+      expect(container.textContent).not.toContain("BIOS");
+    });
+
+    it("re-reads after a core change whose detail could not answer", async () => {
+      // The core the requirement is computed against just changed, so the
+      // previous core's requirement standing is the wrong answer, not a stale one.
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(staleDetail({ ...biosAnswer(1), stale_fields: [] }));
+      const { container } = render(<RomMGameInfoPanel appId={testAppId} />);
+      await flushAsync();
+      await openBiosTab();
+      expect(container.textContent).toContain("1/3 files ready");
+
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(staleDetail({ bios_status_unknown: true }));
+      vi.mocked(backend.getBiosStatus).mockResolvedValue(biosAnswer(3));
+      await act(async () => {
+        globalThis.dispatchEvent(
+          new CustomEvent("romm_data_changed", { detail: { type: "core_changed", platform_slug: "snes" } }),
+        );
+      });
+      await flushAsync();
+
+      expect(vi.mocked(backend.getBiosStatus)).toHaveBeenCalledWith(60);
+      expect(container.textContent).toContain("All ready (3/3)");
+    });
+
+    it("re-reads after a version switch whose detail could not answer", async () => {
+      // Keeping the shown status here is showing the PREVIOUS version's
+      // requirement under the new one's name.
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(staleDetail({ ...biosAnswer(1), stale_fields: [] }));
+      const { container } = render(<RomMGameInfoPanel appId={testAppId} />);
+      await flushAsync();
+      await openBiosTab();
+      expect(container.textContent).toContain("1/3 files ready");
+
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(
+        staleDetail({ rom_id: 61, bios_status_unknown: true }),
+      );
+      vi.mocked(backend.getBiosStatus).mockResolvedValue(biosAnswer(3));
+      await act(async () => {
+        globalThis.dispatchEvent(
+          new CustomEvent("romm_data_changed", {
+            detail: { type: "version_switched", app_id: testAppId, rom_id: 61 },
+          }),
+        );
+      });
+      await flushAsync();
+
+      expect(vi.mocked(backend.getBiosStatus)).toHaveBeenCalledWith(61);
+      expect(container.textContent).toContain("All ready (3/3)");
+    });
+  });
+
   // ------------------------------------------------------------------
   // I. Render: cover art, no-metadata fallback, etc.
   // ------------------------------------------------------------------
@@ -4279,6 +4436,37 @@ describe("RomMGameInfoPanel", () => {
         expect(container.textContent).not.toContain("Snes9x");
       });
 
+      it("does not fold a BIOS answer read for the previous version into the switched-to version", async () => {
+        // The live re-read the stale mark triggers (#1752) is the newest bound
+        // site: both versions need BIOS, so the tab stays across the switch and
+        // the previous version's readiness has somewhere to land.
+        const bios = holdReadFor<backend.BiosAnswer>(1, {
+          bios_status: { platform_slug: "snes", server_count: 3, local_count: 3, all_downloaded: true },
+          bios_level: "ok",
+        });
+        vi.mocked(backend.getBiosStatus).mockImplementation(bios.impl);
+        vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(
+          detailFor(1, { ...biosNeed, stale_fields: ["bios"] }),
+        );
+        const { container } = render(<RomMGameInfoPanel appId={testAppId} />);
+        await flushAsync();
+
+        await switchToRom2({ ...biosNeed, stale_fields: ["bios"] });
+        await openBiosTab();
+        expect(container.textContent).toContain("All ready (3/3)");
+
+        await act(async () => {
+          bios.release({
+            bios_status: { platform_slug: "snes", server_count: 3, local_count: 0, all_downloaded: false },
+            bios_level: "missing",
+          });
+        });
+        await flushAsync();
+
+        expect(container.textContent).toContain("All ready (3/3)");
+        expect(container.textContent).not.toContain("0/3");
+      });
+
       it("does not fold the previous version's slot configuration into the switched-to version", async () => {
         // slotConfirmed is the SlotSetupWizard-vs-SavesTab gate: a stale
         // "configured" answer replaces the new version's unconfigured wizard
@@ -4605,6 +4793,13 @@ describe("RomMGameInfoPanel", () => {
       await flushAsync();
     };
 
+    const openBiosTab = async () => {
+      await act(async () => {
+        globalThis.dispatchEvent(new CustomEvent("romm_tab_switch", { detail: { tab: "bios" } }));
+      });
+      await flushAsync();
+    };
+
     const statusWithFile = (romId: number, filename: string): SaveStatus => ({
       rom_id: romId,
       files: [
@@ -4669,6 +4864,42 @@ describe("RomMGameInfoPanel", () => {
       expect(container.textContent).toContain("Game (Europe)");
       expect(container.textContent).toContain("Europe");
       expect(container.textContent).not.toContain("Game (Japan)");
+    });
+
+    it("keeps the newest BIOS answer when an earlier read lands last", async () => {
+      // Two live re-reads for the same rom: the mount load's, and the one the
+      // core change issues because the requirement is computed against the core
+      // it just switched (#1752). The rom binding admits both.
+      const biosStatusFor = (localCount: number) => ({
+        bios_status: {
+          platform_slug: "snes",
+          server_count: 3,
+          local_count: localCount,
+          all_downloaded: localCount === 3,
+        },
+        bios_level: localCount === 3 ? ("ok" as const) : ("partial" as const),
+      });
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(
+        detailFor(1, "Game", { bios_status_unknown: true, stale_fields: ["bios"] }),
+      );
+      const firstRead = heldRead<backend.BiosAnswer>();
+      vi.mocked(backend.getBiosStatus).mockImplementationOnce(() => firstRead.promise);
+      const { container } = render(<RomMGameInfoPanel appId={testAppId} />);
+      await flushAsync();
+
+      vi.mocked(backend.getBiosStatus).mockResolvedValue(biosStatusFor(3));
+      await dispatchDataChanged({ type: "core_changed", platform_slug: "snes" });
+      await flushAsync();
+      await openBiosTab();
+      expect(container.textContent).toContain("All ready (3/3)");
+
+      await act(async () => {
+        firstRead.release(biosStatusFor(1));
+      });
+      await flushAsync();
+
+      expect(container.textContent).toContain("All ready (3/3)");
+      expect(container.textContent).not.toContain("1/3 files ready");
     });
 
     it("keeps the newest save-status answer when an earlier read lands last", async () => {

--- a/src/components/RomMGameInfoPanel.test.tsx
+++ b/src/components/RomMGameInfoPanel.test.tsx
@@ -17,6 +17,7 @@ import { RomMGameInfoPanel } from "./RomMGameInfoPanel";
 import * as backend from "../api/backend";
 import type { CachedGameDetail } from "../api/backend";
 import * as cachedStore from "../utils/cachedGameDetailStore";
+import { _resetSharedReadsForTests } from "../api/sharedReads";
 import * as slotState from "../utils/slotState";
 import {
   installDomEventListenerSpy,
@@ -221,6 +222,9 @@ describe("RomMGameInfoPanel", () => {
     currentSaveSortState = { pending: false };
     testAppId++;
     installDomEventListenerSpy();
+    // A shared read releases itself only by settling, so a test that leaves one
+    // pending would hand it to the next test reading the same ROM.
+    _resetSharedReadsForTests();
 
     // Reset the real connection store so each test starts connected (#1345).
     setRommConnectionState("connected");
@@ -3295,6 +3299,16 @@ describe("RomMGameInfoPanel", () => {
       await flushAsync();
     };
 
+    /** An answer the test hands over by hand, so a read can still be open while
+     *  the next event runs. */
+    function heldAnswer<T>() {
+      let release!: (value: T) => void;
+      const promise = new Promise<T>((resolve) => {
+        release = resolve;
+      });
+      return { promise, release: (value: T) => release(value) };
+    }
+
     it("re-reads on mount when the cached detail carries no answer, and the live one brings the tab back", async () => {
       vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(staleDetail({ bios_status_unknown: true }));
       vi.mocked(backend.getBiosStatus).mockResolvedValue(biosAnswer(1));
@@ -3410,6 +3424,60 @@ describe("RomMGameInfoPanel", () => {
 
       expect(vi.mocked(backend.getBiosStatus)).toHaveBeenCalledWith(61);
       expect(container.textContent).toContain("All ready (3/3)");
+    });
+
+    it("keeps the re-read a version switch issues when a core change is re-keyed under it", async () => {
+      // The core change captures its identity before its two reads, so a switch
+      // landing in that window leaves it answering for the version the panel
+      // moved off. The rom binding refuses its write either way; the ticket its
+      // re-read would claim is what has to be withheld, because it would fence
+      // the switch's own re-read and nothing would re-issue that answer.
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(staleDetail({ ...biosAnswer(1), stale_fields: [] }));
+      const { container } = render(<RomMGameInfoPanel appId={testAppId} />);
+      await flushAsync();
+      await openBiosTab();
+      expect(container.textContent).toContain("1/3 files ready");
+
+      // The core change's cache read stays open...
+      const coreChangeDetail = heldAnswer<CachedGameDetail>();
+      vi.mocked(cachedStore.getCachedGameDetail).mockImplementationOnce(() => coreChangeDetail.promise);
+      await act(async () => {
+        globalThis.dispatchEvent(
+          new CustomEvent("romm_data_changed", { detail: { type: "core_changed", platform_slug: "snes" } }),
+        );
+      });
+
+      // ...while a version switch re-keys the panel to rom 61 and issues the
+      // re-read its own unreadable detail needs.
+      const switchedBios = heldAnswer<backend.BiosAnswer>();
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(
+        staleDetail({ rom_id: 61, bios_status_unknown: true }),
+      );
+      vi.mocked(backend.getBiosStatus).mockImplementation((romId: number) =>
+        romId === 61 ? switchedBios.promise : Promise.resolve({ bios_status_unknown: true }),
+      );
+      await act(async () => {
+        globalThis.dispatchEvent(
+          new CustomEvent("romm_data_changed", {
+            detail: { type: "version_switched", app_id: testAppId, rom_id: 61 },
+          }),
+        );
+      });
+      await flushAsync();
+
+      await act(async () => {
+        coreChangeDetail.release(staleDetail({ bios_status_unknown: true }));
+      });
+      await flushAsync();
+
+      await act(async () => {
+        switchedBios.release(biosAnswer(3));
+      });
+      await flushAsync();
+
+      expect(container.textContent).toContain("All ready (3/3)");
+      // The re-keyed core change reads nothing for the version the panel left.
+      expect(vi.mocked(backend.getBiosStatus)).not.toHaveBeenCalledWith(60);
     });
   });
 
@@ -4436,10 +4504,13 @@ describe("RomMGameInfoPanel", () => {
         expect(container.textContent).not.toContain("Snes9x");
       });
 
-      it("does not fold a BIOS answer read for the previous version into the switched-to version", async () => {
-        // The live re-read the stale mark triggers (#1752) is the newest bound
-        // site: both versions need BIOS, so the tab stays across the switch and
-        // the previous version's readiness has somewhere to land.
+      it("refuses a BIOS answer read for the previous version — by the binding and the switch's ticket alike", async () => {
+        // The one site in this block where the two fences overlap: the switch's
+        // own fold claims the `bios` ticket whether or not it re-reads, so
+        // either fence refuses the held rom-1 answer on its own. Named for the
+        // combined refusal because no arrangement of this test can isolate the
+        // binding here. Both versions need BIOS, so the tab stays across the
+        // switch and the previous version's readiness has somewhere to land.
         const bios = holdReadFor<backend.BiosAnswer>(1, {
           bios_status: { platform_slug: "snes", server_count: 3, local_count: 3, all_downloaded: true },
           bios_level: "ok",
@@ -4866,19 +4937,22 @@ describe("RomMGameInfoPanel", () => {
       expect(container.textContent).not.toContain("Game (Japan)");
     });
 
+    /** A BIOS answer — cached or live, one shape — with `localCount` of 3 files
+     *  present. */
+    const biosStatusFor = (localCount: number) => ({
+      bios_status: {
+        platform_slug: "snes",
+        server_count: 3,
+        local_count: localCount,
+        all_downloaded: localCount === 3,
+      },
+      bios_level: localCount === 3 ? ("ok" as const) : ("partial" as const),
+    });
+
     it("keeps the newest BIOS answer when an earlier read lands last", async () => {
       // Two live re-reads for the same rom: the mount load's, and the one the
       // core change issues because the requirement is computed against the core
       // it just switched (#1752). The rom binding admits both.
-      const biosStatusFor = (localCount: number) => ({
-        bios_status: {
-          platform_slug: "snes",
-          server_count: 3,
-          local_count: localCount,
-          all_downloaded: localCount === 3,
-        },
-        bios_level: localCount === 3 ? ("ok" as const) : ("partial" as const),
-      });
       vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(
         detailFor(1, "Game", { bios_status_unknown: true, stale_fields: ["bios"] }),
       );
@@ -4895,6 +4969,38 @@ describe("RomMGameInfoPanel", () => {
 
       await act(async () => {
         firstRead.release(biosStatusFor(1));
+      });
+      await flushAsync();
+
+      expect(container.textContent).toContain("All ready (3/3)");
+      expect(container.textContent).not.toContain("1/3 files ready");
+    });
+
+    it("does not let a BIOS read issued before a core change land on the core change's own answer", async () => {
+      // The core change's detail ANSWERS, so it issues no re-read of its own and
+      // the mount's older read is the only one still open. What holds it off is
+      // the ticket the fold claims whether or not it reads — the answer it
+      // carries is about the core the user just switched away from.
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(
+        detailFor(1, "Game", { bios_status_unknown: true, stale_fields: ["bios"] }),
+      );
+      const mountRead = heldRead<backend.BiosAnswer>();
+      vi.mocked(backend.getBiosStatus).mockImplementationOnce(() => mountRead.promise);
+      const { container } = render(<RomMGameInfoPanel appId={testAppId} />);
+      await flushAsync();
+
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(
+        detailFor(1, "Game", { ...biosStatusFor(3), stale_fields: [] }),
+      );
+      await dispatchDataChanged({ type: "core_changed", platform_slug: "snes" });
+      await flushAsync();
+      await openBiosTab();
+      expect(container.textContent).toContain("All ready (3/3)");
+      // The fold answered from the cache — no second read was issued.
+      expect(vi.mocked(backend.getBiosStatus)).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        mountRead.release(biosStatusFor(1));
       });
       await flushAsync();
 

--- a/src/components/RomMGameInfoPanel.tsx
+++ b/src/components/RomMGameInfoPanel.tsx
@@ -85,7 +85,7 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => {
   // Read sequences ordering two answers about the same ROM; the rule they
   // enforce is stated at `takeReadTicket`. They live here because the loads, the
   // event lane and the lazy slots lane take tickets from the same counters.
-  const readSeqs = useRef<PanelReadSeqs>({ detail: 0, saveStatus: 0, slots: 0, slotTracking: 0 });
+  const readSeqs = useRef<PanelReadSeqs>({ detail: 0, saveStatus: 0, slots: 0, slotTracking: 0, bios: 0 });
   const [migration, setMigration] = useState(getMigrationState());
   const [settingsReset, setSettingsReset] = useState(getSettingsResetState());
   const [saveSortPending, setSaveSortPending] = useState(getSaveSortMigrationState().pending);

--- a/src/components/RomMPlaySection.test.tsx
+++ b/src/components/RomMPlaySection.test.tsx
@@ -15,6 +15,7 @@ import { render, act, waitFor } from "@testing-library/react";
 import { createElement, type ComponentProps, type ReactElement } from "react";
 import { RomMPlaySection } from "./RomMPlaySection";
 import * as backend from "../api/backend";
+import { _resetSharedReadsForTests } from "../api/sharedReads";
 import { showContextMenu, showModal } from "@decky/ui";
 import { toaster } from "@decky/api";
 import {
@@ -284,6 +285,10 @@ describe("RomMPlaySection", () => {
     capturedPlayButton.length = 0;
     testAppId++;
     installDomEventListenerSpy();
+    // The load lane's BIOS and core-info reads go through the shared seam, and a
+    // shared request releases itself only by settling — a test that left one
+    // open would hand it to the next test reading the same rom.
+    _resetSharedReadsForTests();
 
     // Reset the shared connection store (real module) so each test starts from a
     // neutral verdict and no version error leaks across tests (#1345).

--- a/src/components/SystemPage.test.tsx
+++ b/src/components/SystemPage.test.tsx
@@ -97,6 +97,15 @@ function lastConfirmModalProps(): ConfirmModalProps | null {
   return el?.props ?? null;
 }
 
+// The `romm_data_changed` events SystemPage put on the window during the test,
+// in dispatch order — `fireEvent` and React put unrelated events through the
+// same spy.
+function rommDataChangedEvents(spy: { mock: { calls: unknown[][] } }): CustomEvent[] {
+  return spy.mock.calls
+    .map((c) => c[0])
+    .filter((e): e is CustomEvent => e instanceof CustomEvent && e.type === "romm_data_changed");
+}
+
 // Flush mount-time + chained promise resolutions.
 const flushAsync = () =>
   act(async () => {
@@ -410,6 +419,100 @@ describe("SystemPage", () => {
       // CATCH-REJECTION assert: status string rendered
       expect(container.textContent).toContain("Download failed: Error: io");
     });
+
+    it("dispatches a romm_data_changed {type:'bios', platform_slug} event when files were downloaded", async () => {
+      vi.mocked(backend.getFirmwareStatus).mockResolvedValue({
+        success: true,
+        platforms: [biosPlatformWithMissingOptional()],
+      });
+      vi.mocked(backend.downloadAllFirmware).mockResolvedValue({
+        success: true,
+        downloaded: 2,
+      });
+      const dispatchSpy = vi.spyOn(globalThis, "dispatchEvent");
+      const { getByText } = render(<SystemPage onBack={vi.fn()} />);
+      await flushAsync();
+      await act(async () => {
+        fireEvent.click(getByText("Download All"));
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      const events = rommDataChangedEvents(dispatchSpy);
+      expect(events).toHaveLength(1);
+      expect(events[0]!.detail).toEqual({ type: "bios", platform_slug: "snes" });
+      dispatchSpy.mockRestore();
+    });
+
+    it("does NOT dispatch romm_data_changed when the download succeeded but moved no files", async () => {
+      vi.mocked(backend.getFirmwareStatus).mockResolvedValue({
+        success: true,
+        platforms: [biosPlatformWithMissingOptional()],
+      });
+      vi.mocked(backend.downloadAllFirmware).mockResolvedValue({
+        success: true,
+        message: "Downloaded 0 firmware files (1 failed: boot.rom)",
+        downloaded: 0,
+      });
+      const dispatchSpy = vi.spyOn(globalThis, "dispatchEvent");
+      const { getByText, container } = render(<SystemPage onBack={vi.fn()} />);
+      await flushAsync();
+      await act(async () => {
+        fireEvent.click(getByText("Download All"));
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      // The run still reports itself — it just changed no firmware.
+      expect(container.textContent).toContain("Downloaded 0 firmware files (1 failed: boot.rom)");
+      expect(rommDataChangedEvents(dispatchSpy)).toHaveLength(0);
+      dispatchSpy.mockRestore();
+    });
+
+    it("does NOT dispatch romm_data_changed when downloadAllFirmware reports success=false", async () => {
+      vi.mocked(backend.getFirmwareStatus).mockResolvedValue({
+        success: true,
+        platforms: [biosPlatformWithMissingOptional()],
+      });
+      vi.mocked(backend.downloadAllFirmware).mockResolvedValue({
+        success: false,
+        message: "Server unreachable",
+        downloaded: 0,
+      });
+      const dispatchSpy = vi.spyOn(globalThis, "dispatchEvent");
+      const { getByText, container } = render(<SystemPage onBack={vi.fn()} />);
+      await flushAsync();
+      await act(async () => {
+        fireEvent.click(getByText("Download All"));
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(container.textContent).toContain("Server unreachable");
+      expect(rommDataChangedEvents(dispatchSpy)).toHaveLength(0);
+      dispatchSpy.mockRestore();
+    });
+
+    it("does NOT dispatch romm_data_changed when downloadAllFirmware throws", async () => {
+      vi.mocked(backend.getFirmwareStatus).mockResolvedValue({
+        success: true,
+        platforms: [biosPlatformWithMissingOptional()],
+      });
+      vi.mocked(backend.downloadAllFirmware).mockRejectedValue(new Error("io"));
+      const dispatchSpy = vi.spyOn(globalThis, "dispatchEvent");
+      const { getByText, container } = render(<SystemPage onBack={vi.fn()} />);
+      await flushAsync();
+      await act(async () => {
+        fireEvent.click(getByText("Download All"));
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      // CATCH-REJECTION assert: status string rendered, and the catch announces nothing.
+      expect(container.textContent).toContain("Download failed: Error: io");
+      expect(rommDataChangedEvents(dispatchSpy)).toHaveLength(0);
+      dispatchSpy.mockRestore();
+    });
   });
 
   // ------------------------------------------------------------------
@@ -491,6 +594,99 @@ describe("SystemPage", () => {
         await Promise.resolve();
       });
       expect(container.textContent).toContain("Download failed");
+    });
+
+    it("dispatches a romm_data_changed {type:'bios', platform_slug} event when files were downloaded", async () => {
+      vi.mocked(backend.getFirmwareStatus).mockResolvedValue({
+        success: true,
+        platforms: [biosPlatformWithMissingRequired()],
+      });
+      vi.mocked(backend.downloadRequiredFirmware).mockResolvedValue({
+        success: true,
+        downloaded: 1,
+      });
+      const dispatchSpy = vi.spyOn(globalThis, "dispatchEvent");
+      const { getByText } = render(<SystemPage onBack={vi.fn()} />);
+      await flushAsync();
+      await act(async () => {
+        fireEvent.click(getByText("Download Required"));
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      const events = rommDataChangedEvents(dispatchSpy);
+      expect(events).toHaveLength(1);
+      expect(events[0]!.detail).toEqual({ type: "bios", platform_slug: "snes" });
+      dispatchSpy.mockRestore();
+    });
+
+    it("does NOT dispatch romm_data_changed when the download succeeded but moved no files", async () => {
+      vi.mocked(backend.getFirmwareStatus).mockResolvedValue({
+        success: true,
+        platforms: [biosPlatformWithMissingRequired()],
+      });
+      vi.mocked(backend.downloadRequiredFirmware).mockResolvedValue({
+        success: true,
+        message: "Downloaded 0 required firmware files (1 failed: bios.rom)",
+        downloaded: 0,
+      });
+      const dispatchSpy = vi.spyOn(globalThis, "dispatchEvent");
+      const { getByText, container } = render(<SystemPage onBack={vi.fn()} />);
+      await flushAsync();
+      await act(async () => {
+        fireEvent.click(getByText("Download Required"));
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(container.textContent).toContain("Downloaded 0 required firmware files (1 failed: bios.rom)");
+      expect(rommDataChangedEvents(dispatchSpy)).toHaveLength(0);
+      dispatchSpy.mockRestore();
+    });
+
+    it("does NOT dispatch romm_data_changed when downloadRequiredFirmware reports success=false", async () => {
+      vi.mocked(backend.getFirmwareStatus).mockResolvedValue({
+        success: true,
+        platforms: [biosPlatformWithMissingRequired()],
+      });
+      vi.mocked(backend.downloadRequiredFirmware).mockResolvedValue({
+        success: false,
+        message: "Server unreachable",
+        downloaded: 0,
+      });
+      const dispatchSpy = vi.spyOn(globalThis, "dispatchEvent");
+      const { getByText, container } = render(<SystemPage onBack={vi.fn()} />);
+      await flushAsync();
+      await act(async () => {
+        fireEvent.click(getByText("Download Required"));
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(container.textContent).toContain("Server unreachable");
+      expect(rommDataChangedEvents(dispatchSpy)).toHaveLength(0);
+      dispatchSpy.mockRestore();
+    });
+
+    it("does NOT dispatch romm_data_changed when downloadRequiredFirmware throws", async () => {
+      vi.mocked(backend.getFirmwareStatus).mockResolvedValue({
+        success: true,
+        platforms: [biosPlatformWithMissingRequired()],
+      });
+      vi.mocked(backend.downloadRequiredFirmware).mockRejectedValue(new Error("io"));
+      const dispatchSpy = vi.spyOn(globalThis, "dispatchEvent");
+      const { getByText, container } = render(<SystemPage onBack={vi.fn()} />);
+      await flushAsync();
+      await act(async () => {
+        fireEvent.click(getByText("Download Required"));
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      // CATCH-REJECTION assert: status string rendered, and the catch announces nothing.
+      expect(container.textContent).toContain("Download failed: Error: io");
+      expect(rommDataChangedEvents(dispatchSpy)).toHaveLength(0);
+      dispatchSpy.mockRestore();
     });
   });
 
@@ -1600,9 +1796,7 @@ describe("SystemPage", () => {
         await Promise.resolve();
         await Promise.resolve();
       });
-      const biosEvents = dispatchSpy.mock.calls
-        .map((c) => c[0])
-        .filter((e): e is CustomEvent => e instanceof CustomEvent && e.type === "romm_data_changed");
+      const biosEvents = rommDataChangedEvents(dispatchSpy);
       expect(biosEvents).toHaveLength(1);
       expect(biosEvents[0]!.detail).toEqual({ type: "bios", platform_slug: "ps1" });
       dispatchSpy.mockRestore();
@@ -1628,10 +1822,7 @@ describe("SystemPage", () => {
         await Promise.resolve();
         await Promise.resolve();
       });
-      const biosEvents = dispatchSpy.mock.calls
-        .map((c) => c[0])
-        .filter((e): e is CustomEvent => e instanceof CustomEvent && e.type === "romm_data_changed");
-      expect(biosEvents).toHaveLength(0);
+      expect(rommDataChangedEvents(dispatchSpy)).toHaveLength(0);
       dispatchSpy.mockRestore();
     });
   });

--- a/src/components/SystemPage.tsx
+++ b/src/components/SystemPage.tsx
@@ -67,6 +67,23 @@ function getBiosSummary(
   };
 }
 
+/**
+ * Tell an open game-detail page that this platform's firmware changed, so it
+ * re-reads its BIOS requirement instead of leaving the pre-change one standing
+ * (#939). Every download and delete on this page is such a change; nothing else
+ * on the page is.
+ *
+ * Call it only when firmware actually changed. The event fans out to every
+ * mounted panel and each one that matches the slug pays a live
+ * `check_platform_bios` for it (#1082), so a run that moved no files must stay
+ * silent rather than send an event no panel can act on.
+ */
+function announceBiosChange(platformSlug: string) {
+  globalThis.dispatchEvent(
+    new CustomEvent("romm_data_changed", { detail: { type: "bios", platform_slug: platformSlug } }),
+  );
+}
+
 function hashIndicator(hv: boolean | null): string {
   if (hv === true) return " ✓";
   if (hv === false) return " ⚠";
@@ -146,6 +163,7 @@ export const SystemPage: FC<SystemPageProps> = ({ onBack }) => {
       if (result.success) {
         setBiosStatus(result.message || `Downloaded ${result.downloaded} files`);
         await refreshSystem();
+        if ((result.downloaded ?? 0) > 0) announceBiosChange(platformSlug);
       } else {
         setBiosStatus(result.message || "Download failed");
       }
@@ -163,6 +181,7 @@ export const SystemPage: FC<SystemPageProps> = ({ onBack }) => {
       if (result.success) {
         setBiosStatus(result.message || `Downloaded ${result.downloaded} required files`);
         await refreshSystem();
+        if ((result.downloaded ?? 0) > 0) announceBiosChange(platformSlug);
       } else {
         setBiosStatus(result.message || "Download failed");
       }
@@ -183,11 +202,7 @@ export const SystemPage: FC<SystemPageProps> = ({ onBack }) => {
       setBiosStatus(result.message);
       if (result.success) {
         await refreshSystem();
-        // Notify an open game-detail page so it re-checks BIOS status (#939).
-        // Mirrors the download-path emit in RomMPlaySection.
-        globalThis.dispatchEvent(
-          new CustomEvent("romm_data_changed", { detail: { type: "bios", platform_slug: platformSlug } }),
-        );
+        announceBiosChange(platformSlug);
       }
     } catch (e) {
       setBiosStatus(`Failed to delete BIOS files: ${e}`);

--- a/src/components/panelEvents.ts
+++ b/src/components/panelEvents.ts
@@ -27,6 +27,7 @@ import { detach } from "../utils/detach";
 import {
   bindRom,
   biosFieldsFromCache,
+  refreshBiosIfStale,
   refreshPanelCoreInfo,
   refreshCoverArtInBackground,
   refreshInstalledRomInBackground,
@@ -180,6 +181,11 @@ async function handleCoreChange(
   // makes the re-read a non-answer rather than a "needs none" (#1693).
   const biosFields = biosFieldsFromCache(cached);
   binding.write((prev) => ({ ...prev, ...biosFields, coreInfo: coreInfo ?? prev.coreInfo }));
+  // The core the requirement is computed against just changed, so a re-read that
+  // could not answer leaves the PREVIOUS core's requirement on the page. Going
+  // back for it is what keeps that from standing until the next page open
+  // (#1752).
+  await refreshBiosIfStale(cached, binding, ctx.readSeqs);
 }
 
 async function handleVersionSwitched(
@@ -263,6 +269,10 @@ async function handleVersionSwitched(
   if (newRomId) {
     const binding = bindCurrentRom(ctx, newRomId);
     const reads = [
+      // The switched-to version's requirement is its own, so a detail that could
+      // not answer leaves the PREVIOUS version's on the page — the one case
+      // where keeping the shown status is showing another ROM's (#1752).
+      refreshBiosIfStale(cached, binding, ctx.readSeqs),
       refreshCoverArtInBackground(binding),
       // The BIOS tab's "Active Core" row and its per-file core lines come
       // from the dedicated core-info path (#923), keyed on rom_id so a

--- a/src/components/panelEvents.ts
+++ b/src/components/panelEvents.ts
@@ -16,6 +16,7 @@ import {
   getCachedGameDetail,
   getRomMetadata,
   checkPlatformBios,
+  getBiosStatus,
   getPlatformCoreInfo,
   getSaveStatus,
   isCallableFailure,
@@ -192,8 +193,9 @@ async function handleCoreChange(
   // The core the requirement is computed against just changed, so a re-read that
   // could not answer leaves the PREVIOUS core's requirement on the page. Going
   // back for it is what keeps that from standing until the next page open
-  // (#1752).
-  await refreshBiosIfStale(cached, binding, ctx.readSeqs);
+  // (#1752). Read directly: this handler runs because the requirement may have
+  // just changed, so it must not join a read issued before the change.
+  await refreshBiosIfStale(cached, binding, ctx.readSeqs, getBiosStatus);
 }
 
 async function handleVersionSwitched(
@@ -279,8 +281,10 @@ async function handleVersionSwitched(
     const reads = [
       // The switched-to version's requirement is its own, so a detail that could
       // not answer leaves the PREVIOUS version's on the page — the one case
-      // where keeping the shown status is showing another ROM's (#1752).
-      refreshBiosIfStale(cached, binding, ctx.readSeqs),
+      // where keeping the shown status is showing another ROM's (#1752). Read
+      // directly: the switched-to version is a rom_id no other lane is reading,
+      // so there is nothing to join and a join could only be the wrong ROM's.
+      refreshBiosIfStale(cached, binding, ctx.readSeqs, getBiosStatus),
       refreshCoverArtInBackground(binding),
       // The BIOS tab's "Active Core" row and its per-file core lines come
       // from the dedicated core-info path (#923), keyed on rom_id so a

--- a/src/components/panelEvents.ts
+++ b/src/components/panelEvents.ts
@@ -281,9 +281,15 @@ async function handleVersionSwitched(
     const reads = [
       // The switched-to version's requirement is its own, so a detail that could
       // not answer leaves the PREVIOUS version's on the page — the one case
-      // where keeping the shown status is showing another ROM's (#1752). Read
-      // directly: the switched-to version is a rom_id no other lane is reading,
-      // so there is nothing to join and a join could only be the wrong ROM's.
+      // where keeping the shown status is showing another ROM's (#1752).
+      //
+      // Read directly even though the store's own `version_switched` load reads
+      // this same new rom_id microtasks away, which a join would collapse: a
+      // switch to a version the page showed earlier can join the request opened
+      // back then, and a BIOS download or a core pin since has made that answer
+      // wrong. Both page-open lanes take that residual (`api/sharedReads.ts`
+      // documents it) because they pay a duplicate on every open; one switch is
+      // the cheaper side of the same trade.
       refreshBiosIfStale(cached, binding, ctx.readSeqs, getBiosStatus),
       refreshCoverArtInBackground(binding),
       // The BIOS tab's "Active Core" row and its per-file core lines come

--- a/src/components/panelEvents.ts
+++ b/src/components/panelEvents.ts
@@ -175,7 +175,15 @@ async function handleCoreChange(
     getPlatformCoreInfo(binding.romId).catch((): CoreInfo | null => null),
     getCachedGameDetail(ctx.appId),
   ]);
-  if (ctx.cancelled() || !cached.found) return;
+  // A version switch landing inside the two reads above re-keys the panel, and
+  // everything this handler still has to say is then about the ROM it moved off.
+  // The rom binding already refuses the write, but it cannot give back the
+  // sequence ticket the re-read below would claim on the previous version's
+  // behalf — and that ticket would fence the switch's OWN re-read, dropping the
+  // answer the new version's requirement depends on with nothing left to
+  // re-issue it. `cancelled` does not cover this: a switch re-keys the rom
+  // without changing the appId (#1713).
+  if (ctx.cancelled() || ctx.romIdRef.current !== rid || !cached.found) return;
   // A detail carrying no BIOS answer leaves the shown status alone — the
   // core switch invalidated the cached detail, but a cold firmware cache
   // makes the re-read a non-answer rather than a "needs none" (#1693).

--- a/src/components/panelState.test.ts
+++ b/src/components/panelState.test.ts
@@ -28,7 +28,7 @@ function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
 const flush = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
 
 const seqsRef = (): MutableRefObject<PanelReadSeqs> => ({
-  current: { detail: 0, saveStatus: 0, slots: 0, slotTracking: 0 },
+  current: { detail: 0, saveStatus: 0, slots: 0, slotTracking: 0, bios: 0 },
 });
 
 const slot = (name: string): SaveSlotSummary => ({

--- a/src/components/panelState.ts
+++ b/src/components/panelState.ts
@@ -12,13 +12,12 @@ import {
   getCachedGameDetail,
   getInstalledRom,
   getArtworkBase64,
-  getBiosStatus,
   getSaveSlots,
   isSaveTrackingConfigured,
   debugLog,
 } from "../api/backend";
 import type { BiosAnswer } from "../api/backend";
-import { getPlatformCoreInfoShared, getRomMetadataShared } from "../api/sharedReads";
+import { getBiosStatusShared, getPlatformCoreInfoShared, getRomMetadataShared } from "../api/sharedReads";
 import type {
   RomMetadata,
   InstalledRom,
@@ -278,15 +277,23 @@ export function biosFieldsFromCache(cached: BiosAnswer): Pick<PanelState, "biosS
  *
  *  The ticket is taken whether or not the read is issued: the caller has just
  *  folded the newest cached answer for these two fields, so a live read left
- *  open by an earlier fold must not land on top of it. */
+ *  open by an earlier fold must not land on top of it.
+ *
+ *  `read` is each caller's own claim about joining. The mount load passes
+ *  `getBiosStatusShared`: the play row reads the same ROM's BIOS status off the
+ *  same stale mark microtasks away, and nothing can change the answer in
+ *  between. A caller that re-reads BECAUSE the requirement may have just changed
+ *  passes the direct `getBiosStatus` — joining would hand it the pre-change
+ *  answer. The admission rule both claims answer to is in `api/sharedReads.ts`. */
 export function refreshBiosIfStale(
   cached: Awaited<ReturnType<typeof getCachedGameDetail>>,
   binding: RomBinding,
   readSeqs: MutableRefObject<PanelReadSeqs>,
+  read: (romId: number) => Promise<BiosAnswer>,
 ): Promise<void> {
   const overtaken = takeReadTicket(readSeqs, "bios");
   if (!(cached.stale_fields ?? []).includes("bios")) return Promise.resolve();
-  return getBiosStatus(binding.romId)
+  return read(binding.romId)
     .then((answer) => {
       if (overtaken()) return;
       const biosFields = biosFieldsFromCache(answer);
@@ -338,7 +345,7 @@ function startBackgroundRefreshes(
   binding: RomBinding,
   readSeqs: MutableRefObject<PanelReadSeqs>,
 ): Promise<void[]> {
-  const bgPromises: Promise<void>[] = [refreshBiosIfStale(cached, binding, readSeqs)];
+  const bgPromises: Promise<void>[] = [refreshBiosIfStale(cached, binding, readSeqs, getBiosStatusShared)];
 
   if (cached.installed) {
     bgPromises.push(refreshInstalledRomInBackground(binding));

--- a/src/components/panelState.ts
+++ b/src/components/panelState.ts
@@ -12,6 +12,7 @@ import {
   getCachedGameDetail,
   getInstalledRom,
   getArtworkBase64,
+  getBiosStatus,
   getSaveSlots,
   isSaveTrackingConfigured,
   debugLog,
@@ -173,6 +174,13 @@ export interface PanelReadSeqs {
   slots: number;
   /** `is_save_tracking_configured`, from the slot refresh alone. */
   slotTracking: number;
+  /** `get_bios_status`, from the live re-read every cached-detail fold issues
+   *  when the backend marked its BIOS answer stale — and claimed by the fold
+   *  itself, see {@link refreshBiosIfStale}. The `bios` event's own check is
+   *  deliberately outside it: it answers for the platform's default core rather
+   *  than this ROM's, so ordering it against a rom-keyed answer would settle the
+   *  wrong question (#1718). */
+  bios: number;
 }
 
 /** Take one kind's next ticket for a read being issued now. The returned
@@ -239,11 +247,12 @@ function refreshMetadataInBackground(binding: RomBinding): Promise<void> {
     .catch(() => {});
 }
 
-/** The panel's two BIOS fields as a cached game detail answers them, or `null`
- *  when the payload carries no BIOS answer — a detail derived while the firmware
- *  cache was cold, which every BIOS download and delete makes it. The caller then
- *  leaves the shown status standing instead of hiding the BIOS tab on a
- *  non-answer (#1693).
+/** The panel's two BIOS fields as a BIOS answer carries them — a cached game
+ *  detail or the live `get_bios_status` read below, which ship the identical
+ *  shape — or `null` when the payload carries no BIOS answer at all: a detail
+ *  derived while the firmware cache was cold, which every BIOS download and
+ *  delete makes it. The caller then leaves the shown status standing instead of
+ *  hiding the BIOS tab on a non-answer (#1693).
  *
  *  `bios_level` is computed by the backend (`compute_bios_level`) and threaded
  *  straight through, never re-derived; it is null whenever there is no
@@ -255,6 +264,36 @@ export function biosFieldsFromCache(cached: BiosAnswer): Pick<PanelState, "biosS
     biosStatus: { needs_bios: true, ...cached.bios_status },
     biosLevel: cached.bios_level ?? null,
   };
+}
+
+/** Go back for the BIOS answer the cached detail could not give, and fold it in.
+ *
+ *  Every fold of {@link biosFieldsFromCache} leaves the shown status standing on
+ *  a non-answer (#1693), and nothing else re-reads it — so a panel opened while
+ *  the firmware cache was cold showed the previous answer, or no BIOS tab at
+ *  all, until an unrelated event moved it (#1752). The backend marks exactly
+ *  that payload's `bios` field stale, which is what turns "we don't know" into a
+ *  read; a payload with no stale list at all is one nobody marked, so it is left
+ *  alone rather than re-read on every fold.
+ *
+ *  The ticket is taken whether or not the read is issued: the caller has just
+ *  folded the newest cached answer for these two fields, so a live read left
+ *  open by an earlier fold must not land on top of it. */
+export function refreshBiosIfStale(
+  cached: Awaited<ReturnType<typeof getCachedGameDetail>>,
+  binding: RomBinding,
+  readSeqs: MutableRefObject<PanelReadSeqs>,
+): Promise<void> {
+  const overtaken = takeReadTicket(readSeqs, "bios");
+  if (!(cached.stale_fields ?? []).includes("bios")) return Promise.resolve();
+  return getBiosStatus(binding.romId)
+    .then((answer) => {
+      if (overtaken()) return;
+      const biosFields = biosFieldsFromCache(answer);
+      if (!biosFields) return;
+      binding.write((prev) => ({ ...prev, ...biosFields }));
+    })
+    .catch((e) => detach(debugLog(`RomMGameInfoPanel: BIOS status refresh error: ${e}`)));
 }
 
 /** Build a `SaveStatus` from a cached game detail's `save_status` field. */
@@ -292,12 +331,14 @@ export function saveStatusFromCache(
 }
 
 /** Kick off background fetches that fill in fields not present in the cache:
- *  installed-rom details, cover art, and fresh metadata (if stale or missing). */
+ *  installed-rom details, cover art, fresh metadata (if stale or missing), and a
+ *  live BIOS answer (if the cached one was marked stale). */
 function startBackgroundRefreshes(
   cached: Awaited<ReturnType<typeof getCachedGameDetail>>,
   binding: RomBinding,
+  readSeqs: MutableRefObject<PanelReadSeqs>,
 ): Promise<void[]> {
-  const bgPromises: Promise<void>[] = [];
+  const bgPromises: Promise<void>[] = [refreshBiosIfStale(cached, binding, readSeqs)];
 
   if (cached.installed) {
     bgPromises.push(refreshInstalledRomInBackground(binding));
@@ -409,7 +450,7 @@ export async function loadData(
     }
 
     // Phase 2: Background fetch for data not available in cache
-    await startBackgroundRefreshes(cached, binding);
+    await startBackgroundRefreshes(cached, binding, readSeqs);
   } catch (e) {
     detach(debugLog(`RomMGameInfoPanel: loadData error: ${e}`));
     if (!cancelled() && !overtaken()) setter((prev) => ({ ...prev, loading: false, error: true }));

--- a/src/utils/gameDetailStore.test.ts
+++ b/src/utils/gameDetailStore.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import * as backend from "../api/backend";
-import { _resetSharedReadsForTests } from "../api/sharedReads";
+import { getBiosStatusShared, _resetSharedReadsForTests } from "../api/sharedReads";
 import * as cachedStore from "./cachedGameDetailStore";
 import {
   getGameDetail,
@@ -141,18 +141,20 @@ const laterCoreInfo: CoreInfo = {
 
 const achievementSummary = (earned: number, total: number) => ({ earned, total, earned_hardcore: 0 });
 
+/** A live `get_achievement_progress` answer. Two calls with different counts are
+ *  distinguishable in the shown state, which is what lets a test stage one
+ *  read's answer against another's. */
+const progress = (earned: number, total: number): AchievementProgressResult => ({
+  success: true,
+  earned,
+  total,
+  earned_achievements: [],
+});
+
 const biosMissing: BiosStatusResult = {
   bios_status: { platform_slug: "snes", server_count: 3, local_count: 0, all_downloaded: false },
   bios_level: "missing",
   bios_label: "0/3",
-};
-
-/** The answer a second BIOS read returns, distinct from {@link biosMissing} so a
- *  fold of the first read's answer is visible in the shown level. */
-const biosAllPresent: BiosStatusResult = {
-  bios_status: { platform_slug: "snes", server_count: 3, local_count: 3, all_downloaded: true },
-  bios_level: "ok",
-  bios_label: "3/3",
 };
 
 /** The cached detail of the ROM a version switch moves the entry to, carrying a
@@ -231,6 +233,27 @@ describe("gameDetailStore", () => {
         achievementEarned: 3,
         achievementTotal: 50,
       });
+    });
+
+    it("joins the info panel's open BIOS read rather than opening a second round trip", async () => {
+      // The panel's load reaches this read off the same stale mark on the same
+      // cached detail, microtasks away, on every page open. Standing in for it
+      // here is a direct call to the shared seam both lanes go through.
+      const open = deferred<BiosStatusResult>();
+      vi.mocked(backend.getBiosStatus).mockReturnValue(open.promise);
+      const panelLoad = getBiosStatusShared(42);
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(found({ stale_fields: ["bios"] }));
+
+      subscribe(nextAppId);
+      await flush();
+      open.resolve(biosMissing);
+      await panelLoad;
+      await flush();
+
+      expect(vi.mocked(backend.getBiosStatus)).toHaveBeenCalledExactlyOnceWith(42);
+      // Non-vacuous in the other direction: the JOINED answer is the one folded,
+      // so this is sharing rather than the load having skipped the read.
+      expect(getGameDetail(nextAppId)).toMatchObject({ biosStatus: "missing", biosLabel: "0/3" });
     });
 
     it("serves a second subscriber from the same entry — one cached-detail read, both notified", async () => {
@@ -1052,32 +1075,41 @@ describe("gameDetailStore", () => {
     });
 
     // Same rom throughout, so the rom binding admits the earlier answer — the
-    // load sequence is the only thing that can tell the two apart. The vehicle is
-    // the BIOS read rather than the core read because the core read is shared
-    // with the info panel's load (`api/sharedReads.ts`): a second load of the
-    // same rom joins the first read instead of issuing one that can answer
-    // differently, so two distinct answers cannot be staged through it.
+    // load sequence is the only thing that can tell the two apart. That fence is
+    // what this test pins; the READ it pins it through is incidental, and it has
+    // now moved twice. It drove `get_platform_core_info` until #1758 shared that
+    // read with the info panel's load, and `get_bios_status` until #1752 shared
+    // that one too: a second load of the same rom joins the first read instead of
+    // issuing one that can answer differently, so two distinct answers cannot be
+    // staged through a shared read at all. `get_achievement_progress` is the last
+    // stale-driven read that is not shared — there is no fourth vehicle behind
+    // it. Whoever shares it next should re-shape this test so it stops depending
+    // on a per-read vehicle, not hunt for another one.
     it("drops a background answer read under a load a later load overtook", async () => {
-      const overtakenBios = deferred<BiosStatusResult>();
-      vi.mocked(backend.getBiosStatus).mockReturnValueOnce(overtakenBios.promise);
-      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(found({ installed: false, stale_fields: ["bios"] }));
+      const overtakenProgress = deferred<AchievementProgressResult>();
+      vi.mocked(backend.getAchievementProgress).mockReturnValueOnce(overtakenProgress.promise);
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(
+        found({ installed: false, ra_id: 7, stale_fields: ["achievements"] }),
+      );
       subscribe(nextAppId);
       await flush();
-      expect(vi.mocked(backend.getBiosStatus)).toHaveBeenCalledExactlyOnceWith(42);
+      expect(vi.mocked(backend.getAchievementProgress)).toHaveBeenCalledExactlyOnceWith(42);
 
-      vi.mocked(backend.getBiosStatus).mockResolvedValue(biosAllPresent);
-      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(found({ installed: true, stale_fields: ["bios"] }));
+      vi.mocked(backend.getAchievementProgress).mockResolvedValue(progress(30, 50));
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(
+        found({ installed: true, ra_id: 7, stale_fields: ["achievements"] }),
+      );
       await act(async () => {
         emitDeckyEvent<[DownloadCompleteEvent]>("download_complete", downloadComplete(42));
         await Promise.resolve();
       });
       await flush();
-      expect(getGameDetail(nextAppId)).toMatchObject({ romId: 42, biosStatus: "ok", biosLabel: "3/3" });
+      expect(getGameDetail(nextAppId)).toMatchObject({ romId: 42, achievementEarned: 30, achievementTotal: 50 });
 
-      overtakenBios.resolve(biosMissing);
+      overtakenProgress.resolve(progress(3, 50));
       await flush();
 
-      expect(getGameDetail(nextAppId)).toMatchObject({ biosStatus: "ok", biosLabel: "3/3" });
+      expect(getGameDetail(nextAppId)).toMatchObject({ achievementEarned: 30, achievementTotal: 50 });
     });
   });
 

--- a/src/utils/sectionRefresh.test.ts
+++ b/src/utils/sectionRefresh.test.ts
@@ -6,6 +6,7 @@ import {
   refreshAchievementsInBackground,
 } from "./sectionRefresh";
 import * as backend from "../api/backend";
+import { _resetSharedReadsForTests } from "../api/sharedReads";
 import { libretroEmu } from "../test-utils/coreFixtures";
 import type { EmulatorOption } from "../types";
 
@@ -50,6 +51,11 @@ function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void; reje
   });
   return { promise, resolve, reject };
 }
+
+// The BIOS and core-info helpers read through the shared seam, and a shared
+// request releases itself only by settling — a test that left one open would
+// hand it to the next test reading the same rom.
+beforeEach(() => _resetSharedReadsForTests());
 
 describe("refreshBiosInBackground", () => {
   beforeEach(() => vi.restoreAllMocks());

--- a/src/utils/sectionRefresh.ts
+++ b/src/utils/sectionRefresh.ts
@@ -8,8 +8,8 @@
  */
 
 import type { Dispatch, SetStateAction } from "react";
-import { getBiosStatus, getAchievementProgress, debugLog } from "../api/backend";
-import { getPlatformCoreInfoShared } from "../api/sharedReads";
+import { getAchievementProgress, debugLog } from "../api/backend";
+import { getBiosStatusShared, getPlatformCoreInfoShared } from "../api/sharedReads";
 import { extractBiosInfo, extractCoreInfo, type BiosInfoFields, type CoreInfoFields } from "./playSection";
 
 interface AchievementFields {
@@ -20,13 +20,19 @@ interface AchievementFields {
 /** Re-read this ROM's BIOS status and fold the answer in — including an answer
  *  reporting no requirement, which clears the shown one (#1690). Nothing is
  *  written when the read fails or comes back carrying no answer, so the shown
- *  level stands: neither is "no BIOS need", both are "we don't know" (#1693). */
+ *  level stands: neither is "no BIOS need", both are "we don't know" (#1693).
+ *
+ *  Its one caller is the load lane, reaching it off the cached detail's `bios`
+ *  stale mark — the same mark the info panel's load reads microtasks away, so
+ *  the two share one request (`api/sharedReads.ts`). A caller that re-reads
+ *  BECAUSE the BIOS state just changed does not belong here: it would join the
+ *  pre-change answer. */
 export function refreshBiosInBackground<S extends BiosInfoFields>(
   romId: number,
   cancelled: () => boolean,
   setter: Dispatch<SetStateAction<S>>,
 ): void {
-  getBiosStatus(romId)
+  getBiosStatusShared(romId)
     .then((result) => {
       if (cancelled()) return;
       const biosInfo = extractBiosInfo(result);


### PR DESCRIPTION
The panel keeps its last BIOS answer when a fresh detail carries none — a
detail derived while the firmware cache was cold means "we don't know", not
"needs none", and writing it would drop the whole BIOS tab. What it never did
was come back for the real answer. The cached-detail store does exactly that
off stale_fields; the panel read that field for metadata only.

So a game opened while its requirement was unread showed no BIOS tab at all
until something else happened to move it, and a core or version switch left
the previous core's or the previous version's readiness on screen. The panel
now re-reads at all three places it folds a cached BIOS answer, through the
binding and a new read ticket, so two answers for one rom land in the order
they were issued rather than the order they arrive.

The core-change path needed one more fence than the others. It reaches its
re-read on an identity captured before an await, and cancelled() covers an
appId change but not a rom re-key — so a version switch landing in that window
let the previous rom claim the newest ticket and fence the switch's own
re-read. The switched-to version's answer was then dropped with nothing left
to re-issue it, which is the failure this change exists to prevent.

The page-open read is shared with the play row's, which issues the same read
off the same stale mark microtasks away. The two change-driven sites read
directly: a switch to a version the page showed earlier could otherwise join a
request opened back then, which a BIOS download or a core pin since has made
wrong. That is a trade rather than a rule — the page-open lanes take the same
exposure because they would otherwise pay a duplicate on every single open.

One mutation site stayed silent. The System page's two BIOS download buttons
dispatched nothing, while its delete button and the two on the game page all
announce — so a download started there never reached an open game page at all.
They announce now, gated on files having actually moved: the backend reports
success even when every individual file failed, so the count is the only honest
signal.

One existing test lost its vehicle. It proves a load sequence drops an answer a
later load overtook, which needs a read that can answer differently twice —
exactly what sharing removes. It drove the core read until #1758 shared that
one, the BIOS read until now, and moves to the achievements read here. That is
the last unshared stale-driven read, and its comment now says so: whoever
shares it next should re-shape the test rather than look for a fourth vehicle.

Closes #1752
