### PR TITLE
refactor(ui): own the sync stats and session budget in one store

### DIFF
--- a/src/components/MainPage.test.tsx
+++ b/src/components/MainPage.test.tsx
@@ -54,6 +54,7 @@ import * as syncEta from "../utils/syncEta";
 import { NEW_ITEM_SEC, UPDATED_ITEM_SEC, COVER_DOWNLOAD_SEC, FETCH_ALLOWANCE_SEC } from "../utils/syncEstimate";
 import { setDownloads } from "../utils/downloadStore";
 import { resetConnectionProbeForTests } from "../utils/connectionProbe";
+import { resetSyncStatsStoreForTests } from "../utils/syncStatsStore";
 import { showModal } from "@decky/ui";
 import * as syncManager from "../utils/syncManager";
 import * as connectionState from "../utils/connectionState";
@@ -212,6 +213,16 @@ const flushAsync = () =>
     await Promise.resolve();
   });
 
+/** A promise plus the handle to settle it, so a test can hold a backend read
+ *  open across an event and decide when — and in which order — it answers. */
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
 function defaultSettings(): PluginSettings {
   return {
     romm_url: "https://romm.local",
@@ -267,6 +278,9 @@ describe("MainPage", () => {
     // The connection probe outlives the panel by design (#1730), so its verdict
     // survives unmount and would carry a prior test's answer into the next.
     resetConnectionProbeForTests();
+    // Same for the sync stats and session budget: both the stored answers and
+    // any read still open outlive the render that issued them.
+    resetSyncStatsStoreForTests();
     setSyncProgress({
       running: false,
       stage: "",
@@ -4412,6 +4426,87 @@ describe("MainPage", () => {
       expect(buttonByExactText(container, "Cancel Sync")).toBeNull();
       expect(fieldLabels(container)).toContain("Sync complete: 7 games");
       expect(vi.mocked(backend.getSyncStats)).toHaveBeenCalledTimes(2);
+    });
+
+    // The terminal stage rewrites last_sync, last_attempt and the counts, and it
+    // re-measures the heap the run consumed — so both re-reads below are issued
+    // BECAUSE the facts changed, and neither may join a read issued while the run
+    // was still going. Open the panel in a run's last seconds and the mount reads
+    // are exactly such reads. Nothing re-reads afterwards for a completed run —
+    // the poll interval needs `syncing || lastRunPaused` and stops on the same
+    // tick — so a joined pre-run answer is the last one the panel ever shows.
+    it("re-reads the stats itself at the terminal stage rather than joining the read still open", async () => {
+      const mountRead = deferred<SyncStats>();
+      const terminalRead = deferred<SyncStats>();
+      vi.mocked(backend.getSyncStatus).mockResolvedValue({
+        running: true,
+        stage: "applying",
+        message: "Working",
+      });
+      vi.mocked(backend.getSyncStats).mockReturnValueOnce(mountRead.promise).mockReturnValueOnce(terminalRead.promise);
+
+      const { container } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+      // Still open: the mount read has not answered, so the library line is blank.
+      expect(container.textContent).not.toContain("games");
+
+      await act(async () => {
+        setSyncProgress({ running: false, stage: "done", message: "Sync complete" });
+        await Promise.resolve();
+      });
+      // Two reads, not one — a joined read would answer for the run that just ended.
+      expect(vi.mocked(backend.getSyncStats)).toHaveBeenCalledTimes(2);
+
+      terminalRead.resolve({ ...defaultStats(), roms: 7, platforms: 1, last_sync: new Date().toISOString() });
+      await flushAsync();
+      // The overtaken pre-run answer lands last and must change nothing.
+      mountRead.resolve({ ...defaultStats(), roms: 3, platforms: 1 });
+      await flushAsync();
+
+      expect(container.textContent).toContain("7 games");
+      expect(container.textContent).not.toContain("3 games");
+    });
+
+    it("re-reads the heap itself at the terminal stage rather than joining the read still open", async () => {
+      const liveBudget = (rssKb: number): SessionBudgetStatus => ({
+        success: true,
+        rss_kb: rssKb,
+        warn_kb: 1_800_000,
+        ceiling_kb: 2_200_000,
+        cliff_kb: 2_450_000,
+        memory_delta_kb: null,
+        resume_ready: null,
+        run_done_items: null,
+        run_total_items: null,
+      });
+      const mountRead = deferred<SessionBudgetStatus>();
+      const terminalRead = deferred<SessionBudgetStatus>();
+      vi.mocked(backend.getSyncStatus).mockResolvedValue({
+        running: true,
+        stage: "applying",
+        message: "Working",
+      });
+      vi.mocked(backend.getSessionBudgetStatus)
+        .mockReturnValueOnce(mountRead.promise)
+        .mockReturnValueOnce(terminalRead.promise);
+
+      const { container } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+
+      await act(async () => {
+        setSyncProgress({ running: false, stage: "done", message: "Sync complete" });
+        await Promise.resolve();
+      });
+      expect(vi.mocked(backend.getSessionBudgetStatus)).toHaveBeenCalledTimes(2);
+
+      terminalRead.resolve(liveBudget(500_000));
+      await flushAsync();
+      mountRead.resolve(liveBudget(1_300_000));
+      await flushAsync();
+
+      const memoryRow = container.querySelector('[data-testid="steam-memory"]')?.textContent ?? "";
+      expect(memoryRow).toContain("0.5 GB");
+      expect(memoryRow).not.toContain("1.3 GB");
     });
 
     it("a bare running:false (no terminal stage) does NOT tear down the in-flight UI", async () => {

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -15,7 +15,6 @@ import {
 import { FaCheckCircle, FaTimesCircle, FaExclamationTriangle } from "react-icons/fa";
 import {
   cancelSync,
-  getSyncStats,
   getSettings,
   fixRetroarchInputDriver,
   startSync,
@@ -25,7 +24,6 @@ import {
   clearSyncCache,
   refreshMigrationState,
   getSyncStatus,
-  getSessionBudgetStatus,
   getRetroDeckStatus,
   logError,
 } from "../api/backend";
@@ -46,6 +44,14 @@ import {
   withinUnitFraction,
 } from "../utils/syncProgress";
 import { useDownloads } from "../utils/downloadStore";
+import {
+  refreshSessionBudget,
+  refreshSessionBudgetAfterChange,
+  refreshSyncStats,
+  refreshSyncStatsAfterChange,
+  useSessionBudget,
+  useSyncStats,
+} from "../utils/syncStatsStore";
 import { getMigrationState, onMigrationChange, setMigrationStatus } from "../utils/migrationStore";
 import { getSettingsResetState, onSettingsResetChange } from "../utils/settingsResetStore";
 import { getPlaytimeScopeState, onPlaytimeScopeChange, fetchPlaytimeScopeState } from "../utils/playtimeScopeStore";
@@ -71,7 +77,6 @@ import type {
   SyncStats,
   SyncPreview,
   SyncPreviewSummary,
-  SessionBudgetStatus,
   MigrationStatus,
   Page,
 } from "../types";
@@ -393,8 +398,13 @@ function terminalStatusTone(stage: SyncProgress["stage"]): StatusTone {
 }
 
 export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
-  const [stats, setStats] = useState<SyncStats | null>(null);
-  const [budgetStatus, setBudgetStatus] = useState<SessionBudgetStatus | null>(null);
+  // Both facts are owned by `utils/syncStatsStore.ts`: seven refresh sites in
+  // this file ask for them, and the store is what keeps an older answer from
+  // landing last and overwriting a newer one. What stays here is the SCHEDULE —
+  // the mount burst, the terminal-stage re-read and the poll interval below
+  // decide when to ask; the store only owns the data.
+  const stats = useSyncStats();
+  const budgetStatus = useSessionBudget();
   // `failure` classifies a resolved-but-failed probe so the connection row can
   // show a specific label (auth rejected / server unreachable / no URL / not
   // signed in). Null for every non-failed state and for a probe that never
@@ -448,15 +458,11 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
         setSaveSortMigrationStatus(save_sort);
       })
       .catch((e) => logError(`Failed to refresh migration state: ${e}`));
-    getSyncStats()
-      .then(setStats)
-      .catch((e) => logError(`Failed to load sync stats: ${e}`));
+    detach(refreshSyncStats());
     // Live renderer-heap reading for the session-budget banners (#1383). Fail-open:
     // the backend always resolves (rss_kb null when unreadable), so the banners
     // degrade to text-only rather than erroring.
-    getSessionBudgetStatus()
-      .then(setBudgetStatus)
-      .catch((e) => logError(`Failed to load session budget status: ${e}`));
+    detach(refreshSessionBudget());
 
     getSettings()
       .then((s) => {
@@ -566,14 +572,13 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
           // drain state (#1202, RC-B).
           setCancelling(false);
           showTransientStatus(progress.message || "Sync finished", terminalStatusTone(progress.stage));
-          getSyncStats()
-            .then(setStats)
-            .catch((e) => logError(`Failed to refresh sync stats: ${e}`));
+          // Both re-reads are provoked by the run ending, so neither may join a
+          // read issued while it was still going — see the two AfterChange
+          // functions.
+          detach(refreshSyncStatsAfterChange());
           // Refresh the live heap reading so the paused / high-heap banner reflects
           // the run's end state (a pause leaves it high; a completed run may too).
-          getSessionBudgetStatus()
-            .then(setBudgetStatus)
-            .catch((e) => logError(`Failed to refresh session budget status: ${e}`));
+          detach(refreshSessionBudgetAfterChange());
         } else {
           // Feed the live-rate estimator from applying frames that carry ITEM
           // progress only — fetch frames carry page/cover counters, and an
@@ -622,18 +627,14 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
     if (!syncing && !lastRunPaused) return;
     const id = setInterval(
       () => {
-        getSessionBudgetStatus()
-          .then(setBudgetStatus)
-          .catch((e) => logError(`Failed to poll session budget status: ${e}`));
+        detach(refreshSessionBudget());
         // Belt-and-braces on top of the backend emit-last fix (#39): while the paused
         // banner is showing (idle), also re-read stats so the "Last sync" line + the
         // paused banner (which keys on last_attempt) recover if the one-shot terminal
         // refetch was ever missed/dropped. Then this poll self-stops (last_attempt is
         // no longer paused).
         if (!syncing) {
-          getSyncStats()
-            .then(setStats)
-            .catch((e) => logError(`Failed to poll sync stats: ${e}`));
+          detach(refreshSyncStats());
         }
       },
       syncing ? 5000 : 10000,
@@ -1162,9 +1163,10 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
                     } catch {
                       showTransientStatus("Failed to clear sync cache");
                     }
-                    getSyncStats()
-                      .then(setStats)
-                      .catch((e) => logError(`Failed to refresh sync stats: ${e}`));
+                    // The clear just CHANGED the stats, so this re-read must
+                    // not join one issued before it — see
+                    // refreshSyncStatsAfterChange.
+                    detach(refreshSyncStatsAfterChange());
                   })(),
                 );
               }}

--- a/src/utils/syncStatsStore.test.ts
+++ b/src/utils/syncStatsStore.test.ts
@@ -1,0 +1,326 @@
+// The store's contract is the two properties it exists for:
+//   - answers apply in ISSUE order, never in arrival order (the defect: an
+//     older poll landing after Force Full Sync's post-clear read overwrote it);
+//   - concurrent refreshes collapse into one request, EXCEPT the after-change
+//     one, which must issue its own so it cannot be handed pre-change data.
+// Plus the `useSyncExternalStore` obligation every store here carries: a getter
+// that hands back a fresh object per call renders forever. Those assertions are
+// `toBe`, not `toEqual`, on purpose — `toEqual` cannot see the difference.
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { getSessionBudgetStatus, getSyncStats } from "../api/backend";
+import type { SessionBudgetStatus, SyncStats } from "../types";
+import {
+  getSessionBudgetSnapshot,
+  getSyncStatsSnapshot,
+  onSyncStatsStoreChange,
+  refreshSessionBudget,
+  refreshSessionBudgetAfterChange,
+  refreshSyncStats,
+  refreshSyncStatsAfterChange,
+  resetSyncStatsStoreForTests,
+  useSessionBudget,
+  useSyncStats,
+} from "./syncStatsStore";
+
+vi.mock("../api/backend", () => ({
+  getSyncStats: vi.fn(),
+  getSessionBudgetStatus: vi.fn(),
+  logError: vi.fn(),
+}));
+
+function stats(overrides: Partial<SyncStats> = {}): SyncStats {
+  return {
+    last_sync: "2026-08-01T10:00:00",
+    platforms: 3,
+    roms: 42,
+    total_shortcuts: 42,
+    ...overrides,
+  };
+}
+
+function budget(rssKb: number | null): SessionBudgetStatus {
+  return {
+    success: true,
+    rss_kb: rssKb,
+    warn_kb: 1_800_000,
+    ceiling_kb: 2_200_000,
+    cliff_kb: 2_450_000,
+    memory_delta_kb: null,
+    resume_ready: null,
+    run_done_items: null,
+    run_total_items: null,
+  };
+}
+
+/** A promise plus the handle to settle it, so a test can decide the order two
+ *  reads resolve in independently of the order they were issued. */
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void; reject: (e: unknown) => void } {
+  let resolve!: (value: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("syncStatsStore", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    resetSyncStatsStoreForTests();
+  });
+
+  describe("issue ordering", () => {
+    it("keeps the later-issued answer when an earlier read resolves last", async () => {
+      // The reachable case: the paused poll has a stats read open when the user
+      // presses Force Full Sync. The post-clear read is issued second and
+      // resolves first; the poll's pre-clear answer lands after it and must not
+      // be installed.
+      const poll = deferred<SyncStats>();
+      const afterClear = deferred<SyncStats>();
+      vi.mocked(getSyncStats).mockReturnValueOnce(poll.promise).mockReturnValueOnce(afterClear.promise);
+
+      const first = refreshSyncStats();
+      const second = refreshSyncStatsAfterChange();
+
+      afterClear.resolve(stats({ roms: 0, last_sync: null }));
+      await second;
+      expect(getSyncStatsSnapshot()?.roms).toBe(0);
+
+      poll.resolve(stats({ roms: 42 }));
+      await first;
+      expect(getSyncStatsSnapshot()?.roms).toBe(0);
+      expect(getSyncStatsSnapshot()?.last_sync).toBeNull();
+    });
+
+    it("installs the later-issued answer when it resolves last too", async () => {
+      // The same two reads in the other arrival order — the ordering must not
+      // depend on which one won the race.
+      const poll = deferred<SyncStats>();
+      const afterClear = deferred<SyncStats>();
+      vi.mocked(getSyncStats).mockReturnValueOnce(poll.promise).mockReturnValueOnce(afterClear.promise);
+
+      const first = refreshSyncStats();
+      const second = refreshSyncStatsAfterChange();
+
+      poll.resolve(stats({ roms: 42 }));
+      await first;
+      expect(getSyncStatsSnapshot()?.roms).toBe(42);
+
+      afterClear.resolve(stats({ roms: 0, last_sync: null }));
+      await second;
+      expect(getSyncStatsSnapshot()?.roms).toBe(0);
+    });
+
+    it("lets an older read answer when the newer one failed", async () => {
+      // A rejection installs nothing and moves nothing, so the older read still
+      // open is free to answer — the display keeps the last SUCCESSFUL answer
+      // rather than nothing at all.
+      const older = deferred<SyncStats>();
+      const newer = deferred<SyncStats>();
+      vi.mocked(getSyncStats).mockReturnValueOnce(older.promise).mockReturnValueOnce(newer.promise);
+
+      const first = refreshSyncStats();
+      const second = refreshSyncStatsAfterChange();
+
+      newer.reject(new Error("boom"));
+      await second;
+      expect(getSyncStatsSnapshot()).toBeNull();
+
+      older.resolve(stats({ roms: 42 }));
+      await first;
+      expect(getSyncStatsSnapshot()?.roms).toBe(42);
+    });
+
+    it("logs a failed read and leaves the last answer standing", async () => {
+      vi.mocked(getSyncStats).mockResolvedValueOnce(stats({ roms: 42 }));
+      await refreshSyncStats();
+
+      vi.mocked(getSyncStats).mockRejectedValueOnce(new Error("boom"));
+      await refreshSyncStats();
+
+      const { logError } = await import("../api/backend");
+      expect(vi.mocked(logError)).toHaveBeenCalledWith(expect.stringContaining("Failed to load sync stats"));
+      expect(getSyncStatsSnapshot()?.roms).toBe(42);
+    });
+  });
+
+  describe("request sharing", () => {
+    it("collapses two concurrent refreshes into one callable call", async () => {
+      const open = deferred<SyncStats>();
+      vi.mocked(getSyncStats).mockReturnValue(open.promise);
+
+      const a = refreshSyncStats();
+      const b = refreshSyncStats();
+      expect(vi.mocked(getSyncStats)).toHaveBeenCalledTimes(1);
+
+      open.resolve(stats({ roms: 7 }));
+      await Promise.all([a, b]);
+      expect(getSyncStatsSnapshot()?.roms).toBe(7);
+    });
+
+    it("reads again once the shared request has settled", async () => {
+      vi.mocked(getSyncStats).mockResolvedValue(stats());
+      await refreshSyncStats();
+      await refreshSyncStats();
+      expect(vi.mocked(getSyncStats)).toHaveBeenCalledTimes(2);
+    });
+
+    it("shares the session-budget read the same way", async () => {
+      const open = deferred<SessionBudgetStatus>();
+      vi.mocked(getSessionBudgetStatus).mockReturnValue(open.promise);
+
+      const a = refreshSessionBudget();
+      const b = refreshSessionBudget();
+      expect(vi.mocked(getSessionBudgetStatus)).toHaveBeenCalledTimes(1);
+
+      open.resolve(budget(600_000));
+      await Promise.all([a, b]);
+      expect(getSessionBudgetSnapshot()?.rss_kb).toBe(600_000);
+    });
+
+    it("issues its own read after a change even while one is open, and that answer wins", async () => {
+      const preClear = deferred<SyncStats>();
+      const postClear = deferred<SyncStats>();
+      vi.mocked(getSyncStats).mockReturnValueOnce(preClear.promise).mockReturnValueOnce(postClear.promise);
+
+      const poll = refreshSyncStats();
+      const forced = refreshSyncStatsAfterChange();
+      // Two calls, not one: joining the pre-clear read would hand the post-clear
+      // caller the pre-clear counts.
+      expect(vi.mocked(getSyncStats)).toHaveBeenCalledTimes(2);
+
+      preClear.resolve(stats({ roms: 42 }));
+      postClear.resolve(stats({ roms: 0, last_sync: null }));
+      await Promise.all([poll, forced]);
+      expect(getSyncStatsSnapshot()?.roms).toBe(0);
+    });
+
+    it("issues its own budget read after a change even while one is open, and that answer wins", async () => {
+      // The budget lane needs the same twin: the terminal stage re-reads BECAUSE
+      // the run ended, and the 5s poll it would otherwise join took its reading
+      // while the run was still consuming memory.
+      const midRun = deferred<SessionBudgetStatus>();
+      const runEnded = deferred<SessionBudgetStatus>();
+      vi.mocked(getSessionBudgetStatus).mockReturnValueOnce(midRun.promise).mockReturnValueOnce(runEnded.promise);
+
+      const poll = refreshSessionBudget();
+      const terminal = refreshSessionBudgetAfterChange();
+      expect(vi.mocked(getSessionBudgetStatus)).toHaveBeenCalledTimes(2);
+
+      runEnded.resolve(budget(500_000));
+      midRun.resolve(budget(1_300_000));
+      await Promise.all([poll, terminal]);
+      expect(getSessionBudgetSnapshot()?.rss_kb).toBe(500_000);
+    });
+
+    it("hands a later refresh the post-change read to join, not the superseded one", async () => {
+      const preClear = deferred<SyncStats>();
+      const postClear = deferred<SyncStats>();
+      vi.mocked(getSyncStats).mockReturnValueOnce(preClear.promise).mockReturnValueOnce(postClear.promise);
+
+      const poll = refreshSyncStats();
+      const forced = refreshSyncStatsAfterChange();
+      // The post-change read replaced the pre-change one as the joinable open
+      // request, so this joins it instead of opening a third.
+      const joiner = refreshSyncStats();
+      expect(vi.mocked(getSyncStats)).toHaveBeenCalledTimes(2);
+
+      preClear.resolve(stats({ roms: 42 }));
+      postClear.resolve(stats({ roms: 0 }));
+      await Promise.all([poll, forced, joiner]);
+      expect(getSyncStatsSnapshot()?.roms).toBe(0);
+    });
+  });
+
+  describe("snapshot identity", () => {
+    it("returns the same reference while nothing changes", async () => {
+      vi.mocked(getSyncStats).mockResolvedValue(stats());
+      vi.mocked(getSessionBudgetStatus).mockResolvedValue(budget(600_000));
+      await refreshSyncStats();
+      await refreshSessionBudget();
+
+      expect(getSyncStatsSnapshot()).toBe(getSyncStatsSnapshot());
+      expect(getSessionBudgetSnapshot()).toBe(getSessionBudgetSnapshot());
+    });
+
+    it("returns a different reference after a real change", async () => {
+      vi.mocked(getSyncStats).mockResolvedValue(stats({ roms: 1 }));
+      await refreshSyncStats();
+      const before = getSyncStatsSnapshot();
+
+      vi.mocked(getSyncStats).mockResolvedValue(stats({ roms: 2 }));
+      await refreshSyncStats();
+
+      expect(getSyncStatsSnapshot()).not.toBe(before);
+      expect(before?.roms).toBe(1);
+    });
+
+    it("notifies subscribers on an applied answer and not on an overtaken one", async () => {
+      const notified = vi.fn();
+      const unsubscribe = onSyncStatsStoreChange(notified);
+      const older = deferred<SyncStats>();
+      const newer = deferred<SyncStats>();
+      vi.mocked(getSyncStats).mockReturnValueOnce(older.promise).mockReturnValueOnce(newer.promise);
+
+      const first = refreshSyncStats();
+      const second = refreshSyncStatsAfterChange();
+      newer.resolve(stats({ roms: 0 }));
+      await second;
+      expect(notified).toHaveBeenCalledTimes(1);
+
+      older.resolve(stats({ roms: 42 }));
+      await first;
+      expect(notified).toHaveBeenCalledTimes(1);
+
+      unsubscribe();
+    });
+  });
+
+  describe("component subscription", () => {
+    it("re-renders a subscriber when an answer lands", async () => {
+      const open = deferred<SyncStats>();
+      vi.mocked(getSyncStats).mockReturnValue(open.promise);
+
+      const { result } = renderHook(() => useSyncStats());
+      expect(result.current).toBeNull();
+
+      const request = refreshSyncStats();
+      open.resolve(stats({ roms: 42 }));
+      await act(async () => {
+        await request;
+      });
+      expect(result.current?.roms).toBe(42);
+    });
+
+    it("keeps the last answer across an unmount and remount", async () => {
+      vi.mocked(getSyncStats).mockResolvedValue(stats({ roms: 42 }));
+      vi.mocked(getSessionBudgetStatus).mockResolvedValue(budget(600_000));
+      await refreshSyncStats();
+      await refreshSessionBudget();
+
+      const first = renderHook(() => ({ stats: useSyncStats(), budget: useSessionBudget() }));
+      expect(first.result.current.stats?.roms).toBe(42);
+      first.unmount();
+
+      // The store outlives the panel: the remount renders the known answer on
+      // its first pass, with no read in flight and nothing blanked.
+      const second = renderHook(() => ({ stats: useSyncStats(), budget: useSessionBudget() }));
+      expect(second.result.current.stats?.roms).toBe(42);
+      expect(second.result.current.budget?.rss_kb).toBe(600_000);
+      expect(vi.mocked(getSyncStats)).toHaveBeenCalledTimes(1);
+      second.unmount();
+    });
+
+    it("stops notifying an unsubscribed listener", async () => {
+      vi.mocked(getSyncStats).mockResolvedValue(stats({ roms: 1 }));
+      const notified = vi.fn();
+      onSyncStatsStoreChange(notified)();
+
+      await refreshSyncStats();
+      expect(notified).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/utils/syncStatsStore.ts
+++ b/src/utils/syncStatsStore.ts
@@ -1,0 +1,221 @@
+/**
+ * Module-level owner of the two panel-wide sync facts: the library/run stats
+ * (`get_sync_stats`) and the live session-budget reading
+ * (`get_session_budget_status`).
+ *
+ * Both were read straight from `api/backend` by `components/MainPage.tsx`, from
+ * four call sites for the stats and three for the budget, each with its own
+ * `.then(setState)` and none aware of the others. Two consequences, and the
+ * first was a defect: an older answer could land after a newer one and overwrite
+ * it — press Force Full Sync while the paused poll has a read open and the
+ * pre-clear counts win, reverting the Last-sync line and the paused derivation.
+ * And because the panel owned the state, leaving the page for any submenu threw
+ * it away, so coming back re-issued every read and displayed nothing until they
+ * landed.
+ *
+ * Owning both facts here fixes both. The store holds the data; the POLICY about
+ * when to ask stays with the caller — MainPage keeps its 5s/10s interval and
+ * decides when a re-read is worth issuing.
+ *
+ * Two properties carry it:
+ *
+ * **Responses apply in issue order.** Every read takes a sequence number the
+ * moment it is ISSUED, and applies its answer only if no later-issued read for
+ * that fact has already applied one. Arrival order is then irrelevant: whichever
+ * of the callers won the race, the answer that stands is the one asked for last.
+ * A read that REJECTS applies nothing and moves nothing, so an older read still
+ * open remains free to answer — a failed read is not an answer, and leaving the
+ * display on the last successful one is the same thing every call site did
+ * before.
+ *
+ * **Concurrent refreshes share one request — except a read the change itself
+ * provoked.** A refresh issued while one is open joins it rather than opening a
+ * second round-trip, under the admission rule stated in `api/sharedReads.ts`:
+ * joinable only where the answer cannot change between the moment the first
+ * caller issued the read and the moment this one joins it. Both facts here are
+ * whole-plugin reads taking no argument, so the join needs no key.
+ *
+ * What that rule excludes is every read issued BECAUSE the fact just changed.
+ * The open read such a caller would join was issued before the change, so
+ * joining hands it the pre-change answer as though it were the post-change one —
+ * the very overwrite the issue ordering exists to prevent, except permanent: a
+ * change-driven read is typically the last one its call site will issue, so no
+ * later answer follows to correct it. Those callers take the `…AfterChange`
+ * twin, which issues its own read and, by being issued last, supersedes the one
+ * already open for every later joiner too. The rule decides this, not a list of
+ * call sites: a new caller re-reading because something changed takes the twin,
+ * whatever it was that changed.
+ *
+ * Read by `components/MainPage.tsx` through {@link useSyncStats} and
+ * {@link useSessionBudget}; nothing else consumes either fact.
+ */
+
+import { useSyncExternalStore } from "react";
+import { getSessionBudgetStatus, getSyncStats, logError } from "../api/backend";
+import type { SessionBudgetStatus, SyncStats } from "../types";
+
+const _listeners = new Set<() => void>();
+
+function notify(): void {
+  _listeners.forEach((fn) => fn());
+}
+
+/** One fact's stored answer plus the bookkeeping that orders its reads. */
+interface ReadLane<T> {
+  /** The newest applied answer, or `null` until one lands. Handed out as the
+   *  `useSyncExternalStore` snapshot, which React compares by identity, so it is
+   *  only ever REPLACED, never written into: an in-place write would leave a
+   *  subscriber unable to tell the answer moved. The mirror-image hazard is a
+   *  getter that allocates — hence {@link getSyncStatsSnapshot} and
+   *  {@link getSessionBudgetSnapshot} hand this field back as it stands. */
+  value: T | null;
+  read: () => Promise<T>;
+  /** Sequence number of the most recently issued read. */
+  issued: number;
+  /** Sequence number of the newest read whose answer has been applied. */
+  applied: number;
+  /** The open read a concurrent refresh may join, or `null` when none is open.
+   *  Never rejects — a failure is logged where it happens, so a joiner cannot
+   *  inherit an unhandled rejection from a caller it never met. */
+  open: Promise<void> | null;
+  /** Prefix of the log line a failed read writes. */
+  failureLabel: string;
+}
+
+const _stats: ReadLane<SyncStats> = {
+  value: null,
+  read: getSyncStats,
+  issued: 0,
+  applied: 0,
+  open: null,
+  failureLabel: "Failed to load sync stats",
+};
+
+const _budget: ReadLane<SessionBudgetStatus> = {
+  value: null,
+  read: getSessionBudgetStatus,
+  issued: 0,
+  applied: 0,
+  open: null,
+  failureLabel: "Failed to load session budget status",
+};
+
+/** Install an answer unless a later-issued read has already answered. */
+function applyAnswer<T>(lane: ReadLane<T>, seq: number, value: T): void {
+  if (seq <= lane.applied) return;
+  lane.applied = seq;
+  lane.value = value;
+  notify();
+}
+
+/** Issue a fresh read for this lane and make it the one a concurrent refresh
+ *  joins, superseding whatever was open. */
+function issueRead<T>(lane: ReadLane<T>): Promise<void> {
+  const seq = ++lane.issued;
+  const request = lane
+    .read()
+    .then(
+      (value) => applyAnswer(lane, seq, value),
+      (e) => logError(`${lane.failureLabel}: ${e}`),
+    )
+    .finally(() => {
+      // Identity-checked: a read superseded by a later one must not clear the
+      // later one's slot when it finally settles.
+      if (lane.open === request) lane.open = null;
+    });
+  lane.open = request;
+  return request;
+}
+
+/** Join the open read for this lane, or issue one when none is open. */
+function joinOrIssue<T>(lane: ReadLane<T>): Promise<void> {
+  return lane.open ?? issueRead(lane);
+}
+
+/** The stats as last read, or `null` before the first answer lands. */
+export function getSyncStatsSnapshot(): SyncStats | null {
+  return _stats.value;
+}
+
+/** The session-budget reading as last read, or `null` before the first answer lands. */
+export function getSessionBudgetSnapshot(): SessionBudgetStatus | null {
+  return _budget.value;
+}
+
+export function onSyncStatsStoreChange(fn: () => void): () => void {
+  _listeners.add(fn);
+  return () => {
+    _listeners.delete(fn);
+  };
+}
+
+/** Subscribe a component to the stats. Renders the last known answer
+ *  immediately — the store outlives the panel, so returning from a submenu no
+ *  longer blanks the display while a fresh read is in flight. */
+export function useSyncStats(): SyncStats | null {
+  return useSyncExternalStore(onSyncStatsStoreChange, getSyncStatsSnapshot);
+}
+
+/** Subscribe a component to the session-budget reading. */
+export function useSessionBudget(): SessionBudgetStatus | null {
+  return useSyncExternalStore(onSyncStatsStoreChange, getSessionBudgetSnapshot);
+}
+
+/** Ask for the stats. Joins a read already open — for a caller with no reason to
+ *  believe they just changed. Resolves once this refresh has been answered or
+ *  has failed; a failure is logged here, never thrown at the caller. */
+export function refreshSyncStats(): Promise<void> {
+  return joinOrIssue(_stats);
+}
+
+/**
+ * Re-read the stats BECAUSE they just changed — a run reaching a terminal stage,
+ * which rewrites `last_sync`, `last_attempt` and the counts, and Force Full
+ * Sync's clear of the per-platform stamps.
+ *
+ * Never joins an open read: this is the case the admission rule in
+ * `api/sharedReads.ts` excludes, spelled out in this module's docstring. Both
+ * callers are also the last read their path issues — for a completed run the
+ * poll interval stops on the same tick — so a joined pre-change answer is not
+ * merely wrong for a moment, it is the last thing the panel shows.
+ */
+export function refreshSyncStatsAfterChange(): Promise<void> {
+  return issueRead(_stats);
+}
+
+/** Ask for the live session-budget reading. Joins a read already open — the
+ *  mount read and the poll tick both simply want the current reading, and
+ *  neither follows a change to it. */
+export function refreshSessionBudget(): Promise<void> {
+  return joinOrIssue(_budget);
+}
+
+/**
+ * Re-read the session budget BECAUSE the run whose consumption it reports just
+ * ended. The terminal stage is what turns a climbing mid-run reading into the
+ * run's end state — the figure the paused / high-heap banners are about — so the
+ * same exclusion applies: a reading taken a round-trip before the run ended
+ * answers the old question. It sticks, too. While a run is live the 5s poll
+ * keeps a read open for this one to join, and that poll stops on the terminal
+ * frame, so for a completed run a joined mid-run figure is the last reading the
+ * panel ever shows.
+ */
+export function refreshSessionBudgetAfterChange(): Promise<void> {
+  return issueRead(_budget);
+}
+
+/** Reset the module state between tests. Not for production use. A read only
+ *  ever releases its slot by settling, so a test that leaves one pending would
+ *  otherwise hand it to the next test's first refresh. */
+export function resetSyncStatsStoreForTests(): void {
+  resetLane(_stats);
+  resetLane(_budget);
+  _listeners.clear();
+}
+
+function resetLane<T>(lane: ReadLane<T>): void {
+  lane.value = null;
+  lane.issued = 0;
+  lane.applied = 0;
+  lane.open = null;
+}


### PR DESCRIPTION
The main page asked the backend for its sync stats from four places that did not
know about each other — the mount effect, the terminal stage of the progress
subscriber, the poll interval, and Force Full Sync — and for the session budget
from three. Each was its own `.then(setState)` with its own catch, and one of
them carried a comment explaining that it re-reads the stats in case the other
path's read was ever missed. That is the shape a second path takes when the
first is not trusted.

It also had a reachable defect. While the last run is paused a ten-second poll
issues a stats read; pressing Force Full Sync inside that round-trip clears the
stamps, reads again, and then the *older* poll response lands last and
overwrites the fresh answer with pre-clear counts. The Last sync line and the
resume state revert with nothing to correct them.

One module now owns both facts. Every read takes a sequence number when it is
issued, and an answer is installed only if no later-issued read has already
answered — so the last question asked wins, whichever answer arrives first.
Concurrent refreshes share one open request instead of opening a second
round-trip.

Sharing has one exclusion, and it is stated as a rule rather than a list of call
sites, because a list has to be remembered and extended while a rule answers the
next site by itself: a read issued *because* the fact just changed may never join
one issued before the change. Two sites are of that kind. Force Full Sync clears
the stamps and reads again, so joining a read from before the clear would install
pre-clear counts permanently. The terminal stage re-reads both facts because the
run just rewrote them, and after a completed run nothing reads again — the poll
requires a run in flight or a paused one — so a joined pre-completion answer
would stand for the rest of the visit.

Because the store outlives the component, and leaving the main page for any
submenu unmounts it, coming back now shows the last known answer immediately
instead of flashing empty while seven callables go out again.

Every property that carries this was checked by breaking it: removing the
ordering guard fails the two tests that describe it; making either change-driven
site join fails the two that hold a read open across a terminal frame, with
`expected vi.fn() to be called 2 times, but got 1 times`; making a snapshot
getter allocate per call fails with React's own "Maximum update depth exceeded".

docs: N/A — no page describes how often these two facts are read or by which
path; the only user-visible change is the main page no longer blanking on the way
back from a submenu.

Step of #1751.
