### PR TITLE
fix(downloads): notify download-store subscribers instead of polling

### DIFF
--- a/src/components/DownloadQueue.test.tsx
+++ b/src/components/DownloadQueue.test.tsx
@@ -1,9 +1,5 @@
 // CATCH-REJECTION ASSERTION RULE:
-// DownloadQueue has 3 catch sites:
-//   - useEffect mount: getDownloadQueue().catch → falls back to
-//     setLocalDownloads([...getDownloadState()]). Observable side effect:
-//     pre-seeded store items render. Asserted in "mount: rejection falls back
-//     to store".
+// DownloadQueue has 2 catch sites:
 //   - handleCancel `try/catch`. Both the failure RESULT (success: false) and a
 //     rejection now surface a toast — a cancel is never a silent no-op (#149
 //     downloads-round). Asserted in "a failing cancel result surfaces a toast"
@@ -13,22 +9,29 @@
 //     removeTerminalDownloads(), so the finished rows stay visible and the
 //     store is untouched. Asserted in "a failed clear leaves the finished
 //     rows in place".
+// The mount fetch's rejection is handed to detach(): the store already holds
+// whatever the event listeners put there, and that is what stays on screen —
+// asserted in "a rejected mount fetch leaves the store's entries on screen".
 //
 // MUTATION CHECKS (by inspection):
-//   1. If clearInterval(pollRef.current) is removed from stopPolling, the
-//      "interval is cleared on unmount" test fails — clearIntervalSpy would
-//      not be called with the captured pollRef id after unmount.
-//   2. If removeTerminalDownloads() is removed from handleClearCompleted, the
+//   1. If removeTerminalDownloads() is removed from handleClearCompleted, the
 //      "cleared downloads do not reappear on remount" test fails — the store
-//      keeps the terminal entries, so the poll re-shows them.
+//      keeps the terminal entries, so a remount re-shows them.
+//   2. If a store mutator notifies (or installs a new array) when it changed
+//      nothing, "a store mutation that changes nothing does not re-render"
+//      fails on the render count.
 
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { render, fireEvent, act } from "@testing-library/react";
 import { toaster } from "@decky/api";
 import { DownloadQueue } from "./DownloadQueue";
 import * as backend from "../api/backend";
-import { setDownloads, getDownloadState, removeDownload } from "../utils/downloadStore";
+import { setDownloads, getDownloadState, removeDownload, removeTerminalDownloads } from "../utils/downloadStore";
 import type { DownloadItem } from "../types";
+
+// Counts every DownloadQueue render: its two PanelSections are re-created on
+// each one, so the counter moves with the component, not with the store.
+const renderCounter = vi.hoisted(() => ({ count: 0 }));
 
 // Local @decky/ui mock adds ProgressBar (not in the global stub) and exposes
 // per-prop testids so we can assert progress bar wiring directly. The active
@@ -40,7 +43,10 @@ vi.mock("@decky/ui", async () => {
   const { createElement: ce } = await import("react");
   const passthrough = (tag: string) => (p: AnyProps) => ce(tag, p, p.children as never);
   return {
-    PanelSection: (p: AnyProps & { title?: unknown }) => ce("section", { title: p.title }, p.children as never),
+    PanelSection: (p: AnyProps & { title?: unknown }) => {
+      renderCounter.count += 1;
+      return ce("section", { title: p.title }, p.children as never);
+    },
     PanelSectionRow: passthrough("div"),
     ButtonItem: ({ children, onClick, disabled }: AnyProps & { onClick?: () => void; disabled?: boolean }) =>
       ce("button", { onClick, disabled }, children as never),
@@ -104,9 +110,9 @@ async function flushMount(): Promise<void> {
 
 describe("DownloadQueue", () => {
   beforeEach(() => {
-    vi.useFakeTimers();
     // Reset shared module-level store between tests.
     setDownloads([]);
+    renderCounter.count = 0;
     // Default mount fetch resolves to an empty queue; tests override per case.
     vi.mocked(backend.getDownloadQueue).mockResolvedValue({ downloads: [] });
     vi.mocked(backend.cancelDownload).mockResolvedValue({ success: true, message: "" });
@@ -116,16 +122,11 @@ describe("DownloadQueue", () => {
     vi.mocked(toaster.toast).mockClear();
   });
 
-  afterEach(() => {
-    vi.useRealTimers();
-    setDownloads([]);
-  });
-
   // ---------------------------------------------------------------------------
   // Mount-time fetch (useEffect)
   // ---------------------------------------------------------------------------
   describe("mount fetch", () => {
-    it("seeds the store + local state from getDownloadQueue() on mount", async () => {
+    it("seeds the store from getDownloadQueue() on mount and renders it", async () => {
       const item = makeItem({ rom_id: 7, rom_name: "Item7" });
       vi.mocked(backend.getDownloadQueue).mockResolvedValue({
         downloads: [item],
@@ -136,14 +137,14 @@ describe("DownloadQueue", () => {
 
       // Store was seeded — verifies setDownloads(result.downloads) ran.
       expect(getDownloadState()).toEqual([item]);
-      // Local state rendered — caption present for the active item.
+      // The subscription rendered it — caption present for the active item.
       const caption = container.querySelector('[data-testid="dl-caption"]');
       expect(caption?.textContent).toBe("Item7 (Genesis)");
     });
 
-    it("rejection falls back to current getDownloadState() store contents", async () => {
-      // Pre-seed the store; the mount fetch will reject and the catch branch
-      // should rebuild local state from this.
+    it("a rejected mount fetch leaves the store's entries on screen", async () => {
+      // The fetch is fire-and-forget: on a rejection nothing writes the store,
+      // so what the event listeners already put there stays rendered.
       const fallback = makeItem({ rom_id: 99, rom_name: "Fallback" });
       setDownloads([fallback]);
       vi.mocked(backend.getDownloadQueue).mockRejectedValue(new Error("net"));
@@ -153,7 +154,7 @@ describe("DownloadQueue", () => {
 
       const caption = container.querySelector('[data-testid="dl-caption"]');
       expect(caption?.textContent).toBe("Fallback (Genesis)");
-      // Store unchanged by the catch branch.
+      // Store untouched by the failed fetch.
       expect(getDownloadState()).toEqual([fallback]);
     });
   });
@@ -186,61 +187,48 @@ describe("DownloadQueue", () => {
   });
 
   // ---------------------------------------------------------------------------
-  // Polling (500ms setInterval)
+  // Store subscription (#1181 — replaced the 500ms poll)
   // ---------------------------------------------------------------------------
-  describe("polling", () => {
-    it("each 500ms tick re-reads getDownloadState() and updates local state", async () => {
+  describe("store subscription", () => {
+    it("a store write from outside the component renders on the spot", async () => {
       const { container } = render(<DownloadQueue onBack={() => {}} />);
       await flushMount();
       // Empty queue at mount.
       expect(container.textContent).toContain("No downloads");
 
-      // Push a new item to the store from outside the component, then tick.
-      const incoming = makeItem({ rom_id: 5, rom_name: "Ticked" });
-      setDownloads([incoming]);
-
+      // Push a new item to the store from outside the component — no timer.
       await act(async () => {
-        await vi.advanceTimersByTimeAsync(500);
+        setDownloads([makeItem({ rom_id: 5, rom_name: "Notified" })]);
       });
 
       const caption = container.querySelector('[data-testid="dl-caption"]');
-      expect(caption?.textContent).toBe("Ticked (Genesis)");
+      expect(caption?.textContent).toBe("Notified (Genesis)");
     });
 
-    it("interval is cleared on unmount — clearInterval is invoked with the pollRef id", async () => {
-      // Spy on setInterval to capture the timer id assigned to pollRef, and
-      // on clearInterval to assert stopPolling runs it with that exact id.
-      // The prior `not.toContain("AfterUnmount")` assertion was vacuous:
-      // setLocalDownloads no-ops on unmounted components and the container
-      // is detached, so it passed whether or not clearInterval ran. A
-      // mutation that drops `clearInterval(pollRef.current)` from stopPolling
-      // now fails — clearIntervalSpy is never called with the captured id.
-      const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
-      const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval");
-
-      const { unmount } = render(<DownloadQueue onBack={() => {}} />);
+    it("a store mutation that changes nothing does not re-render (#1181)", async () => {
+      vi.mocked(backend.getDownloadQueue).mockResolvedValue({
+        downloads: [makeItem({ rom_id: 5, rom_name: "Idle" })],
+      });
+      const { container } = render(<DownloadQueue onBack={() => {}} />);
       await flushMount();
+      const settled = renderCounter.count;
 
-      // startPolling calls setInterval(pollTick, 500). Pick out that id.
-      const pollIntervalIds = setIntervalSpy.mock.results
-        .filter((_, i) => setIntervalSpy.mock.calls[i]![1] === 500)
-        .map((r) => r.value as ReturnType<typeof setInterval>);
-      const expectedId = pollIntervalIds[pollIntervalIds.length - 1];
-      expect(expectedId).toBeDefined();
+      // Neither call finds anything to do: rom 999 is not queued and the one
+      // entry is active. The old 500ms poll spread a fresh array regardless and
+      // re-rendered the list on every tick, which is the churn #1181 reports.
+      await act(async () => {
+        removeDownload(999);
+        removeTerminalDownloads();
+      });
+      expect(renderCounter.count).toBe(settled);
+      expect(container.querySelector('[data-testid="dl-caption"]')?.textContent).toBe("Idle (Genesis)");
 
-      // startPolling's leading stopPolling() runs before pollRef is set, so
-      // its clearInterval calls do nothing — capture the baseline regardless.
-      const callsBeforeUnmount = clearIntervalSpy.mock.calls.length;
-
-      unmount();
-
-      // After unmount, clearInterval must have been called with the id we
-      // captured from setInterval.
-      expect(clearIntervalSpy.mock.calls.length).toBeGreaterThan(callsBeforeUnmount);
-      expect(clearIntervalSpy).toHaveBeenCalledWith(expectedId);
-
-      setIntervalSpy.mockRestore();
-      clearIntervalSpy.mockRestore();
+      // A real change still re-renders — the guard is not simply mute.
+      await act(async () => {
+        removeDownload(5);
+      });
+      expect(renderCounter.count).toBeGreaterThan(settled);
+      expect(container.textContent).toContain("No downloads");
     });
   });
 
@@ -282,9 +270,8 @@ describe("DownloadQueue", () => {
       expect(container.textContent).toContain("No downloads");
 
       // Now the same rom_id restarts: store contains it with status="downloading".
-      setDownloads([makeItem({ rom_id: 42, rom_name: "Restart" })]);
       await act(async () => {
-        await vi.advanceTimersByTimeAsync(500);
+        setDownloads([makeItem({ rom_id: 42, rom_name: "Restart" })]);
       });
 
       // The re-entered download renders again — nothing keeps it hidden.
@@ -313,9 +300,8 @@ describe("DownloadQueue", () => {
       });
       expect(container.textContent).toContain("No downloads");
 
-      setDownloads([makeItem({ rom_id: 13, rom_name: "Queued", status: "queued" })]);
       await act(async () => {
-        await vi.advanceTimersByTimeAsync(500);
+        setDownloads([makeItem({ rom_id: 13, rom_name: "Queued", status: "queued" })]);
       });
       expect(container.querySelector('[data-testid="dl-caption"]')?.textContent).toBe("Queued (Genesis)");
     });
@@ -383,10 +369,10 @@ describe("DownloadQueue", () => {
       expect(container.querySelector('[data-testid="dl-caption"]')?.textContent).toBe("Cancellable (Genesis)");
     });
 
-    it("a paused download cancelled + removed from the store disappears on the next poll (#149 downloads-round)", async () => {
+    it("a paused download cancelled + removed from the store disappears at once (#149 downloads-round)", async () => {
       // The row drops via the backend's terminal cancelled frame → the index.tsx
       // store listener's removeDownload (stood in for here) → DownloadQueue's
-      // poll. No client-side 'cancelled' row lingers.
+      // subscription. No client-side 'cancelled' row lingers.
       const paused = makeItem({ rom_id: 42, rom_name: "Paused", status: "paused", resumable: true });
       vi.mocked(backend.getDownloadQueue).mockResolvedValue({ downloads: [paused] });
       const { container } = render(<DownloadQueue onBack={() => {}} />);
@@ -401,9 +387,8 @@ describe("DownloadQueue", () => {
       expect(backend.cancelDownload).toHaveBeenCalledWith(42);
 
       // Backend evicted + emitted the cancelled frame; the store loses the entry.
-      removeDownload(42);
       await act(async () => {
-        await vi.advanceTimersByTimeAsync(500);
+        removeDownload(42);
       });
       expect(container.textContent).toContain("No downloads");
     });
@@ -564,7 +549,7 @@ describe("DownloadQueue", () => {
       expect(container.querySelector('[data-testid="dl-caption"]')?.textContent).toBe("Active (Genesis)");
       // Clear Completed button is gone (no finished items remain).
       expect(buttonByExactText(container, "Clear Completed")).toBeNull();
-      // The finished entries left the shared store too, so the poll won't re-show
+      // The finished entries left the shared store too, so nothing re-shows
       // them and a remount fetch (from the evicted backend queue) stays clean.
       expect(getDownloadState().map((d) => d.rom_id)).toEqual([1]);
     });

--- a/src/components/DownloadQueue.tsx
+++ b/src/components/DownloadQueue.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, FC, Fragment } from "react";
+import { useEffect, FC, Fragment } from "react";
 import { PanelSection, PanelSectionRow, ButtonItem, Field } from "@decky/ui";
 import { showToast } from "../utils/toast";
 import {
@@ -8,7 +8,7 @@ import {
   resumeDownload,
   clearCompletedDownloads,
 } from "../api/backend";
-import { getDownloadState, setDownloads, removeTerminalDownloads } from "../utils/downloadStore";
+import { setDownloads, removeTerminalDownloads, useDownloads } from "../utils/downloadStore";
 import { formatBytes } from "../utils/formatters";
 import { scrollToTop } from "../utils/scrollHelpers";
 import { detach } from "../utils/detach";
@@ -29,41 +29,18 @@ function formatFinishedDescription(item: DownloadItem): string {
 }
 
 export const DownloadQueue: FC<DownloadQueueProps> = ({ onBack }) => {
-  const [downloads, setLocalDownloads] = useState<DownloadItem[]>([]); // NOSONAR(typescript:S6754) — setter intentionally renamed (local wrapper around global download state).
-  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const downloads = useDownloads();
 
   useEffect(() => {
-    // The interval machinery is scoped to the effect: nothing outside it drives
-    // the poll, and keeping these helpers here means the mount-only effect has no
-    // reactive dependencies to track.
-    const stopPolling = () => {
-      if (pollRef.current) {
-        clearInterval(pollRef.current);
-        pollRef.current = null;
-      }
-    };
-
-    const pollTick = () => {
-      setLocalDownloads([...getDownloadState()]);
-    };
-
-    const startPolling = () => {
-      stopPolling();
-      pollRef.current = setInterval(pollTick, 500);
-    };
-
-    // Seed from backend on mount, then poll the store
-    getDownloadQueue()
-      .then((result) => {
+    // Seed the store from the backend queue on mount; the subscription renders
+    // whatever lands there. A rejected fetch needs no handling of its own — the
+    // store keeps whatever the event listeners have already put in it, and that
+    // is exactly what stays on screen.
+    detach(
+      getDownloadQueue().then((result) => {
         setDownloads(result.downloads);
-        setLocalDownloads([...result.downloads]);
-      })
-      .catch(() => {
-        // Fall back to whatever is in the store already
-        setLocalDownloads([...getDownloadState()]);
-      });
-    startPolling();
-    return () => stopPolling();
+      }),
+    );
   }, []);
 
   const handleCancel = async (romId: number) => {
@@ -106,9 +83,8 @@ export const DownloadQueue: FC<DownloadQueueProps> = ({ onBack }) => {
       return;
     }
     // The backend evicted the terminal entries; drop them from the store too so
-    // the poll and any remount reflect the cleared queue immediately (#149).
+    // this view and any remount reflect the cleared queue immediately (#149).
     removeTerminalDownloads();
-    setLocalDownloads([...getDownloadState()]);
   };
 
   // Paused and extracting downloads stay in the active section — they're not

--- a/src/components/MainPage.test.tsx
+++ b/src/components/MainPage.test.tsx
@@ -817,14 +817,11 @@ describe("MainPage", () => {
       };
       setDownloads([item]);
       const { container } = render(<MainPage onNavigate={vi.fn()} />);
-      // mount useEffect resolves, then advance the 1000ms downloadPollRef so
-      // local `downloads` state populates from the store.
+      // The store is seeded before render, so the subscription has it from the
+      // first pass — only the mount useEffect's microtasks need flushing.
       await act(async () => {
         await Promise.resolve();
         await Promise.resolve();
-      });
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(1100);
       });
       return container;
     }
@@ -4176,10 +4173,6 @@ describe("MainPage", () => {
           await Promise.resolve();
           await Promise.resolve();
         });
-        // downloadPollRef ticks at 1000ms — advance one tick to populate state.
-        await act(async () => {
-          await vi.advanceTimersByTimeAsync(1100);
-        });
         fireEvent.click(buttonByExactText(container, "View All")!);
         expect(onNavigate).toHaveBeenCalledWith("downloads");
       } finally {
@@ -4192,9 +4185,9 @@ describe("MainPage", () => {
   // M. Downloads section render
   // ===========================================================================
   describe("downloads section", () => {
-    // The downloads section local state is populated by downloadPollRef
-    // (1000ms setInterval reading getDownloadState()). Use fake timers +
-    // advance one tick so the store contents propagate into render.
+    // The downloads section reads the store through useDownloads(), so seeding
+    // the store before render is enough. Fake timers stay for MainPage's other
+    // timed effects.
     beforeEach(() => {
       vi.useFakeTimers({
         toFake: ["setInterval", "clearInterval", "setTimeout", "clearTimeout"],
@@ -4205,20 +4198,17 @@ describe("MainPage", () => {
       vi.useRealTimers();
     });
 
-    async function renderAndTick(): Promise<HTMLElement> {
+    async function renderSection(): Promise<HTMLElement> {
       const { container } = render(<MainPage onNavigate={vi.fn()} />);
       await act(async () => {
         await Promise.resolve();
         await Promise.resolve();
       });
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(1100);
-      });
       return container;
     }
 
     it("hidden when no downloads in the store", async () => {
-      const container = await renderAndTick();
+      const container = await renderSection();
       // The downloads block is heading-less; its "View All" button is the
       // presence anchor.
       expect(buttonByExactText(container, "View All")).toBeNull();
@@ -4238,7 +4228,7 @@ describe("MainPage", () => {
           resumable: false,
         },
       ]);
-      const container = await renderAndTick();
+      const container = await renderSection();
       expect(buttonByExactText(container, "View All")).not.toBeNull();
       // The rom name lands in the full-width caption (not clipped in a Field
       // label column) — see the #751 ProgressBarWithInfo fix.
@@ -4281,7 +4271,7 @@ describe("MainPage", () => {
           resumable: false,
         },
       ]);
-      const container = await renderAndTick();
+      const container = await renderSection();
       expect(container.textContent).toContain("+1 more downloading");
     });
 
@@ -4310,7 +4300,7 @@ describe("MainPage", () => {
           resumable: false,
         },
       ]);
-      const container = await renderAndTick();
+      const container = await renderSection();
       // Self-describing label — the heading-less downloads block gives the row
       // no context of its own.
       expect(container.textContent).toContain("2 downloads completed");
@@ -4332,7 +4322,7 @@ describe("MainPage", () => {
           resumable: false,
         },
       ]);
-      const container = await renderAndTick();
+      const container = await renderSection();
       const progress = container.querySelector('[data-testid="progress-progress"]');
       expect(progress?.textContent).toBe("25");
       const indet = container.querySelector('[data-testid="progress-indeterminate"]');
@@ -4355,7 +4345,7 @@ describe("MainPage", () => {
           resumable: false,
         },
       ]);
-      const container = await renderAndTick();
+      const container = await renderSection();
       const indet = container.querySelector('[data-testid="progress-indeterminate"]');
       expect(indet?.textContent).toBe("true");
       expect(container.querySelector('[data-testid="dl-caption"]')?.textContent).toBe("P");
@@ -4364,32 +4354,9 @@ describe("MainPage", () => {
   });
 
   // ===========================================================================
-  // N. Polling cleanup — setInterval / clearInterval spy pattern
+  // N. Subscription cleanup
   // ===========================================================================
-  describe("polling cleanup", () => {
-    it("downloadPollRef setInterval is cleared on unmount", async () => {
-      const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
-      const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval");
-
-      const { unmount } = render(<MainPage onNavigate={vi.fn()} />);
-      await flushAsync();
-
-      // Capture the 1000ms (downloadPollRef) interval id.
-      const downloadIds = setIntervalSpy.mock.results
-        .filter((_, i) => setIntervalSpy.mock.calls[i]![1] === 1000)
-        .map((r) => r.value as ReturnType<typeof setInterval>);
-      const expectedId = downloadIds[downloadIds.length - 1];
-      expect(expectedId).toBeDefined();
-
-      const callsBeforeUnmount = clearIntervalSpy.mock.calls.length;
-      unmount();
-      expect(clearIntervalSpy.mock.calls.length).toBeGreaterThan(callsBeforeUnmount);
-      expect(clearIntervalSpy).toHaveBeenCalledWith(expectedId);
-
-      setIntervalSpy.mockRestore();
-      clearIntervalSpy.mockRestore();
-    });
-
+  describe("subscription cleanup", () => {
     it("onSyncProgressChange subscription is removed on unmount", async () => {
       vi.mocked(backend.getSyncStatus).mockResolvedValue({
         running: true,

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -45,7 +45,7 @@ import {
   onSyncProgressChange,
   withinUnitFraction,
 } from "../utils/syncProgress";
-import { getDownloadState } from "../utils/downloadStore";
+import { useDownloads } from "../utils/downloadStore";
 import { getMigrationState, onMigrationChange, setMigrationStatus } from "../utils/migrationStore";
 import { getSettingsResetState, onSettingsResetChange } from "../utils/settingsResetStore";
 import { getPlaytimeScopeState, onPlaytimeScopeChange, fetchPlaytimeScopeState } from "../utils/playtimeScopeStore";
@@ -72,7 +72,6 @@ import type {
   SyncPreview,
   SyncPreviewSummary,
   SessionBudgetStatus,
-  DownloadItem,
   MigrationStatus,
   Page,
 } from "../types";
@@ -433,9 +432,8 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
   const [settingsReset, setSettingsReset] = useState(getSettingsResetState());
   const [playtimeScope, setPlaytimeScope] = useState(getPlaytimeScopeState());
   const [saveSortMigration, setSaveSortMigration] = useState(getSaveSortMigrationState());
-  const [downloads, setDownloads] = useState<DownloadItem[]>([]);
+  const downloads = useDownloads();
   const statusTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const downloadPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const showTransientStatus = (text: string, tone: StatusTone = "neutral") => {
     if (statusTimeoutRef.current) clearTimeout(statusTimeoutRef.current);
@@ -599,11 +597,6 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
       }
     });
 
-    // Poll download state for inline display
-    downloadPollRef.current = setInterval(() => {
-      setDownloads([...getDownloadState()]);
-    }, 1000);
-
     const unsubMigration = onMigrationChange(() => setMigration(getMigrationState()));
     const unsubSettingsReset = onSettingsResetChange(() => setSettingsReset(getSettingsResetState()));
     const unsubPlaytimeScope = onPlaytimeScopeChange(() => setPlaytimeScope(getPlaytimeScopeState()));
@@ -615,7 +608,6 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
       unsubPlaytimeScope();
       unsubSaveSort();
       if (statusTimeoutRef.current) clearTimeout(statusTimeoutRef.current);
-      if (downloadPollRef.current) clearInterval(downloadPollRef.current);
     };
   }, []);
 

--- a/src/utils/downloadFailure.ts
+++ b/src/utils/downloadFailure.ts
@@ -19,7 +19,7 @@ export interface ToasterLike {
 }
 
 export interface DownloadStoreLike {
-  getDownloadState: () => DownloadItem[];
+  getDownloadState: () => readonly DownloadItem[];
   updateDownload: (item: DownloadItem) => void;
 }
 

--- a/src/utils/downloadStore.test.ts
+++ b/src/utils/downloadStore.test.ts
@@ -1,0 +1,243 @@
+// The store's contract is what replaced the two pollers (#1181), so these tests
+// pin both halves of it:
+//   - a real change installs a NEW array and notifies;
+//   - a change that changes nothing does neither, and a subscriber does not
+//     re-render.
+// The reference assertions are `toBe`, not `toEqual`, on purpose: a
+// `useSyncExternalStore` snapshot that returns a fresh array per call renders
+// forever, and `toEqual` cannot see the difference.
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import {
+  getDownloadState,
+  onDownloadsChange,
+  removeDownload,
+  removeTerminalDownloads,
+  setDownloads,
+  updateDownload,
+  useDownloads,
+} from "./downloadStore";
+import type { DownloadItem } from "../types";
+
+function makeItem(overrides: Partial<DownloadItem> = {}): DownloadItem {
+  return {
+    rom_id: 1,
+    rom_name: "Sonic",
+    platform_name: "Genesis",
+    file_name: "sonic.bin",
+    status: "downloading",
+    progress: 25,
+    bytes_downloaded: 256,
+    total_bytes: 1024,
+    resumable: false,
+    ...overrides,
+  };
+}
+
+describe("downloadStore", () => {
+  beforeEach(() => {
+    setDownloads([]);
+  });
+
+  describe("snapshot identity", () => {
+    it("returns the same array reference while nothing changes", () => {
+      setDownloads([makeItem()]);
+      expect(getDownloadState()).toBe(getDownloadState());
+    });
+
+    it("returns a different array reference after a real change", () => {
+      setDownloads([makeItem()]);
+      const before = getDownloadState();
+      updateDownload(makeItem({ progress: 80 }));
+      expect(getDownloadState()).not.toBe(before);
+      // The old snapshot is untouched — the update did not write in place.
+      expect(before[0]!.progress).toBe(25);
+    });
+
+    it("keeps the same array reference when a mutation changes nothing", () => {
+      setDownloads([makeItem()]);
+      const before = getDownloadState();
+      removeDownload(999);
+      removeTerminalDownloads();
+      setDownloads(before);
+      expect(getDownloadState()).toBe(before);
+    });
+  });
+
+  describe("setDownloads", () => {
+    it("replaces the queue and notifies", () => {
+      const listener = vi.fn();
+      const unsub = onDownloadsChange(listener);
+      const item = makeItem({ rom_id: 7 });
+      setDownloads([item]);
+      expect(getDownloadState()).toEqual([item]);
+      expect(listener).toHaveBeenCalledTimes(1);
+      unsub();
+    });
+
+    it("stores a copy — mutating the caller's array afterwards does not reach the store", () => {
+      const items = [makeItem({ rom_id: 1 })];
+      setDownloads(items);
+      const stored = getDownloadState();
+      items.push(makeItem({ rom_id: 2 }));
+      expect(getDownloadState()).toBe(stored);
+      expect(getDownloadState().map((d) => d.rom_id)).toEqual([1]);
+    });
+
+    it("is silent when handed the same entries in the same order", () => {
+      const item = makeItem();
+      setDownloads([item]);
+      const listener = vi.fn();
+      const unsub = onDownloadsChange(listener);
+      setDownloads([item]);
+      expect(listener).not.toHaveBeenCalled();
+      unsub();
+    });
+  });
+
+  describe("updateDownload", () => {
+    it("replaces the matching entry by rom_id and notifies", () => {
+      setDownloads([makeItem({ rom_id: 1 }), makeItem({ rom_id: 2, rom_name: "Mario" })]);
+      const listener = vi.fn();
+      const unsub = onDownloadsChange(listener);
+      updateDownload(makeItem({ rom_id: 2, rom_name: "Mario", status: "completed" }));
+      expect(getDownloadState().map((d) => d.status)).toEqual(["downloading", "completed"]);
+      expect(listener).toHaveBeenCalledTimes(1);
+      unsub();
+    });
+
+    it("appends an entry whose rom_id is not in the queue yet", () => {
+      setDownloads([makeItem({ rom_id: 1 })]);
+      updateDownload(makeItem({ rom_id: 5, rom_name: "New" }));
+      expect(getDownloadState().map((d) => d.rom_id)).toEqual([1, 5]);
+    });
+
+    it("is silent when handed the entry already stored", () => {
+      const item = makeItem();
+      setDownloads([item]);
+      const listener = vi.fn();
+      const unsub = onDownloadsChange(listener);
+      updateDownload(item);
+      expect(listener).not.toHaveBeenCalled();
+      unsub();
+    });
+  });
+
+  describe("removeDownload", () => {
+    it("drops the entry and notifies", () => {
+      setDownloads([makeItem({ rom_id: 1 }), makeItem({ rom_id: 2 })]);
+      const listener = vi.fn();
+      const unsub = onDownloadsChange(listener);
+      removeDownload(1);
+      expect(getDownloadState().map((d) => d.rom_id)).toEqual([2]);
+      expect(listener).toHaveBeenCalledTimes(1);
+      unsub();
+    });
+
+    it("is silent for a rom_id the queue does not hold", () => {
+      setDownloads([makeItem({ rom_id: 1 })]);
+      const listener = vi.fn();
+      const unsub = onDownloadsChange(listener);
+      removeDownload(42);
+      expect(getDownloadState().map((d) => d.rom_id)).toEqual([1]);
+      expect(listener).not.toHaveBeenCalled();
+      unsub();
+    });
+  });
+
+  describe("removeTerminalDownloads", () => {
+    it("drops completed / failed / cancelled entries, keeps the rest, and notifies", () => {
+      setDownloads([
+        makeItem({ rom_id: 1, status: "downloading" }),
+        makeItem({ rom_id: 2, status: "completed" }),
+        makeItem({ rom_id: 3, status: "failed" }),
+        makeItem({ rom_id: 4, status: "cancelled" }),
+        makeItem({ rom_id: 5, status: "paused" }),
+        makeItem({ rom_id: 6, status: "queued" }),
+        makeItem({ rom_id: 7, status: "extracting" }),
+      ]);
+      const listener = vi.fn();
+      const unsub = onDownloadsChange(listener);
+      removeTerminalDownloads();
+      expect(getDownloadState().map((d) => d.rom_id)).toEqual([1, 5, 6, 7]);
+      expect(listener).toHaveBeenCalledTimes(1);
+      unsub();
+    });
+
+    it("is silent when no entry is terminal", () => {
+      setDownloads([makeItem({ rom_id: 1, status: "downloading" })]);
+      const listener = vi.fn();
+      const unsub = onDownloadsChange(listener);
+      removeTerminalDownloads();
+      expect(listener).not.toHaveBeenCalled();
+      unsub();
+    });
+  });
+
+  describe("onDownloadsChange", () => {
+    it("stops notifying after the returned unsubscribe runs", () => {
+      const listener = vi.fn();
+      const unsub = onDownloadsChange(listener);
+      setDownloads([makeItem({ rom_id: 1 })]);
+      expect(listener).toHaveBeenCalledTimes(1);
+      unsub();
+      setDownloads([makeItem({ rom_id: 2 })]);
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("useDownloads", () => {
+    it("renders the current queue and re-renders on a real change", () => {
+      setDownloads([makeItem({ rom_id: 1 })]);
+      const { result, unmount } = renderHook(() => useDownloads());
+      expect(result.current.map((d) => d.rom_id)).toEqual([1]);
+
+      act(() => {
+        updateDownload(makeItem({ rom_id: 2, rom_name: "Mario" }));
+      });
+      expect(result.current.map((d) => d.rom_id)).toEqual([1, 2]);
+      unmount();
+    });
+
+    it("does not re-render a subscriber when a mutation changes nothing (#1181)", () => {
+      setDownloads([makeItem({ rom_id: 1 })]);
+      let renders = 0;
+      const { unmount } = renderHook(() => {
+        renders += 1;
+        return useDownloads();
+      });
+      const settled = renders;
+
+      // Each of these leaves the queue exactly as it was. Before the store
+      // notified, both callers polled and spread a fresh array every tick, so
+      // the equivalent of this produced a render each time.
+      act(() => {
+        removeDownload(999);
+        removeTerminalDownloads();
+      });
+      expect(renders).toBe(settled);
+
+      // A real change still gets through — the guard is not simply mute.
+      act(() => {
+        removeDownload(1);
+      });
+      expect(renders).toBeGreaterThan(settled);
+      unmount();
+    });
+
+    it("stops re-rendering after unmount", () => {
+      let renders = 0;
+      const { unmount } = renderHook(() => {
+        renders += 1;
+        return useDownloads();
+      });
+      unmount();
+      const afterUnmount = renders;
+      act(() => {
+        setDownloads([makeItem({ rom_id: 3 })]);
+      });
+      expect(renders).toBe(afterUnmount);
+    });
+  });
+});

--- a/src/utils/downloadStore.ts
+++ b/src/utils/downloadStore.ts
@@ -10,6 +10,9 @@
  *
  * Read by:
  *   - MainPage.tsx and DownloadQueue.tsx, both through {@link useDownloads}
+ *   - the download_progress / download_failed handlers themselves, which read
+ *     the current entry through {@link getDownloadState} to carry forward the
+ *     fields their event frame does not carry
  *
  * The state is held immutably: every mutation that changes something installs a
  * NEW array and notifies, and one that changes nothing does neither. That is
@@ -40,7 +43,7 @@ function sameEntries(a: readonly DownloadItem[], b: readonly DownloadItem[]): bo
 
 /** Replace the whole queue. Stores a copy, so a caller that keeps mutating the
  *  array it passed in cannot change store state behind the subscribers' backs. */
-export function setDownloads(items: DownloadItem[]): void {
+export function setDownloads(items: readonly DownloadItem[]): void {
   if (sameEntries(_downloads, items)) return;
   _downloads = items.slice();
   notify();
@@ -70,7 +73,7 @@ export function removeDownload(romId: number): void {
   notify();
 }
 
-export function getDownloadState(): DownloadItem[] {
+export function getDownloadState(): readonly DownloadItem[] {
   return _downloads;
 }
 
@@ -95,6 +98,6 @@ export function onDownloadsChange(fn: () => void): () => void {
 
 /** Subscribe to the download queue from a component. Re-renders the caller
  *  whenever the queue changes and drops its subscription on unmount. */
-export function useDownloads(): DownloadItem[] {
+export function useDownloads(): readonly DownloadItem[] {
   return useSyncExternalStore(onDownloadsChange, getDownloadState);
 }

--- a/src/utils/downloadStore.ts
+++ b/src/utils/downloadStore.ts
@@ -5,30 +5,69 @@
  *   - download_progress events from the backend (persistent listener in index.tsx)
  *   - download_complete events from the backend (persistent listener in index.tsx)
  *   - download_failed events from the backend (persistent listener in index.tsx)
+ *   - DownloadQueue.tsx, which seeds the store from the backend queue on mount
+ *     and drops the terminal entries after a successful "Clear Completed"
  *
  * Read by:
- *   - DownloadQueue.tsx via a cheap setInterval (no callable round-trips)
+ *   - MainPage.tsx and DownloadQueue.tsx, both through {@link useDownloads}
+ *
+ * The state is held immutably: every mutation that changes something installs a
+ * NEW array and notifies, and one that changes nothing does neither. That is
+ * what lets {@link getDownloadState} serve as a `useSyncExternalStore` snapshot
+ * — React compares snapshots by identity, so a getter handing back a fresh copy
+ * per call would re-render forever, and an in-place write would leave a
+ * subscriber unable to tell that a download's progress moved.
+ *
+ * "Changed something" is decided by entry identity, never by comparing fields:
+ * every store write is fed by an event frame or a fetch that builds fresh
+ * objects, so a re-used object reference is the only case in which the caller
+ * genuinely carries no news.
  */
 
+import { useSyncExternalStore } from "react";
 import type { DownloadItem } from "../types";
 
 let _downloads: DownloadItem[] = [];
+const _listeners = new Set<() => void>();
 
+function notify(): void {
+  _listeners.forEach((fn) => fn());
+}
+
+function sameEntries(a: readonly DownloadItem[], b: readonly DownloadItem[]): boolean {
+  return a.length === b.length && a.every((item, i) => item === b[i]);
+}
+
+/** Replace the whole queue. Stores a copy, so a caller that keeps mutating the
+ *  array it passed in cannot change store state behind the subscribers' backs. */
 export function setDownloads(items: DownloadItem[]): void {
-  _downloads = items;
+  if (sameEntries(_downloads, items)) return;
+  _downloads = items.slice();
+  notify();
 }
 
 export function updateDownload(item: DownloadItem): void {
   const idx = _downloads.findIndex((d) => d.rom_id === item.rom_id);
-  if (idx >= 0) _downloads[idx] = item;
-  else _downloads.push(item);
+  if (idx >= 0) {
+    if (_downloads[idx] === item) return;
+    const next = _downloads.slice();
+    next[idx] = item;
+    _downloads = next;
+  } else {
+    _downloads = [..._downloads, item];
+  }
+  notify();
 }
 
 // Drop a single entry by rom_id. The download_progress cancelled listener calls
 // this so a cancelled download — an explicit user discard — leaves no residue in
-// the queue view or QAM summary (#149 downloads-round). Idempotent.
+// the queue view or QAM summary (#149 downloads-round). Idempotent: an unknown
+// rom_id keeps the array and stays silent.
 export function removeDownload(romId: number): void {
-  _downloads = _downloads.filter((d) => d.rom_id !== romId);
+  const next = _downloads.filter((d) => d.rom_id !== romId);
+  if (next.length === _downloads.length) return;
+  _downloads = next;
+  notify();
 }
 
 export function getDownloadState(): DownloadItem[] {
@@ -41,5 +80,21 @@ export function getDownloadState(): DownloadItem[] {
 // succeeds so the store matches the freshly-evicted backend queue immediately,
 // rather than waiting for the next mount fetch.
 export function removeTerminalDownloads(): void {
-  _downloads = _downloads.filter((d) => d.status !== "completed" && d.status !== "failed" && d.status !== "cancelled");
+  const next = _downloads.filter((d) => d.status !== "completed" && d.status !== "failed" && d.status !== "cancelled");
+  if (next.length === _downloads.length) return;
+  _downloads = next;
+  notify();
+}
+
+export function onDownloadsChange(fn: () => void): () => void {
+  _listeners.add(fn);
+  return () => {
+    _listeners.delete(fn);
+  };
+}
+
+/** Subscribe to the download queue from a component. Re-renders the caller
+ *  whenever the queue changes and drops its subscription on unmount. */
+export function useDownloads(): DownloadItem[] {
+  return useSyncExternalStore(onDownloadsChange, getDownloadState);
 }


### PR DESCRIPTION
`downloadStore` was the only one of ten module stores in `src/utils/` with no
change notification, and the only one two components polled independently — the
main page every second, the queue view twice as often, both spreading the queue
into a fresh array on every tick so React re-rendered them and their rows
whether or not anything had happened. The missing notification is what produced
the duplication, so this adds it and deletes both polls rather than damping
their effects.

That is deliberately not what #1181 proposes. Its fix is a shallow-equal guard
on each poll: keep asking, and compare what comes back. This removes the reason
to ask.

The part that made the polls necessary was not the missing listener but
`updateDownload`, which wrote into the existing array in place. The queue's
identity therefore never changed when a download's progress did, and neither
consumer could tell from the reference whether it had missed something — so both
copied, every tick, forever. The store now holds its state immutably: a mutation
that changes something installs a new array and notifies, and one that changes
nothing does neither. Those two halves are what let `getDownloadState` serve as
a `useSyncExternalStore` snapshot, which React compares by identity: a getter
handing back a fresh copy per call would re-render forever.

"Changed nothing" is decided by entry identity, never by comparing fields. Every
writer — the two event handlers, the failure path, the queue view's mount fetch
— builds fresh objects, so a re-used reference is the only case in which a
caller genuinely carries no news. Comparing fields instead would be the
shallow-equal guard this change exists to avoid, and it would have to be kept in
step with the item shape forever.

The immutability was a claim in a docstring; it is now a type. `getDownloadState`
hands out a readonly array, so writing into the snapshot is a compile error
instead of a corruption React could not even see — the reference would not
change, so nothing would re-render.

Both acceptance criteria have tests, and the ones that matter were checked
against a deliberately broken store rather than assumed: removing either no-op
guard makes the render counters move and fails them; making the getter return a
copy fails a large part of the queue view's suite with "Maximum update depth
exceeded". The store had no test file at all before this; it has seventeen now.

One incidental fix in the tests. The queue view's suite reset the store in an
`afterEach`, and Vitest runs those in reverse registration order — so it fired
before the render cleanup, mutating a store while the component was still
mounted. Silent while the store was silent; with notification it re-rendered a
live tree outside `act`. The suite's `beforeEach` already provides the
isolation.

docs: N/A — no page describes the download store or the polls, and there is no
user-visible behaviour change beyond the queue appearing on first paint instead
of up to a second later.

Closes #1181
