### PR TITLE
refactor(sync): move the shortcut-bake inputs out of the orchestrator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,9 @@ jobs:
       - name: Check sync-lifecycle owner confinement
         run: python scripts/check_sync_lifecycle_owner.py
 
+      - name: Check library-sync seam-owner confinement
+        run: python scripts/check_seam_owner.py
+
       - name: Check dependency locks satisfy their source constraints
         run: python scripts/check_lock_sync.py
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,6 +185,18 @@ Format: **invariant** — tier — enforced by.
   `scripts/check_settings_owner.py`
 - **Sync run-lifecycle (`sync_state` / `current_sync_id`) written only via `LibrarySyncStateBox` verbs** — check —
   `scripts/check_sync_lifecycle_owner.py`
+- **A library-sync seam is held only by the module owning the job it belongs to: `active_core` / `disc_resolver` by
+  `services/library/bake_inputs.py`, `renderer_rss` / `renderer_gc` by `services/library/session_budget.py`; the
+  `service.py` façade co-owns every seam because it receives them from `bootstrap` and hands each to its owner** — check
+  — `scripts/check_seam_owner.py` (AST over attributes named after a seam and over annotations naming its Protocol,
+  resolved per seam rather than per module — owning one grants nothing about another. It sees the injection, not every
+  later use: a seam aliased to a differently-named attribute or local, one reached through `getattr`, one passed
+  positionally into a helper that holds it, and a quoted string annotation all slip past it). What the confinement buys
+  is that each module's transactions stay separable: `bake_inputs` holds a read UoW across its install-path scan while
+  the `active_core` seam opens its own `BEGIN IMMEDIATE` per ROM, so folding the two into one pass deadlocks — on a real
+  device only, since `FakeUnitOfWork` shares no connection (`check_uow_seam_nesting.py` is the gate that would fire). On
+  the budget side it holds `session_budget`'s stated promise that no renderer-RSS reading is taken anywhere else in the
+  package
 - **An emitted `sync_progress` frame stops a run (`running: False`) only with a terminal stage, and a terminal stage is
   only ever emitted with the run stopped** — test — `tests/services/library/test_terminal_frame_contract.py`
   (structural, AST call sites and dict literals across all of `py_modules/services` — it covers the error paths a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,17 +186,23 @@ Format: **invariant** — tier — enforced by.
 - **Sync run-lifecycle (`sync_state` / `current_sync_id`) written only via `LibrarySyncStateBox` verbs** — check —
   `scripts/check_sync_lifecycle_owner.py`
 - **A library-sync seam is held only by the module owning the job it belongs to: `active_core` / `disc_resolver` by
-  `services/library/bake_inputs.py`, `renderer_rss` / `renderer_gc` by `services/library/session_budget.py`; the
-  `service.py` façade co-owns every seam because it receives them from `bootstrap` and hands each to its owner** — check
-  — `scripts/check_seam_owner.py` (AST over attributes named after a seam and over annotations naming its Protocol,
-  resolved per seam rather than per module — owning one grants nothing about another. It sees the injection, not every
-  later use: a seam aliased to a differently-named attribute or local, one reached through `getattr`, one passed
-  positionally into a helper that holds it, and a quoted string annotation all slip past it). What the confinement buys
-  is that each module's transactions stay separable: `bake_inputs` holds a read UoW across its install-path scan while
-  the `active_core` seam opens its own `BEGIN IMMEDIATE` per ROM, so folding the two into one pass deadlocks — on a real
-  device only, since `FakeUnitOfWork` shares no connection (`check_uow_seam_nesting.py` is the gate that would fire). On
-  the budget side it holds `session_budget`'s stated promise that no renderer-RSS reading is taken anywhere else in the
-  package
+  `services/library/bake_inputs.py`, `renderer_rss` / `renderer_gc` by `services/library/session_budget.py`. The
+  `service.py` façade is not a co-owner — it may **pass** a seam on and may not **use** one, which the check reads
+  structurally: a seam attribute standing as a call's keyword-argument value, and a seam annotation on a field of
+  `LibraryServiceConfig`, are wiring; anything else in the façade is a finding** — check — `scripts/check_seam_owner.py`
+  (AST over attributes named after a seam and over annotations naming its Protocol, resolved per seam rather than per
+  module — owning one grants nothing about another. It sees the injection, not every later use: a seam aliased to a
+  differently-named attribute or local, one reached through `getattr`, one passed positionally into a helper that holds
+  it, a quoted string annotation, and a Protocol imported under an alias all slip past it — the last two only on the
+  annotation half, because the constructor read that unpacks the config is flagged whatever the field is called). What
+  the confinement buys is that each module's transactions stay separable: `bake_inputs` holds a read UoW across its
+  install-path scan while the `active_core` seam opens its own `BEGIN IMMEDIATE` per ROM, so folding the two into one
+  pass deadlocks — on a real device only, since `FakeUnitOfWork` shares no connection. **Nothing mechanical stands
+  behind that half.** `check_uow_seam_nesting.py` catches the fold only in its inline form (the seam method named inside
+  the `with` block); the peer-call form — `do_build_core_overrides` invoked from inside the install-path readers' own
+  UoW, which is what putting the three methods on one class makes cheapest — is that gate's documented blind spot and
+  passes green. On the budget side the confinement holds `session_budget`'s stated promise that no renderer-RSS reading
+  is taken anywhere else in the package
 - **An emitted `sync_progress` frame stops a run (`running: False`) only with a terminal stage, and a terminal stage is
   only ever emitted with the run stopped** — test — `tests/services/library/test_terminal_frame_contract.py`
   (structural, AST call sites and dict literals across all of `py_modules/services` — it covers the error paths a

--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -276,7 +276,7 @@ continue unrelated groups.
 
 #### LibraryService decomposition (`services/library/`)
 
-The library sync subsystem is a façade over four sub-services that coordinate through a shared `LibrarySyncStateBox`:
+The library sync subsystem is a façade over five sub-services that coordinate through a shared `LibrarySyncStateBox`:
 
 | Module                 | Role                                                                                                                                                                                                                                 |
 | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
@@ -285,6 +285,7 @@ The library sync subsystem is a façade over four sub-services that coordinate t
 | `sync_orchestrator.py` | `SyncOrchestrator` — preview (read-only), the per-unit apply pipeline, cancel, the heartbeat clock, progress emission                                                                                                                |
 | `reporter.py`          | `SyncReporter` — post-apply finalisation (artwork filenames, per-unit `roms` upsert + `SyncRun` lifecycle) and the `roms`-derived queries                                                                                            |
 | `session_budget.py`    | `SessionBudgetMonitor` — Steam's per-session renderer-heap budget: the GC-settled RSS measurement, the chunk-boundary pause verdict, the post-preview prognosis, the run-start baseline, and the `get_session_budget_status` payload |
+| `bake_inputs.py`       | `ShortcutBakeInputs` — each ROM's launch facts for the shortcut bake: the disc-resolved installed path and the active emulator, both handed to `build_shortcuts_data`                                                                |
 | `_state.py`            | `LibrarySyncStateBox` — shared mutable in-flight sync state; single source of truth threaded through every sub-service, and the **sole owner** of the run-lifecycle pair (`sync_state` / `current_sync_id`) via its verb methods     |
 
 The pipeline is split **fetch (read-only) / apply (owns persistence)**: the fetcher never mutates the `roms` registry or

--- a/docs/architecture/core-emulator-selection.md
+++ b/docs/architecture/core-emulator-selection.md
@@ -262,11 +262,11 @@ Sync** to re-bake — see [A frozen default needs a Force Full Sync](#a-frozen-d
 emulator** through the same `ActiveCoreResolver.active_emulator_for_rom` seam and pass the `EmulatorInvocation` into
 `resolve_emulator_invocation`, so the read-path core and the launched emulator cannot diverge:
 
-| Bake site                                    | When it runs                             | How it resolves the emulator                                                             |
-| -------------------------------------------- | ---------------------------------------- | ---------------------------------------------------------------------------------------- |
-| `SyncOrchestrator` → `_build_core_overrides` | every sync (preview + apply)             | each ROM through `active_emulator_for_rom` → `{rom_id: EmulatorInvocation}` for the bake |
-| `DownloadService` → `_resolve_bound_app_id`  | on download-complete (install/reinstall) | the ROM through `active_emulator_for_rom` in the same flow                               |
-| `MigrationService` → `_build_relaunch_items` | on RetroDECK-home migration              | each relocated ROM through `active_emulator_for_rom`                                     |
+| Bake site                                        | When it runs                             | How it resolves the emulator                                                             |
+| ------------------------------------------------ | ---------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `ShortcutBakeInputs` → `do_build_core_overrides` | every sync (preview + apply)             | each ROM through `active_emulator_for_rom` → `{rom_id: EmulatorInvocation}` for the bake |
+| `DownloadService` → `_resolve_bound_app_id`      | on download-complete (install/reinstall) | the ROM through `active_emulator_for_rom` in the same flow                               |
+| `MigrationService` → `_build_relaunch_items`     | on RetroDECK-home migration              | each relocated ROM through `active_emulator_for_rom`                                     |
 
 The download-complete bake is the one that re-applies a pin after reinstall — the exact path `roms` storage was chosen
 to protect. Each site bakes `-e` for every ROM that resolves to a concrete emulator (libretro or standalone), and the
@@ -392,11 +392,11 @@ resolver yields the **path**, `ActiveCoreResolver` yields the **`EmulatorInvocat
 `resolve_emulator_invocation(rom, emulator)` + `build_launch_options(invocation, disc_path)` fold them into one command
 — a per-game core (or standalone emulator) and a pinned disc on the same shortcut coexist.
 
-| Bake site                                                              | How it resolves the disc path                                                             |
-| ---------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
-| `SyncOrchestrator` (`_scan_installed_paths` / `_read_installed_paths`) | each installed ROM through `resolve_for_install` → `{rom_id: bake_path}` for the bake     |
-| `DownloadService._resolve_bound_app_id`                                | the freshly-installed ROM through `resolve_for_install` → re-applies the pin on reinstall |
-| `MigrationService._build_relaunch_items`                               | each relocated ROM through `resolve_for_install` against the moved install directory      |
+| Bake site                                                                    | How it resolves the disc path                                                             |
+| ---------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| `ShortcutBakeInputs` (`do_scan_installed_paths` / `do_read_installed_paths`) | each installed ROM through `resolve_for_install` → `{rom_id: bake_path}` for the bake     |
+| `DownloadService._resolve_bound_app_id`                                      | the freshly-installed ROM through `resolve_for_install` → re-applies the pin on reinstall |
+| `MigrationService._build_relaunch_items`                                     | each relocated ROM through `resolve_for_install` against the moved install directory      |
 
 ### The picker callables
 

--- a/mise.toml
+++ b/mise.toml
@@ -62,6 +62,7 @@ run = [
     "python scripts/check_event_parity.py",
     "python scripts/check_settings_owner.py",
     "python scripts/check_sync_lifecycle_owner.py",
+    "python scripts/check_seam_owner.py",
     "python scripts/check_lock_sync.py",
     "python scripts/check_markdown_links.py",
     "python scripts/check_romm_min_version.py",

--- a/py_modules/services/library/__init__.py
+++ b/py_modules/services/library/__init__.py
@@ -3,7 +3,7 @@
 The package's public API is the :class:`LibraryService` façade — it
 composes the library sync sub-services (:class:`LibraryFetcher`,
 :class:`SyncOrchestrator`, :class:`SyncReporter`,
-:class:`SessionBudgetMonitor`) over a shared
+:class:`SessionBudgetMonitor`, :class:`ShortcutBakeInputs`) over a shared
 :class:`LibrarySyncStateBox` and exposes the callable surface consumed
 by the Decky entrypoints (platform/collection metadata, sync preview/
 apply, post-apply reporting, registry queries). RomM

--- a/py_modules/services/library/bake_inputs.py
+++ b/py_modules/services/library/bake_inputs.py
@@ -1,0 +1,119 @@
+"""Each ROM's launch facts — where its file is, and what runs it.
+
+Answers the two questions :func:`domain.shortcut_data.build_shortcuts_data`
+asks about every ROM it bakes into a Steam shortcut: the disc-resolved path of
+the installed file (``{rom_id: bake_path}``) and the emulator that should run it
+(``{rom_id: EmulatorInvocation}``). Both preview and the per-unit apply resolve
+their maps here and hand them straight to the bake. Anything that is not a
+launch fact of a single ROM belongs elsewhere: the shortcut's *shape* is the
+domain builder's, and what the run does with the built shortcuts is
+:class:`~services.library.sync_orchestrator.SyncOrchestrator`'s.
+
+The install-path readers own their own read Unit of Work; the core resolution
+opens none, because the injected ``active_core`` seam opens one per ROM.
+**Those two must never share a transaction.** A Unit of Work takes SQLite's
+non-reentrant ``BEGIN IMMEDIATE``, so resolving a core inside an open UoW
+blocks until ``busy_timeout`` and then raises ``database is locked`` — on a
+real device only, since ``FakeUnitOfWork`` shares no connection and stays
+green. Folding the path read and the core read into one pass looks like an
+obvious win from inside this module and is exactly that deadlock;
+``scripts/check_uow_seam_nesting.py`` is what would catch it, so do not write
+the fold that makes it fire.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from domain.shortcut_data import EmulatorInvocation
+    from services.protocols import ActiveCoreReader, DiscResolver, UnitOfWorkFactory
+
+
+@dataclass(frozen=True)
+class ShortcutBakeInputsConfig:
+    """Frozen wiring bundle handed to ``ShortcutBakeInputs.__init__``.
+
+    Holds the SQLite Unit-of-Work factory the install lookups read through and
+    the two per-ROM resolvers the bake's inputs are drawn from: ``active_core``
+    folds the per-game ``emulator_override`` and the per-platform
+    ``settings.json`` core over the standalone-aware es_systems default, and
+    ``disc_resolver`` resolves a multi-disc ROM's persisted ``selected_disc``
+    pin against its install directory.
+    """
+
+    uow_factory: UnitOfWorkFactory
+    active_core: ActiveCoreReader
+    disc_resolver: DiscResolver
+
+
+class ShortcutBakeInputs:
+    """The per-ROM launch facts a shortcut bake is built from."""
+
+    def __init__(self, *, config: ShortcutBakeInputsConfig) -> None:
+        self._uow_factory = config.uow_factory
+        self._active_core = config.active_core
+        self._disc_resolver = config.disc_resolver
+
+    def do_build_core_overrides(self, roms: list[dict[str, Any]]) -> dict[int, EmulatorInvocation]:
+        """Resolve each ROM's FULL active emulator for the bake.
+
+        Runs every ROM in *roms* through the shared per-ROM ``active_core``
+        resolver (the single seam that folds the per-game ``emulator_override``
+        and per-platform ``settings.json`` core over the standalone-aware
+        es_systems default). Only ROMs that resolve to an emulator (libretro core
+        or standalone) appear in the returned ``{rom_id: EmulatorInvocation}``
+        map, so :func:`build_shortcuts_data` bakes their ``-e`` form; a ROM that
+        resolves to nothing (a genuinely unresolvable platform) is absent and
+        falls back to the plain launch. The resolver already warns + degrades on
+        a stale label, so no bogus invocation ever reaches the bake.
+        """
+        resolved: dict[int, EmulatorInvocation] = {}
+        for rom in roms:
+            emulator = self._active_core.active_emulator_for_rom(rom["id"])
+            if emulator is not None:
+                resolved[rom["id"]] = emulator
+        return resolved
+
+    def do_scan_installed_paths(self) -> dict[int, str]:
+        """Read ``{rom_id: bake_path}`` for the whole installed library in one scan.
+
+        Used by the preview path, which already operates over every ROM in the
+        library — a single ``iter_all()`` is the cheapest way to cover them all.
+        Each path is the disc-resolved launch path: a multi-disc ROM resolves its
+        persisted ``selected_disc`` pin against its install directory (a
+        single-disc ROM resolves to its own ``file_path``, unchanged), or ``""``
+        when the install has no launch target. Only ROMs with a current install
+        record appear in the map; a ROM not downloaded is absent, and both cases
+        reach :func:`build_shortcuts_data` as the same empty launch command.
+        """
+        with self._uow_factory() as uow:
+            paths: dict[int, str] = {}
+            for install in uow.rom_installs.iter_all():
+                rom = uow.roms.get(install.rom_id)
+                selected_disc = rom.selected_disc if rom is not None else None
+                paths[install.rom_id] = self._disc_resolver.resolve_for_install(install, selected_disc)
+            return paths
+
+    def do_read_installed_paths(self, rom_ids: set[int]) -> dict[int, str]:
+        """Read ``{rom_id: bake_path}`` for *rom_ids* via targeted point-lookups.
+
+        Used by the per-unit apply path: scanning the whole ``rom_installs``
+        table once per unit is O(units * all-installs) (#797), so this resolves
+        only the unit's ROMs via ``get(rom_id)``. Each path is the disc-resolved
+        launch path — a multi-disc ROM resolves its persisted ``selected_disc``
+        pin against its install directory (a single-disc ROM resolves to its own
+        ``file_path``, unchanged), or ``""`` when the install has no launch
+        target. A ROM with no install record is absent; both cases reach
+        :func:`build_shortcuts_data` as the same empty launch command.
+        """
+        with self._uow_factory() as uow:
+            paths: dict[int, str] = {}
+            for rom_id in rom_ids:
+                install = uow.rom_installs.get(rom_id)
+                if install is not None:
+                    rom = uow.roms.get(rom_id)
+                    selected_disc = rom.selected_disc if rom is not None else None
+                    paths[rom_id] = self._disc_resolver.resolve_for_install(install, selected_disc)
+            return paths

--- a/py_modules/services/library/bake_inputs.py
+++ b/py_modules/services/library/bake_inputs.py
@@ -14,11 +14,21 @@ opens none, because the injected ``active_core`` seam opens one per ROM.
 **Those two must never share a transaction.** A Unit of Work takes SQLite's
 non-reentrant ``BEGIN IMMEDIATE``, so resolving a core inside an open UoW
 blocks until ``busy_timeout`` and then raises ``database is locked`` — on a
-real device only, since ``FakeUnitOfWork`` shares no connection and stays
-green. Folding the path read and the core read into one pass looks like an
-obvious win from inside this module and is exactly that deadlock;
-``scripts/check_uow_seam_nesting.py`` is what would catch it, so do not write
-the fold that makes it fire.
+real device only, since ``FakeUnitOfWork`` shares no connection and every test
+stays green. Holding all three methods on one class is what makes folding the
+path read and the core read into one pass a one-liner, and only half of that
+one-liner is gated: ``scripts/check_uow_seam_nesting.py`` fires on the inline
+form (naming ``active_emulator_for_rom`` inside the ``with`` block) and is
+silent on the peer-call form (``self.do_build_core_overrides(...)`` inside it),
+a blind spot its own docstring records. So the reason not to write the fold is
+the deadlock, not a check that would stop you — nothing will.
+
+One rule this module does not keep, inherited with the code rather than
+introduced by it: both install-path readers hold their UoW open across the disc
+resolver's directory listing, once per installed ROM. CONTEXT.md's Unit of Work
+entry keeps a transaction narrow — database reads and writes, never file I/O —
+so this file is where that fix lands when it comes, and a reader should not
+take the boundary above as evidence the rest is clean.
 """
 
 from __future__ import annotations

--- a/py_modules/services/library/service.py
+++ b/py_modules/services/library/service.py
@@ -8,7 +8,8 @@ sub-service modules: :class:`LibraryFetcher` for ROM/metadata
 roundtrips, :class:`SyncOrchestrator` for the preview/apply
 lifecycle and safety heartbeat, :class:`SyncReporter` for post-apply
 finalisation and registry queries, :class:`SessionBudgetMonitor` for
-Steam's renderer-heap budget. The façade itself only wires the
+Steam's renderer-heap budget, :class:`ShortcutBakeInputs` for each
+ROM's launch facts. The façade itself only wires the
 pieces together and delegates — anything that touches RomM or mutates
 in-flight sync state belongs in a sub-service.
 """
@@ -20,6 +21,7 @@ from typing import TYPE_CHECKING, Any
 
 from lib.late_binding import LateBinding
 from services.library._state import CollectionMembership, LibrarySyncStateBox
+from services.library.bake_inputs import ShortcutBakeInputs, ShortcutBakeInputsConfig
 from services.library.fetcher import LibraryFetcher, LibraryFetcherConfig
 from services.library.reporter import SyncReporter, SyncReporterConfig
 from services.library.session_budget import SessionBudgetMonitor, SessionBudgetMonitorConfig
@@ -94,8 +96,10 @@ class LibraryService:
     Composes :class:`LibraryFetcher` (platform/collection roundtrips +
     metadata-cache stamping), :class:`SyncOrchestrator` (preview/apply
     lifecycle + safety heartbeat), :class:`SyncReporter`
-    (post-apply finalisation + registry queries), and
-    :class:`SessionBudgetMonitor` (Steam's renderer-heap budget) over a
+    (post-apply finalisation + registry queries),
+    :class:`SessionBudgetMonitor` (Steam's renderer-heap budget), and
+    :class:`ShortcutBakeInputs` (each ROM's installed path + active
+    emulator) over a
     single shared :class:`LibrarySyncStateBox`. The façade itself owns the box and
     exposes the callable surface; every implementation method lives on
     one of the sub-services.
@@ -123,6 +127,17 @@ class LibraryService:
                 uow_factory=config.uow_factory,
                 sync_state_box=self._box,
                 emit_progress=self._emit_progress_proxy,
+            )
+        )
+
+        # Sub-service: shortcut-bake inputs. Constructed before the
+        # orchestrator, which holds it and resolves every bake's per-ROM
+        # launch facts through it.
+        self._bake_inputs = ShortcutBakeInputs(
+            config=ShortcutBakeInputsConfig(
+                uow_factory=config.uow_factory,
+                active_core=config.active_core,
+                disc_resolver=config.disc_resolver,
             )
         )
 
@@ -159,8 +174,7 @@ class LibraryService:
                 fetcher=self._fetcher,
                 reporter=reporter_binding,
                 artwork=config.artwork,
-                active_core=config.active_core,
-                disc_resolver=config.disc_resolver,
+                bake_inputs=self._bake_inputs,
                 session_budget=self._session_budget,
             )
         )

--- a/py_modules/services/library/sync_orchestrator.py
+++ b/py_modules/services/library/sync_orchestrator.py
@@ -9,7 +9,9 @@ surface progress receive the orchestrator's ``emit_progress`` callback
 through their config. Anything that fetches ROMs belongs in
 :class:`LibraryFetcher`; anything that finalises shortcuts after the apply
 completes belongs in :class:`SyncReporter`; Steam's renderer memory belongs
-in :class:`SessionBudgetMonitor`. Cached ``rom_metadata`` is written by the
+in :class:`SessionBudgetMonitor`; a single ROM's launch facts — where its
+file is and what runs it — belong in :class:`ShortcutBakeInputs`. Cached
+``rom_metadata`` is written by the
 reporter's per-unit commit (the same write UoW as the ``roms`` upsert), so
 preview never persists metadata and an interrupted apply leaves only
 already-committed units' metadata.
@@ -33,7 +35,7 @@ from domain.session_budget import (
     post_run_advisory,
     session_memory_delta,
 )
-from domain.shortcut_data import EmulatorInvocation, build_shortcuts_data
+from domain.shortcut_data import build_shortcuts_data
 from domain.sibling_group import compute_component_group_keys
 from domain.sibling_resolution import AUTO_REGION
 from domain.sync_chunking import build_unit_chunks, wire_shortcuts
@@ -59,13 +61,12 @@ if TYPE_CHECKING:
     from domain.work_unit import WorkUnit
     from lib.late_binding import LateBinding
     from services.library._state import LibrarySyncStateBox
+    from services.library.bake_inputs import ShortcutBakeInputs
     from services.library.fetcher import LibraryFetcher
     from services.library.reporter import SyncReporter
     from services.protocols import (
-        ActiveCoreReader,
         ArtworkManager,
         Clock,
-        DiscResolver,
         EventEmitter,
         Sleeper,
         UnitOfWorkFactory,
@@ -127,11 +128,10 @@ class SyncOrchestratorConfig:
     field is a :class:`LateBinding` because :class:`LibraryService`
     constructs the orchestrator before the reporter exists; the façade
     plugs the reader in via ``set()`` once the reporter is built. The
-    shared ``active_core`` resolver bakes each ROM's full active core (the
-    per-game/per-platform deviation folded over the es_systems default)
-    into ``launch_options`` at sync time, and the shared ``disc_resolver`` bakes
-    each multi-disc ROM's selected disc (the persisted ``selected_disc`` pin) into
-    the installed-launch path at sync time. The ``session_budget`` seam owns every
+    ``bake_inputs`` peer answers the two per-ROM questions each shortcut bake
+    needs — the disc-resolved installed path and the active emulator — which
+    preview and the per-unit apply both hand straight to
+    :func:`build_shortcuts_data`. The ``session_budget`` seam owns every
     renderer-heap reading and verdict: at each chunk boundary the orchestrator asks
     it whether applying the chunk would exhaust Steam's per-session heap budget, and
     the run pauses itself when it would (#1383).
@@ -150,8 +150,7 @@ class SyncOrchestratorConfig:
     fetcher: LibraryFetcher
     reporter: LateBinding[SyncReporter]
     artwork: ArtworkManager
-    active_core: ActiveCoreReader
-    disc_resolver: DiscResolver
+    bake_inputs: ShortcutBakeInputs
     session_budget: SessionBudgetMonitor
 
 
@@ -190,8 +189,7 @@ class SyncOrchestrator:
         self._fetcher = config.fetcher
         self._artwork = config.artwork
         self._reporter = config.reporter
-        self._active_core = config.active_core
-        self._disc_resolver = config.disc_resolver
+        self._bake_inputs = config.bake_inputs
         self._session_budget = config.session_budget
 
     # ── Sync control ─────────────────────────────────────────────
@@ -284,8 +282,8 @@ class SyncOrchestrator:
                     progress_total_steps=total_units,
                 )
 
-            installed_paths = await self._loop.run_in_executor(None, self._scan_installed_paths)
-            core_overrides = await self._loop.run_in_executor(None, self._build_core_overrides, all_roms)
+            installed_paths = await self._loop.run_in_executor(None, self._bake_inputs.do_scan_installed_paths)
+            core_overrides = await self._loop.run_in_executor(None, self._bake_inputs.do_build_core_overrides, all_roms)
             # Stamp each fresh ROM's component sibling-group key before the build so
             # the collapse below groups games, not dumps. The preview union is a
             # complete view of every enabled platform's groups; the DB's persisted
@@ -1067,9 +1065,9 @@ class SyncOrchestrator:
         # full launch command; uninstalled ROMs get an empty placeholder until
         # they are downloaded.
         installed_paths = await self._loop.run_in_executor(
-            None, self._read_installed_paths, {rom["id"] for rom in unit_roms}
+            None, self._bake_inputs.do_read_installed_paths, {rom["id"] for rom in unit_roms}
         )
-        core_overrides = await self._loop.run_in_executor(None, self._build_core_overrides, unit_roms)
+        core_overrides = await self._loop.run_in_executor(None, self._bake_inputs.do_build_core_overrides, unit_roms)
 
         # Read the bound-row registry once, before the build: its persisted keys
         # seed the component keying (a fresh member edging into a DB-resident
@@ -1711,68 +1709,6 @@ class SyncOrchestrator:
             interrupt_reason=interrupt_reason,
             restart_recommended=restart_recommended,
         )
-
-    def _build_core_overrides(self, roms: list[dict[str, Any]]) -> dict[int, EmulatorInvocation]:
-        """Resolve each ROM's FULL active emulator for the bake.
-
-        Runs every ROM in *roms* through the shared per-ROM ``active_core``
-        resolver (the single seam that folds the per-game ``emulator_override``
-        and per-platform ``settings.json`` core over the standalone-aware
-        es_systems default). Only ROMs that resolve to an emulator (libretro core
-        or standalone) appear in the returned ``{rom_id: EmulatorInvocation}``
-        map, so :func:`build_shortcuts_data` bakes their ``-e`` form; a ROM that
-        resolves to nothing (a genuinely unresolvable platform) is absent and
-        falls back to the plain launch. The resolver already warns + degrades on
-        a stale label, so no bogus invocation ever reaches the bake.
-        """
-        resolved: dict[int, EmulatorInvocation] = {}
-        for rom in roms:
-            emulator = self._active_core.active_emulator_for_rom(rom["id"])
-            if emulator is not None:
-                resolved[rom["id"]] = emulator
-        return resolved
-
-    def _scan_installed_paths(self) -> dict[int, str]:
-        """Read ``{rom_id: bake_path}`` for the whole installed library in one scan.
-
-        Used by the preview path, which already operates over every ROM in the
-        library — a single ``iter_all()`` is the cheapest way to cover them all.
-        Each path is the disc-resolved launch path: a multi-disc ROM resolves its
-        persisted ``selected_disc`` pin against its install directory (a
-        single-disc ROM resolves to its own ``file_path``, unchanged), or ``""``
-        when the install has no launch target. Only ROMs with a current install
-        record appear in the map; a ROM not downloaded is absent, and both cases
-        reach :func:`build_shortcuts_data` as the same empty launch command.
-        """
-        with self._uow_factory() as uow:
-            paths: dict[int, str] = {}
-            for install in uow.rom_installs.iter_all():
-                rom = uow.roms.get(install.rom_id)
-                selected_disc = rom.selected_disc if rom is not None else None
-                paths[install.rom_id] = self._disc_resolver.resolve_for_install(install, selected_disc)
-            return paths
-
-    def _read_installed_paths(self, rom_ids: set[int]) -> dict[int, str]:
-        """Read ``{rom_id: bake_path}`` for *rom_ids* via targeted point-lookups.
-
-        Used by the per-unit apply path: scanning the whole ``rom_installs``
-        table once per unit is O(units * all-installs) (#797), so this resolves
-        only the unit's ROMs via ``get(rom_id)``. Each path is the disc-resolved
-        launch path — a multi-disc ROM resolves its persisted ``selected_disc``
-        pin against its install directory (a single-disc ROM resolves to its own
-        ``file_path``, unchanged), or ``""`` when the install has no launch
-        target. A ROM with no install record is absent; both cases reach
-        :func:`build_shortcuts_data` as the same empty launch command.
-        """
-        with self._uow_factory() as uow:
-            paths: dict[int, str] = {}
-            for rom_id in rom_ids:
-                install = uow.rom_installs.get(rom_id)
-                if install is not None:
-                    rom = uow.roms.get(rom_id)
-                    selected_disc = rom.selected_disc if rom is not None else None
-                    paths[rom_id] = self._disc_resolver.resolve_for_install(install, selected_disc)
-            return paths
 
     def _scan_stale_roms(self, synced_rom_ids: set[int], synced_app_ids: set[int]) -> list[tuple[int, int]]:
         """Return ``(rom_id, app_id)`` for bound ROMs not synced this run.

--- a/scripts/check_module_size.py
+++ b/scripts/check_module_size.py
@@ -74,7 +74,7 @@ SCOPE_DIRS = (
 ALLOWLIST = {
     "py_modules/services/downloads.py": 1119,
     "py_modules/services/library/fetcher.py": 1150,
-    "py_modules/services/library/sync_orchestrator.py": 1340,
+    "py_modules/services/library/sync_orchestrator.py": 1282,
 }
 
 

--- a/scripts/check_seam_owner.py
+++ b/scripts/check_seam_owner.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Seam-owner confinement gate for the library sync package.
+
+``py_modules/services/library/`` is a decomposition: each module owns one job,
+and a job's injected seams are what identify it. When a seam leaks into a second
+module the decomposition quietly reverses — the module that "does not do that
+any more" grows a second reason to open the same resource, and the boundary the
+split was for stops being checkable by reading one file.
+
+Two confinements are enforced here, each recording a promise a module docstring
+already makes:
+
+* ``active_core`` / ``disc_resolver`` belong to ``bake_inputs.py``. They are the
+  only reason the sync ever resolves a ROM's emulator or its disc-pinned launch
+  path, and holding them in one module is what keeps the per-ROM UoW the
+  ``active_core`` seam opens out of the read UoW the install-path scan holds
+  (:mod:`services.library.bake_inputs`).
+* ``renderer_rss`` / ``renderer_gc`` belong to ``session_budget.py``. Its
+  contract is that no renderer-RSS **reading** is taken anywhere else in the
+  package — every other budget site prices against a reading that module handed
+  it (:mod:`services.library.session_budget`).
+
+``service.py`` co-owns every seam: it is the façade that receives them from
+``bootstrap`` and hands each to the sub-service that owns it. Passing a seam
+through the composition root is not holding it.
+
+The scan is AST-shaped and covers the two ways a module takes hold of a seam:
+
+* an **attribute** named after the seam's config attribute, read or written
+  (``config.active_core``, and any other receiver — the names are distinctive,
+  so this cannot be dodged by renaming the holding object), and
+* an **annotation** naming the seam's Protocol type (``ActiveCoreReader``,
+  ``RendererRssFn``, …) on a dataclass field, a parameter, or a return.
+
+It is a surface-syntax guardrail, not dataflow analysis. What it cannot see:
+a seam aliased to a differently-named attribute or local, one reached through
+``getattr``, one passed positionally into a helper that holds it, and a
+quoted (string) annotation. Those stay on review.
+
+Exit 0 when every seam is held only by its owners, 1 (one line per offending
+site) otherwise.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+LIBRARY_DIR = REPO_ROOT / "py_modules" / "services" / "library"
+
+# --- The seam table ------------------------------------------------------
+# Seam config-attribute name -> the modules (relative to LIBRARY_DIR) allowed
+# to hold it. A new confinement is a one-line addition here plus its Protocol
+# type in SEAM_PROTOCOLS below.
+SEAM_OWNERS: dict[str, frozenset[str]] = {
+    "active_core": frozenset({"service.py", "bake_inputs.py"}),
+    "disc_resolver": frozenset({"service.py", "bake_inputs.py"}),
+    "renderer_rss": frozenset({"service.py", "session_budget.py"}),
+    "renderer_gc": frozenset({"service.py", "session_budget.py"}),
+}
+
+# Protocol type name -> the seam it types, so an annotation is attributed to
+# the same owner set as the attribute.
+SEAM_PROTOCOLS: dict[str, str] = {
+    "ActiveCoreReader": "active_core",
+    "DiscResolver": "disc_resolver",
+    "RendererRssFn": "renderer_rss",
+    "RendererGcFn": "renderer_gc",
+}
+
+
+def _iter_scanned_files(library_dir: Path) -> list[Path]:
+    """Every ``.py`` under the library package, owners included.
+
+    Ownership is decided per seam, not per file, so no file is skipped up
+    front — ``session_budget.py`` owning the renderer seams says nothing about
+    its right to hold ``disc_resolver``.
+    """
+    return sorted(library_dir.rglob("*.py"))
+
+
+def _annotation_names(node: ast.AST) -> list[ast.expr]:
+    """The annotation expressions a node introduces (empty for everything else)."""
+    if isinstance(node, ast.AnnAssign):
+        return [node.annotation]
+    if isinstance(node, ast.arg):
+        return [node.annotation] if node.annotation is not None else []
+    if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+        return [node.returns] if node.returns is not None else []
+    return []
+
+
+def _annotation_leaf(annotation: ast.expr) -> str | None:
+    """The bare type name an annotation ends in (``x.Y`` -> ``Y``), or ``None``.
+
+    Subscripted annotations (``X | None`` is a ``BinOp``, ``list[X]`` a
+    ``Subscript``) are reached by the caller's ``ast.walk``, which visits the
+    inner ``Name`` / ``Attribute`` nodes in their own right.
+    """
+    if isinstance(annotation, ast.Name):
+        return annotation.id
+    if isinstance(annotation, ast.Attribute):
+        return annotation.attr
+    return None
+
+
+def find_violations(files: list[Path] | None = None) -> list[str]:
+    """Return one human-readable line per seam held outside its owner modules."""
+    if files is None:
+        files = _iter_scanned_files(LIBRARY_DIR)
+    findings: list[str] = []
+    for path in files:
+        try:
+            source = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        try:
+            tree = ast.parse(source, filename=str(path))
+        except SyntaxError:
+            continue
+        module = path.relative_to(LIBRARY_DIR).as_posix()
+        rel = path.relative_to(REPO_ROOT)
+        for node in ast.walk(tree):
+            findings.extend(_node_findings(node, module=module, rel=rel))
+    return sorted(findings)
+
+
+def _node_findings(node: ast.AST, *, module: str, rel: Path) -> list[str]:
+    """Seam violations introduced by a single AST node."""
+    findings: list[str] = []
+    if isinstance(node, ast.Attribute) and node.attr in SEAM_OWNERS:
+        findings.extend(_report(node.attr, node, module=module, rel=rel, held_as=f"holds '....{node.attr}'"))
+    for annotation in _annotation_names(node):
+        for inner in ast.walk(annotation):
+            leaf = _annotation_leaf(inner) if isinstance(inner, ast.Name | ast.Attribute) else None
+            seam = SEAM_PROTOCOLS.get(leaf) if leaf is not None else None
+            if seam is not None:
+                findings.extend(_report(seam, inner, module=module, rel=rel, held_as=f"annotates '{leaf}'"))
+    return findings
+
+
+def _report(seam: str, node: ast.expr, *, module: str, rel: Path, held_as: str) -> list[str]:
+    """One finding line, or none when *module* is allowed to hold *seam*."""
+    owners = SEAM_OWNERS[seam]
+    if module in owners:
+        return []
+    owner_list = " / ".join(sorted(owners))
+    return [f"{rel}:{node.lineno}:{node.col_offset} {held_as} — the '{seam}' seam is held only by {owner_list}."]
+
+
+def main(argv: list[str]) -> int:
+    if any(a in {"-h", "--help"} for a in argv):
+        print(__doc__)
+        return 0
+    findings = find_violations()
+    if findings:
+        for line in findings:
+            print(line)
+        print()
+        print(
+            "ERROR: a library-sync seam is held outside its owner module — reach it through the "
+            "sub-service that owns it instead of injecting it a second time "
+            "(CLAUDE.md → Invariant register, #1777)."
+        )
+        return 1
+    print(f"OK: all {len(SEAM_OWNERS)} confined seams are held only by their owners (services/library/).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/check_seam_owner.py
+++ b/scripts/check_seam_owner.py
@@ -20,10 +20,6 @@ already makes:
   package — every other budget site prices against a reading that module handed
   it (:mod:`services.library.session_budget`).
 
-``service.py`` co-owns every seam: it is the façade that receives them from
-``bootstrap`` and hands each to the sub-service that owns it. Passing a seam
-through the composition root is not holding it.
-
 The scan is AST-shaped and covers the two ways a module takes hold of a seam:
 
 * an **attribute** named after the seam's config attribute, read or written
@@ -32,12 +28,37 @@ The scan is AST-shaped and covers the two ways a module takes hold of a seam:
 * an **annotation** naming the seam's Protocol type (``ActiveCoreReader``,
   ``RendererRssFn``, …) on a dataclass field, a parameter, or a return.
 
-It is a surface-syntax guardrail, not dataflow analysis. What it cannot see:
-a seam aliased to a differently-named attribute or local, one reached through
-``getattr``, one passed positionally into a helper that holds it, and a
-quoted (string) annotation. Those stay on review.
+**A composition root may pass a seam on; it may not use one.** The façade takes
+all four from ``bootstrap`` and hands each to the sub-service that owns it, so
+two shapes are allowed everywhere rather than one file being exempted wholesale:
+a seam attribute that *is* a call's keyword-argument value
+(``ShortcutBakeInputsConfig(active_core=config.active_core)`` — handed on, not
+held) and a seam annotation on a field of :data:`FACADE_CONFIG_CLASS`, the one
+class ``bootstrap`` delivers into. A façade method that *reaches through* the
+seam (``self._config.active_core.active_emulator_for_rom(...)``) is neither, and
+is a finding — which a blanket file exemption could not tell from wiring.
 
-Exit 0 when every seam is held only by its owners, 1 (one line per offending
+It is a surface-syntax guardrail, not dataflow analysis. What it cannot see:
+
+* a seam aliased to a differently-named attribute or local, or reached through
+  ``getattr``;
+* a seam passed positionally into a helper that then holds it;
+* a quoted (string) annotation, which is a ``Constant`` and never a type name;
+* a Protocol imported under an alias
+  (``from services.protocols import ActiveCoreReader as CoreReader``), which
+  leaves the annotation leaf unmatched — the aliasing this catches is of the
+  *value*, not of the *type*;
+* the field **name** in a foreign config, which is never inspected — so
+  ``active_core: CoreReader`` combines the previous two and is invisible on both
+  halves of the scan.
+
+The last two are precision in the documented reach rather than a way through:
+whatever the field is called and however its type was imported, the constructor
+that unpacks it reads ``config.<seam>`` outside a keyword argument, and that
+read is flagged. What actually stays on review is a seam reached without ever
+naming it.
+
+Exit 0 when every seam is held only by its owner, 1 (one line per offending
 site) otherwise.
 """
 
@@ -55,10 +76,10 @@ LIBRARY_DIR = REPO_ROOT / "py_modules" / "services" / "library"
 # to hold it. A new confinement is a one-line addition here plus its Protocol
 # type in SEAM_PROTOCOLS below.
 SEAM_OWNERS: dict[str, frozenset[str]] = {
-    "active_core": frozenset({"service.py", "bake_inputs.py"}),
-    "disc_resolver": frozenset({"service.py", "bake_inputs.py"}),
-    "renderer_rss": frozenset({"service.py", "session_budget.py"}),
-    "renderer_gc": frozenset({"service.py", "session_budget.py"}),
+    "active_core": frozenset({"bake_inputs.py"}),
+    "disc_resolver": frozenset({"bake_inputs.py"}),
+    "renderer_rss": frozenset({"session_budget.py"}),
+    "renderer_gc": frozenset({"session_budget.py"}),
 }
 
 # Protocol type name -> the seam it types, so an annotation is attributed to
@@ -69,6 +90,11 @@ SEAM_PROTOCOLS: dict[str, str] = {
     "RendererRssFn": "renderer_rss",
     "RendererGcFn": "renderer_gc",
 }
+
+# The one config class ``bootstrap`` delivers a seam into. A seam annotation on
+# one of ITS fields is the package's entry point for that seam, not a second
+# holder of it.
+FACADE_CONFIG_CLASS = "LibraryServiceConfig"
 
 
 def _iter_scanned_files(library_dir: Path) -> list[Path]:
@@ -106,8 +132,30 @@ def _annotation_leaf(annotation: ast.expr) -> str | None:
     return None
 
 
+def _passed_on_nodes(tree: ast.AST) -> set[int]:
+    """Node ids a composition root is allowed to name: wiring, not use.
+
+    Two shapes, collected by node identity so nothing else inherits the
+    exemption: an attribute standing as a call's keyword-argument value (the
+    seam handed to a sub-service's config), and an annotation on a field of
+    :data:`FACADE_CONFIG_CLASS` (the seam arriving from ``bootstrap``).
+    """
+    allowed: set[int] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            allowed.update(id(kw.value) for kw in node.keywords if isinstance(kw.value, ast.Attribute))
+        elif isinstance(node, ast.ClassDef) and node.name == FACADE_CONFIG_CLASS:
+            allowed.update(
+                id(inner)
+                for field in node.body
+                if isinstance(field, ast.AnnAssign)
+                for inner in ast.walk(field.annotation)
+            )
+    return allowed
+
+
 def find_violations(files: list[Path] | None = None) -> list[str]:
-    """Return one human-readable line per seam held outside its owner modules."""
+    """Return one human-readable line per seam held outside its owner module."""
     if files is None:
         files = _iter_scanned_files(LIBRARY_DIR)
     findings: list[str] = []
@@ -122,18 +170,21 @@ def find_violations(files: list[Path] | None = None) -> list[str]:
             continue
         module = path.relative_to(LIBRARY_DIR).as_posix()
         rel = path.relative_to(REPO_ROOT)
+        passed_on = _passed_on_nodes(tree)
         for node in ast.walk(tree):
-            findings.extend(_node_findings(node, module=module, rel=rel))
+            findings.extend(_node_findings(node, module=module, rel=rel, passed_on=passed_on))
     return sorted(findings)
 
 
-def _node_findings(node: ast.AST, *, module: str, rel: Path) -> list[str]:
+def _node_findings(node: ast.AST, *, module: str, rel: Path, passed_on: set[int]) -> list[str]:
     """Seam violations introduced by a single AST node."""
     findings: list[str] = []
-    if isinstance(node, ast.Attribute) and node.attr in SEAM_OWNERS:
+    if isinstance(node, ast.Attribute) and node.attr in SEAM_OWNERS and id(node) not in passed_on:
         findings.extend(_report(node.attr, node, module=module, rel=rel, held_as=f"holds '....{node.attr}'"))
     for annotation in _annotation_names(node):
         for inner in ast.walk(annotation):
+            if id(inner) in passed_on:
+                continue
             leaf = _annotation_leaf(inner) if isinstance(inner, ast.Name | ast.Attribute) else None
             seam = SEAM_PROTOCOLS.get(leaf) if leaf is not None else None
             if seam is not None:

--- a/tests/scripts/test_check_seam_owner.py
+++ b/tests/scripts/test_check_seam_owner.py
@@ -1,0 +1,253 @@
+"""Tests for ``scripts/check_seam_owner.py``.
+
+The check is loaded via ``importlib`` because ``scripts/`` is not on
+``sys.path`` (and is excluded from ruff/basedpyright). Fixtures lay out a small
+``py_modules/services/library/`` tree under ``tmp_path`` so the check walks it
+with its real file discovery.
+
+Coverage centres on the confinement rule (a seam is held only by the modules
+its ``SEAM_OWNERS`` entry names), the two shapes of "holding" the scan sees
+(an attribute named after the seam, an annotation naming its Protocol), the
+per-seam nature of ownership (owning one seam grants nothing about another),
+and the documented blind spots.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+_SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "check_seam_owner.py"
+
+
+def _load_check_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("check_seam_owner", _SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+check = _load_check_module()
+
+# The owner table the fixtures run against — the real one, restated so a
+# deliberate change to production ownership shows up as a test edit.
+_OWNERS = {
+    "active_core": frozenset({"service.py", "bake_inputs.py"}),
+    "disc_resolver": frozenset({"service.py", "bake_inputs.py"}),
+    "renderer_rss": frozenset({"service.py", "session_budget.py"}),
+    "renderer_gc": frozenset({"service.py", "session_budget.py"}),
+}
+
+
+def _make_library_tree(tmp_path: Path, files: dict[str, str]) -> Path:
+    """Build a fake ``py_modules/services/library/`` tree: ``name -> source``."""
+    library_dir = tmp_path / "py_modules" / "services" / "library"
+    library_dir.mkdir(parents=True)
+    for name, source in files.items():
+        (library_dir / name).write_text(source, encoding="utf-8")
+    return library_dir
+
+
+@pytest.fixture
+def patched_check(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """Yield a helper that retargets the check at a tmp-path library tree + runs it."""
+
+    def _run(files: dict[str, str]) -> list[str]:
+        library_dir = _make_library_tree(tmp_path, files)
+        monkeypatch.setattr(check, "REPO_ROOT", tmp_path)
+        monkeypatch.setattr(check, "LIBRARY_DIR", library_dir)
+        monkeypatch.setattr(check, "SEAM_OWNERS", dict(_OWNERS))
+        return check.find_violations(check._iter_scanned_files(library_dir))
+
+    return _run
+
+
+class TestFindViolations:
+    def test_flags_seam_read_in_a_foreign_module(self, patched_check):
+        holder = "class H:\n    def __init__(self, config):\n        self._a = config.active_core\n"
+        findings = patched_check({"bake_inputs.py": holder, "sync_orchestrator.py": holder})
+        assert len(findings) == 1
+        assert "sync_orchestrator.py" in findings[0]
+        assert "active_core" in findings[0]
+        assert "bake_inputs.py" in findings[0]  # the message names the owners
+
+    def test_flags_protocol_annotation_in_a_foreign_module(self, patched_check):
+        findings = patched_check(
+            {
+                "sync_orchestrator.py": "class Config:\n    disc_resolver: DiscResolver\n",
+            }
+        )
+        assert len(findings) == 1
+        assert "DiscResolver" in findings[0]
+        assert "disc_resolver" in findings[0]
+
+    def test_flags_annotation_nested_in_a_subscript(self, patched_check):
+        # ``RendererRssFn | None`` / ``list[RendererRssFn]`` reach the Protocol
+        # name through a BinOp / Subscript, which the walk descends into.
+        findings = patched_check(
+            {
+                "reporter.py": "def go(rss: RendererRssFn | None) -> None:\n    return None\n",
+            }
+        )
+        assert len(findings) == 1
+        assert "renderer_rss" in findings[0]
+
+    def test_flags_annotated_return(self, patched_check):
+        findings = patched_check(
+            {
+                "fetcher.py": "def get() -> RendererGcFn:\n    raise NotImplementedError\n",
+            }
+        )
+        assert len(findings) == 1
+        assert "renderer_gc" in findings[0]
+
+    def test_ownership_is_per_seam_not_per_module(self, patched_check):
+        # session_budget.py owns the renderer seams and nothing else — reaching
+        # for disc_resolver there is exactly the drift this gate exists for.
+        findings = patched_check(
+            {
+                "session_budget.py": (
+                    "class M:\n    def __init__(self, config):\n"
+                    "        self._gc = config.renderer_gc\n"
+                    "        self._d = config.disc_resolver\n"
+                ),
+            }
+        )
+        assert len(findings) == 1
+        assert "disc_resolver" in findings[0]
+
+    def test_owner_module_not_flagged(self, patched_check):
+        findings = patched_check(
+            {
+                "bake_inputs.py": (
+                    "class Config:\n    active_core: ActiveCoreReader\n    disc_resolver: DiscResolver\n\n"
+                    "class B:\n    def __init__(self, config):\n"
+                    "        self._a = config.active_core\n        self._d = config.disc_resolver\n"
+                ),
+            }
+        )
+        assert findings == []
+
+    def test_facade_co_owns_every_seam(self, patched_check):
+        # The composition root receives all four from bootstrap and hands each
+        # to the sub-service that owns it.
+        findings = patched_check(
+            {
+                "service.py": (
+                    "class Config:\n"
+                    "    active_core: ActiveCoreReader\n"
+                    "    disc_resolver: DiscResolver\n"
+                    "    renderer_rss: RendererRssFn\n"
+                    "    renderer_gc: RendererGcFn\n\n"
+                    "def wire(config):\n"
+                    "    return (config.active_core, config.disc_resolver, config.renderer_rss, config.renderer_gc)\n"
+                ),
+            }
+        )
+        assert findings == []
+
+    def test_unrelated_attribute_and_annotation_not_flagged(self, patched_check):
+        findings = patched_check(
+            {
+                "reporter.py": (
+                    "class Config:\n    artwork: ArtworkManager\n\n"
+                    "def go(config):\n    return config.artwork, config.active_core_label\n"
+                ),
+            }
+        )
+        assert findings == []
+
+    def test_private_holding_attribute_alone_is_not_flagged(self, patched_check):
+        # Documented blind spot: only the seam's own name is matched, so a
+        # module that already holds it under ``_active_core`` is invisible —
+        # the gate catches the injection, not every later use.
+        findings = patched_check(
+            {
+                "sync_orchestrator.py": "def go(self):\n    return self._active_core.active_emulator_for_rom(1)\n",
+            }
+        )
+        assert findings == []
+
+    def test_string_annotation_is_not_flagged(self, patched_check):
+        # Documented blind spot: a quoted annotation is a Constant, not a Name.
+        findings = patched_check(
+            {
+                "sync_orchestrator.py": 'class Config:\n    disc_resolver_alias: "DiscResolver"\n',
+            }
+        )
+        assert findings == []
+
+    def test_syntax_error_file_is_skipped(self, patched_check):
+        findings = patched_check(
+            {
+                "broken.py": "def (:\n",
+                "reporter.py": "def go(config):\n    return config.renderer_rss\n",
+            }
+        )
+        assert len(findings) == 1
+        assert "reporter.py" in findings[0]
+
+    def test_every_seam_is_reported_once_per_site(self, patched_check):
+        findings = patched_check(
+            {
+                "reporter.py": (
+                    "def go(config):\n"
+                    "    return config.active_core, config.disc_resolver, config.renderer_rss, config.renderer_gc\n"
+                ),
+            }
+        )
+        assert len(findings) == 4
+
+
+class TestMainEntryPoint:
+    def test_help_flag_returns_zero(self, capsys):
+        rc = check.main(["--help"])
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "Seam-owner confinement gate" in captured.out
+
+    def test_real_repo_run_is_clean(self, capsys):
+        # The real library package holds each seam only in its owner modules —
+        # the check must exit 0.
+        rc = check.main([])
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "OK:" in captured.out
+
+    def test_main_reports_and_returns_one_on_planted_violation(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys
+    ):
+        library_dir = _make_library_tree(
+            tmp_path,
+            {
+                "sync_orchestrator.py": "def go(config):\n    return config.disc_resolver\n",
+            },
+        )
+        monkeypatch.setattr(check, "REPO_ROOT", tmp_path)
+        monkeypatch.setattr(check, "LIBRARY_DIR", library_dir)
+
+        rc = check.main([])
+        assert rc == 1
+        captured = capsys.readouterr()
+        assert "disc_resolver" in captured.out
+        assert "ERROR:" in captured.out
+
+
+class TestSeamTable:
+    def test_every_protocol_maps_to_a_known_seam(self):
+        assert set(check.SEAM_PROTOCOLS.values()) <= set(check.SEAM_OWNERS)
+
+    def test_every_seam_has_a_protocol(self):
+        # A seam with no Protocol entry would be enforced on the attribute name
+        # only, silently halving the scan.
+        assert set(check.SEAM_PROTOCOLS.values()) == set(check.SEAM_OWNERS)

--- a/tests/scripts/test_check_seam_owner.py
+++ b/tests/scripts/test_check_seam_owner.py
@@ -5,10 +5,11 @@ The check is loaded via ``importlib`` because ``scripts/`` is not on
 ``py_modules/services/library/`` tree under ``tmp_path`` so the check walks it
 with its real file discovery.
 
-Coverage centres on the confinement rule (a seam is held only by the modules
-its ``SEAM_OWNERS`` entry names), the two shapes of "holding" the scan sees
-(an attribute named after the seam, an annotation naming its Protocol), the
+Coverage centres on the confinement rule (a seam is held only by the module its
+``SEAM_OWNERS`` entry names), the two shapes of "holding" the scan sees (an
+attribute named after the seam, an annotation naming its Protocol), the
 per-seam nature of ownership (owning one seam grants nothing about another),
+the composition root's narrow licence to **pass** a seam without **using** one,
 and the documented blind spots.
 """
 
@@ -42,10 +43,10 @@ check = _load_check_module()
 # The owner table the fixtures run against — the real one, restated so a
 # deliberate change to production ownership shows up as a test edit.
 _OWNERS = {
-    "active_core": frozenset({"service.py", "bake_inputs.py"}),
-    "disc_resolver": frozenset({"service.py", "bake_inputs.py"}),
-    "renderer_rss": frozenset({"service.py", "session_budget.py"}),
-    "renderer_gc": frozenset({"service.py", "session_budget.py"}),
+    "active_core": frozenset({"bake_inputs.py"}),
+    "disc_resolver": frozenset({"bake_inputs.py"}),
+    "renderer_rss": frozenset({"session_budget.py"}),
+    "renderer_gc": frozenset({"session_budget.py"}),
 }
 
 
@@ -79,7 +80,7 @@ class TestFindViolations:
         assert len(findings) == 1
         assert "sync_orchestrator.py" in findings[0]
         assert "active_core" in findings[0]
-        assert "bake_inputs.py" in findings[0]  # the message names the owners
+        assert "bake_inputs.py" in findings[0]  # the message names the owner
 
     def test_flags_protocol_annotation_in_a_foreign_module(self, patched_check):
         findings = patched_check(
@@ -138,24 +139,6 @@ class TestFindViolations:
         )
         assert findings == []
 
-    def test_facade_co_owns_every_seam(self, patched_check):
-        # The composition root receives all four from bootstrap and hands each
-        # to the sub-service that owns it.
-        findings = patched_check(
-            {
-                "service.py": (
-                    "class Config:\n"
-                    "    active_core: ActiveCoreReader\n"
-                    "    disc_resolver: DiscResolver\n"
-                    "    renderer_rss: RendererRssFn\n"
-                    "    renderer_gc: RendererGcFn\n\n"
-                    "def wire(config):\n"
-                    "    return (config.active_core, config.disc_resolver, config.renderer_rss, config.renderer_gc)\n"
-                ),
-            }
-        )
-        assert findings == []
-
     def test_unrelated_attribute_and_annotation_not_flagged(self, patched_check):
         findings = patched_check(
             {
@@ -163,26 +146,6 @@ class TestFindViolations:
                     "class Config:\n    artwork: ArtworkManager\n\n"
                     "def go(config):\n    return config.artwork, config.active_core_label\n"
                 ),
-            }
-        )
-        assert findings == []
-
-    def test_private_holding_attribute_alone_is_not_flagged(self, patched_check):
-        # Documented blind spot: only the seam's own name is matched, so a
-        # module that already holds it under ``_active_core`` is invisible —
-        # the gate catches the injection, not every later use.
-        findings = patched_check(
-            {
-                "sync_orchestrator.py": "def go(self):\n    return self._active_core.active_emulator_for_rom(1)\n",
-            }
-        )
-        assert findings == []
-
-    def test_string_annotation_is_not_flagged(self, patched_check):
-        # Documented blind spot: a quoted annotation is a Constant, not a Name.
-        findings = patched_check(
-            {
-                "sync_orchestrator.py": 'class Config:\n    disc_resolver_alias: "DiscResolver"\n',
             }
         )
         assert findings == []
@@ -209,6 +172,157 @@ class TestFindViolations:
         assert len(findings) == 4
 
 
+class TestCompositionRoot:
+    """A composition root may PASS a seam on; it may not USE one."""
+
+    def test_facade_wiring_is_not_flagged(self, patched_check):
+        # The seam arrives annotated on LibraryServiceConfig and leaves as a
+        # keyword-argument value — the whole of the real façade's seam contact.
+        findings = patched_check(
+            {
+                "service.py": (
+                    "class LibraryServiceConfig:\n"
+                    "    active_core: ActiveCoreReader\n"
+                    "    disc_resolver: DiscResolver\n"
+                    "    renderer_rss: RendererRssFn\n"
+                    "    renderer_gc: RendererGcFn\n\n"
+                    "class LibraryService:\n"
+                    "    def __init__(self, config):\n"
+                    "        self._bake = ShortcutBakeInputs(\n"
+                    "            config=ShortcutBakeInputsConfig(\n"
+                    "                active_core=config.active_core, disc_resolver=config.disc_resolver\n"
+                    "            )\n"
+                    "        )\n"
+                    "        self._budget = SessionBudgetMonitor(\n"
+                    "            config=SessionBudgetMonitorConfig(\n"
+                    "                renderer_rss=config.renderer_rss, renderer_gc=config.renderer_gc\n"
+                    "            )\n"
+                    "        )\n"
+                ),
+            }
+        )
+        assert findings == []
+
+    def test_facade_method_that_uses_a_seam_is_flagged(self, patched_check):
+        # The regression a blanket file exemption could not tell from wiring:
+        # the façade grows a second holder of a UoW-opening seam.
+        findings = patched_check(
+            {
+                "service.py": (
+                    "class LibraryServiceConfig:\n    active_core: ActiveCoreReader\n\n"
+                    "class LibraryService:\n"
+                    "    def peek(self, rom_id):\n"
+                    "        return self._config.active_core.active_emulator_for_rom(rom_id)\n"
+                ),
+            }
+        )
+        assert len(findings) == 1
+        assert "service.py" in findings[0]
+        assert "active_core" in findings[0]
+
+    def test_facade_storing_a_seam_on_itself_is_flagged(self, patched_check):
+        # Storing is holding, not passing: the assignment's RHS is not a
+        # keyword-argument value.
+        findings = patched_check(
+            {
+                "service.py": (
+                    "class LibraryServiceConfig:\n    disc_resolver: DiscResolver\n\n"
+                    "class LibraryService:\n"
+                    "    def __init__(self, config):\n        self._disc = config.disc_resolver\n"
+                ),
+            }
+        )
+        assert len(findings) == 1
+        assert "disc_resolver" in findings[0]
+
+    def test_seam_annotation_on_a_non_facade_config_is_flagged(self, patched_check):
+        # Only LibraryServiceConfig is bootstrap's delivery point; a second
+        # config declaring the same seam is a second holder.
+        findings = patched_check(
+            {
+                "sync_orchestrator.py": "class SyncOrchestratorConfig:\n    active_core: ActiveCoreReader\n",
+            }
+        )
+        assert len(findings) == 1
+        assert "active_core" in findings[0]
+
+    def test_facade_config_field_of_another_class_in_the_same_file_is_flagged(self, patched_check):
+        findings = patched_check(
+            {
+                "service.py": (
+                    "class LibraryServiceConfig:\n    renderer_rss: RendererRssFn\n\n"
+                    "class OtherConfig:\n    renderer_rss: RendererRssFn\n"
+                ),
+            }
+        )
+        assert len(findings) == 1
+        assert "renderer_rss" in findings[0]
+
+    def test_pass_through_licence_does_not_leak_to_the_receiver(self, patched_check):
+        # A keyword value is exempt; the same attribute read into a local or
+        # returned is not.
+        findings = patched_check(
+            {
+                "reporter.py": (
+                    "def wire(config):\n    Thing(active_core=config.active_core)\n    return config.active_core\n"
+                ),
+            }
+        )
+        assert len(findings) == 1
+        assert findings[0].endswith("the 'active_core' seam is held only by bake_inputs.py.")
+
+
+class TestDocumentedBlindSpots:
+    def test_private_holding_attribute_alone_is_not_flagged(self, patched_check):
+        # Only the seam's own name is matched, so a module that already holds it
+        # under ``_active_core`` is invisible — the gate catches the injection,
+        # not every later use.
+        findings = patched_check(
+            {
+                "sync_orchestrator.py": "def go(self):\n    return self._active_core.active_emulator_for_rom(1)\n",
+            }
+        )
+        assert findings == []
+
+    def test_string_annotation_is_not_flagged(self, patched_check):
+        # A quoted annotation is a Constant, not a Name.
+        findings = patched_check(
+            {
+                "sync_orchestrator.py": 'class Config:\n    resolver_alias: "DiscResolver"\n',
+            }
+        )
+        assert findings == []
+
+    def test_aliased_protocol_import_escapes_the_annotation_half(self, patched_check):
+        # ``ActiveCoreReader as CoreReader`` leaves the annotation leaf
+        # unmatched, and the field NAME is never inspected — but the ctor read
+        # that unpacks the config is still flagged, which is why this is
+        # precision in the reach rather than a way through.
+        annotation_only = (
+            "from services.protocols import ActiveCoreReader as CoreReader\n\n"
+            "class Config:\n    active_core: CoreReader\n"
+        )
+        assert patched_check({"sync_orchestrator.py": annotation_only}) == []
+
+    def test_the_constructor_read_still_catches_the_aliased_case(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+        library_dir = _make_library_tree(
+            tmp_path,
+            {
+                "sync_orchestrator.py": (
+                    "from services.protocols import ActiveCoreReader as CoreReader\n\n"
+                    "class Config:\n    active_core: CoreReader\n\n"
+                    "class O:\n    def __init__(self, config):\n        self._a = config.active_core\n"
+                ),
+            },
+        )
+        monkeypatch.setattr(check, "REPO_ROOT", tmp_path)
+        monkeypatch.setattr(check, "LIBRARY_DIR", library_dir)
+        monkeypatch.setattr(check, "SEAM_OWNERS", dict(_OWNERS))
+        findings = check.find_violations(check._iter_scanned_files(library_dir))
+        assert len(findings) == 1
+        assert "active_core" in findings[0]
+
+
 class TestMainEntryPoint:
     def test_help_flag_returns_zero(self, capsys):
         rc = check.main(["--help"])
@@ -217,8 +331,8 @@ class TestMainEntryPoint:
         assert "Seam-owner confinement gate" in captured.out
 
     def test_real_repo_run_is_clean(self, capsys):
-        # The real library package holds each seam only in its owner modules —
-        # the check must exit 0.
+        # The real library package holds each seam only in its owner module,
+        # and the façade only passes them on — the check must exit 0.
         rc = check.main([])
         assert rc == 0
         captured = capsys.readouterr()
@@ -251,3 +365,8 @@ class TestSeamTable:
         # A seam with no Protocol entry would be enforced on the attribute name
         # only, silently halving the scan.
         assert set(check.SEAM_PROTOCOLS.values()) == set(check.SEAM_OWNERS)
+
+    def test_no_owner_set_names_the_facade(self):
+        # The façade's licence is structural (pass-through only). Re-adding it
+        # as an owner would restore the hole this narrowing closed.
+        assert all("service.py" not in owners for owners in check.SEAM_OWNERS.values())

--- a/tests/services/library/_helpers.py
+++ b/tests/services/library/_helpers.py
@@ -1,10 +1,11 @@
 """Shared helpers for the LibraryService sub-service test files.
 
 Mock-loop factories for the executor pattern (LibraryService runs
-sync RomM calls in an executor) and small ROM/registry/page builders
+sync RomM calls in an executor), small ROM/registry/page builders
 used across :class:`TestFetchCollectionRoms`,
 :class:`TestCollectionSyncEdgeCases`, and the facade-integration
-collection tests.
+collection tests, plus the shared-UoW seeders the sub-service test
+files drive their fixtures with.
 """
 
 from unittest.mock import AsyncMock, MagicMock
@@ -15,10 +16,11 @@ from services.library.fetcher import _SUPPORTED_VIRTUAL_TYPES
 def rebind_loop(library_service, loop):
     """Rebind the event loop on every LibraryService sub-service.
 
-    The façade composes four sub-services (fetcher, orchestrator,
-    reporter, session-budget monitor) that each hold their own ctor-bound
-    ``_loop``. Tests that swap in a mock loop must propagate it to all
-    four so async calls land on the override.
+    Four of the façade's sub-services (fetcher, orchestrator, reporter,
+    session-budget monitor) hold their own ctor-bound ``_loop``. Tests that
+    swap in a mock loop must propagate it to all four so async calls land on
+    the override. ``ShortcutBakeInputs`` holds none — its methods are
+    synchronous workers the orchestrator offloads through *its* loop.
     """
     library_service._fetcher._loop = loop
     library_service._orchestrator._loop = loop
@@ -96,3 +98,31 @@ def _make_registry_entry(name, platform_name, app_id, platform_slug="gba", appli
 def _page(items):
     """Wrap items in a paginated API response dict."""
     return {"items": items, "total": len(items)}
+
+
+def _seed_install(plugin, rom_id, *, file_path, platform_slug="n64"):
+    """Insert a ``RomInstall`` record (with its FK-parent ``Rom``) into the shared UoW."""
+    from domain.rom import Rom
+    from domain.rom_install import RomInstall
+
+    with plugin._uow:
+        plugin._uow.roms.save(
+            Rom(
+                rom_id=rom_id,
+                platform_slug=platform_slug,
+                name=f"Game {rom_id}",
+                fs_name=f"game_{rom_id}.z64",
+                shortcut_app_id=None,
+                last_synced_at="2025-01-01T00:00:00",
+            )
+        )
+        plugin._uow.rom_installs.save(
+            RomInstall.mark_installed(
+                rom_id=rom_id,
+                file_path=file_path,
+                rom_dir=None,
+                platform_slug=platform_slug,
+                system=platform_slug,
+                installed_at="2025-01-01T00:00:00",
+            )
+        )

--- a/tests/services/library/test_bake_inputs.py
+++ b/tests/services/library/test_bake_inputs.py
@@ -1,0 +1,66 @@
+"""Tests for ShortcutBakeInputs — the per-ROM launch facts a shortcut bake reads.
+
+Driven through the shared ``plugin`` fixture so the emulator resolution runs
+against the real :class:`ActiveCoreResolver` over the shared fake UoW — the same
+seam the sync's bake sites draw from — rather than a mock of it.
+
+The disc-resolved install paths (``do_scan_installed_paths`` /
+``do_read_installed_paths``) are pinned in ``tests/services/test_disc_bake_sites.py``
+alongside the other launch-bake sites, so a change to the disc pin's handling
+fails every site at once.
+"""
+
+from domain.shortcut_data import EmulatorInvocation
+
+# conftest.py patches decky before this import
+from tests.services.library._helpers import _seed_install
+
+
+class TestBuildCoreOverrides:
+    """The ``core_overrides`` map both preview and apply pass to ``build_shortcuts_data``.
+
+    Maps ``rom_id -> resolved core_so`` for every ROM in the unit that carries a
+    still-valid ``emulator_override``; NULL pins never enter the map, and a stale
+    LABEL is omitted with a WARNING so the bake degrades to the plain launch.
+    """
+
+    def test_resolved_override_included_null_omitted(self, plugin):
+        """A resolvable pin maps to its libretro EmulatorInvocation; an unpinned ROM is absent."""
+        plugin._core_info.available_cores = [
+            {"core_so": "pcsx_rearmed_libretro", "label": "PCSX ReARMed", "is_default": True},
+        ]
+        _seed_install(plugin, 10, file_path="/roms/psx/a.chd", platform_slug="psx")
+        _seed_install(plugin, 11, file_path="/roms/psx/b.chd", platform_slug="psx")
+        with plugin._uow:
+            plugin._uow.roms.set_emulator_override(10, "PCSX ReARMed")
+
+        roms = [{"id": 10, "platform_slug": "psx"}, {"id": 11, "platform_slug": "psx"}]
+        result = plugin._sync_service._bake_inputs.do_build_core_overrides(roms)
+
+        assert result == {10: EmulatorInvocation.libretro("pcsx_rearmed_libretro", "PCSX ReARMed")}
+        assert 11 not in result
+
+    def test_stale_override_omitted_with_warning(self, plugin, caplog):
+        """A pin whose LABEL no longer resolves is omitted and a WARNING is logged."""
+        import logging
+
+        plugin._core_info.available_cores = [
+            {"core_so": "pcsx_rearmed_libretro", "label": "PCSX ReARMed", "is_default": True},
+        ]
+        _seed_install(plugin, 10, file_path="/roms/psx/a.chd", platform_slug="psx")
+        with plugin._uow:
+            plugin._uow.roms.set_emulator_override(10, "Removed Core")
+
+        roms = [{"id": 10, "platform_slug": "psx"}]
+        with caplog.at_level(logging.WARNING):
+            result = plugin._sync_service._bake_inputs.do_build_core_overrides(roms)
+
+        assert result == {}
+        assert "Removed Core" in caplog.text
+        assert "no longer resolves" in caplog.text
+
+    def test_no_overrides_returns_empty(self, plugin):
+        """No pins anywhere → empty map (no available-cores lookups needed)."""
+        _seed_install(plugin, 10, file_path="/roms/n64/a.z64", platform_slug="n64")
+        result = plugin._sync_service._bake_inputs.do_build_core_overrides([{"id": 10, "platform_slug": "n64"}])
+        assert result == {}

--- a/tests/services/library/test_sync_orchestrator.py
+++ b/tests/services/library/test_sync_orchestrator.py
@@ -34,7 +34,6 @@ from adapters.persistence import (
     PersistenceAdapter,
 )
 from domain.preview_delta import PreviewDelta
-from domain.shortcut_data import EmulatorInvocation
 from domain.sync_diff import BIND_ROM_ID_KEY
 from domain.sync_stage import SyncStage
 from domain.sync_state import SyncState
@@ -42,7 +41,7 @@ from domain.work_unit import WorkUnit
 from lib.romm_paging import LIST_PAGE_SIZE
 
 # conftest.py patches decky before this import
-
+from tests.services.library._helpers import _seed_install
 
 # ── Test helpers ─────────────────────────────────────────────────
 
@@ -158,34 +157,6 @@ def _seed_rom_row(
         plugin._uow.roms.set_applied_launch_options(rom_id, applied_launch_options)
 
 
-def _seed_install(plugin, rom_id, *, file_path, platform_slug="n64"):
-    """Insert a ``RomInstall`` record (with its FK-parent ``Rom``) into the shared UoW."""
-    from domain.rom import Rom
-    from domain.rom_install import RomInstall
-
-    with plugin._uow:
-        plugin._uow.roms.save(
-            Rom(
-                rom_id=rom_id,
-                platform_slug=platform_slug,
-                name=f"Game {rom_id}",
-                fs_name=f"game_{rom_id}.z64",
-                shortcut_app_id=None,
-                last_synced_at="2025-01-01T00:00:00",
-            )
-        )
-        plugin._uow.rom_installs.save(
-            RomInstall.mark_installed(
-                rom_id=rom_id,
-                file_path=file_path,
-                rom_dir=None,
-                platform_slug=platform_slug,
-                system=platform_slug,
-                installed_at="2025-01-01T00:00:00",
-            )
-        )
-
-
 def _seed_completed_run(plugin, *, at, platforms=None, collections=None, run_id="run-prev"):
     """Insert a completed ``SyncRun`` so ``last_sync`` / ``last_synced_*`` reads resolve."""
     from domain.sync_run import SyncRun
@@ -290,56 +261,6 @@ class TestShortcutDataFormat:
 
         result = build_shortcuts_data([{"id": 1, "name": "Game"}], decky.DECKY_PLUGIN_DIR, {}, {})
         assert result[0]["start_dir"] == os.path.dirname(result[0]["exe"])
-
-
-class TestBuildCoreOverrides:
-    """The ``core_overrides`` map both preview and apply pass to ``build_shortcuts_data``.
-
-    Maps ``rom_id -> resolved core_so`` for every ROM in the unit that carries a
-    still-valid ``emulator_override``; NULL pins never enter the map, and a stale
-    LABEL is omitted with a WARNING so the bake degrades to the plain launch.
-    """
-
-    def test_resolved_override_included_null_omitted(self, plugin):
-        """A resolvable pin maps to its libretro EmulatorInvocation; an unpinned ROM is absent."""
-        plugin._core_info.available_cores = [
-            {"core_so": "pcsx_rearmed_libretro", "label": "PCSX ReARMed", "is_default": True},
-        ]
-        _seed_install(plugin, 10, file_path="/roms/psx/a.chd", platform_slug="psx")
-        _seed_install(plugin, 11, file_path="/roms/psx/b.chd", platform_slug="psx")
-        with plugin._uow:
-            plugin._uow.roms.set_emulator_override(10, "PCSX ReARMed")
-
-        roms = [{"id": 10, "platform_slug": "psx"}, {"id": 11, "platform_slug": "psx"}]
-        result = plugin._sync_service._orchestrator._build_core_overrides(roms)
-
-        assert result == {10: EmulatorInvocation.libretro("pcsx_rearmed_libretro", "PCSX ReARMed")}
-        assert 11 not in result
-
-    def test_stale_override_omitted_with_warning(self, plugin, caplog):
-        """A pin whose LABEL no longer resolves is omitted and a WARNING is logged."""
-        import logging
-
-        plugin._core_info.available_cores = [
-            {"core_so": "pcsx_rearmed_libretro", "label": "PCSX ReARMed", "is_default": True},
-        ]
-        _seed_install(plugin, 10, file_path="/roms/psx/a.chd", platform_slug="psx")
-        with plugin._uow:
-            plugin._uow.roms.set_emulator_override(10, "Removed Core")
-
-        roms = [{"id": 10, "platform_slug": "psx"}]
-        with caplog.at_level(logging.WARNING):
-            result = plugin._sync_service._orchestrator._build_core_overrides(roms)
-
-        assert result == {}
-        assert "Removed Core" in caplog.text
-        assert "no longer resolves" in caplog.text
-
-    def test_no_overrides_returns_empty(self, plugin):
-        """No pins anywhere → empty map (no available-cores lookups needed)."""
-        _seed_install(plugin, 10, file_path="/roms/n64/a.z64", platform_slug="n64")
-        result = plugin._sync_service._orchestrator._build_core_overrides([{"id": 10, "platform_slug": "n64"}])
-        assert result == {}
 
 
 class TestSyncPreview:

--- a/tests/services/test_disc_bake_sites.py
+++ b/tests/services/test_disc_bake_sites.py
@@ -8,7 +8,8 @@ existing per-site happy-path tests already assert; here we pin the disc-aware
 behavior.
 
 Bake sites covered:
-  * ``services.library.sync_orchestrator`` — the ``installed_paths`` map.
+  * ``services.library.bake_inputs`` — the ``installed_paths`` map both the
+    preview scan and the per-unit apply read hand to the bake.
   * ``services.rom_install_recorder`` — ``do_resolve_launch_bake``, which both a
     completed download and an adoption re-bake through.
 
@@ -21,13 +22,12 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fakes.fake_active_core_resolver import FakeActiveCoreResolver
 from fakes.fake_disc_resolver import FakeDiscResolver
 from fakes.fake_unit_of_work import FakeUnitOfWork, FakeUnitOfWorkFactory
-from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
+from fakes.system_time import FakeClock
 
 from domain.disc_selection import Disc
 from domain.rom import Rom
@@ -95,52 +95,39 @@ def disc_resolver() -> FakeDiscResolver:
     return resolver
 
 
-# ── sync_orchestrator bake site ──────────────────────────────────────────
+# ── library-sync bake site ───────────────────────────────────────────────
 
 
-class TestSyncOrchestratorBakeSite:
-    def _orchestrator(self, uow_factory, disc_resolver):
-        from services.library.sync_orchestrator import SyncOrchestrator, SyncOrchestratorConfig
+class TestLibrarySyncBakeSite:
+    def _bake_inputs(self, uow_factory, disc_resolver):
+        from services.library.bake_inputs import ShortcutBakeInputs, ShortcutBakeInputsConfig
 
-        return SyncOrchestrator(
-            config=SyncOrchestratorConfig(
-                settings={},
-                loop=MagicMock(),
-                logger=logging.getLogger("test_disc_bake"),
-                plugin_dir="/plugin",
-                emit=MagicMock(),
-                clock=FakeClock(),
-                uuid_gen=FakeUuidGen(),
-                sleeper=FakeSleeper(),
+        return ShortcutBakeInputs(
+            config=ShortcutBakeInputsConfig(
                 uow_factory=uow_factory,
-                sync_state_box=MagicMock(),
-                fetcher=MagicMock(),
-                reporter=MagicMock(),
-                artwork=MagicMock(),
                 active_core=FakeActiveCoreResolver(default=(None, None)),
                 disc_resolver=disc_resolver,
-                session_budget=AsyncMock(),
             )
         )
 
     def test_scan_installed_paths_honors_pin(self, disc_resolver):
         uow = FakeUnitOfWork()
         _seed_multi_disc(uow, rom_id=1, selected_disc=_DISC2)
-        orch = self._orchestrator(FakeUnitOfWorkFactory(uow=uow), disc_resolver)
-        assert orch._scan_installed_paths() == {1: _DISC2_PATH}
+        bake = self._bake_inputs(FakeUnitOfWorkFactory(uow=uow), disc_resolver)
+        assert bake.do_scan_installed_paths() == {1: _DISC2_PATH}
 
     def test_read_installed_paths_honors_pin(self, disc_resolver):
         uow = FakeUnitOfWork()
         _seed_multi_disc(uow, rom_id=1, selected_disc=_DISC2)
-        orch = self._orchestrator(FakeUnitOfWorkFactory(uow=uow), disc_resolver)
-        assert orch._read_installed_paths({1}) == {1: _DISC2_PATH}
+        bake = self._bake_inputs(FakeUnitOfWorkFactory(uow=uow), disc_resolver)
+        assert bake.do_read_installed_paths({1}) == {1: _DISC2_PATH}
 
     def test_scan_installed_paths_unpinned_defaults_to_disc_1(self, disc_resolver):
         uow = FakeUnitOfWork()
         _seed_multi_disc(uow, rom_id=1, selected_disc=None)
-        orch = self._orchestrator(FakeUnitOfWorkFactory(uow=uow), disc_resolver)
+        bake = self._bake_inputs(FakeUnitOfWorkFactory(uow=uow), disc_resolver)
         # file_path is disc 1 (not an m3u) → default resolves to disc 1.
-        assert orch._scan_installed_paths() == {1: _DISC1_PATH}
+        assert bake.do_scan_installed_paths() == {1: _DISC1_PATH}
 
     def test_scan_installed_paths_maps_an_unlaunchable_install_to_the_empty_path(self, disc_resolver):
         # The ROM stays IN the map — it IS downloaded, and collapse_sibling_groups
@@ -148,14 +135,14 @@ class TestSyncOrchestratorBakeSite:
         # launch path, so build_shortcuts_data emits the empty launch command (#1652).
         uow = FakeUnitOfWork()
         _seed_multi_disc(uow, rom_id=1, selected_disc=_DISC2, launchable=False)
-        orch = self._orchestrator(FakeUnitOfWorkFactory(uow=uow), disc_resolver)
-        assert orch._scan_installed_paths() == {1: ""}
+        bake = self._bake_inputs(FakeUnitOfWorkFactory(uow=uow), disc_resolver)
+        assert bake.do_scan_installed_paths() == {1: ""}
 
     def test_read_installed_paths_maps_an_unlaunchable_install_to_the_empty_path(self, disc_resolver):
         uow = FakeUnitOfWork()
         _seed_multi_disc(uow, rom_id=1, selected_disc=_DISC2, launchable=False)
-        orch = self._orchestrator(FakeUnitOfWorkFactory(uow=uow), disc_resolver)
-        assert orch._read_installed_paths({1}) == {1: ""}
+        bake = self._bake_inputs(FakeUnitOfWorkFactory(uow=uow), disc_resolver)
+        assert bake.do_read_installed_paths({1}) == {1: ""}
 
 
 # ── install-recorder bake site ───────────────────────────────────────────


### PR DESCRIPTION
The second cut of #1777, and the first half of it: the three methods that answer, for one ROM, where its file is and what runs it — `_scan_installed_paths`, `_read_installed_paths`, `_build_core_overrides` — move into `services/library/bake_inputs.py` as `ShortcutBakeInputs`. The module's contract is a boundary, not an inventory: anything that is not a launch fact of a single ROM belongs elsewhere.

They belong together for a reason the code states rather than taste. `active_core` and `disc_resolver` appeared in the orchestrator only inside these three, so both leave `SyncOrchestratorConfig` entirely — the orchestrator no longer knows what an emulator or a disc is. The methods are now peer-called, so they lose their leading underscore and take the `do_` prefix the conventions give a peer-called worker.

Behaviour is unchanged: the bodies moved verbatim, each opens the same Unit of Work at the same point, and each is still offloaded through the same executor with nothing open on the calling path.

A new gate comes with it. `scripts/check_seam_owner.py` pins which module inside `services/library/` may hold a seam — one owner per seam. It covers the two this cut confines, and also the two renderer seams that the previous cut's `session_budget.py` docstring promised were held only there while nothing checked it; that promise was verified against the tree before being encoded. The façade is not an owner: a composition root may pass a seam on to the module that owns it, and may not use one itself, which the gate distinguishes structurally. A façade method that reads or stores a seam fails it.

One thing the gate deliberately does not claim. Putting these three on one class makes a future fold of their two transactions into one a single line — and that fold would deadlock on a device, invisibly under the test doubles, because the emulator seam opens its own write transaction per ROM. `check_uow_seam_nesting.py` catches that fold only when it is written inline; the peer-call form, which is exactly the cheap one here, it does not see. The module docstring and the invariant register both say so plainly rather than implying cover that does not exist. The reason not to write the fold is the deadlock, not a check.

The docstring also records a rule this module does not keep, inherited rather than introduced: both install-path readers hold their transaction open across the disc resolver's directory listing, once per installed ROM, which is narrower-transaction guidance the project sets elsewhere. Naming it stops the next reader taking the new boundary as evidence the rest is clean. Tracked in #1779.

Counted size 1340 → 1282; the allowlist entry drops to match.

Step of #1777.
