### PR TITLE
fix(ui): let the sync-progress store own whether a run is in flight

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,6 +185,17 @@ Format: **invariant** — tier — enforced by.
   `scripts/check_settings_owner.py`
 - **Sync run-lifecycle (`sync_state` / `current_sync_id`) written only via `LibrarySyncStateBox` verbs** — check —
   `scripts/check_sync_lifecycle_owner.py`
+- **An emitted `sync_progress` frame stops a run (`running: False`) only with a terminal stage, and a terminal stage is
+  only ever emitted with the run stopped** — test — `tests/services/library/test_terminal_frame_contract.py`
+  (structural, AST call sites and dict literals across all of `py_modules/services` — it covers the error paths a
+  behavioural test would have to provoke one at a time, but a frame assembled by a helper it cannot follow, or emitted
+  through an aliased callable, slips past it; its own scope tests pin the producers and the root it reaches, so a
+  narrowing fails rather than shrinking the rule in silence. Frame producers are not confined to `services/library/`:
+  `services/artwork.py` emits through an injected `emit_progress`). The QAM panel derives "a run is in flight" from
+  `running` and keys the run's end — the status line, the live-ETA teardown, the two change-driven re-reads — on the
+  stage, so a stopping frame with a non-terminal stage would collapse the in-progress rows while ending nothing. The
+  panel cannot defend against it: a bare `running: false` is exactly what its own retraction of an optimistic start
+  looks like
 - **Aggregate state mutated only via verb-named methods (no field assignment)** — check —
   `scripts/check_aggregate_field_assignment.py`
 - **No UoW-opening seam (ActiveCoreResolver, RelaunchOptionsResolver, uow_factory) is called while a UoW is open on the

--- a/docs/user-guide/syncing-your-library.md
+++ b/docs/user-guide/syncing-your-library.md
@@ -28,7 +28,9 @@ games appear in the Steam Library with cover art, metadata, and organized into c
 
 You can tap **Cancel Sync** to stop mid-sync. Games already added will remain. A cancelled sync never removes any Steam
 collections — stale-collection cleanup only runs after a sync finishes in full, so cancelling can never wipe the
-collections for platforms the run did not reach.
+collections for platforms the run did not reach. If the cancel request itself does not get through, the run is still
+going, so the panel keeps showing its progress with **Cancel Sync** ready to try again rather than offering to start a
+second run on top of the first.
 
 ## Time estimate and progress
 

--- a/src/components/MainPage.test.tsx
+++ b/src/components/MainPage.test.tsx
@@ -15,9 +15,9 @@
 //   - handleApply try/catch → setStatus("Failed to apply sync") — asserted.
 //   - handleDismiss inline `.catch(() => {})` — truly-ignored; asserted by
 //     verifying the dismiss path completed (preview cleared, no crash).
-//   - handleCancel try/catch → finishCancelWithStatus("Failed to cancel sync")
-//     surfaces the message after stopPolling + setSyncing(false) + setLoading(false)
-//     un-gate the status field; #733 fix landed — message now visible.
+//   - handleCancel try/catch → showTransientStatus("Failed to cancel sync"),
+//     surfaced under the still-running progress rows (the status field is gated
+//     on the preview only, not on the run being idle).
 //   - fixRetroarchInputDriver inline `.catch(() => {})` (inside ConfirmModal
 //     onOK) — truly-ignored; warning state remains (no clear).
 //
@@ -1449,6 +1449,12 @@ describe("MainPage", () => {
       expect(container.querySelector('[data-testid="budget-paused-banner"]')).not.toBeNull();
       expect(container.textContent).toContain("(paused)");
 
+      // The resume the user pressed is under way — the terminal frame below ends
+      // THIS run, which is what provokes the stats re-read.
+      await act(async () => {
+        setSyncProgress({ running: true, stage: "applying", message: "Working" });
+      });
+
       // A newer cancelled attempt supersedes the paused run; the stats refetch on the
       // terminal event returns it.
       vi.mocked(backend.getSyncStats).mockResolvedValue({
@@ -2456,6 +2462,103 @@ describe("MainPage", () => {
       expect(container.querySelector('[data-testid="estimate-time"]')).toBeNull();
       // Stale fine line from the prior run is gone too.
       expect(container.textContent).not.toContain("PSX: 1200/3084");
+    });
+
+    it("does not replay a stored terminal frame as a fresh completion (#1019)", async () => {
+      // The last run's terminal frame is still in the store when the panel comes
+      // back — the state every QAM close leaves behind. Nothing is in flight, so
+      // this mount ends no run: it has nothing to tear down and nothing to
+      // announce, however long ago that run finished.
+      setSyncProgress({
+        running: false,
+        stage: "done",
+        current: 0,
+        total: 0,
+        message: "Preview ready",
+      });
+      vi.mocked(backend.getSyncStatus).mockResolvedValue({
+        running: false,
+        stage: "done",
+        current: 0,
+        total: 0,
+        message: "Preview ready",
+      });
+
+      const { container } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+
+      // No completion line, and specifically not the affirmative green one a
+      // just-finished run gets.
+      expect(fieldLabels(container)).not.toContain("Preview ready");
+      // The two change-driven re-reads are provoked by a run ENDING; only the
+      // mount's own reads may have gone out.
+      expect(vi.mocked(backend.getSyncStats)).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(backend.getSessionBudgetStatus)).toHaveBeenCalledTimes(1);
+      // The idle body, not a run: a stored terminal frame arms no Cancel.
+      expect(buttonByExactText(container, "Sync Library")).not.toBeNull();
+      expect(buttonByExactText(container, "Cancel Sync")).toBeNull();
+    });
+
+    it("takes the completion wording from the run's own terminal frame, not the sync_complete merge", async () => {
+      // The backend ends a run with two signals in a fixed order, and both reach
+      // the store: sync_complete, which index.tsx merges as {running, stage} and
+      // so carries the PREVIOUS frame's message, then the run's own terminal frame
+      // with the summary. The panel must end up showing the second.
+      vi.mocked(backend.getSyncStatus).mockResolvedValue({
+        running: true,
+        stage: "applying",
+        current: 118,
+        total: 120,
+        message: "PSX: 118/120",
+        step: 3,
+        totalSteps: 3,
+        runId: "run-9",
+      });
+      const { container } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+      const statsReadsBefore = vi.mocked(backend.getSyncStats).mock.calls.length;
+
+      // The run's last pre-terminal frame.
+      await act(async () => {
+        setSyncProgress({
+          running: true,
+          stage: "finalizing",
+          current: 120,
+          total: 120,
+          message: "Finalizing…",
+          step: 3,
+          totalSteps: 3,
+          runId: "run-9",
+        });
+        await Promise.resolve();
+      });
+
+      // 1) sync_complete, merged — inherits "Finalizing…".
+      await act(async () => {
+        updateSyncProgress({ running: false, stage: "done" });
+        await Promise.resolve();
+      });
+      // 2) The run's authoritative terminal frame.
+      await act(async () => {
+        setSyncProgress({
+          running: false,
+          stage: "done",
+          current: 120,
+          total: 120,
+          message: "Sync complete: 120 games from 3 platforms",
+          step: 3,
+          totalSteps: 3,
+          runId: "run-9",
+        });
+        await Promise.resolve();
+      });
+
+      expect(fieldLabels(container)).toContain("Sync complete: 120 games from 3 platforms");
+      expect(fieldLabels(container)).not.toContain("Finalizing…");
+      // Still ONE run ending: the second frame corrects the wording, it does not
+      // re-run the change-driven re-reads.
+      expect(vi.mocked(backend.getSyncStats).mock.calls.length - statsReadsBefore).toBe(1);
+      expect(buttonByExactText(container, "Sync Library")).not.toBeNull();
     });
   });
 
@@ -3657,6 +3760,50 @@ describe("MainPage", () => {
       });
       expect(fieldLabels(container)).toContain("could not start");
     });
+
+    it("the panel's own retraction does not blind it to the run's terminal frame", async () => {
+      // The preview run is ended twice over: by its backend terminal frame and by
+      // the panel retracting the optimistic start once the callable answers. The
+      // two arrive over the same socket in that order, but the panel must not
+      // depend on it — retracting a run is not forgetting which run it was, so a
+      // terminal frame landing after the retraction is still that run's ending.
+      const preview = deferred<SyncPreview>();
+      vi.mocked(backend.syncPreview).mockReturnValue(preview.promise);
+      const { container } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+      await act(async () => {
+        fireEvent.click(buttonByExactText(container, "Sync Library")!);
+        await Promise.resolve();
+      });
+      const before = vi.mocked(backend.getSyncStats).mock.calls.length;
+      // The callable answers FIRST — the panel retracts its own optimistic run.
+      await act(async () => {
+        preview.resolve({
+          success: true,
+          summary: {
+            new_count: 0,
+            changed_count: 0,
+            unchanged_count: 0,
+            remove_count: 0,
+            disabled_platform_remove_count: 0,
+          },
+          new_names: [],
+          changed_names: [],
+          preview_id: "p1",
+        });
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      // ...and only then does the preview run's own terminal frame arrive.
+      await act(async () => {
+        setSyncProgress({ running: false, stage: "done", message: "Preview ready" });
+        await Promise.resolve();
+      });
+      // Treated as an ending: the change-driven stats re-read is what an ending
+      // does here (the status line itself is hidden behind the preview it belongs
+      // to), and a swallowed frame would issue none.
+      expect(vi.mocked(backend.getSyncStats).mock.calls.length - before).toBe(1);
+    });
   });
 
   // ===========================================================================
@@ -3721,6 +3868,27 @@ describe("MainPage", () => {
         await Promise.resolve();
       });
       expect(fieldLabels(container)).toContain("Failed to apply sync");
+    });
+
+    it("the preview's own status line does not ride into the apply run", async () => {
+      // The preview run ends with a terminal frame of its own, which arms the
+      // "Preview ready" line for 15s — invisible only while the preview it belongs
+      // to is on screen. Apply replaces that screen with the run's progress rows.
+      vi.mocked(backend.syncApplyDelta).mockResolvedValue({ success: true, message: "" });
+      const container = await openPreviewWithChanges();
+      await act(async () => {
+        setSyncProgress({ running: false, stage: "done", message: "Preview ready" });
+        await Promise.resolve();
+      });
+
+      await act(async () => {
+        fireEvent.click(buttonByExactText(container, "Apply Sync")!);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(buttonByExactText(container, "Cancel Sync")).not.toBeNull();
+      expect(fieldLabels(container)).not.toContain("Preview ready");
     });
   });
 
@@ -3933,10 +4101,39 @@ describe("MainPage", () => {
         await Promise.resolve();
       });
       expect(vi.mocked(backend.cancelSync)).toHaveBeenCalled();
-      // Status field un-gated and shows the failure message; re-armed to idle.
+      // The failure message reaches the user under the still-running progress
+      // rows, and the button is re-armed for the retry — out of "Cancelling…" but
+      // still a Cancel, because the run it would stop never learned of the cancel.
       expect(fieldLabels(container)).toContain("Failed to cancel sync");
-      expect(buttonByExactText(container, "Cancel Sync")).toBeNull();
+      expect(buttonByExactText(container, "Cancel Sync")).not.toBeNull();
       expect(buttonByExactText(container, "Cancelling…")).toBeNull();
+    });
+
+    it("a cancel whose call failed leaves the run in flight for every reader of the store (#1019)", async () => {
+      // DangerZone and RemovedGamesCleanup read `running` straight from the
+      // module store, so whatever the panel concludes here they conclude too.
+      vi.mocked(backend.getSyncStatus).mockResolvedValue({
+        running: true,
+        stage: "applying",
+        message: "Working",
+        runId: "run-x",
+      });
+      vi.mocked(backend.cancelSync).mockRejectedValue(new Error("net"));
+      const { container } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+      await act(async () => {
+        fireEvent.click(buttonByExactText(container, "Cancel Sync")!);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      // The cancel never reached the backend, so the run it would have stopped is
+      // still going — the store keeps saying so...
+      expect(getSyncProgress().running).toBe(true);
+      // ...and the panel says the same thing, rather than offering a Sync button
+      // that can only earn a sync_in_progress reject.
+      expect(buttonByExactText(container, "Sync Library")).toBeNull();
+      expect(buttonByExactText(container, "Cancel Sync")).not.toBeNull();
     });
 
     it("when a preview is showing: clicking Cancel (non-zero preview) routes through handleDismiss", async () => {
@@ -4509,25 +4706,34 @@ describe("MainPage", () => {
       expect(memoryRow).not.toContain("1.3 GB");
     });
 
-    it("a bare running:false (no terminal stage) does NOT tear down the in-flight UI", async () => {
-      // Reproduces the #751 teardown race: a non-terminal running:false must
-      // not collapse the syncing UI (it would right after startSync, before
-      // events land).
-      vi.mocked(backend.getSyncStatus).mockResolvedValue({
-        running: true,
-        stage: "applying",
-        message: "Working",
-      });
+    it("a status read still open when Sync is clicked does not retract the optimistic start (#751)", async () => {
+      // The mount's get_sync_status was issued before the click, so it cannot
+      // answer whether the run the click just started is in flight — and its
+      // "nothing running" must not be allowed to collapse the syncing UI.
+      const status = deferred<SyncProgress>();
+      vi.mocked(backend.getSyncStatus).mockReturnValue(status.promise);
+      // Hold the preview open so the run stays optimistic: no result lands to end
+      // it, leaving the click's running:true as the only thing that could.
+      vi.mocked(backend.syncPreview).mockReturnValue(new Promise<SyncPreview>(() => {}));
+
       const { container } = render(<MainPage onNavigate={vi.fn()} />);
       await flushAsync();
+      await act(async () => {
+        fireEvent.click(buttonByExactText(container, "Sync Library")!);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
       expect(buttonByExactText(container, "Cancel Sync")).not.toBeNull();
 
+      // The pre-click snapshot lands late.
       await act(async () => {
-        setSyncProgress({ running: false, stage: "", message: "" });
+        status.resolve({ running: false, stage: "", current: 0, total: 0, message: "" });
         await Promise.resolve();
       });
 
-      // Still in-flight — only a terminal stage tears down.
+      // The store still carries the run the click started — so the panel, and
+      // every other reader of it, still shows one in flight.
+      expect(getSyncProgress().running).toBe(true);
       expect(buttonByExactText(container, "Cancel Sync")).not.toBeNull();
       expect(buttonByExactText(container, "Sync Library")).toBeNull();
     });

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -397,6 +397,38 @@ function terminalStatusTone(stage: SyncProgress["stage"]): StatusTone {
   return stage === "done" ? "success" : "neutral";
 }
 
+/** The id of the run a frame belongs to, `""` for a frame that names none — the
+ *  panel's own optimistic start, or a backend with no run stamped yet. */
+function frameRunId(progress: SyncProgress): string {
+  return progress.runId ?? "";
+}
+
+/** The run a frame puts in flight, or `null` when the frame has none running. */
+function inFlightRunId(progress: SyncProgress): string | null {
+  return progress.running ? frameRunId(progress) : null;
+}
+
+/**
+ * Whether a terminal frame ends the run the panel is watching — true unless it
+ * names a DIFFERENT run, since an unnamed run on either side (the panel's own
+ * optimistic start before the backend stamps an id, or a frame that carries
+ * none) cannot be shown to be another one, and refusing it would strand the
+ * panel on a run that has already ended. `null` — nothing watched at all — is
+ * the one case that ends nothing: that is a terminal frame the panel FOUND
+ * rather than witnessed, the stored frame every QAM close leaves behind (#1019).
+ *
+ * The leniency leaves one window open, knowingly: between a run's two terminal
+ * signals — the merged `sync_complete` and the frame that follows it, under
+ * 100 ms apart — a user who starts the next run in the gap has the old run's
+ * second frame taken as ending the new one, costing that run its first status
+ * line. Accepted rather than closed: the previous boolean had the same window,
+ * nothing here can widen it, and the alternative — refusing an unnamed terminal
+ * frame — strands the panel on the far more reachable case above.
+ */
+function endsWatchedRun(watched: string | null, runId: string): boolean {
+  return watched !== null && (watched === "" || runId === "" || watched === runId);
+}
+
 export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
   // Both facts are owned by `utils/syncStatsStore.ts`: seven refresh sites in
   // this file ask for them, and the store is what keeps an older answer from
@@ -412,13 +444,20 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
   // not abandon a run that has not reached a verdict yet.
   const { connected, failure: connectionFailure } = useConnectionProbe();
   const versionError = useVersionError();
-  const [syncing, setSyncing] = useState(false);
   // Disarmed "Cancelling…" state during the backend's RUNNING→CANCELLING→IDLE
   // drain. The Sync/Cancel button stays disabled until the terminal
   // sync_progress stage re-arms it, so a quick re-press can't hit the
   // sync_in_progress reject and look like an instant finish (#1202, RC-B).
   const [cancelling, setCancelling] = useState(false);
-  const [syncProgress, setSyncProgress] = useState<SyncProgress | null>(null);
+  // The frame this panel last saw, seeded from the store so a remount mid-run
+  // renders the live run on its first pass rather than a frame later.
+  const [syncProgress, setSyncProgress] = useState<SyncProgress | null>(() => getSyncProgress());
+  // "A run is in flight" is DERIVED from that frame, never mirrored in a second
+  // boolean: DangerZone and RemovedGamesCleanup read the same store field, so a
+  // path that ends the run locally without ending it in the store would make the
+  // three disagree (#1019). The optimistic start is not lost — a Sync click writes
+  // running:true into the store, which the subscription below feeds straight back.
+  const syncing = syncProgress?.running ?? false;
   // Last non-empty fine-detail line, carried across unit-boundary anchor frames
   // so the fine-detail row (and its inline spinner) stay MOUNTED when the next
   // unit's FETCHING anchor frame resets current/total to 0 (#1415) — otherwise
@@ -435,7 +474,6 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
   const [status, setStatus] = useState<TransientStatus | null>(null);
   const [preview, setPreview] = useState<SyncPreview | null>(null);
   const [skipPreview, setSkipPreview] = useState(false);
-  const [loading, setLoading] = useState(false);
   const [retroarchWarning, setRetroarchWarning] = useState<{ warning: boolean; current?: string } | null>(null);
   const [retrodeckBanner, setRetrodeckBanner] = useState<RetroDeckBanner | null>(null);
   const [migration, setMigration] = useState<MigrationStatus>(getMigrationState());
@@ -444,6 +482,22 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
   const [saveSortMigration, setSaveSortMigration] = useState(getSaveSortMigrationState());
   const downloads = useDownloads();
   const statusTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // The run this panel is watching, by id, and whether its end has been handled.
+  // Seeded at first render — BEFORE the subscription below exists, so the mount
+  // seed's own write is measured against the state it replaced rather than against
+  // itself; a stored terminal frame the panel merely finds therefore watches
+  // nothing and announces nothing (#1019).
+  //
+  // The pair is a run key rather than a "have I seen a terminal" boolean because
+  // the backend signals a run's end TWICE, in a fixed order: `sync_complete`,
+  // which index.tsx merges into the store as `{running:false, stage}` — keeping
+  // the PREVIOUS frame's message, e.g. "Finalizing…" — and then the run's own
+  // terminal frame carrying the authoritative wording ("Sync complete: N games
+  // from M platforms", the cancelled/interrupted sentence, or a budget pause's
+  // resume guidance). Both belong to the same run: the first does the once-per-run
+  // teardown, the second is allowed to correct the text it left behind.
+  const watchedRunId = useRef<string | null>(inFlightRunId(getSyncProgress()));
+  const watchedRunEnded = useRef(false);
 
   const showTransientStatus = (text: string, tone: StatusTone = "neutral") => {
     if (statusTimeoutRef.current) clearTimeout(statusTimeoutRef.current);
@@ -498,9 +552,16 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
     // authoritative running/stage/runId. Run identity is compared via runId when
     // both sides carry it; when the backend is idle or the runs differ, keep the
     // replace behavior (the store holds nothing worth preserving).
+    const storeAtIssue = getSyncProgress();
     getSyncStatus()
       .then((backendProgress) => {
         const stored = getSyncProgress();
+        // An answer reporting nothing in flight has no authority over a write
+        // that landed after the read was issued: a Sync click in that window
+        // writes the optimistic running:true, and this snapshot was taken before
+        // it existed, so applying it would retract a run that has just started
+        // (#751). The store's own frames then carry the run from here.
+        if (!backendProgress.running && stored !== storeAtIssue) return;
         const sameRun = backendProgress.runId && stored.runId ? backendProgress.runId === stored.runId : true;
         const isSameLiveRun = backendProgress.running && stored.running && sameRun;
         // Same live run: spread the store (keeping its fine fields + etaSeconds)
@@ -522,18 +583,15 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
             }
           : backendProgress;
         setStoredSyncProgress(progress);
-        if (progress.running) {
-          setSyncing(true);
-          setLoading(true);
-          setSyncProgress(progress);
-        }
       })
       .catch((e) => logError(`Failed to query sync status: ${e}`));
 
     // Subscribe to the module store — every backend sync_progress event and
-    // every frontend updateSyncProgress notifies, driving a re-render. The
-    // in-progress UI is torn down ONLY on a terminal stage, never on a bare
-    // running:false (which can transiently race a fresh run's first event).
+    // every frontend updateSyncProgress notifies, driving a re-render. What the
+    // end-of-run work keys on is the watched RUN reaching a terminal stage, not a
+    // terminal stage being present: the frame the panel finds in the store on
+    // mount ends nothing, and the two frames that end the same run are one ending
+    // (see the run refs above).
     const unsubProgress = onSyncProgressChange(() => {
       // The local mirror must update FIRST and unconditionally — it is what
       // drives the re-render. Everything after it is derived work (terminal
@@ -541,6 +599,21 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
       // the re-render chain (on-device freeze, cause not yet reproduced in tests).
       const progress = getSyncProgress();
       setSyncProgress(progress);
+      // Run bookkeeping, taken before the refs move on and outside the try below so
+      // a subscriber throw can never leave the panel believing a finished run is
+      // still live. A running frame is what starts a watch; the frames that end one
+      // split into the first (the run ended: tear down and announce) and any that
+      // follow it (the same run's authoritative wording: the text, nothing else).
+      const inFlight = inFlightRunId(progress);
+      if (inFlight !== null) {
+        watchedRunId.current = inFlight;
+        watchedRunEnded.current = false;
+      }
+      const terminal = isTerminalStage(progress.stage);
+      const runEndedNow =
+        terminal && !watchedRunEnded.current && endsWatchedRun(watchedRunId.current, frameRunId(progress));
+      const laterTerminalFrame = terminal && watchedRunEnded.current;
+      if (runEndedNow) watchedRunEnded.current = true;
       // Carry the fine-detail line so the row survives a unit boundary's anchor
       // frame (which resets current/total, #1415); drop it the moment the run
       // ends so the next run starts clean. Kept outside the try below so the
@@ -561,13 +634,11 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
         setCarriedFineDetail(progress.message);
       }
       try {
-        if (isTerminalStage(progress.stage)) {
+        if (runEndedNow) {
           // Tear down the run's live-ETA state (deadline included) so the next run
           // measures fresh, and clear the display mirror.
           resetEta();
           setLiveEtaDisplay(null);
-          setSyncing(false);
-          setLoading(false);
           // True terminal reached — re-arm the button out of any "Cancelling…"
           // drain state (#1202, RC-B).
           setCancelling(false);
@@ -579,7 +650,14 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
           // Refresh the live heap reading so the paused / high-heap banner reflects
           // the run's end state (a pause leaves it high; a completed run may too).
           detach(refreshSessionBudgetAfterChange());
-        } else {
+        } else if (laterTerminalFrame && progress.message) {
+          // The same run's second terminal signal. Everything above has already
+          // happened for this run; what this frame adds is the run's own account of
+          // how it ended, which replaces the text the merged sync_complete frame
+          // carried over from mid-run. A frame with no message of its own changes
+          // nothing rather than blanking the one already shown.
+          showTransientStatus(progress.message, terminalStatusTone(progress.stage));
+        } else if (!terminal) {
           // Feed the live-rate estimator from applying frames that carry ITEM
           // progress only — fetch frames carry page/cover counters, and an
           // applying-stage cover-refresh frame (``coverRefresh``, #1456) carries a
@@ -642,13 +720,11 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
     return () => clearInterval(id);
   }, [syncing, lastRunPaused]);
 
-  // A start/apply call never reached a running backend sync (rejected up
-  // front or threw). Reset both the local UI and the MODULE store so the
-  // store mirrors reality — the optimistic running:true must not linger.
+  // A start/apply call never reached a running backend sync (rejected up front or
+  // threw). Nothing is draining, so the optimistic running:true is retracted from
+  // the store — which is also what returns this panel to its idle body.
   const abortOptimisticSync = (msg: string) => {
     setStatus({ text: msg, tone: "neutral" });
-    setSyncing(false);
-    setLoading(false);
     setCancelling(false);
     setStoredSyncProgress({ running: false, stage: "" });
   };
@@ -662,8 +738,6 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
     // the backend's first sync_progress event lands — writing running:true
     // into the MODULE store (the single source of truth the subscription
     // reads), not a shadowing local state.
-    setLoading(true);
-    setSyncing(true);
     setCancelling(false);
     setStatus(null);
     setPreview(null);
@@ -703,8 +777,12 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
         return;
       }
       setPreview(result);
-      setSyncing(false);
-      setLoading(false);
+      // The preview run is over — retract the optimistic running:true rather than
+      // waiting for the backend's own terminal frame for it. That frame can be
+      // dropped or raced (the reason index.tsx also drives teardown from
+      // sync_complete), and a dropped one would leave every reader of the store
+      // waiting on a run that has already answered.
+      setStoredSyncProgress({ running: false, stage: "" });
     } catch {
       abortOptimisticSync("Failed to start sync");
     }
@@ -724,8 +802,10 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
     // cancel (#1202).
     resetSyncCancel();
     setPreview(null);
-    setLoading(true);
-    setSyncing(true);
+    // The preview's own "Preview ready" line is still armed for its 15s lifetime,
+    // hidden only by the preview it belongs to; clearing the preview without it
+    // would carry a finished run's status into this one's progress rows.
+    setStatus(null);
     setCancelling(false);
     setStoredSyncProgress({ running: true, stage: "applying", message: "Applying changes...", etaSeconds });
     try {
@@ -749,18 +829,9 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
     }
   };
 
-  const finishCancelWithStatus = (msg: string) => {
-    setCancelling(false);
-    setSyncing(false);
-    setLoading(false);
-    showTransientStatus(msg);
-  };
-
   const handleCancel = async () => {
     if (preview) {
       await handleDismiss();
-      setSyncing(false);
-      setLoading(false);
       return;
     }
     // RC-B (#1202): do NOT re-arm the Sync button here. The backend drains
@@ -778,9 +849,14 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
       // re-arms, surfacing the backend's final message — no status here, so no
       // instant-finish flash during the drain.
     } catch {
-      // The cancel call itself failed — no terminal will arrive from a cancel
-      // that never landed, so re-arm and surface the failure for a retry.
-      finishCancelWithStatus("Failed to cancel sync");
+      // The cancel call itself failed — no terminal will arrive from a cancel that
+      // never landed, so re-arm the button and surface the failure for a retry. The
+      // run is NOT ended here: a cancel that never reached the backend leaves it
+      // draining or still working, and claiming otherwise would both re-offer a
+      // Sync button that only earns a sync_in_progress reject and tell the other
+      // readers of the store that a live run had stopped (#1019).
+      setCancelling(false);
+      showTransientStatus("Failed to cancel sync");
     }
   };
 
@@ -1108,6 +1184,9 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
       </>
     );
   } else {
+    // The idle body. A run in flight renders the branch above instead, so nothing
+    // here needs an "already syncing" guard — the buttons only ever exist while
+    // there is no run to collide with, and the connection is all that can gate them.
     syncBody = (
       <>
         {/* Persistent session-budget banner (#1383): blue while the last run was
@@ -1118,7 +1197,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
           lastAttemptStatus={stats?.last_attempt?.status}
           rssKb={budgetStatus?.rss_kb ?? null}
           resumeReady={budgetStatus?.resume_ready ?? null}
-          restartDisabled={loading || connectionUnavailable}
+          restartDisabled={connectionUnavailable}
           runDoneItems={budgetStatus?.run_done_items ?? null}
           runTotalItems={budgetStatus?.run_total_items ?? null}
         />
@@ -1129,7 +1208,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
             onClick={() => {
               detach(handleSync());
             }}
-            disabled={loading || connectionUnavailable}
+            disabled={connectionUnavailable}
           >
             {syncButtonLabel}
           </ButtonItem>
@@ -1170,7 +1249,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
                   })(),
                 );
               }}
-              disabled={loading || connectionUnavailable}
+              disabled={connectionUnavailable}
             >
               Force Full Sync
             </ButtonItem>
@@ -1335,7 +1414,13 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
 
       <PanelSection>
         {syncBody}
-        {status?.text && !syncing && !preview && (
+        {/* Not gated on the run being idle: a cancel whose CALL failed leaves the
+            run in flight, and its "Failed to cancel sync" line has to reach the
+            user under the progress rows or it is lost entirely. Every other status
+            is set by a path that has already ended its run — but a status OUTLIVES
+            the run that set it (15s), so the two paths that start a run clear it
+            rather than let it ride into the next one. */}
+        {status?.text && !preview && (
           <PanelSectionRow>
             <Field
               label={

--- a/tests/services/library/test_terminal_frame_contract.py
+++ b/tests/services/library/test_terminal_frame_contract.py
@@ -1,0 +1,267 @@
+"""Every emitted ``sync_progress`` frame that stops a run names a terminal stage.
+
+The QAM panel derives "a sync run is in flight" from the emitted frame's
+``running`` flag, and keys the run's end — the status line the run gets, the
+live-ETA teardown, the stats and session-budget re-reads — on the frame's
+*stage* (``src/components/MainPage.tsx``). A frame emitted with ``running``
+false and a non-terminal stage would therefore collapse the in-progress rows
+while ending nothing: no completion line, no re-read, and a coarse bar frozen
+where it stood. Neither side's call site shows the coupling, and the frontend
+cannot defend against it — a bare ``running: false`` is indistinguishable from
+the panel's own retraction of an optimistic start.
+
+The scan is structural rather than behavioural because the rule is about every
+path that *can* emit, error paths included, not the ones a fixture happens to
+provoke. It reaches three producer shapes across ``py_modules/services``, all
+three of which exist today:
+
+* a call to the orchestrator's ``emit_progress``, which the reporter reaches
+  through its injected ``_emit_progress`` and ``services/artwork.py`` through an
+  ``emit_progress`` callable passed in per operation;
+* a direct write of the frame to ``sync_progress``, which the cancelled finalize
+  and the error path use because they build the snapshot themselves;
+* a frame handed straight to the emit primitive as ``_emit("sync_progress", {…})``.
+
+Where the enforcement ends, stated plainly because the invariant register cites
+this file: the scan reads call sites and dict literals, so a frame assembled by
+a helper it cannot follow, or emitted through an aliased callable, is outside it.
+Two such indirections exist today and are inert rather than holes — the
+parameterized snapshot inside ``emit_progress`` itself (its ``running`` and
+``stage`` are its parameters, and every caller of it IS scanned) and the
+fetcher's late-bound proxy in ``services/library/service.py``, which forwards
+whatever its own — scanned — callers passed it.
+
+:class:`TestScanScope` pins the rest of the scope so it cannot shrink unnoticed:
+that the scan still reaches every module producing frames today, that no producer
+lives outside its root, and that ``services/prune``'s unrelated method of the same
+name lands inert rather than as a false offender in a foreign API.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import TYPE_CHECKING, NamedTuple
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SERVICES_ROOT = _REPO_ROOT / "py_modules" / "services"
+_TERMINAL_STAGES = frozenset({"DONE", "CANCELLED", "ERROR"})
+_EMIT_PROGRESS_NAMES = frozenset({"emit_progress", "_emit_progress"})
+_EMIT_NAMES = frozenset({"emit", "_emit"})
+_PROGRESS_EVENT = "sync_progress"
+
+# The modules that produce frames today. Named so a narrowing of the scan — back
+# to one directory, or to a non-recursive glob — fails loudly instead of quietly
+# shrinking what the rule covers.
+_KNOWN_PRODUCERS = frozenset(
+    {
+        "services/library/sync_orchestrator.py",
+        "services/library/reporter.py",
+        "services/artwork.py",
+    }
+)
+
+
+class _Site(NamedTuple):
+    """One frame producer: where it is, and how it names ``running`` / the stage."""
+
+    where: str
+    stage: str | None
+    stops_the_run: bool
+
+    @property
+    def module(self) -> str:
+        return self.where.rsplit(":", 1)[0]
+
+
+def _modules() -> Iterator[tuple[str, ast.Module]]:
+    """Every module under ``py_modules/services``, recursively."""
+    for path in sorted(_SERVICES_ROOT.rglob("*.py")):
+        yield (
+            path.relative_to(_SERVICES_ROOT.parent).as_posix(),
+            ast.parse(path.read_text(encoding="utf-8")),
+        )
+
+
+def _keyword(call: ast.Call, name: str) -> ast.expr | None:
+    return next((kw.value for kw in call.keywords if kw.arg == name), None)
+
+
+def _dict_value(node: ast.Dict, key: str) -> ast.expr | None:
+    return next(
+        (v for k, v in zip(node.keys, node.values, strict=True) if isinstance(k, ast.Constant) and k.value == key),
+        None,
+    )
+
+
+def _is_false(node: ast.expr | None) -> bool:
+    return isinstance(node, ast.Constant) and node.value is False
+
+
+def _stage_name(node: ast.expr | None) -> str | None:
+    """``SyncStage.DONE`` or ``SyncStage.DONE.value`` -> ``"DONE"``; else ``None``."""
+    if isinstance(node, ast.Attribute) and node.attr == "value":
+        node = node.value
+    if isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name) and node.value.id == "SyncStage":
+        return node.attr
+    return None
+
+
+def _called_name(call: ast.Call) -> str | None:
+    func = call.func
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    if isinstance(func, ast.Name):
+        return func.id
+    return None
+
+
+def _is_progress_event(node: ast.expr) -> bool:
+    return isinstance(node, ast.Constant) and node.value == _PROGRESS_EVENT
+
+
+def _frame_from_dict(where: str, frame: ast.Dict) -> _Site:
+    return _Site(where, _stage_name(_dict_value(frame, "stage")), _is_false(_dict_value(frame, "running")))
+
+
+def _emit_progress_sites() -> list[_Site]:
+    """Every call that emits a frame through an ``emit_progress`` helper."""
+    sites: list[_Site] = []
+    for module, tree in _modules():
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call) or _called_name(node) not in _EMIT_PROGRESS_NAMES:
+                continue
+            stage = node.args[0] if node.args else _keyword(node, "stage")
+            sites.append(_Site(f"{module}:{node.lineno}", _stage_name(stage), _is_false(_keyword(node, "running"))))
+    return sites
+
+
+def _snapshot_write_sites() -> list[_Site]:
+    """Every direct write of a frame to ``…sync_progress``, which is then emitted."""
+    sites: list[_Site] = []
+    for module, tree in _modules():
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Assign) or not isinstance(node.value, ast.Dict):
+                continue
+            if any(isinstance(t, ast.Attribute) and t.attr == "sync_progress" for t in node.targets):
+                sites.append(_frame_from_dict(f"{module}:{node.lineno}", node.value))
+    return sites
+
+
+def _inline_emit_sites() -> list[_Site]:
+    """Every frame handed to the emit primitive inline: ``_emit("sync_progress", {…})``."""
+    sites: list[_Site] = []
+    for module, tree in _modules():
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call) or _called_name(node) not in _EMIT_NAMES:
+                continue
+            if len(node.args) < 2:
+                continue
+            payload = node.args[1]
+            if _is_progress_event(node.args[0]) and isinstance(payload, ast.Dict):
+                sites.append(_frame_from_dict(f"{module}:{node.lineno}", payload))
+    return sites
+
+
+def _frame_sites() -> list[_Site]:
+    return [*_emit_progress_sites(), *_snapshot_write_sites(), *_inline_emit_sites()]
+
+
+def _parameter_default(fn: ast.AsyncFunctionDef, name: str) -> ast.expr | None:
+    params = [*fn.args.posonlyargs, *fn.args.args]
+    first_defaulted = len(params) - len(fn.args.defaults)
+    for index, param in enumerate(params):
+        if param.arg == name and index >= first_defaulted:
+            return fn.args.defaults[index - first_defaulted]
+    return next((d for kw, d in zip(fn.args.kwonlyargs, fn.args.kw_defaults, strict=True) if kw.arg == name), None)
+
+
+def _emit_progress_definition() -> ast.AsyncFunctionDef:
+    for module, tree in _modules():
+        if module != "services/library/sync_orchestrator.py":
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.AsyncFunctionDef) and node.name == "emit_progress":
+                return node
+    raise AssertionError("emit_progress is not defined in services/library/sync_orchestrator.py")
+
+
+class TestTerminalFrameContract:
+    def test_every_emitted_frame_that_stops_a_run_names_a_terminal_stage(self):
+        offenders = [s for s in _frame_sites() if s.stops_the_run and s.stage not in _TERMINAL_STAGES]
+        assert offenders == [], (
+            "a sync_progress frame emitted with running=False must name a terminal stage "
+            f"({sorted(_TERMINAL_STAGES)}), or the QAM panel ends the run's UI without ending the run: {offenders}"
+        )
+
+    def test_a_terminal_stage_is_never_emitted_as_a_run_still_going(self):
+        # The converse half, and the reason the panel can key its teardown on the
+        # stage alone: a terminal stage always comes with the run stopped.
+        offenders = [s for s in _frame_sites() if s.stage in _TERMINAL_STAGES and not s.stops_the_run]
+        assert offenders == [], f"a terminal stage was emitted without running=False: {offenders}"
+
+    def test_a_frame_keeps_the_run_running_unless_it_says_otherwise(self):
+        # An omitted ``running`` is what every mid-run frame passes — including the
+        # cover frames in services/artwork.py, which never name it — so the default
+        # decides what a caller that leaves it out emits.
+        default = _parameter_default(_emit_progress_definition(), "running")
+        assert isinstance(default, ast.Constant), f"``running``'s default is not a literal: {default}"
+        assert default.value is True, f"``running`` defaults to {default.value}, so an omitted one could stop a run"
+
+
+class TestScanScope:
+    """What the scan reaches, pinned so a narrowing of it cannot pass unnoticed."""
+
+    def test_it_reaches_every_module_that_produces_frames_today(self):
+        # Non-vacuity with teeth: an empty scan, or one narrowed back to a single
+        # non-recursive directory, satisfies every assertion above. artwork.py is
+        # the one that a services/library-only glob loses — it emits through an
+        # ``emit_progress`` callable the orchestrator passes in.
+        reached = {site.module for site in _frame_sites()}
+        assert reached >= _KNOWN_PRODUCERS, f"the scan no longer reaches {sorted(_KNOWN_PRODUCERS - reached)}"
+
+    def test_it_reaches_all_three_producer_shapes(self):
+        assert len([s for s in _emit_progress_sites() if s.stops_the_run]) >= 4
+        assert len([s for s in _snapshot_write_sites() if s.stops_the_run]) >= 2
+        # The inline shape has no instance today — the two hand-built frames are
+        # written to ``sync_progress`` first — so this pins the collector itself
+        # against a fixture rather than against production code.
+        parsed = ast.parse('await self._emit("sync_progress", {"running": False, "stage": SyncStage.FETCHING.value})')
+        call = next(n for n in ast.walk(parsed) if isinstance(n, ast.Call) and _called_name(n) == "_emit")
+        assert isinstance(call.args[1], ast.Dict)
+        site = _frame_from_dict("fixture:1", call.args[1])
+        assert site.stops_the_run, "the inline collector missed running=False"
+        assert site.stage == "FETCHING", f"the inline collector read the stage as {site.stage}"
+
+    def test_no_frame_producer_lives_outside_the_scanned_root(self):
+        # The root is the other half of the scope: a producer added outside
+        # py_modules/services would be invisible rather than wrong. Nothing emits a
+        # frame from there today — main.py and the rest of py_modules reach the
+        # sync only through the service — and this is what says so if that changes.
+        outside: list[str] = []
+        candidates = [_REPO_ROOT / "main.py", *(_REPO_ROOT / "py_modules").rglob("*.py")]
+        for path in sorted(candidates):
+            if _SERVICES_ROOT in path.parents or "_vendor" in path.parts:
+                continue
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                name = _called_name(node)
+                emits_frame = name in _EMIT_NAMES and bool(node.args) and _is_progress_event(node.args[0])
+                if name in _EMIT_PROGRESS_NAMES or emits_frame:
+                    outside.append(f"{path.relative_to(_REPO_ROOT).as_posix()}:{node.lineno}")
+        assert outside == [], f"a sync_progress producer outside the scan's root is unchecked by it: {outside}"
+
+    def test_a_foreign_emit_progress_is_inert_rather_than_a_false_offender(self):
+        # ``services/prune`` has its own ``emit_progress`` — a different event
+        # (prune_progress), a plain-string stage, no ``running`` flag, and
+        # ``run_id`` where this one takes the stage. Matching by name reaches those
+        # sites, so they must land as "names no stage, stops no run": inert for
+        # both assertions above rather than offenders in a foreign API.
+        foreign = [s for s in _emit_progress_sites() if s.module.startswith("services/prune/")]
+        assert foreign, "expected the prune emit_progress call sites to be scanned"
+        assert all(s.stage is None and not s.stops_the_run for s in foreign), foreign


### PR DESCRIPTION
The main page kept its own idea of whether a sync was running alongside the
module store's, and the two could disagree. Of the two paths that give up on a
run, one reset the store and the other did not — so after a cancel whose request
failed, the panel showed an enabled Sync Library while the store still said a
run was in flight, and Data Management and the removed-games page, which read
that store directly, showed one. Starting a second run then rejected as "already
running", and the rejection handler stamped the store idle while the first run
was still draining. That is #1019, reached through the door that was left after
#1202 fixed the one the issue describes.

The store owns it now. `loading` goes with it: it was assigned at eight sites,
every one paired with `setSyncing` and always to the same value, and read at
three — all of which turned out to be dead, since they sit in a branch where the
compiler already knows no run is in flight. The guard had never done anything.

**A user-reported bug goes with the same change.** Returning to the main page
replayed the last terminal frame as a fresh completion: the mount effect writes
the backend's status into the store, that notifies, and the subscriber's terminal
branch fired as though the run had just ended. So a green "Preview ready" or
"Sync complete: …" appeared on every return, for a run that had finished long
before — and with no way to act on it, because the preview payload lived in
component state the unmount had discarded. The branch now acts on a transition
into terminal rather than on finding a terminal state. You cannot tear down what
you were never watching.

That has a deliberate other half: a run that finishes while the panel is closed
is no longer announced when you open it. The end-of-run toast is unaffected — it
fires when the run ends, whether or not the panel is open. Announcing it once and
only once would need the frame to record that it had been announced, which is not
built here.

Keying the announcement needed more care than a flag. The backend sends two
terminal signals in order — `sync_complete` first, then the authoritative
progress frame — and the first arrives as a merged store write that keeps the
previous frame's message. A one-shot flag therefore announces "Finalizing…" and
ignores the real "Sync complete: N games from M platforms". So the announcement
is keyed on the run: its first terminal frame does the once-per-run work, a later
terminal frame of the same run updates only the wording, and a frame found at
mount is refused. A terminal frame may legitimately carry no run id at all — a
cancel does — so it ends the watched run unless it names a different one.

Un-gating the status row so a failed cancel can speak during a run exposed that a
status outlives its run by fifteen seconds: tapping Apply within that window
showed a green "Preview ready" under the live progress. The run-starting paths
clear it, which `handleApply` had not been doing.

The whole derivation rests on the backend never emitting a frame that stops a run
without naming a terminal stage — a bare `running: false` is exactly what the
panel's own retraction of an optimistic start looks like, so the panel cannot tell
them apart and must not have to. That was an assumption; it is now a test over
every producer in `py_modules/services`, in both directions, and the invariant
register says plainly where its reach ends. Its first version scanned one
directory and missed the artwork frames, which are emitted through an injected
callable from a sibling package — so it also asserts that no producer lives
outside the root it scans.

Closes #1019
