### PR TITLE
refactor(ui): subscribe to the notice stores through their own hooks

### DIFF
--- a/src/components/MainPage.test.tsx
+++ b/src/components/MainPage.test.tsx
@@ -23,9 +23,12 @@
 //
 // MUTATION CHECKS (by inspection — auto-mode classifier likely blocks on
 // React state internals + listener cleanup, so confidence is recorded here):
-//   1. Removing the `unsubMigration()` call from the unmount cleanup would
-//      break the "subscribes on mount and unsubscribes on unmount" test —
-//      migrationListeners.length would stay at 1 after unmount.
+//   1. Removing the useMigrationStatus() call from MainPage would break the
+//      "subscribes on mount and unsubscribes on unmount" test —
+//      migrationListeners.length would stay at 0 after mount. (The real hook's
+//      own teardown is NOT covered here: this file module-mocks
+//      ../utils/migrationStore, so neither it nor the real onMigrationChange
+//      ever runs. Its unsubscribe is pinned in src/utils/migrationStore.test.ts.)
 //   2. Removing `clearInterval(pollRef.current)` from stopPolling would
 //      break the "interval cleared on unmount" test — clearIntervalSpy
 //      would not be called with the captured pollRef id.
@@ -36,7 +39,7 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { render, fireEvent, act } from "@testing-library/react";
-import { createElement, type ReactElement } from "react";
+import { createElement, useSyncExternalStore, type ReactElement } from "react";
 import { MainPage, ConnectionIndicator } from "./MainPage";
 import * as backend from "../api/backend";
 import { useVersionError } from "./VersionErrorCard";
@@ -89,39 +92,55 @@ vi.mock("./MigrationBlockedPage", () => ({
 // deterministically. resetAllMocks wipes impls; re-stubbed in beforeEach.
 const migrationListeners: Array<() => void> = [];
 let currentMigrationState: MigrationStatus = { pending: false };
-vi.mock("../utils/migrationStore", () => ({
-  getMigrationState: vi.fn(() => currentMigrationState),
-  setMigrationStatus: vi.fn((s: MigrationStatus) => {
-    currentMigrationState = s;
-    migrationListeners.forEach((fn) => fn());
-  }),
-  onMigrationChange: vi.fn((cb: () => void) => {
-    migrationListeners.push(cb);
-    return () => {
-      const i = migrationListeners.indexOf(cb);
-      if (i >= 0) migrationListeners.splice(i, 1);
-    };
-  }),
-}));
+// useMigrationStatus routes through the mocked seams rather than being stubbed
+// with a constant, so the listener-array assertions still measure the panel's
+// real subscribe/unsubscribe. subscribe/snapshot are built once — a fresh
+// subscribe reference per render makes React re-subscribe on every render.
+vi.mock("../utils/migrationStore", () => {
+  const subscribe = (cb: () => void) => mod.onMigrationChange(cb);
+  const snapshot = () => mod.getMigrationState();
+  const mod = {
+    getMigrationState: vi.fn(() => currentMigrationState),
+    setMigrationStatus: vi.fn((s: MigrationStatus) => {
+      currentMigrationState = s;
+      migrationListeners.forEach((fn) => fn());
+    }),
+    onMigrationChange: vi.fn((cb: () => void) => {
+      migrationListeners.push(cb);
+      return () => {
+        const i = migrationListeners.indexOf(cb);
+        if (i >= 0) migrationListeners.splice(i, 1);
+      };
+    }),
+    useMigrationStatus: () => useSyncExternalStore(subscribe, snapshot),
+  };
+  return mod;
+});
 import * as migrationStore from "../utils/migrationStore";
 
 // saveSortMigrationStore — same listener-array pattern.
 const saveSortListeners: Array<() => void> = [];
 let currentSaveSortState: SaveSortMigrationStatus = { pending: false };
-vi.mock("../utils/saveSortMigrationStore", () => ({
-  getSaveSortMigrationState: vi.fn(() => currentSaveSortState),
-  setSaveSortMigrationStatus: vi.fn((s: SaveSortMigrationStatus) => {
-    currentSaveSortState = s;
-    saveSortListeners.forEach((fn) => fn());
-  }),
-  onSaveSortMigrationChange: vi.fn((cb: () => void) => {
-    saveSortListeners.push(cb);
-    return () => {
-      const i = saveSortListeners.indexOf(cb);
-      if (i >= 0) saveSortListeners.splice(i, 1);
-    };
-  }),
-}));
+vi.mock("../utils/saveSortMigrationStore", () => {
+  const subscribe = (cb: () => void) => mod.onSaveSortMigrationChange(cb);
+  const snapshot = () => mod.getSaveSortMigrationState();
+  const mod = {
+    getSaveSortMigrationState: vi.fn(() => currentSaveSortState),
+    setSaveSortMigrationStatus: vi.fn((s: SaveSortMigrationStatus) => {
+      currentSaveSortState = s;
+      saveSortListeners.forEach((fn) => fn());
+    }),
+    onSaveSortMigrationChange: vi.fn((cb: () => void) => {
+      saveSortListeners.push(cb);
+      return () => {
+        const i = saveSortListeners.indexOf(cb);
+        if (i >= 0) saveSortListeners.splice(i, 1);
+      };
+    }),
+    useSaveSortMigrationState: () => useSyncExternalStore(subscribe, snapshot),
+  };
+  return mod;
+});
 import * as saveSortMigrationStore from "../utils/saveSortMigrationStore";
 
 vi.mock("../utils/syncManager", () => ({

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -52,14 +52,10 @@ import {
   useSessionBudget,
   useSyncStats,
 } from "../utils/syncStatsStore";
-import { getMigrationState, onMigrationChange, setMigrationStatus } from "../utils/migrationStore";
-import { getSettingsResetState, onSettingsResetChange } from "../utils/settingsResetStore";
-import { getPlaytimeScopeState, onPlaytimeScopeChange, fetchPlaytimeScopeState } from "../utils/playtimeScopeStore";
-import {
-  getSaveSortMigrationState,
-  onSaveSortMigrationChange,
-  setSaveSortMigrationStatus,
-} from "../utils/saveSortMigrationStore";
+import { setMigrationStatus, useMigrationStatus } from "../utils/migrationStore";
+import { useSettingsResetState } from "../utils/settingsResetStore";
+import { fetchPlaytimeScopeState, usePlaytimeScopeState } from "../utils/playtimeScopeStore";
+import { setSaveSortMigrationStatus, useSaveSortMigrationState } from "../utils/saveSortMigrationStore";
 import { reconcileStaleShortcuts, requestSyncCancel, isCancelRequested, resetSyncCancel } from "../utils/syncManager";
 import { useConnectionProbe } from "../utils/connectionProbe";
 import type { BackendFailed, ConnectionFailure } from "../utils/connectionProbe";
@@ -71,15 +67,7 @@ import { MigrationBlockedPage } from "./MigrationBlockedPage";
 import { SettingsResetBanner } from "./SettingsResetBanner";
 import { PlaytimeScopeBanner } from "./PlaytimeScopeBanner";
 import { SessionBudgetBanner, formatGb, formatSignedGb, memoryLevelColor } from "./SessionBudgetBanner";
-import type {
-  SyncProgress,
-  SyncStage,
-  SyncStats,
-  SyncPreview,
-  SyncPreviewSummary,
-  MigrationStatus,
-  Page,
-} from "../types";
+import type { SyncProgress, SyncStage, SyncStats, SyncPreview, SyncPreviewSummary, Page } from "../types";
 import { detach } from "../utils/detach";
 import { wrapText } from "../utils/textStyles";
 
@@ -476,10 +464,10 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
   const [skipPreview, setSkipPreview] = useState(false);
   const [retroarchWarning, setRetroarchWarning] = useState<{ warning: boolean; current?: string } | null>(null);
   const [retrodeckBanner, setRetrodeckBanner] = useState<RetroDeckBanner | null>(null);
-  const [migration, setMigration] = useState<MigrationStatus>(getMigrationState());
-  const [settingsReset, setSettingsReset] = useState(getSettingsResetState());
-  const [playtimeScope, setPlaytimeScope] = useState(getPlaytimeScopeState());
-  const [saveSortMigration, setSaveSortMigration] = useState(getSaveSortMigrationState());
+  const migration = useMigrationStatus();
+  const settingsReset = useSettingsResetState();
+  const playtimeScope = usePlaytimeScopeState();
+  const saveSortMigration = useSaveSortMigrationState();
   const downloads = useDownloads();
   const statusTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // The run this panel is watching, by id, and whether its end has been handled.
@@ -680,16 +668,8 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
       }
     });
 
-    const unsubMigration = onMigrationChange(() => setMigration(getMigrationState()));
-    const unsubSettingsReset = onSettingsResetChange(() => setSettingsReset(getSettingsResetState()));
-    const unsubPlaytimeScope = onPlaytimeScopeChange(() => setPlaytimeScope(getPlaytimeScopeState()));
-    const unsubSaveSort = onSaveSortMigrationChange(() => setSaveSortMigration(getSaveSortMigrationState()));
     return () => {
       unsubProgress();
-      unsubMigration();
-      unsubSettingsReset();
-      unsubPlaytimeScope();
-      unsubSaveSort();
       if (statusTimeoutRef.current) clearTimeout(statusTimeoutRef.current);
     };
   }, []);

--- a/src/components/MigrationBlockedPage.test.tsx
+++ b/src/components/MigrationBlockedPage.test.tsx
@@ -6,15 +6,14 @@
 // Both surface through the rendered <Field label={migrateResult} /> — the
 // catch tests below assert that label text.
 
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { render, fireEvent, act, renderHook } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, fireEvent, act } from "@testing-library/react";
 import { createElement, type ComponentProps, type ReactElement } from "react";
 import { showModal } from "@decky/ui";
 import { toaster } from "@decky/api";
-import { MigrationBlockedPage, useMigrationStatus } from "./MigrationBlockedPage";
+import { MigrationBlockedPage } from "./MigrationBlockedPage";
 import * as backend from "../api/backend";
 import { setMigrationStatus, clearMigration, getMigrationState } from "../utils/migrationStore";
-import * as migrationStore from "../utils/migrationStore";
 import type { MigrationStatus, MigrationResult } from "../types";
 // Type-only — vi.mock("./MigrationConflictModal") below replaces the runtime
 // impl; the captured-props type stays pinned to the real component.
@@ -76,7 +75,8 @@ describe("MigrationBlockedPage component", () => {
     vi.mocked(toaster.toast).mockClear();
     vi.mocked(backend.migrateRetroDeckFiles).mockReset();
     vi.mocked(backend.dismissRetrodeckMigration).mockReset();
-    // Reset migrationStore so listener-based hooks aren't carrying leak state.
+    // The clearMigration/getMigrationState assertions below read the real store,
+    // which outlives the test — reset it so each case starts from not-pending.
     clearMigration();
   });
 
@@ -381,59 +381,5 @@ describe("MigrationBlockedPage component", () => {
       const confirm = lastShownModalProps<{ strTitle?: string }>();
       expect(confirm?.strTitle).toBe("Dismiss Migration?");
     });
-  });
-});
-
-describe("useMigrationStatus hook", () => {
-  // act-wrapped: this teardown runs before RTL's cleanup(), so the hook is still
-  // mounted and the reset notifies its subscriber — a real state update.
-  afterEach(() => {
-    act(() => {
-      clearMigration();
-    });
-  });
-
-  it("returns the current state from getMigrationState() on mount", () => {
-    setMigrationStatus({ pending: true, old_path: "/x" });
-    const { result } = renderHook(() => useMigrationStatus());
-    expect(result.current).toEqual({ pending: true, old_path: "/x" });
-  });
-
-  it("updates when setMigrationStatus fires after mount", () => {
-    const { result } = renderHook(() => useMigrationStatus());
-    expect(result.current).toEqual({ pending: false });
-    act(() => {
-      setMigrationStatus({ pending: true, roms_count: 9 });
-    });
-    expect(result.current).toEqual({ pending: true, roms_count: 9 });
-  });
-
-  it("updates when clearMigration fires", () => {
-    setMigrationStatus({ pending: true, roms_count: 9 });
-    const { result } = renderHook(() => useMigrationStatus());
-    expect(result.current.pending).toBe(true);
-    act(() => {
-      clearMigration();
-    });
-    expect(result.current).toEqual({ pending: false });
-  });
-
-  it("unsubscribes on unmount — useEffect cleanup invokes the returned unsubscribe", () => {
-    // Spy on onMigrationChange so the test owns the unsubscribe callback.
-    // The "updates after mount" tests above cover the subscribe-then-callback
-    // path; this test isolates the cleanup invocation. Asserting unsubSpy
-    // was called proves the hook returns its unsubscribe from useEffect — a
-    // mutation that drops the return fails this test, where the prior
-    // `not.toThrow()` pattern passed vacuously under React 19's silent
-    // no-op-on-unmounted-setState.
-    const unsubSpy = vi.fn();
-    vi.spyOn(migrationStore, "onMigrationChange").mockImplementation((_cb) => {
-      return unsubSpy;
-    });
-
-    const { unmount } = renderHook(() => useMigrationStatus());
-    expect(unsubSpy).not.toHaveBeenCalled();
-    unmount();
-    expect(unsubSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/MigrationBlockedPage.tsx
+++ b/src/components/MigrationBlockedPage.tsx
@@ -1,22 +1,12 @@
-import { FC, useEffect, useState } from "react";
+import { FC, useState } from "react";
 import { PanelSection, PanelSectionRow, ButtonItem, Field, ConfirmModal, showModal } from "@decky/ui";
 import { showToast } from "../utils/toast";
 import { migrateRetroDeckFiles, dismissRetrodeckMigration } from "../api/backend";
 import type { MigrationStatus } from "../types";
-import { getMigrationState, onMigrationChange, clearMigration } from "../utils/migrationStore";
+import { clearMigration } from "../utils/migrationStore";
 import { MigrationConflictModal } from "./MigrationConflictModal";
 import { scrollToTop } from "../utils/scrollHelpers";
 import { detach } from "../utils/detach";
-
-/**
- * Subscribe to migration state changes.
- * Returns the current migration status.
- */
-export function useMigrationStatus(): MigrationStatus {
-  const [status, setStatus] = useState<MigrationStatus>(getMigrationState());
-  useEffect(() => onMigrationChange(() => setStatus(getMigrationState())), []);
-  return status;
-}
 
 interface MigrationBlockedPageProps {
   migration: MigrationStatus;

--- a/src/components/RomMGameInfoPanel.test.tsx
+++ b/src/components/RomMGameInfoPanel.test.tsx
@@ -12,7 +12,7 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { render, act } from "@testing-library/react";
-import { createElement, type ComponentProps } from "react";
+import { createElement, useSyncExternalStore, type ComponentProps } from "react";
 import { RomMGameInfoPanel } from "./RomMGameInfoPanel";
 import * as backend from "../api/backend";
 import type { CachedGameDetail } from "../api/backend";
@@ -113,42 +113,57 @@ vi.mock("../utils/cachedGameDetailStore", () => ({
 // `vi.resetAllMocks()` in beforeEach wipes the impls — re-stubbed there.
 const migrationListeners: Array<() => void> = [];
 let currentMigrationState: MigrationStatus = { pending: false };
-vi.mock("../utils/migrationStore", () => ({
-  getMigrationState: vi.fn(() => currentMigrationState),
-  setMigrationStatus: vi.fn((s: MigrationStatus) => {
-    currentMigrationState = s;
-    migrationListeners.forEach((fn) => fn());
-  }),
-  onMigrationChange: vi.fn((cb: () => void) => {
-    migrationListeners.push(cb);
-    return () => {
-      const i = migrationListeners.indexOf(cb);
-      if (i >= 0) migrationListeners.splice(i, 1);
-    };
-  }),
-}));
+// useMigrationStatus routes through the mocked seams rather than being stubbed
+// with a constant, so the listener-array assertions still measure the panel's
+// real subscribe/unsubscribe. subscribe/snapshot are built once — a fresh
+// subscribe reference per render makes React re-subscribe on every render.
+vi.mock("../utils/migrationStore", () => {
+  const subscribe = (cb: () => void) => mod.onMigrationChange(cb);
+  const snapshot = () => mod.getMigrationState();
+  const mod = {
+    getMigrationState: vi.fn(() => currentMigrationState),
+    setMigrationStatus: vi.fn((s: MigrationStatus) => {
+      currentMigrationState = s;
+      migrationListeners.forEach((fn) => fn());
+    }),
+    onMigrationChange: vi.fn((cb: () => void) => {
+      migrationListeners.push(cb);
+      return () => {
+        const i = migrationListeners.indexOf(cb);
+        if (i >= 0) migrationListeners.splice(i, 1);
+      };
+    }),
+    useMigrationStatus: () => useSyncExternalStore(subscribe, snapshot),
+  };
+  return mod;
+});
 import * as migrationStore from "../utils/migrationStore";
 
 // ----- saveSortMigrationStore — same listener-array pattern as
 // migrationStore. The panel reads .pending on mount and re-renders when the
-// store notifies. clearSaveSortMigration isn't used by the panel but the mock
-// declares it as a vi.fn for shape parity with the real module.
+// store notifies.
 const saveSortListeners: Array<() => void> = [];
 let currentSaveSortState: SaveSortMigrationStatus = { pending: false };
-vi.mock("../utils/saveSortMigrationStore", () => ({
-  getSaveSortMigrationState: vi.fn(() => currentSaveSortState),
-  setSaveSortMigrationStatus: vi.fn((s: SaveSortMigrationStatus) => {
-    currentSaveSortState = s;
-    saveSortListeners.forEach((fn) => fn());
-  }),
-  onSaveSortMigrationChange: vi.fn((cb: () => void) => {
-    saveSortListeners.push(cb);
-    return () => {
-      const i = saveSortListeners.indexOf(cb);
-      if (i >= 0) saveSortListeners.splice(i, 1);
-    };
-  }),
-}));
+vi.mock("../utils/saveSortMigrationStore", () => {
+  const subscribe = (cb: () => void) => mod.onSaveSortMigrationChange(cb);
+  const snapshot = () => mod.getSaveSortMigrationState();
+  const mod = {
+    getSaveSortMigrationState: vi.fn(() => currentSaveSortState),
+    setSaveSortMigrationStatus: vi.fn((s: SaveSortMigrationStatus) => {
+      currentSaveSortState = s;
+      saveSortListeners.forEach((fn) => fn());
+    }),
+    onSaveSortMigrationChange: vi.fn((cb: () => void) => {
+      saveSortListeners.push(cb);
+      return () => {
+        const i = saveSortListeners.indexOf(cb);
+        if (i >= 0) saveSortListeners.splice(i, 1);
+      };
+    }),
+    useSaveSortMigrationState: () => useSyncExternalStore(subscribe, snapshot),
+  };
+  return mod;
+});
 import * as saveSortMigrationStore from "../utils/saveSortMigrationStore";
 
 // ----- @decky/ui — global stub from test-setup.ts covers Focusable +

--- a/src/components/RomMGameInfoPanel.tsx
+++ b/src/components/RomMGameInfoPanel.tsx
@@ -26,13 +26,9 @@ import { bindRomInState, loadData, type PanelReadSeqs, type PanelState } from ".
 import { wirePanelEvents } from "./panelEvents";
 import { useSaveSlotsLoad } from "./panelSlotsLoad";
 import { buildTabContent } from "./panelTabContent";
-import { getMigrationState, onMigrationChange, setMigrationStatus } from "../utils/migrationStore";
-import { getSettingsResetState, onSettingsResetChange } from "../utils/settingsResetStore";
-import {
-  getSaveSortMigrationState,
-  onSaveSortMigrationChange,
-  setSaveSortMigrationStatus,
-} from "../utils/saveSortMigrationStore";
+import { setMigrationStatus, useMigrationStatus } from "../utils/migrationStore";
+import { useSettingsResetState } from "../utils/settingsResetStore";
+import { setSaveSortMigrationStatus, useSaveSortMigrationState } from "../utils/saveSortMigrationStore";
 import { VersionErrorCard, useVersionError } from "./VersionErrorCard";
 import { MigrationBlockedCard } from "./MigrationBlockedCard";
 import { SettingsResetCard } from "./SettingsResetCard";
@@ -85,20 +81,9 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => {
   // enforce is stated at `takeReadTicket`. They live here because the loads, the
   // event lane and the lazy slots lane take tickets from the same counters.
   const readSeqs = useRef<PanelReadSeqs>({ detail: 0, saveStatus: 0, slots: 0, slotTracking: 0, bios: 0 });
-  const [migration, setMigration] = useState(getMigrationState());
-  const [settingsReset, setSettingsReset] = useState(getSettingsResetState());
-  const [saveSortPending, setSaveSortPending] = useState(getSaveSortMigrationState().pending);
-
-  useEffect(() => {
-    const unsub = onMigrationChange(() => setMigration(getMigrationState()));
-    const unsubSettingsReset = onSettingsResetChange(() => setSettingsReset(getSettingsResetState()));
-    const unsubSaveSort = onSaveSortMigrationChange(() => setSaveSortPending(getSaveSortMigrationState().pending));
-    return () => {
-      unsub();
-      unsubSettingsReset();
-      unsubSaveSort();
-    };
-  }, []);
+  const migration = useMigrationStatus();
+  const settingsReset = useSettingsResetState();
+  const saveSortPending = useSaveSortMigrationState().pending;
 
   useEffect(() => {
     refreshMigrationState()

--- a/src/components/RomMPlaySection.test.tsx
+++ b/src/components/RomMPlaySection.test.tsx
@@ -34,7 +34,7 @@ import * as saveStatusUtils from "../utils/saveStatus";
 import * as formatters from "../utils/formatters";
 import { getGameDetail } from "../utils/gameDetailStore";
 import { useVersionError } from "./VersionErrorCard";
-import { useMigrationStatus } from "./MigrationBlockedPage";
+import { useMigrationStatus } from "../utils/migrationStore";
 
 // Type-only import — vi.mock("./CustomPlayButton", ...) below replaces the
 // runtime impl, but pinning the captured-props shape to the real component
@@ -45,7 +45,10 @@ import type { CustomPlayButton } from "./CustomPlayButton";
 vi.mock("./VersionErrorCard", () => ({
   useVersionError: vi.fn(() => null),
 }));
-vi.mock("./MigrationBlockedPage", () => ({
+// Only the hook is replaced — the store's writers stay real, so anything else
+// in the tree that reads migration state still sees a consistent module.
+vi.mock("../utils/migrationStore", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../utils/migrationStore")>()),
   useMigrationStatus: vi.fn(() => ({ pending: false })),
 }));
 

--- a/src/components/RomMPlaySection.tsx
+++ b/src/components/RomMPlaySection.tsx
@@ -172,7 +172,7 @@ import {
 } from "../utils/connectionState";
 import { registerConnectionHeartbeat } from "../utils/connectionHeartbeat";
 import { useVersionError } from "./VersionErrorCard";
-import { useMigrationStatus } from "./MigrationBlockedPage";
+import { useMigrationStatus } from "../utils/migrationStore";
 import { detach } from "../utils/detach";
 
 // S3776 is raised on the declaration line, so its NOSONAR must stay there. prettier-ignore stops

--- a/src/components/SettingsPage.test.tsx
+++ b/src/components/SettingsPage.test.tsx
@@ -7,7 +7,7 @@
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { render, fireEvent, act } from "@testing-library/react";
-import { createElement, type ComponentProps, type ReactElement } from "react";
+import { createElement, useSyncExternalStore, type ComponentProps, type ReactElement } from "react";
 import { SettingsPage } from "./SettingsPage";
 import * as backend from "../api/backend";
 import type { SaveSortMigrationStatus, RegisteredDevice } from "../types";
@@ -142,24 +142,34 @@ vi.mock("../utils/scrollHelpers", () => ({ scrollToTop: vi.fn() }));
 // drive the subscribe/unsubscribe + state-change flow deterministically.
 const saveSortListeners: Array<() => void> = [];
 let currentSortState: SaveSortMigrationStatus = { pending: false };
-vi.mock("../utils/saveSortMigrationStore", () => ({
-  getSaveSortMigrationState: vi.fn(() => currentSortState),
-  setSaveSortMigrationStatus: vi.fn((s: SaveSortMigrationStatus) => {
-    currentSortState = s;
-    saveSortListeners.forEach((fn) => fn());
-  }),
-  clearSaveSortMigration: vi.fn(() => {
-    currentSortState = { pending: false };
-    saveSortListeners.forEach((fn) => fn());
-  }),
-  onSaveSortMigrationChange: vi.fn((cb: () => void) => {
-    saveSortListeners.push(cb);
-    return () => {
-      const i = saveSortListeners.indexOf(cb);
-      if (i >= 0) saveSortListeners.splice(i, 1);
-    };
-  }),
-}));
+// useSaveSortMigrationState routes through the mocked seams rather than being
+// stubbed with a constant, so the listener assertions still measure the page's
+// real subscribe/unsubscribe. subscribe/snapshot are built once — a fresh
+// subscribe reference per render makes React re-subscribe on every render.
+vi.mock("../utils/saveSortMigrationStore", () => {
+  const subscribe = (cb: () => void) => mod.onSaveSortMigrationChange(cb);
+  const snapshot = () => mod.getSaveSortMigrationState();
+  const mod = {
+    getSaveSortMigrationState: vi.fn(() => currentSortState),
+    setSaveSortMigrationStatus: vi.fn((s: SaveSortMigrationStatus) => {
+      currentSortState = s;
+      saveSortListeners.forEach((fn) => fn());
+    }),
+    clearSaveSortMigration: vi.fn(() => {
+      currentSortState = { pending: false };
+      saveSortListeners.forEach((fn) => fn());
+    }),
+    onSaveSortMigrationChange: vi.fn((cb: () => void) => {
+      saveSortListeners.push(cb);
+      return () => {
+        const i = saveSortListeners.indexOf(cb);
+        if (i >= 0) saveSortListeners.splice(i, 1);
+      };
+    }),
+    useSaveSortMigrationState: () => useSyncExternalStore(subscribe, snapshot),
+  };
+  return mod;
+});
 
 // Wait one microtask for the mount-time useEffect promises to resolve.
 const flushAsync = () =>

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -29,17 +29,15 @@ import {
   logError,
 } from "../api/backend";
 import type {
-  SaveSortMigrationStatus,
   RegisteredDevice,
   CollectionNamingMode,
   SaveSyncSettings as SaveSyncSettingsType,
   RetroArchInputCheck,
 } from "../types";
 import {
-  getSaveSortMigrationState,
   setSaveSortMigrationStatus as setStoreSaveSortStatus,
   clearSaveSortMigration,
-  onSaveSortMigrationChange,
+  useSaveSortMigrationState,
 } from "../utils/saveSortMigrationStore";
 import { scrollToTop } from "../utils/scrollHelpers";
 import { detach } from "../utils/detach";
@@ -94,7 +92,7 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
   const [retroarchFixStatus, setRetroarchFixStatus] = useState("");
 
   // Save sort migration state
-  const [saveSortMigration, setSaveSortMigration] = useState<SaveSortMigrationStatus>(getSaveSortMigrationState());
+  const saveSortMigration = useSaveSortMigrationState();
   const [saveSortMigrating, setSaveSortMigrating] = useState(false);
   const [saveSortResult, setSaveSortResult] = useState("");
 
@@ -158,15 +156,9 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
       .then((s) => {
         if (s.pending) {
           setStoreSaveSortStatus(s);
-          setSaveSortMigration(s);
         }
       })
       .catch(() => {});
-
-    const unsubSaveSort = onSaveSortMigrationChange(() => setSaveSortMigration(getSaveSortMigrationState()));
-    return () => {
-      unsubSaveSort();
-    };
   }, []);
 
   function loadDevices() {

--- a/src/components/playRowSaveSync.test.tsx
+++ b/src/components/playRowSaveSync.test.tsx
@@ -16,11 +16,16 @@ import { setRommConnectionState, setVersionError } from "../utils/connectionStat
 import { registerConnectionHeartbeat } from "../utils/connectionHeartbeat";
 import { stubAppStore } from "../test-utils/steamStubs";
 import { useVersionError } from "./VersionErrorCard";
-import { useMigrationStatus } from "./MigrationBlockedPage";
+import { useMigrationStatus } from "../utils/migrationStore";
 import type { SaveStatus, SyncConflict } from "../types";
 
 vi.mock("./VersionErrorCard", () => ({ useVersionError: vi.fn(() => null) }));
-vi.mock("./MigrationBlockedPage", () => ({ useMigrationStatus: vi.fn(() => ({ pending: false })) }));
+// Only the hook is replaced — the store's writers stay real, so anything else
+// in the tree that reads migration state still sees a consistent module.
+vi.mock("../utils/migrationStore", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../utils/migrationStore")>()),
+  useMigrationStatus: vi.fn(() => ({ pending: false })),
+}));
 // The heartbeat owns a real setInterval; the artwork apply and the playtime
 // overview write both reach into Steam. None of the three is on the path under
 // test, so they are stubbed inert rather than driven.

--- a/src/test-utils/store-hook-subscription.ts
+++ b/src/test-utils/store-hook-subscription.ts
@@ -1,0 +1,78 @@
+/**
+ * Asserts that a module store's `useSyncExternalStore` hook hands React ONE
+ * stable subscribe function — the store's own exported `onXChange` seam — for
+ * the life of a component, rather than a fresh closure per render.
+ *
+ * WHY THIS NEEDS A HELPER AT ALL. The property has no behavioral signature.
+ * React tears the old subscription down before making the new one, so an
+ * unstable subscribe leaks nothing and the store's live listener count is 1
+ * either way; the whole cost is a re-subscribe on every render. Tidying
+ *
+ *     useSyncExternalStore(onMigrationChange, getMigrationState)
+ *
+ * into `useSyncExternalStore((cb) => onMigrationChange(cb), …)` is therefore
+ * invisible: it was verified that the entire frontend suite stays green under
+ * exactly that edit, applied to all four notice stores at once.
+ *
+ * WHY IT CANNOT BE OBSERVED FROM THE STORE'S SIDE. Two independent reasons:
+ *   - each store's `_listeners` is module-private, so the number of live
+ *     subscriptions is not readable from a test; and
+ *   - the hook calls `onXChange` as a module-LOCAL binding, so a namespace spy
+ *     (`vi.spyOn(store, "onXChange")`) does not intercept it. That is the same
+ *     intra-module problem that forced `useMigrationStatus`'s unmount test to
+ *     be rewritten when the hook moved next to its store: a spy on the module
+ *     object only intercepts calls made from OTHER modules.
+ *
+ * What is left is the other side of the seam — what the hook passes to React —
+ * and `useSyncExternalStore` is imported from "react", a different module, so
+ * a module mock does reach it. `vi.spyOn(React, "useSyncExternalStore")` does
+ * not work (the namespace is frozen: "Cannot redefine property"), so the
+ * calling test file must install a CALL-THROUGH mock of react. It fakes
+ * nothing — the real implementation runs, and the wrapper exists only to
+ * record its arguments:
+ *
+ *     vi.mock("react", async (importOriginal) => {
+ *       const actual = await importOriginal<typeof import("react")>();
+ *       return { ...actual, useSyncExternalStore: vi.fn(actual.useSyncExternalStore) };
+ *     });
+ *
+ * The `vi.mock` call is hoisted, so it has to sit in the test file itself and
+ * cannot be moved in here. Everything after it can.
+ */
+
+import { expect, vi } from "vitest";
+import { useSyncExternalStore } from "react";
+import { renderHook } from "@testing-library/react";
+
+/**
+ * Render `useStoreHook`, re-render it twice, and assert that every
+ * `useSyncExternalStore` call received the same subscribe function, and that it
+ * is `subscribeSeam` — the store's own exported subscribe.
+ *
+ * Requires the calling test file to have installed the call-through react mock
+ * described in this module's docstring; throws a pointed error if it has not,
+ * rather than passing vacuously.
+ */
+export function expectStableSubscribe<T>(useStoreHook: () => T, subscribeSeam: (fn: () => void) => () => void): void {
+  if (!vi.isMockFunction(useSyncExternalStore)) {
+    throw new Error(
+      "expectStableSubscribe needs the call-through react mock in the calling test file — " +
+        "see src/test-utils/store-hook-subscription.ts.",
+    );
+  }
+  const passed = vi.mocked(useSyncExternalStore);
+  passed.mockClear();
+
+  const { rerender, unmount } = renderHook(() => useStoreHook());
+  rerender();
+  rerender();
+
+  const subscribes = passed.mock.calls.map(([subscribe]) => subscribe);
+  // Guards the assertions below against a hook that stopped rendering at all,
+  // which would otherwise satisfy both of them vacuously.
+  expect(subscribes.length).toBeGreaterThan(1);
+  expect(new Set(subscribes).size).toBe(1);
+  expect(subscribes[0]).toBe(subscribeSeam);
+
+  unmount();
+}

--- a/src/utils/migrationStore.test.ts
+++ b/src/utils/migrationStore.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { expectStableSubscribe } from "../test-utils/store-hook-subscription";
+import {
+  clearMigration,
+  getMigrationState,
+  onMigrationChange,
+  setMigrationStatus,
+  useMigrationStatus,
+} from "./migrationStore";
+
+// Fakes nothing — the real useSyncExternalStore runs. The wrapper only records
+// what the hook passes it, which is the one way to see whether the subscribe
+// reference is stable; expectStableSubscribe's docstring explains why the
+// property is unreachable from the store's side. The vi.mock is hoisted, so it
+// has to live here rather than in the helper.
+vi.mock("react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react")>();
+  return { ...actual, useSyncExternalStore: vi.fn(actual.useSyncExternalStore) };
+});
+
+describe("migrationStore", () => {
+  beforeEach(() => {
+    clearMigration();
+  });
+
+  describe("snapshot identity", () => {
+    it("returns the same object reference while nothing changes", () => {
+      setMigrationStatus({ pending: true, old_path: "/old" });
+      expect(getMigrationState()).toBe(getMigrationState());
+    });
+
+    it("returns a different object reference after a real change", () => {
+      setMigrationStatus({ pending: true, old_path: "/old" });
+      const before = getMigrationState();
+      setMigrationStatus({ pending: true, old_path: "/new" });
+      expect(getMigrationState()).not.toBe(before);
+      // The old snapshot is untouched — the write did not go in place.
+      expect(before.old_path).toBe("/old");
+    });
+
+    it("clearMigration installs a fresh not-pending status", () => {
+      setMigrationStatus({ pending: true, roms_count: 9 });
+      const before = getMigrationState();
+      clearMigration();
+      expect(getMigrationState()).not.toBe(before);
+      expect(getMigrationState()).toEqual({ pending: false });
+    });
+  });
+
+  describe("onMigrationChange", () => {
+    it("notifies subscribers and stops after the unsubscribe", () => {
+      let calls = 0;
+      const unsub = onMigrationChange(() => {
+        calls += 1;
+      });
+      setMigrationStatus({ pending: true });
+      expect(calls).toBe(1);
+      unsub();
+      setMigrationStatus({ pending: false });
+      expect(calls).toBe(1);
+    });
+  });
+
+  describe("useMigrationStatus", () => {
+    it("renders the current status and re-renders on a real change", () => {
+      setMigrationStatus({ pending: true, old_path: "/x" });
+      const { result, unmount } = renderHook(() => useMigrationStatus());
+      expect(result.current).toEqual({ pending: true, old_path: "/x" });
+
+      act(() => {
+        setMigrationStatus({ pending: true, roms_count: 9 });
+      });
+      expect(result.current).toEqual({ pending: true, roms_count: 9 });
+
+      act(() => {
+        clearMigration();
+      });
+      expect(result.current).toEqual({ pending: false });
+      unmount();
+    });
+
+    it("does not re-render when a notification carries the same status object", () => {
+      const status = { pending: true, roms_count: 3 };
+      setMigrationStatus(status);
+      let renders = 0;
+      const { unmount } = renderHook(() => {
+        renders += 1;
+        return useMigrationStatus();
+      });
+      const settled = renders;
+
+      // Re-installing the very object already stored notifies, but the snapshot
+      // is unchanged by identity — React bails out rather than re-rendering.
+      act(() => {
+        setMigrationStatus(status);
+      });
+      expect(renders).toBe(settled);
+
+      // A real change still gets through — the snapshot is not simply frozen.
+      act(() => {
+        setMigrationStatus({ pending: true, roms_count: 4 });
+      });
+      expect(renders).toBeGreaterThan(settled);
+      unmount();
+    });
+
+    it("stops re-rendering after unmount", () => {
+      let renders = 0;
+      const { unmount } = renderHook(() => {
+        renders += 1;
+        return useMigrationStatus();
+      });
+      unmount();
+      const afterUnmount = renders;
+      act(() => {
+        setMigrationStatus({ pending: true });
+      });
+      expect(renders).toBe(afterUnmount);
+    });
+
+    it("subscribes with the store's own seam, so a re-render does not re-subscribe", () => {
+      expectStableSubscribe(useMigrationStatus, onMigrationChange);
+    });
+  });
+});

--- a/src/utils/migrationStore.ts
+++ b/src/utils/migrationStore.ts
@@ -5,12 +5,23 @@
  *   - plugin load init in index.tsx (getMigrationStatus callable)
  *   - refreshMigrationState return value in MainPage, RomMGameInfoPanel,
  *     launchInterceptor, sessionManager
- *   - clearMigration() from SettingsPage after successful migration
+ *   - clearMigration() from MigrationBlockedPage, on a successful migration and
+ *     on a successful dismiss
  *
  * Read by:
- *   - MainPage.tsx and ConnectionSettings.tsx
+ *   - MainPage.tsx, RomMGameInfoPanel.tsx and RomMPlaySection.tsx, all through
+ *     {@link useMigrationStatus}
+ *   - CustomPlayButton.tsx and launchInterceptor.ts, which read the current
+ *     status through {@link getMigrationState} outside of any render
+ *
+ * Every write installs a NEW status object and notifies. That is what lets
+ * {@link getMigrationState} serve as a `useSyncExternalStore` snapshot — React
+ * compares snapshots by identity, so a getter handing back a fresh object per
+ * call would re-render forever, and an in-place write would leave a subscriber
+ * unable to tell that the status moved.
  */
 
+import { useSyncExternalStore } from "react";
 import type { MigrationStatus } from "../types";
 
 let _migration: MigrationStatus = { pending: false };
@@ -35,4 +46,10 @@ export function onMigrationChange(fn: () => void): () => void {
   return () => {
     _listeners = _listeners.filter((l) => l !== fn);
   };
+}
+
+/** Subscribe to the RetroDECK migration status from a component. Re-renders the
+ *  caller whenever the status changes and drops its subscription on unmount. */
+export function useMigrationStatus(): MigrationStatus {
+  return useSyncExternalStore(onMigrationChange, getMigrationState);
 }

--- a/src/utils/playtimeScopeStore.test.ts
+++ b/src/utils/playtimeScopeStore.test.ts
@@ -1,11 +1,24 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { expectStableSubscribe } from "../test-utils/store-hook-subscription";
 import { getPlaytimeScopeNotice } from "../api/backend";
 import {
   getPlaytimeScopeState,
   setPlaytimeScopeState,
   onPlaytimeScopeChange,
   fetchPlaytimeScopeState,
+  usePlaytimeScopeState,
 } from "./playtimeScopeStore";
+
+// Fakes nothing — the real useSyncExternalStore runs. The wrapper only records
+// what the hook passes it, which is the one way to see whether the subscribe
+// reference is stable; expectStableSubscribe's docstring explains why the
+// property is unreachable from the store's side. The vi.mock is hoisted, so it
+// has to live here rather than in the helper.
+vi.mock("react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react")>();
+  return { ...actual, useSyncExternalStore: vi.fn(actual.useSyncExternalStore) };
+});
 
 describe("playtimeScopeStore", () => {
   beforeEach(() => {
@@ -46,5 +59,78 @@ describe("playtimeScopeStore", () => {
     const result = await fetchPlaytimeScopeState();
     expect(result).toEqual({ pending: false });
     expect(getPlaytimeScopeState()).toEqual({ pending: false });
+  });
+
+  describe("snapshot identity", () => {
+    it("returns the same object reference while nothing changes", () => {
+      setPlaytimeScopeState({ pending: true });
+      expect(getPlaytimeScopeState()).toBe(getPlaytimeScopeState());
+    });
+
+    it("returns a different object reference after a real change", () => {
+      setPlaytimeScopeState({ pending: true });
+      const before = getPlaytimeScopeState();
+      setPlaytimeScopeState({ pending: false });
+      expect(getPlaytimeScopeState()).not.toBe(before);
+      // The old snapshot is untouched — the write did not go in place.
+      expect(before.pending).toBe(true);
+    });
+  });
+
+  describe("usePlaytimeScopeState", () => {
+    it("renders the current notice and re-renders on a real change", () => {
+      setPlaytimeScopeState({ pending: true });
+      const { result, unmount } = renderHook(() => usePlaytimeScopeState());
+      expect(result.current).toEqual({ pending: true });
+
+      act(() => {
+        setPlaytimeScopeState({ pending: false });
+      });
+      expect(result.current).toEqual({ pending: false });
+      unmount();
+    });
+
+    it("does not re-render when a notification carries the same state object", () => {
+      const state = { pending: true };
+      setPlaytimeScopeState(state);
+      let renders = 0;
+      const { unmount } = renderHook(() => {
+        renders += 1;
+        return usePlaytimeScopeState();
+      });
+      const settled = renders;
+
+      // Re-installing the very object already stored notifies, but the snapshot
+      // is unchanged by identity — React bails out rather than re-rendering.
+      act(() => {
+        setPlaytimeScopeState(state);
+      });
+      expect(renders).toBe(settled);
+
+      // A real change still gets through — the snapshot is not simply frozen.
+      act(() => {
+        setPlaytimeScopeState({ pending: false });
+      });
+      expect(renders).toBeGreaterThan(settled);
+      unmount();
+    });
+
+    it("stops re-rendering after unmount", () => {
+      let renders = 0;
+      const { unmount } = renderHook(() => {
+        renders += 1;
+        return usePlaytimeScopeState();
+      });
+      unmount();
+      const afterUnmount = renders;
+      act(() => {
+        setPlaytimeScopeState({ pending: true });
+      });
+      expect(renders).toBe(afterUnmount);
+    });
+
+    it("subscribes with the store's own seam, so a re-render does not re-subscribe", () => {
+      expectStableSubscribe(usePlaytimeScopeState, onPlaytimeScopeChange);
+    });
   });
 });

--- a/src/utils/playtimeScopeStore.ts
+++ b/src/utils/playtimeScopeStore.ts
@@ -13,9 +13,17 @@
  *   - PlaytimeScopeBanner Dismiss button (setPlaytimeScopeState — local dismiss)
  *
  * Read by:
- *   - PlaytimeScopeBanner (QAM)
+ *   - MainPage.tsx through {@link usePlaytimeScopeState}, which decides whether
+ *     to render the PlaytimeScopeBanner (QAM)
+ *
+ * Every write installs a NEW state object and notifies. That is what lets
+ * {@link getPlaytimeScopeState} serve as a `useSyncExternalStore` snapshot —
+ * React compares snapshots by identity, so a getter handing back a fresh object
+ * per call would re-render forever, and an in-place write would leave a
+ * subscriber unable to tell that the notice moved.
  */
 
+import { useSyncExternalStore } from "react";
 import { getPlaytimeScopeNotice } from "../api/backend";
 
 export interface PlaytimeScopeState {
@@ -39,6 +47,12 @@ export function onPlaytimeScopeChange(fn: () => void): () => void {
   return () => {
     _listeners = _listeners.filter((l) => l !== fn);
   };
+}
+
+/** Subscribe to the playtime-scope notice from a component. Re-renders the
+ *  caller whenever it changes and drops its subscription on unmount. */
+export function usePlaytimeScopeState(): PlaytimeScopeState {
+  return useSyncExternalStore(onPlaytimeScopeChange, getPlaytimeScopeState);
 }
 
 /**

--- a/src/utils/saveSortMigrationStore.test.ts
+++ b/src/utils/saveSortMigrationStore.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { expectStableSubscribe } from "../test-utils/store-hook-subscription";
+import {
+  clearSaveSortMigration,
+  getSaveSortMigrationState,
+  onSaveSortMigrationChange,
+  setSaveSortMigrationStatus,
+  useSaveSortMigrationState,
+} from "./saveSortMigrationStore";
+
+// Fakes nothing — the real useSyncExternalStore runs. The wrapper only records
+// what the hook passes it, which is the one way to see whether the subscribe
+// reference is stable; expectStableSubscribe's docstring explains why the
+// property is unreachable from the store's side. The vi.mock is hoisted, so it
+// has to live here rather than in the helper.
+vi.mock("react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react")>();
+  return { ...actual, useSyncExternalStore: vi.fn(actual.useSyncExternalStore) };
+});
+
+describe("saveSortMigrationStore", () => {
+  beforeEach(() => {
+    clearSaveSortMigration();
+  });
+
+  describe("snapshot identity", () => {
+    it("returns the same object reference while nothing changes", () => {
+      setSaveSortMigrationStatus({ pending: true, saves_count: 2 });
+      expect(getSaveSortMigrationState()).toBe(getSaveSortMigrationState());
+    });
+
+    it("returns a different object reference after a real change", () => {
+      setSaveSortMigrationStatus({ pending: true, saves_count: 2 });
+      const before = getSaveSortMigrationState();
+      setSaveSortMigrationStatus({ pending: true, saves_count: 5 });
+      expect(getSaveSortMigrationState()).not.toBe(before);
+      // The old snapshot is untouched — the write did not go in place.
+      expect(before.saves_count).toBe(2);
+    });
+
+    it("clearSaveSortMigration installs a fresh not-pending status", () => {
+      setSaveSortMigrationStatus({ pending: true, saves_count: 2 });
+      const before = getSaveSortMigrationState();
+      clearSaveSortMigration();
+      expect(getSaveSortMigrationState()).not.toBe(before);
+      expect(getSaveSortMigrationState()).toEqual({ pending: false });
+    });
+  });
+
+  describe("onSaveSortMigrationChange", () => {
+    it("notifies subscribers and stops after the unsubscribe", () => {
+      let calls = 0;
+      const unsub = onSaveSortMigrationChange(() => {
+        calls += 1;
+      });
+      setSaveSortMigrationStatus({ pending: true });
+      expect(calls).toBe(1);
+      unsub();
+      setSaveSortMigrationStatus({ pending: false });
+      expect(calls).toBe(1);
+    });
+  });
+
+  describe("useSaveSortMigrationState", () => {
+    it("renders the current status and re-renders on a real change", () => {
+      setSaveSortMigrationStatus({ pending: true, saves_count: 2 });
+      const { result, unmount } = renderHook(() => useSaveSortMigrationState());
+      expect(result.current).toEqual({ pending: true, saves_count: 2 });
+
+      act(() => {
+        setSaveSortMigrationStatus({ pending: true, saves_count: 7 });
+      });
+      expect(result.current).toEqual({ pending: true, saves_count: 7 });
+
+      act(() => {
+        clearSaveSortMigration();
+      });
+      expect(result.current).toEqual({ pending: false });
+      unmount();
+    });
+
+    it("does not re-render when a notification carries the same status object", () => {
+      const status = { pending: true, saves_count: 2 };
+      setSaveSortMigrationStatus(status);
+      let renders = 0;
+      const { unmount } = renderHook(() => {
+        renders += 1;
+        return useSaveSortMigrationState();
+      });
+      const settled = renders;
+
+      // Re-installing the very object already stored notifies, but the snapshot
+      // is unchanged by identity — React bails out rather than re-rendering.
+      act(() => {
+        setSaveSortMigrationStatus(status);
+      });
+      expect(renders).toBe(settled);
+
+      // A real change still gets through — the snapshot is not simply frozen.
+      act(() => {
+        setSaveSortMigrationStatus({ pending: true, saves_count: 3 });
+      });
+      expect(renders).toBeGreaterThan(settled);
+      unmount();
+    });
+
+    it("stops re-rendering after unmount", () => {
+      let renders = 0;
+      const { unmount } = renderHook(() => {
+        renders += 1;
+        return useSaveSortMigrationState();
+      });
+      unmount();
+      const afterUnmount = renders;
+      act(() => {
+        setSaveSortMigrationStatus({ pending: true });
+      });
+      expect(renders).toBe(afterUnmount);
+    });
+
+    it("subscribes with the store's own seam, so a re-render does not re-subscribe", () => {
+      expectStableSubscribe(useSaveSortMigrationState, onSaveSortMigrationChange);
+    });
+  });
+});

--- a/src/utils/saveSortMigrationStore.ts
+++ b/src/utils/saveSortMigrationStore.ts
@@ -8,9 +8,17 @@
  *   - clearSaveSortMigration() from SettingsPage after successful migration
  *
  * Read by:
- *   - MainPage.tsx, SettingsPage.tsx, RomMGameInfoPanel.tsx
+ *   - MainPage.tsx, SettingsPage.tsx and RomMGameInfoPanel.tsx, all through
+ *     {@link useSaveSortMigrationState}
+ *
+ * Every write installs a NEW status object and notifies. That is what lets
+ * {@link getSaveSortMigrationState} serve as a `useSyncExternalStore` snapshot —
+ * React compares snapshots by identity, so a getter handing back a fresh object
+ * per call would re-render forever, and an in-place write would leave a
+ * subscriber unable to tell that the status moved.
  */
 
+import { useSyncExternalStore } from "react";
 import type { SaveSortMigrationStatus } from "../types";
 
 let _status: SaveSortMigrationStatus = { pending: false };
@@ -35,4 +43,10 @@ export function onSaveSortMigrationChange(fn: () => void): () => void {
   return () => {
     _listeners = _listeners.filter((l) => l !== fn);
   };
+}
+
+/** Subscribe to the save-sort migration status from a component. Re-renders the
+ *  caller whenever the status changes and drops its subscription on unmount. */
+export function useSaveSortMigrationState(): SaveSortMigrationStatus {
+  return useSyncExternalStore(onSaveSortMigrationChange, getSaveSortMigrationState);
 }

--- a/src/utils/settingsResetStore.test.ts
+++ b/src/utils/settingsResetStore.test.ts
@@ -1,11 +1,24 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { expectStableSubscribe } from "../test-utils/store-hook-subscription";
 import { getSettingsResetNotice } from "../api/backend";
 import {
   getSettingsResetState,
   setSettingsResetState,
   onSettingsResetChange,
   fetchSettingsResetState,
+  useSettingsResetState,
 } from "./settingsResetStore";
+
+// Fakes nothing — the real useSyncExternalStore runs. The wrapper only records
+// what the hook passes it, which is the one way to see whether the subscribe
+// reference is stable; expectStableSubscribe's docstring explains why the
+// property is unreachable from the store's side. The vi.mock is hoisted, so it
+// has to live here rather than in the helper.
+vi.mock("react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react")>();
+  return { ...actual, useSyncExternalStore: vi.fn(actual.useSyncExternalStore) };
+});
 
 describe("settingsResetStore", () => {
   beforeEach(() => {
@@ -49,5 +62,78 @@ describe("settingsResetStore", () => {
     const result = await fetchSettingsResetState();
     expect(result).toEqual({ pending: false, backedUpTo: null });
     expect(getSettingsResetState()).toEqual({ pending: false, backedUpTo: null });
+  });
+
+  describe("snapshot identity", () => {
+    it("returns the same object reference while nothing changes", () => {
+      setSettingsResetState({ pending: true, backedUpTo: "settings.json.corrupt-1" });
+      expect(getSettingsResetState()).toBe(getSettingsResetState());
+    });
+
+    it("returns a different object reference after a real change", () => {
+      setSettingsResetState({ pending: true, backedUpTo: "settings.json.corrupt-1" });
+      const before = getSettingsResetState();
+      setSettingsResetState({ pending: true, backedUpTo: "settings.json.corrupt-2" });
+      expect(getSettingsResetState()).not.toBe(before);
+      // The old snapshot is untouched — the write did not go in place.
+      expect(before.backedUpTo).toBe("settings.json.corrupt-1");
+    });
+  });
+
+  describe("useSettingsResetState", () => {
+    it("renders the current notice and re-renders on a real change", () => {
+      setSettingsResetState({ pending: true, backedUpTo: "settings.json.corrupt-1" });
+      const { result, unmount } = renderHook(() => useSettingsResetState());
+      expect(result.current).toEqual({ pending: true, backedUpTo: "settings.json.corrupt-1" });
+
+      act(() => {
+        setSettingsResetState({ pending: false, backedUpTo: null });
+      });
+      expect(result.current).toEqual({ pending: false, backedUpTo: null });
+      unmount();
+    });
+
+    it("does not re-render when a notification carries the same state object", () => {
+      const state = { pending: true, backedUpTo: "settings.json.corrupt-1" };
+      setSettingsResetState(state);
+      let renders = 0;
+      const { unmount } = renderHook(() => {
+        renders += 1;
+        return useSettingsResetState();
+      });
+      const settled = renders;
+
+      // Re-installing the very object already stored notifies, but the snapshot
+      // is unchanged by identity — React bails out rather than re-rendering.
+      act(() => {
+        setSettingsResetState(state);
+      });
+      expect(renders).toBe(settled);
+
+      // A real change still gets through — the snapshot is not simply frozen.
+      act(() => {
+        setSettingsResetState({ pending: false, backedUpTo: null });
+      });
+      expect(renders).toBeGreaterThan(settled);
+      unmount();
+    });
+
+    it("stops re-rendering after unmount", () => {
+      let renders = 0;
+      const { unmount } = renderHook(() => {
+        renders += 1;
+        return useSettingsResetState();
+      });
+      unmount();
+      const afterUnmount = renders;
+      act(() => {
+        setSettingsResetState({ pending: true, backedUpTo: "settings.json.corrupt-3" });
+      });
+      expect(renders).toBe(afterUnmount);
+    });
+
+    it("subscribes with the store's own seam, so a re-render does not re-subscribe", () => {
+      expectStableSubscribe(useSettingsResetState, onSettingsResetChange);
+    });
   });
 });

--- a/src/utils/settingsResetStore.ts
+++ b/src/utils/settingsResetStore.ts
@@ -11,9 +11,18 @@
  *   - SettingsResetBanner Dismiss button (setSettingsResetState on ack success)
  *
  * Read by:
- *   - SettingsResetBanner (QAM) and SettingsResetCard (game detail)
+ *   - MainPage.tsx and RomMGameInfoPanel.tsx, both through
+ *     {@link useSettingsResetState}, which decide whether to render the
+ *     SettingsResetBanner (QAM) / SettingsResetCard (game detail)
+ *
+ * Every write installs a NEW state object and notifies. That is what lets
+ * {@link getSettingsResetState} serve as a `useSyncExternalStore` snapshot —
+ * React compares snapshots by identity, so a getter handing back a fresh object
+ * per call would re-render forever, and an in-place write would leave a
+ * subscriber unable to tell that the notice moved.
  */
 
+import { useSyncExternalStore } from "react";
 import { getSettingsResetNotice } from "../api/backend";
 
 export interface SettingsResetState {
@@ -38,6 +47,12 @@ export function onSettingsResetChange(fn: () => void): () => void {
   return () => {
     _listeners = _listeners.filter((l) => l !== fn);
   };
+}
+
+/** Subscribe to the corrupt-settings-reset notice from a component. Re-renders
+ *  the caller whenever it changes and drops its subscription on unmount. */
+export function useSettingsResetState(): SettingsResetState {
+  return useSyncExternalStore(onSettingsResetChange, getSettingsResetState);
 }
 
 /**


### PR DESCRIPTION
Four module stores — the RetroDECK migration flag, the corrupt-settings notice,
the playtime-scope notice and the save-sort migration flag — each expose a getter
and a change notification, and nine consumers across four components hand-rolled
the same mirror: seed local state from the getter, subscribe in an effect, copy
the value across, remember to unsubscribe. The right answer existed exactly once,
as a hook inside `MigrationBlockedPage.tsx`, where nothing else would look for it.

Each store now carries its own hook, next to the store, the way `useDownloads`
and `useSyncStats` already do. Nine mirrors, nine subscriptions and nine cleanup
paths become four one-line hooks. Nothing about *when* anything is fetched
changes: the migration re-read on two mounts, the playtime-scope read on one, and
the plugin-load reads all stay exactly where they were. Whether those three
different refresh policies should become one is a real question rather than a
cleanup — two of these flags can change on disk with no event the frontend would
see — and it is not answered here.

One behaviour improves as a side effect. The old shape seeded at first render and
subscribed on commit, so a write landing in that gap was lost until the next one;
React's own store primitive re-reads after subscribing, which closes it.

Rewriting the reader lists in the four docstrings turned up three claims that were
already false — two stores naming components that never read them, one naming a
file that no longer exists — because the lists had been copied rather than
re-derived. They are correct now.

Two things about the tests are worth stating rather than leaving to be
discovered. A test that proved the hook unsubscribes on unmount could not survive
the move: it worked by spying on the store's notifier from outside, which stops
intercepting once the hook calls it from inside the same module. Its replacement
cannot detect a leaked listener — React discards a notification to an unmounted
component silently — so the invariant is now pinned one layer down, on each
store's own unsubscribe, where it belongs. All four have it.

And the subscribe reference a hook hands React had nothing holding it stable. An
unstable one costs a re-subscribe on every render and has no behavioural
signature at all: React tears the old subscription down before making the new
one, so a live listener count reads the same either way. Each store test now
wraps the primitive, calling through, to see which subscribe it was handed —
mutating all four hooks to build a fresh one per render fails exactly those four
tests and nothing else.

docs: N/A — no page and no path-scoped rule mentions these stores or their seams,
and there is no user-visible change.

Step of #1751.
