### PR TITLE
refactor(ui): de-duplicate the main page's formatter, estimate and page union

### DIFF
--- a/src/components/MainPage.test.tsx
+++ b/src/components/MainPage.test.tsx
@@ -888,6 +888,21 @@ describe("MainPage", () => {
       expect(lastSyncText(container)).toContain("Never");
     });
 
+    it("falls back to the raw value when last_sync cannot be parsed", async () => {
+      vi.mocked(backend.getSyncStats).mockResolvedValue({
+        ...defaultStats(),
+        last_sync: "not-a-timestamp",
+      });
+      const { container } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+      // Neither `new Date` nor `Date.parse` throws on an unparseable string —
+      // they yield an Invalid Date and NaN. A formatter that does the arithmetic
+      // anyway reaches its last branch with NaN and renders it, so the second
+      // assertion is the one that pins the bug rather than the fallback shape.
+      expect(lastSyncText(container)).toContain("not-a-timestamp");
+      expect(lastSyncText(container)).not.toContain("NaN");
+    });
+
     it("renders 'Just now' for a sync within the last minute", async () => {
       vi.mocked(backend.getSyncStats).mockResolvedValue({
         ...defaultStats(),

--- a/src/components/MainPage.test.tsx
+++ b/src/components/MainPage.test.tsx
@@ -867,7 +867,7 @@ describe("MainPage", () => {
     });
   });
 
-  describe("formatLastSync (via Last sync field)", () => {
+  describe("Last sync field", () => {
     function lastSyncText(container: HTMLElement): string | null {
       const labels = Array.from(container.querySelectorAll('[data-testid="field-label"]'));
       const idx = labels.findIndex((n) => n.textContent === "Last sync");

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -29,8 +29,9 @@ import {
   getRetroDeckStatus,
   logError,
 } from "../api/backend";
+import { formatTimeAgo } from "../utils/formatters";
 import { pluralize } from "../utils/pluralize";
-import { estimateApplySeconds, formatDuration } from "../utils/syncEstimate";
+import { formatDuration, previewApplySeconds } from "../utils/syncEstimate";
 import {
   observeApplyProgress,
   displayedEtaSeconds,
@@ -73,14 +74,13 @@ import type {
   SessionBudgetStatus,
   DownloadItem,
   MigrationStatus,
+  Page,
 } from "../types";
 import { detach } from "../utils/detach";
 import { wrapText } from "../utils/textStyles";
 
-type Page = "settings" | "library" | "data" | "downloads" | "system";
-
 interface MainPageProps {
-  onNavigate: (page: Page) => void;
+  onNavigate: (page: Exclude<Page, "main">) => void;
 }
 
 /** The connection-row label for a failed probe, mapped from the backend's
@@ -191,24 +191,6 @@ function formatProgressText(progress: SyncProgress | null): string {
 const FINE_DETAIL_LINE_HEIGHT = 1.4;
 const FINE_DETAIL_CLAMP_LINES = 2;
 
-function formatLastSync(iso: string | null): string {
-  if (!iso) return "Never";
-  try {
-    const d = new Date(iso);
-    const now = new Date();
-    const diffMs = now.getTime() - d.getTime();
-    const diffMins = Math.floor(diffMs / 60000);
-    if (diffMins < 1) return "Just now";
-    if (diffMins < 60) return `${diffMins}m ago`;
-    const diffHours = Math.floor(diffMins / 60);
-    if (diffHours < 24) return `${diffHours}h ago`;
-    const diffDays = Math.floor(diffHours / 24);
-    return `${diffDays}d ago`;
-  } catch {
-    return iso;
-  }
-}
-
 /** Wall-clock ``HH:MM`` for the "last attempt" hint; the raw ISO on a bad parse. */
 function formatClockTime(iso: string): string {
   const d = new Date(iso);
@@ -230,7 +212,7 @@ function lastSyncValue(stats: SyncStats): ReactNode {
   if (stats.last_sync) {
     return (
       <span style={{ fontSize: "12px", display: "flex", flexDirection: "column", alignItems: "flex-end" }}>
-        <span>{formatLastSync(stats.last_sync)}</span>
+        <span>{formatTimeAgo(stats.last_sync) ?? stats.last_sync}</span>
         {stats.last_attempt && (
           <span style={{ opacity: 0.6 }}>
             last attempt: {formatClockTime(stats.last_attempt.finished_at)} ({stats.last_attempt.status})
@@ -370,26 +352,6 @@ function formatLibraryLine(stats: SyncStats): string {
   const collections = stats.collections ?? 0;
   if (collections > 0) parts.push(pluralize(collections, "collection"));
   return parts.join(" · ");
-}
-
-/**
- * Expected apply seconds for a preview — the DELTA cost. The delta-restricted
- * apply (#1383) touches only new + changed shortcuts; content-unchanged items are
- * skipped entirely (no Set* walk, no confirm poll), so they cost nothing and are
- * no longer priced. Creates run at the new-shortcut rate, changed at the lighter
- * update rate, plus the flat fixed-overhead allowance. This is now a tight
- * estimate rather than an inflated upper bound — the old model priced every
- * unchanged item as an update because a resume re-walked them, which the skip has
- * eliminated. Cover refreshes are their own term (#1511): they are backend
- * downloads on already-bound shortcuts, so they carry no shortcut-walk cost, and
- * a cover-only preview must price its covers rather than read the flat allowance.
- * Absent on older backends, where zero is the right reading. Used for BOTH the
- * preview "Estimated time" row and the handleApply seed, so the number the user
- * approves is the number the run starts with; the live countdown still corrects
- * it against the measured apply rate.
- */
-function previewApplySeconds(s: SyncPreviewSummary): number {
-  return estimateApplySeconds(s.new_count, s.changed_count, s.cover_refresh_count ?? 0);
 }
 
 /** Preview apply-time (seconds) at/above which the hint appends the sleep-pause

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -70,6 +70,7 @@ import type {
   SyncStaleData,
   SyncCollectionsData,
   ServerRetryProgressEvent,
+  Page,
 } from "./types";
 import { setLaunchOptionsConfirmed } from "./utils/steamShortcuts";
 import { removeShortcutsPaced } from "./utils/shortcutRemoval";
@@ -89,8 +90,6 @@ import type { PruneActionRequired } from "./utils/pruneActions";
 import { admitPruneFrame, setPruneComplete, setPruneProgress } from "./utils/pruneStore";
 import type { PruneComplete, PruneProgress } from "./utils/pruneStore";
 import { publishCommittedVersionSwitch } from "./utils/versionSwitchApplication";
-
-type Page = "main" | "settings" | "library" | "data" | "downloads" | "system";
 
 // Module-level page state survives QAM remounts (e.g. after modal close)
 let currentPage: Page = "main";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,9 +1,10 @@
 /**
  * Public surface for the frontend type catalog. This file is a façade —
  * actual type definitions live in domain modules (api, sync, downloads,
- * firmware, saves, achievements, navigation). Consumers may deep-import the domain
- * module directly (`from "../types/saves"`) or use the broad re-export
- * surface here (`from "../types"`).
+ * firmware, saves, achievements, migration, devices, retrodeck, navigation).
+ * Consumers may deep-import the domain module directly
+ * (`from "../types/saves"`) or use the broad re-export surface here
+ * (`from "../types"`).
  */
 
 export * from "./api";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,7 +1,7 @@
 /**
  * Public surface for the frontend type catalog. This file is a façade —
  * actual type definitions live in domain modules (api, sync, downloads,
- * firmware, saves, achievements). Consumers may deep-import the domain
+ * firmware, saves, achievements, navigation). Consumers may deep-import the domain
  * module directly (`from "../types/saves"`) or use the broad re-export
  * surface here (`from "../types"`).
  */
@@ -15,3 +15,4 @@ export * from "./achievements";
 export * from "./migration";
 export * from "./devices";
 export * from "./retrodeck";
+export * from "./navigation";

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -1,0 +1,8 @@
+/**
+ * QAM panel navigation — the set of pages the panel can show. Anything that
+ * names a page the QAM router can land on lives here.
+ */
+
+/** Every page the QAM panel can show. A surface that cannot navigate to itself
+ *  narrows this with `Exclude<Page, "...">` rather than restating the union. */
+export type Page = "main" | "settings" | "library" | "data" | "downloads" | "system";

--- a/src/utils/syncEstimate.ts
+++ b/src/utils/syncEstimate.ts
@@ -14,7 +14,7 @@
  * multi-page fetch, inter-chunk gaps, finalize).
  */
 
-import type { SyncPlanUnit } from "../types/sync";
+import type { SyncPlanUnit, SyncPreviewSummary } from "../types/sync";
 
 /**
  * Seconds per newly created shortcut — the AddShortcut + overview poll, the
@@ -73,6 +73,26 @@ export function estimateApplySeconds(newCount: number, changedCount: number, cov
     (created + refreshed) * COVER_DOWNLOAD_SEC +
     FETCH_ALLOWANCE_SEC
   );
+}
+
+/**
+ * Expected apply seconds for a preview — the DELTA cost. The delta-restricted
+ * apply (#1383) touches only new + changed shortcuts; content-unchanged items are
+ * skipped entirely (no Set* walk, no confirm poll), so they cost nothing and are
+ * no longer priced. Creates run at the new-shortcut rate, changed at the lighter
+ * update rate, plus the flat fixed-overhead allowance. This is now a tight
+ * estimate rather than an inflated upper bound — the old model priced every
+ * unchanged item as an update because a resume re-walked them, which the skip has
+ * eliminated. Cover refreshes are their own term (#1511): they are backend
+ * downloads on already-bound shortcuts, so they carry no shortcut-walk cost, and
+ * a cover-only preview must price its covers rather than read the flat allowance.
+ * Absent on older backends, where zero is the right reading. Used for BOTH the
+ * preview "Estimated time" row and the handleApply seed, so the number the user
+ * approves is the number the run starts with; the live countdown still corrects
+ * it against the measured apply rate.
+ */
+export function previewApplySeconds(s: SyncPreviewSummary): number {
+  return estimateApplySeconds(s.new_count, s.changed_count, s.cover_refresh_count ?? 0);
 }
 
 /**


### PR DESCRIPTION
Three de-duplications in and around `MainPage.tsx`, and a test for the bug one
of them fixes.

`formatLastSync` was a fourth copy of a relative-time formatter this repo
already has, and the copy was wrong. Its `catch` could not run — `new Date`
returns an Invalid Date rather than throwing — so an unparseable timestamp fell
through to the last branch with `NaN` and the Last sync line rendered the
literal string `NaNd ago` instead of the raw value the dead `catch` was reaching
for. The call site now uses `formatTimeAgo` from `utils/formatters.ts`, which
produces the same strings for every valid input and returns null on a bad parse,
so the fallback is the raw value.

That branch had no coverage — the field was only ever exercised with a null or a
valid timestamp — so it gets a test. The assertion bites: on the old code the
same input rendered exactly `NaNd ago`.

`previewApplySeconds` is a one-line wrapper around `estimateApplySeconds` that
sat three hundred lines away from it in a component file. It moves next to what
it wraps, where the next person needing an apply estimate will find it instead
of deriving a second one.

The `Page` union was declared twice, and not identically: `index.tsx` had the
full list, `MainPage.tsx` the same list minus `"main"`, because the main page
cannot navigate to itself. That distinction is real and it survives — the union
now lives in `types/navigation.ts` and the narrower prop is
`Exclude<Page, "main">`, so a sixth page is added in one place and the narrowing
follows instead of being restated. The type façade's docstring, which named
seven of the ten modules it re-exports, is completed at the same time.

None of this touches the component body, and none of it is the decomposition
#1751 originally asked for. The reasoning is recorded on the issue: the file's
problem is that several paths ask the backend the same question without knowing
about each other, and that lives in the part of the file a helper extraction
does not reach.

docs: N/A — the user guide describes what the Last sync line shows, not how a
timestamp is formatted or what happens when one cannot be parsed; nothing else
here is user-visible.

First step of #1751.
