### PR TITLE
fix(ui): let the detail store recover from a read that threw

### DIFF
--- a/src/utils/gameDetailStore.test.ts
+++ b/src/utils/gameDetailStore.test.ts
@@ -1282,10 +1282,15 @@ describe("gameDetailStore", () => {
     });
   });
 
-  // The first load is what installs the identity the three triggers above are
-  // gated on, so a first load that threw leaves them nothing to match and the
-  // entry stuck on the neutral default for the whole page visit (#1676).
+  // The first load is what installs the identity the three install-state
+  // triggers above are gated on, so a first load that threw leaves them nothing
+  // to match — and the likeliest cause of a throw, a backend still starting, is
+  // also the situation in which none of those events ever arrives (#1676).
   describe("a load whose read threw", () => {
+    // Comfortably past the store's retry delay. These tests pin that the one
+    // retry happens, and that it happens once — not what the delay is.
+    const PAST_RETRY_DELAY_MS = 60_000;
+
     it("re-derives the entry on the next install-state event, having no identity to match it against", async () => {
       vi.mocked(cachedStore.getCachedGameDetail).mockRejectedValue(new Error("bridge down"));
       subscribe(nextAppId);
@@ -1304,10 +1309,29 @@ describe("gameDetailStore", () => {
       expect(getGameDetail(nextAppId)).toMatchObject({ romId: 42, installed: true, fsSizeBytes: 4096 });
     });
 
-    it("costs one read per event and schedules no retry of its own", async () => {
-      // On fake timers: microtask flushes alone cannot tell a store that
-      // schedules nothing apart from one that schedules a delayed retry, so a
-      // setTimeout-driven spin would pass this test's name unnoticed.
+    it("retries the read once after a delay, on a page where nothing else happens", async () => {
+      vi.useFakeTimers();
+      try {
+        vi.mocked(cachedStore.getCachedGameDetail).mockRejectedValueOnce(new Error("backend reloading"));
+        subscribe(nextAppId);
+        await flush();
+        expect(getGameDetail(nextAppId).romId).toBeNull();
+
+        // No download, no uninstall, no adoption — the user is looking at the
+        // game page, which is exactly the situation that produces this failure.
+        vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(found({ installed: true, fs_size_bytes: 4096 }));
+        await act(async () => {
+          vi.advanceTimersByTime(PAST_RETRY_DELAY_MS);
+        });
+        await flush();
+
+        expect(getGameDetail(nextAppId)).toMatchObject({ romId: 42, installed: true, fsSizeBytes: 4096 });
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("retries once and no more, when the retry throws too", async () => {
       vi.useFakeTimers();
       try {
         vi.mocked(cachedStore.getCachedGameDetail).mockRejectedValue(new Error("backend defect"));
@@ -1316,20 +1340,103 @@ describe("gameDetailStore", () => {
         expect(vi.mocked(cachedStore.getCachedGameDetail)).toHaveBeenCalledTimes(1);
 
         await act(async () => {
-          emitDeckyEvent<[DownloadCompleteEvent]>("download_complete", downloadComplete(999));
-          await Promise.resolve();
+          vi.advanceTimersByTime(PAST_RETRY_DELAY_MS);
         });
         await flush();
+        expect(vi.mocked(cachedStore.getCachedGameDetail)).toHaveBeenCalledTimes(2);
+
+        // A local read that fails the same way twice is a backend defect, and
+        // the one thing this must not turn into is a spin: the retry having
+        // failed too is not itself a reason to read again — not now, and not
+        // five minutes from now either.
         await act(async () => {
           vi.advanceTimersByTime(5 * 60_000);
         });
         await flush();
-
-        // A read that fails the same way every time is a backend defect, and the
-        // one thing this must not turn into is a spin: the retry that failed too
-        // is not itself a reason to read again — not now, and not five minutes
-        // from now either.
         expect(vi.mocked(cachedStore.getCachedGameDetail)).toHaveBeenCalledTimes(2);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("does not retry behind an install-state event that recovered the entry first", async () => {
+      vi.useFakeTimers();
+      try {
+        vi.mocked(cachedStore.getCachedGameDetail).mockRejectedValueOnce(new Error("bridge down"));
+        subscribe(nextAppId);
+        await flush();
+
+        vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(found({ installed: true }));
+        await act(async () => {
+          emitDeckyEvent<[DownloadCompleteEvent]>("download_complete", downloadComplete(999));
+          await Promise.resolve();
+        });
+        await flush();
+        expect(getGameDetail(nextAppId)).toMatchObject({ romId: 42, installed: true });
+
+        await act(async () => {
+          vi.advanceTimersByTime(PAST_RETRY_DELAY_MS);
+        });
+        await flush();
+
+        // Two reads, not three: the event's load answered, so the pending retry
+        // finds nothing left to recover.
+        expect(vi.mocked(cachedStore.getCachedGameDetail)).toHaveBeenCalledTimes(2);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("reads nothing when the page was closed before the retry fell due", async () => {
+      vi.useFakeTimers();
+      try {
+        vi.mocked(cachedStore.getCachedGameDetail).mockRejectedValue(new Error("bridge down"));
+        const unsubscribe = subscribe(nextAppId);
+        await flush();
+        expect(vi.mocked(cachedStore.getCachedGameDetail)).toHaveBeenCalledTimes(1);
+
+        unsubscribe();
+        vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(found({ installed: true }));
+        await act(async () => {
+          vi.advanceTimersByTime(PAST_RETRY_DELAY_MS);
+        });
+        await flush();
+
+        expect(vi.mocked(cachedStore.getCachedGameDetail)).toHaveBeenCalledTimes(1);
+        expect(getGameDetail(nextAppId)).toMatchObject({ romId: null, installed: false });
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("takes a sequence number like any other load, so a newer load refuses its answer", async () => {
+      vi.useFakeTimers();
+      try {
+        vi.mocked(cachedStore.getCachedGameDetail).mockRejectedValueOnce(new Error("bridge down"));
+        subscribe(nextAppId);
+        await flush();
+
+        const retryRead = deferred<CachedGameDetail>();
+        vi.mocked(cachedStore.getCachedGameDetail).mockReturnValueOnce(retryRead.promise);
+        await act(async () => {
+          vi.advanceTimersByTime(PAST_RETRY_DELAY_MS);
+        });
+        await flush();
+
+        // A version switch re-derives the entry while the retry's read is still
+        // open, and answers first.
+        vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(found(switchedDetail));
+        await act(async () => {
+          dispatchVersionSwitch(nextAppId);
+          await Promise.resolve();
+        });
+        await flush();
+        expect(getGameDetail(nextAppId).romId).toBe(43);
+
+        retryRead.resolve(found({ installed: true }));
+        await flush();
+
+        expect(getGameDetail(nextAppId)).toMatchObject({ romId: 43, installed: false });
       } finally {
         vi.useRealTimers();
       }

--- a/src/utils/gameDetailStore.test.ts
+++ b/src/utils/gameDetailStore.test.ts
@@ -1305,22 +1305,54 @@ describe("gameDetailStore", () => {
     });
 
     it("costs one read per event and schedules no retry of its own", async () => {
-      vi.mocked(cachedStore.getCachedGameDetail).mockRejectedValue(new Error("backend defect"));
+      // On fake timers: microtask flushes alone cannot tell a store that
+      // schedules nothing apart from one that schedules a delayed retry, so a
+      // setTimeout-driven spin would pass this test's name unnoticed.
+      vi.useFakeTimers();
+      try {
+        vi.mocked(cachedStore.getCachedGameDetail).mockRejectedValue(new Error("backend defect"));
+        subscribe(nextAppId);
+        await flush();
+        expect(vi.mocked(cachedStore.getCachedGameDetail)).toHaveBeenCalledTimes(1);
+
+        await act(async () => {
+          emitDeckyEvent<[DownloadCompleteEvent]>("download_complete", downloadComplete(999));
+          await Promise.resolve();
+        });
+        await flush();
+        await act(async () => {
+          vi.advanceTimersByTime(5 * 60_000);
+        });
+        await flush();
+
+        // A read that fails the same way every time is a backend defect, and the
+        // one thing this must not turn into is a spin: the retry that failed too
+        // is not itself a reason to read again — not now, and not five minutes
+        // from now either.
+        expect(vi.mocked(cachedStore.getCachedGameDetail)).toHaveBeenCalledTimes(2);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("issues one read for two install-state events in the same tick", async () => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockRejectedValue(new Error("bridge down"));
       subscribe(nextAppId);
       await flush();
-      expect(vi.mocked(cachedStore.getCachedGameDetail)).toHaveBeenCalledTimes(1);
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(found({ installed: true }));
+      vi.mocked(cachedStore.getCachedGameDetail).mockClear();
 
       await act(async () => {
         emitDeckyEvent<[DownloadCompleteEvent]>("download_complete", downloadComplete(999));
+        globalThis.dispatchEvent(new CustomEvent("romm_rom_uninstalled", { detail: { rom_id: 998 } }));
         await Promise.resolve();
       });
       await flush();
-      await flush();
 
-      // A read that fails the same way every time is a backend defect, and the
-      // one thing this must not turn into is a spin: the retry that failed too
-      // is not itself a reason to read again.
-      expect(vi.mocked(cachedStore.getCachedGameDetail)).toHaveBeenCalledTimes(2);
+      // The second event finds the retry already issued: the record is cleared
+      // where the read is ISSUED, not where it answers, so one read serves both.
+      expect(vi.mocked(cachedStore.getCachedGameDetail)).toHaveBeenCalledTimes(1);
+      expect(getGameDetail(nextAppId)).toMatchObject({ romId: 42, installed: true });
     });
 
     it("stops re-deriving once a read answered, even when the answer carries no identity", async () => {

--- a/src/utils/gameDetailStore.test.ts
+++ b/src/utils/gameDetailStore.test.ts
@@ -1312,7 +1312,7 @@ describe("gameDetailStore", () => {
     it("retries the read once after a delay, on a page where nothing else happens", async () => {
       vi.useFakeTimers();
       try {
-        vi.mocked(cachedStore.getCachedGameDetail).mockRejectedValueOnce(new Error("backend reloading"));
+        vi.mocked(cachedStore.getCachedGameDetail).mockRejectedValueOnce(new Error("bridge rejected"));
         subscribe(nextAppId);
         await flush();
         expect(getGameDetail(nextAppId).romId).toBeNull();
@@ -1326,6 +1326,9 @@ describe("gameDetailStore", () => {
         await flush();
 
         expect(getGameDetail(nextAppId)).toMatchObject({ romId: 42, installed: true, fsSizeBytes: 4096 });
+        // The entry's one attempt goes to the backend rather than to whatever
+        // the shared TTL cache is holding by then.
+        expect(vi.mocked(cachedStore.invalidateCachedGameDetail)).toHaveBeenCalledExactlyOnceWith(nextAppId);
       } finally {
         vi.useRealTimers();
       }
@@ -1345,8 +1348,8 @@ describe("gameDetailStore", () => {
         await flush();
         expect(vi.mocked(cachedStore.getCachedGameDetail)).toHaveBeenCalledTimes(2);
 
-        // A local read that fails the same way twice is a backend defect, and
-        // the one thing this must not turn into is a spin: the retry having
+        // The one thing this must not turn into is a spin, or a second
+        // backend-readiness ladder next to the plugin's own: the retry having
         // failed too is not itself a reason to read again — not now, and not
         // five minutes from now either.
         await act(async () => {

--- a/src/utils/gameDetailStore.test.ts
+++ b/src/utils/gameDetailStore.test.ts
@@ -1282,6 +1282,154 @@ describe("gameDetailStore", () => {
     });
   });
 
+  // The first load is what installs the identity the three triggers above are
+  // gated on, so a first load that threw leaves them nothing to match and the
+  // entry stuck on the neutral default for the whole page visit (#1676).
+  describe("a load whose read threw", () => {
+    it("re-derives the entry on the next install-state event, having no identity to match it against", async () => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockRejectedValue(new Error("bridge down"));
+      subscribe(nextAppId);
+      await flush();
+      expect(getGameDetail(nextAppId).romId).toBeNull();
+
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(found({ installed: true, fs_size_bytes: 4096 }));
+      await act(async () => {
+        // Another game's download: with no identity the entry cannot tell whose
+        // event this is, and the read it needs is about its own appId either way.
+        emitDeckyEvent<[DownloadCompleteEvent]>("download_complete", downloadComplete(999));
+        await Promise.resolve();
+      });
+      await flush();
+
+      expect(getGameDetail(nextAppId)).toMatchObject({ romId: 42, installed: true, fsSizeBytes: 4096 });
+    });
+
+    it("costs one read per event and schedules no retry of its own", async () => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockRejectedValue(new Error("backend defect"));
+      subscribe(nextAppId);
+      await flush();
+      expect(vi.mocked(cachedStore.getCachedGameDetail)).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        emitDeckyEvent<[DownloadCompleteEvent]>("download_complete", downloadComplete(999));
+        await Promise.resolve();
+      });
+      await flush();
+      await flush();
+
+      // A read that fails the same way every time is a backend defect, and the
+      // one thing this must not turn into is a spin: the retry that failed too
+      // is not itself a reason to read again.
+      expect(vi.mocked(cachedStore.getCachedGameDetail)).toHaveBeenCalledTimes(2);
+    });
+
+    it("stops re-deriving once a read answered, even when the answer carries no identity", async () => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockRejectedValue(new Error("bridge down"));
+      subscribe(nextAppId);
+      await flush();
+
+      // The retry lands: no ROM maps to this appId. That is an answer rather
+      // than a failure, so the events go back to being gated on an identity —
+      // and this entry has none to install.
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({ found: false });
+      await act(async () => {
+        emitDeckyEvent<[DownloadCompleteEvent]>("download_complete", downloadComplete(999));
+        await Promise.resolve();
+      });
+      await flush();
+      vi.mocked(cachedStore.getCachedGameDetail).mockClear();
+
+      await act(async () => {
+        emitDeckyEvent<[DownloadCompleteEvent]>("download_complete", downloadComplete(999));
+        await Promise.resolve();
+      });
+      await flush();
+
+      expect(vi.mocked(cachedStore.getCachedGameDetail)).not.toHaveBeenCalled();
+    });
+
+    it("keeps the identity the triggers are gated on when it is a re-read that throws", async () => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(found({ installed: false }));
+      subscribe(nextAppId);
+      await flush();
+
+      vi.mocked(cachedStore.getCachedGameDetail).mockRejectedValueOnce(new Error("bridge down"));
+      await act(async () => {
+        emitDeckyEvent<[DownloadCompleteEvent]>("download_complete", downloadComplete(42));
+        await Promise.resolve();
+      });
+      await flush();
+      expect(getGameDetail(nextAppId).romId).toBe(42);
+
+      // And still gated on it: another game's event is not this entry's
+      // business, failed re-read or not.
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(found({ installed: true }));
+      vi.mocked(cachedStore.getCachedGameDetail).mockClear();
+      await act(async () => {
+        emitDeckyEvent<[DownloadCompleteEvent]>("download_complete", downloadComplete(999));
+        await Promise.resolve();
+      });
+      await flush();
+      expect(vi.mocked(cachedStore.getCachedGameDetail)).not.toHaveBeenCalled();
+
+      await act(async () => {
+        emitDeckyEvent<[DownloadCompleteEvent]>("download_complete", downloadComplete(42));
+        await Promise.resolve();
+      });
+      await flush();
+      expect(getGameDetail(nextAppId).installed).toBe(true);
+    });
+
+    it("still consumes a sequence number, so the older load it overtook writes nothing", async () => {
+      const mountLoad = deferred<CachedGameDetail>();
+      vi.mocked(cachedStore.getCachedGameDetail).mockReturnValueOnce(mountLoad.promise);
+      subscribe(nextAppId);
+      await flush();
+
+      vi.mocked(cachedStore.getCachedGameDetail).mockRejectedValue(new Error("bridge down"));
+      await act(async () => {
+        dispatchVersionSwitch(nextAppId);
+        await Promise.resolve();
+      });
+      await flush();
+
+      mountLoad.resolve(found({ installed: true }));
+      await flush();
+
+      expect(getGameDetail(nextAppId)).toMatchObject({ romId: null, installed: false });
+    });
+
+    it("does not mark an entry whose newer load answered", async () => {
+      const mountLoad = deferred<CachedGameDetail>();
+      vi.mocked(cachedStore.getCachedGameDetail).mockReturnValueOnce(mountLoad.promise);
+      subscribe(nextAppId);
+      await flush();
+
+      // The switch's re-derive answers first — nothing maps to this appId — and
+      // the mount load it overtook fails afterwards.
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({ found: false });
+      await act(async () => {
+        dispatchVersionSwitch(nextAppId);
+        await Promise.resolve();
+      });
+      await flush();
+
+      mountLoad.reject(new Error("bridge down"));
+      await flush();
+      vi.mocked(cachedStore.getCachedGameDetail).mockClear();
+
+      await act(async () => {
+        emitDeckyEvent<[DownloadCompleteEvent]>("download_complete", downloadComplete(999));
+        await Promise.resolve();
+      });
+      await flush();
+
+      // An overtaken load's failure is not the entry's state: the newer load
+      // answered, and its answer is that there is nothing here to re-derive.
+      expect(vi.mocked(cachedStore.getCachedGameDetail)).not.toHaveBeenCalled();
+    });
+  });
+
   describe("explicit refreshes", () => {
     beforeEach(() => {
       vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue(found());

--- a/src/utils/gameDetailStore.ts
+++ b/src/utils/gameDetailStore.ts
@@ -143,6 +143,12 @@ interface Entry {
    *  and can finish in either order, so a load that no longer holds this number
    *  has been overtaken and writes nothing. */
   loadSeq: number;
+  /** Whether the last load to settle threw. Cleared the moment the next load is
+   *  issued, so it is never set while one is in flight to answer the question.
+   *  It is the only thing that tells an entry whose read failed apart from one
+   *  that has no identity to install (an appId RomM does not know) or has not
+   *  resolved one yet — the shown state is the same in all three. */
+  loadFailed: boolean;
   saveStatusInFlight: InFlightSaveStatus | null;
   detachListeners: () => void;
 }
@@ -189,6 +195,7 @@ function openEntry(appId: number): Entry {
     listeners: new Set(),
     generation: 0,
     loadSeq: 0,
+    loadFailed: false,
     saveStatusInFlight: null,
     detachListeners: () => {},
   };
@@ -256,6 +263,10 @@ function writerForRom(entry: Entry, generation: number, romId: number): Dispatch
 async function loadDetail(appId: number, entry: Entry): Promise<void> {
   const generation = entry.generation;
   const loadSeq = ++entry.loadSeq;
+  // Ordered by taking the sequence number rather than by a fence: the load
+  // clearing this is the newest one there is, so a load in flight is never
+  // recorded as a failure a trigger below would retry.
+  entry.loadFailed = false;
   // Two separate ends: the generation covers an entry nobody is showing any
   // more, the sequence a load a later one has moved past.
   const cancelled = () => entry.generation !== generation || entry.loadSeq !== loadSeq;
@@ -344,6 +355,11 @@ async function loadDetail(appId: number, entry: Entry): Promise<void> {
     // load leaves every subscribed surface stale either way, so surface at warn
     // level (debugLog is dropped at the default log level).
     logError(`gameDetailStore: load error: ${e}`);
+    // Fenced like every write above — this entry's generation and this load's
+    // sequence — and bound to no rom: the read threw, so there is no rom this
+    // failure is about. A load a later one has moved past says nothing about
+    // whether the entry can load; the newer load's own outcome does.
+    if (!cancelled()) entry.loadFailed = true;
   }
 }
 
@@ -576,6 +592,27 @@ async function handleCoreChange(entry: Entry): Promise<void> {
   }));
 }
 
+/**
+ * Whether an install-state event about `eventRomId` re-derives this entry.
+ *
+ * Normally that is the entry's own ROM and nothing else. The second arm is for
+ * the entry that has no identity to match against because its load threw: the
+ * first load installs the identity all three triggers are gated on, so a first
+ * load that failed is otherwise terminal — the entry stays on the neutral
+ * default for the whole page visit, and only a version switch or leaving the
+ * page can load it again (#1676).
+ *
+ * With no identity the entry cannot tell whether the event is about its game, so
+ * it re-reads on any of them. The cost is bounded by what a user can do: one
+ * network-free `get_cached_game_detail` per install-state event, never a retry
+ * this store schedules itself, and none at all while a load is in flight or once
+ * one has answered.
+ */
+function reloadTriggeredBy(entry: Entry, eventRomId: number | undefined): boolean {
+  if (entry.state.romId !== null) return eventRomId === entry.state.romId;
+  return entry.loadFailed;
+}
+
 function attachListeners(appId: number, entry: Entry): () => void {
   const onDataChanged = (e: Event) => {
     detach(
@@ -602,7 +639,7 @@ function attachListeners(appId: number, entry: Entry): () => void {
               // Adoption writes an install record without a download, so no
               // `download_complete` fires — but `installed` and `fs_size_bytes`
               // changed just the same and the cached detail must be dropped.
-              if (detail.rom_id === entry.state.romId) await reloadDetail(appId, entry);
+              if (reloadTriggeredBy(entry, detail.rom_id)) await reloadDetail(appId, entry);
               break;
           }
         } catch (err) {
@@ -618,13 +655,13 @@ function attachListeners(appId: number, entry: Entry): () => void {
   // whole entry re-derived — reading it back inside the 3s TTL would return the
   // pre-change state.
   const onDownloadComplete = addEventListener<[DownloadCompleteEvent]>("download_complete", (evt) => {
-    if (evt.rom_id !== entry.state.romId) return;
+    if (!reloadTriggeredBy(entry, evt.rom_id)) return;
     detach(reloadDetail(appId, entry));
   });
 
   const onUninstalled = (e: Event) => {
     const romId = (e as CustomEvent).detail?.rom_id;
-    if (romId !== entry.state.romId) return;
+    if (!reloadTriggeredBy(entry, romId)) return;
     detach(reloadDetail(appId, entry));
   };
   globalThis.addEventListener("romm_rom_uninstalled", onUninstalled);

--- a/src/utils/gameDetailStore.ts
+++ b/src/utils/gameDetailStore.ts
@@ -148,8 +148,14 @@ interface Entry {
    *  is issued, so it is never set while one is in flight to answer the question.
    *  It is the only thing that tells an entry whose read failed apart from one
    *  that has no identity to install (an appId RomM does not know) or has not
-   *  resolved one yet — the shown state is the same in all three. */
+   *  resolved one yet — the shown state is the same in all three. Both recovery
+   *  lanes hang on it: {@link scheduleFailedLoadRetry} and {@link
+   *  reloadTriggeredBy}. */
   loadFailed: boolean;
+  /** Whether the one timed retry has been scheduled. Spent for the entry's
+   *  lifetime at the moment it is scheduled, whatever that retry then answers —
+   *  see {@link scheduleFailedLoadRetry}. */
+  timedRetryUsed: boolean;
   saveStatusInFlight: InFlightSaveStatus | null;
   detachListeners: () => void;
 }
@@ -197,6 +203,7 @@ function openEntry(appId: number): Entry {
     generation: 0,
     loadSeq: 0,
     loadFailed: false,
+    timedRetryUsed: false,
     saveStatusInFlight: null,
     detachListeners: () => {},
   };
@@ -360,7 +367,10 @@ async function loadDetail(appId: number, entry: Entry): Promise<void> {
     // sequence — and bound to no rom: the read threw, so there is no rom this
     // failure is about. A load a later one has moved past says nothing about
     // whether the entry can load; the newer load's own outcome does.
-    if (!cancelled()) entry.loadFailed = true;
+    if (!cancelled()) {
+      entry.loadFailed = true;
+      scheduleFailedLoadRetry(appId, entry);
+    }
   }
 }
 
@@ -593,26 +603,61 @@ async function handleCoreChange(entry: Entry): Promise<void> {
   }));
 }
 
+/** How long a failed load waits before its one retry. Long enough for a backend
+ *  that was reloading or still starting when the read went out — the failure
+ *  this recovers — to have come up, and short enough that a user watching the
+ *  page reads the repair as the page still loading. */
+const FAILED_LOAD_RETRY_MS = 2000;
+
+/**
+ * Schedule the one timed re-derive of an entry whose load threw.
+ *
+ * The second occasion on {@link Entry.loadFailed}, next to the install-state
+ * triggers below. It exists because those triggers miss the likeliest case: a
+ * read throws when the backend is reloading or still starting, and a user
+ * looking at a game page and doing nothing else produces no download, no
+ * uninstall and no adoption for the entry to take its cue from.
+ *
+ * Exactly one, for the entry's whole lifetime — {@link Entry.timedRetryUsed} is
+ * spent where the retry is scheduled, so a retry that throws too schedules
+ * nothing further. The read behind it is local and network-free: one that fails
+ * twice is a backend defect, which no amount of waiting longer answers.
+ *
+ * Inert unless the entry is still the one this was scheduled for and is still
+ * failed. The flag is cleared where a load is ISSUED, so an entry the event lane
+ * has already recovered — or is mid-recovery on — reads nothing here; and the
+ * generation covers the page closed in the meantime, so a retry falling due
+ * after `closeEntry` finds a generation the entry has moved past.
+ */
+function scheduleFailedLoadRetry(appId: number, entry: Entry): void {
+  if (entry.timedRetryUsed) return;
+  entry.timedRetryUsed = true;
+  const generation = entry.generation;
+  setTimeout(() => {
+    if (entry.generation !== generation || !entry.loadFailed) return;
+    detach(reloadDetail(appId, entry));
+  }, FAILED_LOAD_RETRY_MS);
+}
+
 /**
  * Whether an install-state event about `eventRomId` re-derives this entry.
  *
  * Normally that is the entry's own ROM and nothing else. The second arm is for
  * the entry that has no identity to match against because its load threw: the
- * first load installs the identity all three triggers are gated on, so a first
- * load that failed is otherwise terminal — the entry stays on the neutral
- * default for the whole page visit, and only a version switch or leaving the
- * page can load it again (#1676).
+ * first load installs the identity all three triggers are gated on, so without
+ * this arm a first load that failed would leave them nothing to match (#1676).
  *
  * With no identity the entry cannot tell whether the event is about its game, so
  * it re-reads on any of them. The cost is bounded by what a user can do: one
- * network-free `get_cached_game_detail` per install-state event, never a retry
- * this store schedules itself, and none at all while a load is in flight or once
- * one has answered.
+ * network-free `get_cached_game_detail` per install-state event, and none at all
+ * while a load is in flight or once one has answered.
  *
- * The residual is the other side of that bound: an entry whose first load threw
- * and which then sees none of the three events stays on the neutral default for
- * the whole page visit, exactly as before. Recovery here is something a user
- * action triggers, not something time does.
+ * This lane is unbounded in time and bounded per event; {@link
+ * scheduleFailedLoadRetry} is the other way round, and covers the page where the
+ * user does nothing at all. What neither covers is a failure that outlives the
+ * one timed retry on a page nothing then happens on: the timed lane is spent and
+ * no event arrives, so the entry stays on the neutral default until a version
+ * switch or the next page visit.
  */
 function reloadTriggeredBy(entry: Entry, eventRomId: number | undefined): boolean {
   if (entry.state.romId !== null) return eventRomId === entry.state.romId;

--- a/src/utils/gameDetailStore.ts
+++ b/src/utils/gameDetailStore.ts
@@ -143,8 +143,9 @@ interface Entry {
    *  and can finish in either order, so a load that no longer holds this number
    *  has been overtaken and writes nothing. */
   loadSeq: number;
-  /** Whether the last load to settle threw. Cleared the moment the next load is
-   *  issued, so it is never set while one is in flight to answer the question.
+  /** Whether the newest load settled by throwing — a load a later one overtook
+   *  answers for nothing, however it settled. Cleared the moment the next load
+   *  is issued, so it is never set while one is in flight to answer the question.
    *  It is the only thing that tells an entry whose read failed apart from one
    *  that has no identity to install (an appId RomM does not know) or has not
    *  resolved one yet — the shown state is the same in all three. */
@@ -607,6 +608,11 @@ async function handleCoreChange(entry: Entry): Promise<void> {
  * network-free `get_cached_game_detail` per install-state event, never a retry
  * this store schedules itself, and none at all while a load is in flight or once
  * one has answered.
+ *
+ * The residual is the other side of that bound: an entry whose first load threw
+ * and which then sees none of the three events stays on the neutral default for
+ * the whole page visit, exactly as before. Recovery here is something a user
+ * action triggers, not something time does.
  */
 function reloadTriggeredBy(entry: Entry, eventRomId: number | undefined): boolean {
   if (entry.state.romId !== null) return eventRomId === entry.state.romId;

--- a/src/utils/gameDetailStore.ts
+++ b/src/utils/gameDetailStore.ts
@@ -603,25 +603,30 @@ async function handleCoreChange(entry: Entry): Promise<void> {
   }));
 }
 
-/** How long a failed load waits before its one retry. Long enough for a backend
- *  that was reloading or still starting when the read went out — the failure
- *  this recovers — to have come up, and short enough that a user watching the
- *  page reads the repair as the page still loading. */
-const FAILED_LOAD_RETRY_MS = 2000;
+/** How long a failed load waits before its one retry. The plugin's own
+ *  backend-readiness ladders — `RETRY_DELAYS` in index.tsx (#1203) and
+ *  `CONNECTION_RETRY_DELAYS` in utils/connectionProbe.ts (#1045) — both go 2000,
+ *  5000, so 2000 is the interval this project has already recorded as regularly
+ *  too early. This lane has one attempt to spend rather than five, and a row
+ *  still filling after five seconds reads no more broken than after two. */
+const FAILED_LOAD_RETRY_MS = 5000;
 
 /**
  * Schedule the one timed re-derive of an entry whose load threw.
  *
  * The second occasion on {@link Entry.loadFailed}, next to the install-state
- * triggers below. It exists because those triggers miss the likeliest case: a
- * read throws when the backend is reloading or still starting, and a user
- * looking at a game page and doing nothing else produces no download, no
- * uninstall and no adoption for the entry to take its cue from.
+ * triggers below. It exists because those triggers miss the case that produces
+ * the failure: the bridge rejects the read — plugin_loader restarting under the
+ * page, a closed WebSocket — while a user looking at a game page and doing
+ * nothing else produces no download, no uninstall and no adoption for the entry
+ * to take its cue from.
  *
- * Exactly one, for the entry's whole lifetime — {@link Entry.timedRetryUsed} is
- * spent where the retry is scheduled, so a retry that throws too schedules
- * nothing further. The read behind it is local and network-free: one that fails
- * twice is a backend defect, which no amount of waiting longer answers.
+ * One TIMER, for the entry's whole lifetime — {@link Entry.timedRetryUsed} is
+ * spent where it is scheduled, so a retry that throws too schedules nothing
+ * further, and a timer already pending when the event lane re-derives is not
+ * withdrawn (that entry can see both). One rather than a ladder because the
+ * plugin runs a readiness ladder at init already; a per-page lane that grew one
+ * of its own would be racing it, page by page.
  *
  * Inert unless the entry is still the one this was scheduled for and is still
  * failed. The flag is cleared where a load is ISSUED, so an entry the event lane
@@ -654,10 +659,14 @@ function scheduleFailedLoadRetry(appId: number, entry: Entry): void {
  *
  * This lane is unbounded in time and bounded per event; {@link
  * scheduleFailedLoadRetry} is the other way round, and covers the page where the
- * user does nothing at all. What neither covers is a failure that outlives the
- * one timed retry on a page nothing then happens on: the timed lane is spent and
- * no event arrives, so the entry stays on the neutral default until a version
- * switch or the next page visit.
+ * user does nothing at all. Two things neither covers. A failure that outlives
+ * the one timed retry on a page nothing then happens on: the timed lane is spent
+ * and no event arrives, so the entry stays on the neutral default until a
+ * version switch or the next page visit. And a read that HANGS rather than
+ * rejects: `callable()` carries no timeout of its own — which is why index.tsx
+ * and utils/connectionProbe.ts race every attempt against `CALLABLE_TIMEOUT` —
+ * and this load awaits it bare, so the catch never runs, the flag both lanes
+ * read is never set, and neither fires.
  */
 function reloadTriggeredBy(entry: Entry, eventRomId: number | undefined): boolean {
   if (entry.state.romId !== null) return eventRomId === entry.state.romId;


### PR DESCRIPTION
The game-detail store's load has two exits that write nothing: the read coming
back not-found, and the read throwing. Both leave every field standing on its
previous value.

The throw is the damaging one, and worse on a first load than the issue
describes. A re-read that throws keeps the rom identity, so the next download
or uninstall re-reads and repairs it. A first load that throws leaves no
identity at all — and the three events that would re-read are each gated on
matching one, so none of them can ever fire. The entry stays neutral for the
whole page visit, which costs more than the Space Required row it was reported
for: the achievements badge, the BIOS row, the automatic artwork fetch, the
core picker's payload and three gear-menu actions all read from the same
identity.

A failed load now records that on the entry, and the three install-state events
take it as a cue to re-derive even with no identity to match against. The flag
clears where a load is issued, which gives the rest for free: nothing retries
while a read is in flight, an answer of any kind ends the retries, and two
events in one tick open one read rather than two.

That lane alone would miss the case that most likely produces the failure — a
page opened while the plugin's bridge is restarting, where nothing installs or
uninstalls afterwards to trigger it. So a failed load also schedules one timed
retry, hanging on the same flag rather than forming a second mechanism, and
cancelled by any of the three ways an entry can recover or disappear. It is one
timer, spent for the entry's lifetime — the plugin already runs a readiness
ladder at startup, and a per-page lane growing its own would race it. Five
seconds is that ladder's second rung; two, its first, is the interval this
project has already recorded as regularly too early, and a lane with a single
attempt cannot afford to spend it there.

What neither lane covers, and the code now says so: a read that hangs instead of
rejecting. A callable has no timeout of its own, which is why the startup ladder
races every attempt against a deadline. This read has no deadline, so a hang
never reaches the catch, the flag is never set, and neither lane fires.

The not-found exit is deliberately unchanged. Handling it honestly would mean
resetting the whole entry, and it is practically unreachable: every path that
produces it removes the Steam shortcut the game page exists on.

docs: N/A — no page under docs/ describes this store, and nothing a user can
name changes; the fix only stops a stale value from standing.

Closes #1676
