### PR TITLE
refactor(sync): move the chunk round-trip out of the orchestrator

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -316,6 +316,17 @@ Format: **invariant** — tier — enforced by.
   is never mutated while the stash is pending (box IDLE) — every run-entry path passes `try_begin_run`, which clears the
   stash before any staging write** — prompt-only — the invariant holds today rather than being aspirational; mechanize
   via a staging-writer call-site audit
+- **An apply chunk's ack identity — `active_unit_id` / `active_chunk_index` and a fresh `unit_complete_event` — is
+  stamped on the box BEFORE that chunk's `sync_apply_unit` is emitted, with nothing awaited in between** — test +
+  prompt-only — `tests/services/library/test_chunk_dispatcher.py::TestAckIdentityPrecedesTheEmit`, which wraps
+  `ChunkDispatcher._emit` and records the box at call time over a two-chunk unit. The rule spans three modules and no
+  diff-scoped review sees it whole: `ChunkDispatcher` stamps, `services/library/_state.py` holds the fields and their
+  verbs, and `SyncReporter.report_unit_results` validates an incoming ack against them (#1041). **What the test pins is
+  the ordering inside the dispatcher, not the round-trip** — it observes a mock's call-time state, so a real frontend
+  ack racing a real emit is still unexercised, and every other suite lets the emit mock swallow the call. The failure
+  mode is why the entry exists rather than being left to the comment: stamp after the emit and a fast ack is rejected as
+  stray, the wait then stalls the full 60-second heartbeat window, and the run ends by stashing a chunk the frontend had
+  already applied — slow, plausible-looking, and silent (#1052 / #1367)
 - **A prune run's claim reservation and its refusal of every conflicting callable happen in one atomic gate hold (the
   preview rebuild does not), and frontend-owned Steam work holds a heartbeated, generation-tombstoned lease through
   every continuation's final write** — test + prompt-only — prune service/gate race tests + contract callable-entry

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -220,9 +220,11 @@ Format: **invariant** — tier — enforced by.
   rather than descriptive: these reads open their own short UoW and are offloaded to an executor at points chosen for
   cheapness, so a write among them would land at a moment nobody picked. The platform stamp's DELETE stayed in
   `sync_orchestrator.py` on those grounds — it is a write, so a read-only module cannot hold it, and it is cohesive with
-  the apply pipeline that performs it, not with the projections a run reasons about. **Why it sits exactly where it sits
-  in that pipeline is a property of its call site, not of its module** — after the fetch, after the artwork, after the
-  cancel guard, before the first chunk (ADR-0023 / #1025) — and that argument lives in full at the call site's own
+  the half of the apply pipeline that performs it: the DELETE stayed with `_sync_one_unit`, which builds a unit's delta,
+  while the re-stamp went to `ChunkDispatcher._build_final_platform_stamp` with the final chunk whose commit UoW it
+  rides, so the stamp's two ends now sit in two modules and each names the other. **Why the DELETE sits exactly where it
+  sits in that pipeline is a property of its call site, not of its module** — after the fetch, after the artwork, after
+  the cancel guard, before the first chunk (ADR-0023 / #1025) — and that argument lives in full at the call site's own
   comment, which is the only place a move could not have carried it away from
 - **An emitted `sync_progress` frame stops a run (`running: False`) only with a terminal stage, and a terminal stage is
   only ever emitted with the run stopped** — test — `tests/services/library/test_terminal_frame_contract.py`

--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -445,11 +445,11 @@ only representatives bound; Rom row then `rom_metadata`, FK-safe) over that chun
 crash-safe on its own and a mid-unit failure forfeits only the in-flight chunk. Chunks cut **only** at sibling-group
 boundaries (overflowing 200 to keep a game's dumps whole so they never straddle two commits); no-emit groups and
 unmatched leftovers ride chunk 0, and an empty unit is one empty chunk (the empty round-trip still commits its unbound
-rows). The whole-unit staging (`pending_sync` / `pending_all_roms` / `pending_cover_sources`) is set once; only the
-per-chunk coordination is re-armed each chunk. The motivating field crash is
-[#797](https://github.com/danielcopper/decky-romm-sync/issues/797): a 3084-shortcut unit emitted in one frame lost ~24
-minutes of work when `steamwebhelper` OOM-crashed before any ack — a 200-chunk caps both the bridge payload (~200 KB vs
-~3 MB) and the crash blast radius (~2 min vs 24+).
+rows). The whole-unit staging (`pending_sync` / `pending_all_roms` / `pending_cover_sources`) is set once by the
+dispatcher, before its first chunk goes out; only the per-chunk coordination is re-armed each chunk. The motivating
+field crash is [#797](https://github.com/danielcopper/decky-romm-sync/issues/797): a 3084-shortcut unit emitted in one
+frame lost ~24 minutes of work when `steamwebhelper` OOM-crashed before any ack — a 200-chunk caps both the bridge
+payload (~200 KB vs ~3 MB) and the crash blast radius (~2 min vs 24+).
 
 **Per-chunk wait: timeout vs. cancel.** The dispatcher emits each chunk's `sync_apply_unit`, then waits on
 `unit_complete_event` (heartbeat-clocked) for the frontend's `report_unit_results` ack. When the wait returns `None` the

--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -276,16 +276,17 @@ continue unrelated groups.
 
 #### LibraryService decomposition (`services/library/`)
 
-The library sync subsystem is a façade over six sub-services that coordinate through a shared `LibrarySyncStateBox`:
+The library sync subsystem is a façade over seven sub-services that coordinate through a shared `LibrarySyncStateBox`:
 
 | Module                        | Role                                                                                                                                                                                                                                                                                                                                       |
 | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `service.py`                  | `LibraryService` façade — public callable surface; wires the sub-services and delegates                                                                                                                                                                                                                                                    |
 | `fetcher.py`                  | `LibraryFetcher` — read-only RomM roundtrips: list platforms/collections, the incremental/full pagination loop, per-unit work-queue construction. The outward half of the read pair below                                                                                                                                                  |
 | `local_library_reader.py`     | `LocalLibraryReader` — the inward pair of `fetcher.py`: what THIS DEVICE recorded about the library, read back out of SQLite (the bound `Rom` rows, the completion stamps, the persisted sibling keys, the last finished run), shaped into the projections a run decides against. Declared read-only (`scripts/check_read_only_module.py`) |
-| `sync_orchestrator.py`        | `SyncOrchestrator` — preview (read-only), the per-unit apply pipeline, cancel, the heartbeat clock, progress emission                                                                                                                                                                                                                      |
+| `sync_orchestrator.py`        | `SyncOrchestrator` — preview (read-only), the per-unit apply pipeline (fetch → collapse → delta, then hand the delta to the dispatcher), cancel, the run lifecycle, the heartbeat clock, progress emission                                                                                                                                 |
+| `chunk_dispatcher.py`         | `ChunkDispatcher` — one unit's apply as durable chunk round-trips: emit `sync_apply_unit`, wait out the heartbeat clock for the ack, commit the chunk through the reporter, and stash or discard a chunk whose ack never came. It opens no transaction, and the run's `try_begin_run` / `finish_run` stay with the orchestrator            |
 | `reporter.py`                 | `SyncReporter` — post-apply finalisation (artwork filenames, per-unit `roms` upsert + `SyncRun` lifecycle) and the `roms`-derived queries                                                                                                                                                                                                  |
-| `session_budget.py`           | `SessionBudgetMonitor` — Steam's per-session renderer-heap budget: the GC-settled RSS measurement, the chunk-boundary pause verdict, the post-preview prognosis, the run-start baseline, and the `get_session_budget_status` payload                                                                                                       |
+| `session_budget.py`           | `SessionBudgetMonitor` — Steam's per-session renderer-heap budget: the GC-settled RSS measurement, the chunk-boundary pause verdict, the headroom clip that trims a chunk's additive cover work to what that verdict left, the post-preview prognosis, the run-start baseline, and the `get_session_budget_status` payload                 |
 | `shortcut_launch_resolver.py` | `ShortcutLaunchResolver` — resolves each ROM's launch facts for the shortcut bake: the disc-resolved installed path and the active emulator, both handed to `build_shortcuts_data`                                                                                                                                                         |
 | `_state.py`                   | `LibrarySyncStateBox` — shared mutable in-flight sync state; single source of truth threaded through every sub-service, and the **sole owner** of the run-lifecycle pair (`sync_state` / `current_sync_id`) via its verb methods                                                                                                           |
 
@@ -436,20 +437,21 @@ the final-chunk-only rule).
 **Per-unit apply is chunked, durable per chunk
 ([ADR-0023](https://github.com/danielcopper/decky-romm-sync/blob/main/docs/adr/0023-chunked-per-unit-apply.md)).** The
 delta emit list is split into fixed-size chunks (`_APPLY_CHUNK_SIZE`, 200) by the pure
-`domain/sync_chunking.py::build_unit_chunks`, and the orchestrator processes them one at a time: emit `sync_apply_unit`
-→ wait for the ack → commit that chunk's `roms` rows durably → next chunk. Each `sync_apply_unit` carries `chunk_index`
-/ `chunk_count` / `chunk_offset` / `unit_total`, and `shortcuts` is the chunk slice; the reporter's per-chunk commit is
-the same group-aware two-pass write (every fetched sibling upserted, only representatives bound; Rom row then
-`rom_metadata`, FK-safe) over that chunk's row subset, so a committed chunk is crash-safe on its own and a mid-unit
-failure forfeits only the in-flight chunk. Chunks cut **only** at sibling-group boundaries (overflowing 200 to keep a
-game's dumps whole so they never straddle two commits); no-emit groups and unmatched leftovers ride chunk 0, and an
-empty unit is one empty chunk (the empty round-trip still commits its unbound rows). The whole-unit staging
-(`pending_sync` / `pending_all_roms` / `pending_cover_sources`) is set once; only the per-chunk coordination is re-armed
-each chunk. The motivating field crash is [#797](https://github.com/danielcopper/decky-romm-sync/issues/797): a
-3084-shortcut unit emitted in one frame lost ~24 minutes of work when `steamwebhelper` OOM-crashed before any ack — a
-200-chunk caps both the bridge payload (~200 KB vs ~3 MB) and the crash blast radius (~2 min vs 24+).
+`domain/sync_chunking.py::build_unit_chunks`, and `ChunkDispatcher` (`services/library/chunk_dispatcher.py`) processes
+them one at a time: emit `sync_apply_unit` → wait for the ack → commit that chunk's `roms` rows durably → next chunk.
+Each `sync_apply_unit` carries `chunk_index` / `chunk_count` / `chunk_offset` / `unit_total`, and `shortcuts` is the
+chunk slice; the reporter's per-chunk commit is the same group-aware two-pass write (every fetched sibling upserted,
+only representatives bound; Rom row then `rom_metadata`, FK-safe) over that chunk's row subset, so a committed chunk is
+crash-safe on its own and a mid-unit failure forfeits only the in-flight chunk. Chunks cut **only** at sibling-group
+boundaries (overflowing 200 to keep a game's dumps whole so they never straddle two commits); no-emit groups and
+unmatched leftovers ride chunk 0, and an empty unit is one empty chunk (the empty round-trip still commits its unbound
+rows). The whole-unit staging (`pending_sync` / `pending_all_roms` / `pending_cover_sources`) is set once; only the
+per-chunk coordination is re-armed each chunk. The motivating field crash is
+[#797](https://github.com/danielcopper/decky-romm-sync/issues/797): a 3084-shortcut unit emitted in one frame lost ~24
+minutes of work when `steamwebhelper` OOM-crashed before any ack — a 200-chunk caps both the bridge payload (~200 KB vs
+~3 MB) and the crash blast radius (~2 min vs 24+).
 
-**Per-chunk wait: timeout vs. cancel.** The orchestrator emits each chunk's `sync_apply_unit`, then waits on
+**Per-chunk wait: timeout vs. cancel.** The dispatcher emits each chunk's `sync_apply_unit`, then waits on
 `unit_complete_event` (heartbeat-clocked) for the frontend's `report_unit_results` ack. When the wait returns `None` the
 teardown branches on the cause (#1052) — and either way, **every chunk committed before this one stays committed**:
 
@@ -457,7 +459,7 @@ teardown branches on the cause (#1052) — and either way, **every chunk committ
   the staging, null `unit_complete_event`, and clear `active_unit_id` + `active_chunk_index`. A stray late ack then
   no-ops.
 - **Heartbeat timeout** (still RUNNING) — the frontend has already created this chunk's Steam shortcuts and will fire a
-  late `report_unit_results`, but in production **after** the run has already wound down. The orchestrator moves the
+  late `report_unit_results`, but in production **after** the run has already wound down. The dispatcher moves the
   abandoned chunk into an `abandoned_chunk` stash on the box (`stash_abandoned_chunk`): its run/unit/chunk identity plus
   **this chunk's** ROMs (only the abandoned chunk, never the whole unit, the `metadatum` source), while it **keeps** the
   whole-unit staging (`pending_sync` / `pending_all_roms` / `pending_cover_sources`) live for the recovery commit to
@@ -478,7 +480,7 @@ teardown branches on the cause (#1052) — and either way, **every chunk committ
 Steam's `SharedJSContext` renderer OOM-crashes at ~2.45–2.53 GB RSS and never self-recovers within a session; each
 created shortcut costs 0.7–1.5 MB permanently (measured on-device). Chunking (ADR-0023) makes hitting that cliff a cheap
 resume; this gate stops the run _before_ it, at a chunk boundary, as a controlled pause. Every renderer reading and
-verdict below belongs to `SessionBudgetMonitor` (`services/library/session_budget.py`), which the orchestrator holds
+verdict below belongs to `SessionBudgetMonitor` (`services/library/session_budget.py`), which the chunk dispatcher holds
 directly — the fakeable seams are the two renderer adapters below, not the monitor. At each chunk boundary the monitor
 reads the renderer's RSS (`RendererRssFn`, `adapters/renderer_rss.py` — the max `VmRSS` across `steamwebhelper`
 processes from `/proc`) and, when that raw reading is at/above `GC_SKIP_BELOW_KB` (1.5 GB), forces a renderer GC

--- a/py_modules/services/library/__init__.py
+++ b/py_modules/services/library/__init__.py
@@ -4,7 +4,7 @@ The package's public API is the :class:`LibraryService` façade — it
 composes the library sync sub-services (:class:`LibraryFetcher`,
 :class:`SyncOrchestrator`, :class:`SyncReporter`,
 :class:`SessionBudgetMonitor`, :class:`ShortcutLaunchResolver`,
-:class:`LocalLibraryReader`) over a shared
+:class:`ChunkDispatcher`, :class:`LocalLibraryReader`) over a shared
 :class:`LibrarySyncStateBox` and exposes the callable surface consumed
 by the Decky entrypoints (platform/collection metadata, sync preview/
 apply, post-apply reporting, the ``roms``-derived queries). RomM

--- a/py_modules/services/library/_state.py
+++ b/py_modules/services/library/_state.py
@@ -110,7 +110,7 @@ class LibrarySyncStateBox:
     # rom_id), not just the emitted representatives in ``pending_sync``. The
     # per-unit commit upserts an identity + version-metadata row for ALL of them
     # (ADR-0021 group-aware persist) while only representatives carry a binding.
-    # Populated alongside ``pending_sync`` in ``_sync_one_unit`` and reset with
+    # Populated alongside ``pending_sync`` by ``ChunkDispatcher`` and reset with
     # it; kept across the heartbeat-timeout abandon window so a late ack can
     # still drive the full persist.
     pending_all_roms: dict[int, dict[str, Any]] = field(default_factory=dict)
@@ -119,8 +119,8 @@ class LibrarySyncStateBox:
     # per-ROM cover cache during this unit's cover download. The per-unit commit
     # merges these onto the upserted Rom rows (``Rom.adopt_cover_source``);
     # a rom absent here keeps its persisted fingerprint — a failed download
-    # never advances it (#1386). Populated alongside ``pending_sync`` in
-    # ``_sync_one_unit`` and reset with it; kept across the heartbeat-timeout
+    # never advances it (#1386). Populated alongside ``pending_sync`` by
+    # ``ChunkDispatcher`` and reset with it; kept across the heartbeat-timeout
     # abandon window so a late ack still stamps the confirmed values.
     pending_cover_sources: dict[int, str] = field(default_factory=dict)
     pending_delta: PreviewDelta | None = None

--- a/py_modules/services/library/_state.py
+++ b/py_modules/services/library/_state.py
@@ -134,7 +134,7 @@ class LibrarySyncStateBox:
     pending_platform_rom_ids: set[int] | None = None
     # Per-unit pipeline coordination. ``unit_complete_event`` is set by
     # :meth:`SyncReporter.report_unit_results` when the frontend acks the
-    # active chunk; the orchestrator awaits it (with a heartbeat-based
+    # active chunk; ``ChunkDispatcher`` awaits it (with a heartbeat-based
     # timeout) before dispatching the next chunk. Cleared back to None
     # between chunks and on either wait-give-up branch (user cancel and
     # heartbeat timeout). On a heartbeat timeout the abandoned chunk is moved
@@ -144,7 +144,7 @@ class LibrarySyncStateBox:
     unit_complete_event: asyncio.Event | None = None
     # Identity of the unit currently dispatched to the frontend: the
     # ``WorkUnit.id`` (a platform's numeric id or a collection's string id).
-    # Set by the orchestrator just before it emits ``sync_apply_unit`` and
+    # Set by ``ChunkDispatcher`` just before it emits ``sync_apply_unit`` and
     # cleared once the unit's ack is committed, the unit is cancelled, or the
     # chunk times out (its identity is moved into ``abandoned_chunk``).
     # ``SyncReporter.report_unit_results`` validates a live ack against this and
@@ -158,13 +158,13 @@ class LibrarySyncStateBox:
     # frontend. A unit's emitted shortcuts are split into chunks emitted +
     # committed one at a time (each chunk is a durable checkpoint); this stamps
     # which chunk is in flight so ``SyncReporter.report_unit_results`` can reject
-    # an ack for a stale chunk alongside the run/unit identity check. Set by the
-    # orchestrator before each chunk's ``sync_apply_unit`` emit and cleared to
+    # an ack for a stale chunk alongside the run/unit identity check. Set by
+    # ``ChunkDispatcher`` before each chunk's ``sync_apply_unit`` emit and cleared to
     # ``None`` once the unit's last chunk is committed, the unit is cancelled, or
     # the chunk times out (its identity is moved into ``abandoned_chunk``).
     active_chunk_index: int | None = None
     # Holds the frontend-supplied ``rom_id_to_app_id`` mapping reported
-    # for the active unit. Surfaces the result so the orchestrator can
+    # for the active unit. Surfaces the result so ``ChunkDispatcher`` can
     # accumulate the per-unit registry into the cross-run accumulators.
     last_unit_results: dict[str, int] | None = None
     # A heartbeat-timed-out apply chunk, stashed for its late

--- a/py_modules/services/library/chunk_dispatcher.py
+++ b/py_modules/services/library/chunk_dispatcher.py
@@ -23,10 +23,10 @@ heartbeat timeout does, so the loop above it stops), but ``try_begin_run`` and
 The per-platform completion stamp is built here, on a platform unit's final
 chunk, so "platform fully synced" ⟺ "stamp exists" is atomic on a crash. Its
 other half — the DELETE that invalidates the stamp the moment a fresh apply
-starts — stayed in ``SyncOrchestrator._sync_one_unit``
-(``_clear_platform_stamp_io``), because *where in the pipeline* that write is
-taken is a property of its call site; the argument for the ordering lives there
-in full.
+starts — is taken by ``SyncOrchestrator._sync_one_unit``
+(``_clear_platform_stamp_io``); *where in the pipeline* that write falls is a
+property of its call site, and the argument for the ordering lives there in
+full.
 """
 
 from __future__ import annotations

--- a/py_modules/services/library/chunk_dispatcher.py
+++ b/py_modules/services/library/chunk_dispatcher.py
@@ -1,0 +1,408 @@
+"""One work unit's apply, driven as a sequence of durable chunk round-trips.
+
+Emit a chunk of the unit's delta shortcuts to the frontend, wait for its
+acknowledgement against the heartbeat clock, commit it through the reporter,
+and decide what becomes of a chunk whose acknowledgement never comes. That loop
+is the whole module: *what* to apply is settled before it — the fetch, the
+group collapse and the delta are
+:class:`~services.library.sync_orchestrator.SyncOrchestrator`'s — and what the
+run makes of the outcome is settled after it.
+
+Nothing here opens a transaction or touches the outside world on its own:
+every durable write goes through :class:`~services.library.reporter.SyncReporter`
+and every message to the frontend through the injected emitter. That is why the
+dependency surface carries no Unit-of-Work factory, no settings, no plugin
+directory and no event loop — reaching for one would mean the round-trip had
+started doing something other than dispatching.
+
+**The run's lifecycle stays with the orchestrator.** A chunk is a step inside a
+run, never its beginning or its end: this module may *request* a cancel (a
+heartbeat timeout does, so the loop above it stops), but ``try_begin_run`` and
+``finish_run`` are the orchestrator's alone.
+
+The per-platform completion stamp is built here, on a platform unit's final
+chunk, so "platform fully synced" ⟺ "stamp exists" is atomic on a crash. Its
+other half — the DELETE that invalidates the stamp the moment a fresh apply
+starts — stayed in ``SyncOrchestrator._sync_one_unit``
+(``_clear_platform_stamp_io``), because *where in the pipeline* that write is
+taken is a property of its call site; the argument for the ordering lives there
+in full.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from domain.collection_sync_state import CollectionSyncState
+from domain.platform_sync_state import PlatformSyncState
+from domain.session_budget import CLIFF_KB, EFFECTIVE_CEILING_KB
+from domain.sync_chunking import build_unit_chunks, wire_shortcuts
+
+if TYPE_CHECKING:
+    import logging
+
+    from domain.work_unit import WorkUnit
+    from lib.late_binding import LateBinding
+    from services.library._state import LibrarySyncStateBox
+    from services.library.reporter import SyncReporter
+    from services.library.session_budget import SessionBudgetMonitor
+    from services.protocols import Clock, EventEmitter, Sleeper
+
+
+# Per-unit heartbeat-based timeout. If the frontend stops calling
+# ``sync_heartbeat`` for this many seconds while the dispatcher is
+# waiting for ``report_unit_results``, the wait is treated as a
+# recoverable cancellation — the in-flight unit is dropped and the
+# next sync resumes via the incremental-skip path.
+_UNIT_HEARTBEAT_TIMEOUT_SEC = 60.0
+# Polling cadence the wait loop uses while watching the heartbeat
+# clock. Kept short so cancel propagation feels responsive without
+# burning CPU.
+_UNIT_WAIT_POLL_SEC = 1.0
+# Emitted-shortcut count per apply chunk. A unit's emitted shortcuts are split
+# into chunks of about this many entries, each emitted → acked → committed
+# durably before the next, so a mid-unit CEF crash forfeits only the in-flight
+# chunk. A chunk may overflow this to keep a sibling group whole (see
+# :func:`domain.sync_chunking.build_unit_chunks`).
+_APPLY_CHUNK_SIZE = 200
+
+
+@dataclass(frozen=True)
+class ChunkDispatcherConfig:
+    """Frozen wiring bundle handed to ``ChunkDispatcher.__init__``.
+
+    Holds the logger, the event emitter the chunk frames go out through, the
+    Clock/Sleeper seams the heartbeat wait is clocked by, the shared
+    :class:`LibrarySyncStateBox` carrying the per-chunk coordination state, the
+    :class:`SessionBudgetMonitor` the loop asks its two budget questions of at
+    each chunk boundary, and the reporter every commit runs through. The
+    ``reporter`` field is a :class:`LateBinding` because :class:`LibraryService`
+    constructs this dispatcher before the reporter exists; the façade plugs it in
+    via ``set()`` once the reporter is built.
+
+    What is absent is the contract: no Unit-of-Work factory (the dispatcher
+    opens no transaction), no event loop (it offloads nothing), no settings and
+    no plugin directory (every decision it acts on was made before the round-trip
+    began).
+    """
+
+    logger: logging.Logger
+    emit: EventEmitter
+    clock: Clock
+    sleeper: Sleeper
+    sync_state_box: LibrarySyncStateBox
+    reporter: LateBinding[SyncReporter]
+    session_budget: SessionBudgetMonitor
+
+
+class ChunkDispatcher:
+    """Drives one work unit's apply as emit → wait → commit, one chunk at a time."""
+
+    def __init__(self, *, config: ChunkDispatcherConfig) -> None:
+        self._logger = config.logger
+        self._emit = config.emit
+        self._clock = config.clock
+        self._sleeper = config.sleeper
+        self._sync_state = config.sync_state_box
+        self._reporter = config.reporter
+        self._session_budget = config.session_budget
+
+    async def apply_unit_in_chunks(
+        self,
+        unit: WorkUnit,
+        *,
+        unit_index: int,
+        total_units: int,
+        emitted: list[dict[str, Any]],
+        shortcuts_data: list[dict[str, Any]],
+        unit_roms: list[dict[str, Any]],
+        new_ids: set[int],
+        cover_refreshes: list[dict[str, int]] | None = None,
+        collection_member_ids: list[int] | None = None,
+    ) -> int:
+        """Emit → wait → commit the unit's DELTA shortcuts one durable chunk at a time.
+
+        ``emitted`` is the delta (new + changed + rebind) the frontend applies;
+        skipped-unchanged entries never reach here but their rows still ride the
+        chunks' ``rom_ids`` (routed to chunk 0's leftover by ``build_unit_chunks``).
+        The delta shortcuts are split into commit chunks processed one at a time
+        (emit → wait → commit durably → next), so a mid-unit CEF crash forfeits
+        only the in-flight chunk, not every prior chunk. ``chunk.rom_ids`` are the
+        chunk's fetched ROMs (its sibling groups' rows, plus chunk 0's skipped
+        leftover); a keyed lookup into the whole unit's live fetch yields the
+        chunk's commit subset. ``new_ids`` (the classified creates) prices each
+        chunk create-vs-update for the session-budget gate. ``cover_refreshes``
+        (the #1386 invalidation pass's ``{rom_id, app_id}`` list) rides the
+        unit's FIRST chunk payload, clipped to the budget headroom left after
+        that chunk's own projected cost — a big refresh list degrades to fewer
+        in-session tile refreshes (the grid files are already updated; a Steam
+        restart shows the rest), never to a run pause. Returns the running
+        count of shortcuts applied — a cancel or heartbeat timeout returns early
+        with the chunks committed so far.
+        """
+        box = self._sync_state
+        # One generation id per platform fetch. The run id serves: a platform is
+        # fetched at most once per run, so it identifies this platform's fetch
+        # uniquely, and every chunk of the unit shares it — unlike a clock reading,
+        # which differs per chunk and would leave the earlier chunks' rows stamped
+        # before the final chunk's completion stamp (#1504).
+        fetch_id = str(box.current_sync_id or "") if unit.type == "platform" else None
+        chunks = build_unit_chunks(emitted, shortcuts_data, _APPLY_CHUNK_SIZE)
+        roms_by_id = {r["id"]: r for r in unit_roms if "id" in r}
+        chunk_count = len(chunks)
+        applied_count = 0
+        for chunk_index, chunk in enumerate(chunks):
+            # A cancel landing in the inter-chunk window — after the prior chunk's
+            # commit but before this chunk's emit — discards the rest of the unit
+            # here, before any per-chunk mutation or emit. Without this the
+            # frontend would fully process another ~200-shortcut chunk (~2 min)
+            # whose ack the backend then rejects, orphaning those shortcuts until
+            # the next sync. Same cleanup as the mid-wait user-cancel branch.
+            if box.is_cancelling():
+                box.clear_active_unit()
+                return applied_count
+
+            # Session-budget gate (#1383): at every chunk boundary ask the monitor
+            # whether applying this chunk would cross Steam's per-session heap budget,
+            # and pause here — a clean chunk boundary — if it would. On pause the
+            # gate sets ``run_paused`` + ``interrupt_reason`` and requests
+            # cancel, so the check just below returns cleanly with the prior chunks
+            # committed — the terminal finalize then records the resumable ``paused``
+            # state (the deliberate sibling of a heartbeat timeout's
+            # ``interrupted``). Both modes are PREDICTIVE (RSS plus this chunk's
+            # worst-case cost) and differ only in the line the projection is
+            # measured against:
+            #  - Every LATER chunk projects against the effective ceiling
+            #    (``cliff - margin`` ≈ 2.2 GB), keeping the anti-thrash safety margin.
+            #  - The run's very FIRST chunk projects against the CLIFF itself
+            #    (``CLIFF_KB`` ≈ 2.45 GB). Forward progress must be guaranteed — the
+            #    run has to apply at least one chunk or it loops forever on a
+            #    no-progress pause — so the first chunk is allowed to spend into the
+            #    safety margin, but the predictive projection still stops it before
+            #    the crash line. Net effect: a resume proceeds only when this chunk's
+            #    worst-case peak stays below the cliff (≈ 1.95 GB for a full 200-item
+            #    chunk of cover-applying creates, each priced create + cover) and can
+            #    never be projected past it; at/above that it re-pauses with zero
+            #    progress and the banner directs the user to restart Steam.
+            # The chunk is priced by composition, so the gate needs its creates and
+            # updates apart. The frontend decides create-vs-update itself via its
+            # existing-shortcut scan; a small backend/frontend mismatch only ever
+            # overprices (worst-case safe).
+            creates = sum(1 for e in chunk.emitted if e["rom_id"] in new_ids)
+            updates = len(chunk.emitted) - creates
+            budget_limit_kb = CLIFF_KB if box.chunks_emitted_this_run == 0 else EFFECTIVE_CEILING_KB
+            rss_kb = await self._session_budget.maybe_pause_for_budget(
+                creates=creates, updates=updates, limit_kb=budget_limit_kb
+            )
+            if box.is_cancelling():
+                box.clear_active_unit()
+                return applied_count
+
+            # The #1386 cover-refresh list rides the unit's FIRST chunk, clipped to
+            # the budget headroom left after this chunk's own projected cost — the
+            # refreshes must never be the reason a run pauses, so they degrade to
+            # fewer in-session tile refreshes instead (grid files already updated).
+            chunk_cover_refreshes: list[dict[str, int]] = []
+            if chunk_index == 0 and cover_refreshes:
+                chunk_cover_refreshes = self._session_budget.clip_cover_refreshes(
+                    cover_refreshes, rss_kb=rss_kb, creates=creates, updates=updates, limit_kb=budget_limit_kb
+                )
+
+            chunk_rows = [roms_by_id[rid] for rid in chunk.rom_ids if rid in roms_by_id]
+
+            # Fresh per-chunk coordination: a new event + identity (run + unit +
+            # chunk index) so the reporter validates each chunk's ack. These four
+            # assignments MUST precede the emit below and nothing may be awaited
+            # between them and it. The frontend can ack within milliseconds of
+            # receiving the frame, and the reporter checks that ack against exactly
+            # this identity: emit first and a fast ack is rejected as stray, the
+            # event it would have set is never set, and the wait below runs its full
+            # heartbeat timeout before giving up — a silent 60 s stall that then
+            # stashes a chunk the frontend already applied (#1041 / #1052 / #1367).
+            box.unit_complete_event = asyncio.Event()
+            box.last_unit_results = None
+            box.active_unit_id = unit.id
+            box.active_chunk_index = chunk_index
+            box.sync_last_heartbeat = self._clock.monotonic()
+            await self._emit(
+                "sync_apply_unit",
+                {
+                    "run_id": str(box.current_sync_id or ""),
+                    "unit_type": unit.type,
+                    "unit_id": unit.id,
+                    "unit_name": unit.name,
+                    "unit_index": unit_index,
+                    "total_units": total_units,
+                    "chunk_index": chunk_index,
+                    "chunk_count": chunk_count,
+                    "chunk_offset": chunk.offset,
+                    "unit_total": len(emitted),
+                    # Strip backend-internal keys (staged cover path, rebind target)
+                    # from the wire — the frontend fetches a created shortcut's cover
+                    # via get_artwork_base64(rom_id); the commit reads them from
+                    # pending_sync, which keeps the full entries.
+                    "shortcuts": wire_shortcuts(chunk.emitted),
+                    # Existing shortcuts whose server-side cover changed (#1386):
+                    # the frontend re-applies each via SetCustomArtworkForApp so
+                    # the tile refreshes in-session. Non-empty only on chunk 0.
+                    "cover_refreshes": chunk_cover_refreshes,
+                },
+            )
+            # Count this emit so the session-budget gate exempts only the very
+            # first chunk of the run (forward-progress guarantee, #1383).
+            box.chunks_emitted_this_run += 1
+
+            applied = await self._wait_for_unit_complete(unit, box.unit_complete_event)
+            if applied is None:
+                # The wait gave up — the reason (user cancel vs heartbeat timeout)
+                # decides whether this chunk's in-flight work is recoverable. Chunks
+                # committed before this one stay committed either way.
+                self._abandon_active_chunk(chunk_rows)
+                return applied_count
+
+            platform_stamp = self._build_final_platform_stamp(unit, chunk_index, chunk_count, fetch_id)
+            collection_stamp = self._build_final_collection_stamp(unit, chunk_index, chunk_count, collection_member_ids)
+
+            # Per-chunk commit: the reporter upserts every fetched ROM of this
+            # chunk into the ``roms`` aggregate (identity + version metadata,
+            # unbound for non-representatives) and binds only the acked
+            # representatives, stamping each ROM's cached ``rom_metadata`` in the
+            # same write UoW (Rom row first, metadata second — FK-safe).
+            # ``chunk_rows`` is this chunk's slice of the live RomM fetch — the
+            # source of ``metadatum`` — so each committed chunk is a crash-safe
+            # checkpoint. The final-chunk ``platform_stamp`` / ``collection_stamp``
+            # (whichever the unit type produces) rides the same UoW.
+            await self._reporter.get().commit_unit_results(
+                applied,
+                chunk_rows,
+                platform_stamp=platform_stamp,
+                collection_stamp=collection_stamp,
+                # The fetch generation for a PLATFORM unit's rows (#1504), passed on
+                # EVERY chunk so the whole unit shares the generation the final
+                # chunk's stamp records. A collection unit passes None — it spans
+                # platforms, and re-marking a foreign platform's row would drop it
+                # from that platform's counted rows.
+                fetch_id=fetch_id,
+            )
+            applied_count += len(applied)
+            # Only a COMMITTED chunk's items count as done (#1383): an emitted chunk
+            # whose ack never landed — a cancel or a heartbeat timeout — returns above,
+            # before this line, so the paused banner never over-reports.
+            box.run_done_items += len(applied)
+
+        box.clear_active_unit()
+        return applied_count
+
+    async def _wait_for_unit_complete(self, unit: WorkUnit, event: asyncio.Event) -> dict[str, int] | None:
+        """Heartbeat-based wait for the active unit's frontend callback.
+
+        Returns the frontend-reported ``rom_id_to_app_id`` on success.
+        Returns ``None`` on timeout or cancel — the outer loop maps that
+        onto a recoverable cancellation. The wait poll polls the
+        heartbeat clock rather than ``asyncio.wait_for(timeout=...)``
+        because the frontend sends ``sync_heartbeat`` calls during long
+        per-unit applies (artwork download, Set* calls) and a 60s
+        absolute cap would still race those.
+        """
+        box = self._sync_state
+        while not event.is_set():
+            if box.is_cancelling():
+                self._logger.info(f"Per-unit cancel observed while waiting for unit {unit.name}")
+                return None
+            elapsed = self._clock.monotonic() - box.sync_last_heartbeat
+            if elapsed > _UNIT_HEARTBEAT_TIMEOUT_SEC:
+                self._logger.warning(f"Per-unit timeout: no heartbeat for {elapsed:.0f}s waiting on unit {unit.name}")
+                return None
+            try:
+                await self._sleeper.sleep(_UNIT_WAIT_POLL_SEC)
+            except asyncio.CancelledError:
+                self._logger.info(f"Per-unit wait cancelled for unit {unit.name}")
+                raise
+
+        results = box.last_unit_results or {}
+        box.last_unit_results = None
+        return results
+
+    def _abandon_active_chunk(self, chunk_rows: list[dict[str, Any]]) -> None:
+        """Tear down or stash the in-flight chunk after its wait gave up.
+
+        A user cancel (box already CANCELLING) intentionally discards the chunk:
+        drop the whole-unit staging, null the event, and clear the unit + chunk
+        identity so a stray late ack can't commit it. A heartbeat timeout (box
+        still RUNNING) instead stashes THIS chunk (its run/unit/chunk identity +
+        rows) into ``abandoned_chunk`` via ``stash_abandoned_chunk`` — inert data
+        that survives the run's teardown — while leaving the whole-unit staging
+        live, so a late ``report_unit_results`` still commits the delivered
+        bindings instead of leaving orphan shortcuts (#1052 / #1367). It then
+        marks the run ``interrupted`` (the frontend went dark, not the user's
+        Cancel — so the terminal SyncRun write records ``interrupted``) and
+        requests the cancel that stops the chunk loop.
+        """
+        box = self._sync_state
+        if box.is_cancelling():
+            box.clear_active_unit()
+        else:
+            box.stash_abandoned_chunk(chunk_rows)
+            box.run_interrupted = True
+            box.request_cancel()
+
+    def _build_final_platform_stamp(
+        self, unit: WorkUnit, chunk_index: int, chunk_count: int, fetch_id: str | None = None
+    ) -> PlatformSyncState | None:
+        """Build the completion stamp for a platform unit's FINAL chunk, else ``None``.
+
+        On the final chunk of a PLATFORM unit the stamp rides that chunk's commit
+        UoW so "platform fully synced" ⟺ "stamp exists" is atomic on a crash. The
+        stamp lets the next sync's incremental-skip gate skip this platform even
+        when the whole run is later cancelled (its library-wide ``last_sync`` never
+        advances). Only platform units carry a skip gate — collections have none,
+        so they are never stamped. A cancel or heartbeat timeout mid-unit returns
+        before the final chunk, so an incomplete platform is never stamped
+        (ADR-0023 / #1025).
+        """
+        if unit.type == "platform" and unit.slug and chunk_index == chunk_count - 1:
+            return PlatformSyncState.stamp(
+                platform_slug=unit.slug,
+                at=self._clock.now().isoformat(),
+                rom_count=unit.rom_count,
+                fetch_id=fetch_id,
+            )
+        return None
+
+    def _build_final_collection_stamp(
+        self,
+        unit: WorkUnit,
+        chunk_index: int,
+        chunk_count: int,
+        member_rom_ids: list[int] | None,
+    ) -> CollectionSyncState | None:
+        """Build the completion stamp for a standard/smart collection's FINAL chunk, else ``None``.
+
+        The collection sibling of :meth:`_build_final_platform_stamp` (#742). On
+        the final chunk of a standard/smart collection unit whose listing carried an
+        ``updated_at``, the stamp rides that chunk's commit UoW so "collection
+        fully synced" ⟺ "stamp exists" is atomic on a crash. ``member_rom_ids`` is
+        the collection's FULL membership (every member id, not just the applied
+        new_roms), which a future skip replays to rebuild the Steam-collection
+        map. Virtual collections carry no stamp (no stable
+        ``updated_at``), and a cancel or heartbeat timeout mid-unit returns before
+        the final chunk — an incomplete collection is never stamped (ADR-0023).
+        """
+        if (
+            unit.type == "collection"
+            and unit.collection_kind in ("standard", "smart")
+            and unit.collection_updated_at
+            and member_rom_ids is not None
+            and chunk_index == chunk_count - 1
+        ):
+            return CollectionSyncState.stamp(
+                collection_id=str(unit.id),
+                collection_kind=unit.collection_kind,
+                updated_at=unit.collection_updated_at,
+                completed_at=self._clock.now().isoformat(),
+                rom_count=unit.rom_count,
+                member_rom_ids=tuple(member_rom_ids),
+            )
+        return None

--- a/py_modules/services/library/chunk_dispatcher.py
+++ b/py_modules/services/library/chunk_dispatcher.py
@@ -119,6 +119,7 @@ class ChunkDispatcher:
         shortcuts_data: list[dict[str, Any]],
         unit_roms: list[dict[str, Any]],
         new_ids: set[int],
+        confirmed_cover_sources: dict[int, str],
         cover_refreshes: list[dict[str, int]] | None = None,
         collection_member_ids: list[int] | None = None,
     ) -> int:
@@ -138,11 +139,24 @@ class ChunkDispatcher:
         unit's FIRST chunk payload, clipped to the budget headroom left after
         that chunk's own projected cost — a big refresh list degrades to fewer
         in-session tile refreshes (the grid files are already updated; a Steam
-        restart shows the rest), never to a run pause. Returns the running
+        restart shows the rest), never to a run pause. ``confirmed_cover_sources``
+        is the unit's ``rom_id → applied cover source`` map — the third of the
+        whole-unit staging dicts the reporter's commit reads. Returns the running
         count of shortcuts applied — a cancel or heartbeat timeout returns early
         with the chunks committed so far.
         """
         box = self._sync_state
+        # Stage the DELTA representatives for cover finalise + binding, and the
+        # full built set for the ack-independent identity + version persist (the
+        # reporter upserts a row for every sibling — skipped ones included — and
+        # binds only the delta's acked representatives). Staging stays whole-unit;
+        # the apply is chunked below, so a mid-unit CEF crash forfeits only the
+        # in-flight chunk, not every prior chunk. Written here rather than by the
+        # caller so these three fields have one production writer module from the
+        # moment they are staged to ``clear_active_unit``'s teardown.
+        box.pending_sync = {e["rom_id"]: e for e in emitted}
+        box.pending_all_roms = {sd["rom_id"]: sd for sd in shortcuts_data}
+        box.pending_cover_sources = confirmed_cover_sources
         # One generation id per platform fetch. The run id serves: a platform is
         # fetched at most once per run, so it identifies this platform's fetch
         # uniquely, and every chunk of the unit shares it — unlike a clock reading,

--- a/py_modules/services/library/local_library_reader.py
+++ b/py_modules/services/library/local_library_reader.py
@@ -27,8 +27,8 @@ declaration is worth having anyway: every method here opens its own short Unit
 of Work and is offloaded through the orchestrator's executor at points chosen
 for cheapness, so a write among them would land at a moment nobody picked.
 
-Two neighbours deliberately stayed with the orchestrator, both touching the same
-tables through the same repositories:
+Two neighbours belong to the orchestrator instead, deliberately, though both
+touch the same tables through the same repositories:
 
 * ``_clear_platform_stamp_io`` **writes**. That alone rules it out of a
   read-only module, and it belongs with the apply pipeline that performs it

--- a/py_modules/services/library/reporter.py
+++ b/py_modules/services/library/reporter.py
@@ -488,8 +488,8 @@ class SyncReporter:
         UoW upserts every ROM (Rom row first, cached metadata second — FK-safe),
         so a ROM and its metadata land atomically.
 
-        ``platform_stamp`` (set by the orchestrator on the final chunk of a
-        platform unit, ADR-0023) is saved inside that same write UoW, so the
+        ``platform_stamp`` (set by :class:`ChunkDispatcher` on the final chunk of
+        a platform unit, ADR-0023) is saved inside that same write UoW, so the
         per-platform completion stamp commits atomically with the chunk's rom
         upserts — the platform is stamped complete iff its last chunk is durable.
         ``collection_stamp`` is the collection sibling (#742), set on the final
@@ -670,7 +670,7 @@ class SyncReporter:
 
         * **Active chunk** — the ack matches the dispatched
           ``current_sync_id`` / ``active_unit_id`` / ``active_chunk_index``
-          (#1041). Record the rom_id→app_id mapping and, if the orchestrator is
+          (#1041). Record the rom_id→app_id mapping and, if the dispatcher is
           still waiting (``unit_complete_event`` live), signal the event so it
           drives the per-chunk commit. The happy path. A duplicate ack whose
           event was already consumed (identity still matches, event ``None``)
@@ -747,9 +747,10 @@ class SyncReporter:
     ):
         """Per-chunk commit: cover-path finalize then atomic ``roms`` + metadata upsert.
 
-        Called once the frontend has acked an apply chunk's shortcuts — by the
-        orchestrator on the happy path, or by :meth:`report_unit_results`
-        itself on the heartbeat-timeout late-ack path (#1052). ``unit_roms`` is
+        Called once the frontend has acked an apply chunk's shortcuts — by
+        :class:`ChunkDispatcher` on the happy path, or by
+        :meth:`report_unit_results` itself on the heartbeat-timeout late-ack
+        path (#1052). ``unit_roms`` is
         this chunk's slice of the live RomM fetch: a ``roms`` row is upserted for
         EVERY sibling in the slice (identity + version metadata, ADR-0021), but
         only the acked representatives carry a binding. The upsert and the
@@ -757,9 +758,9 @@ class SyncReporter:
         ``rom_metadata`` — FK-safe), so a ROM and its metadata are always
         consistent across a crash, and each committed chunk is durable on its own.
 
-        ``platform_stamp`` / ``collection_stamp`` are passed only by the
-        orchestrator on the **final chunk of a platform / user-smart-collection
-        unit** (ADR-0023, #742); the relevant one rides the same write UoW so the
+        ``platform_stamp`` / ``collection_stamp`` are passed only by
+        :class:`ChunkDispatcher` on the **final chunk of a platform /
+        user-smart-collection unit** (ADR-0023, #742); the relevant one rides the same write UoW so the
         completion stamp is atomic with the chunk's rom upserts. The
         heartbeat-timeout late-ack path never sets either — a timed-out unit is
         incomplete and must not be stamped.

--- a/py_modules/services/library/reporter.py
+++ b/py_modules/services/library/reporter.py
@@ -68,7 +68,7 @@ class SyncReporterConfig:
     the SQLite Unit-of-Work factory (the transactional seam over the
     ``roms`` / ``rom_installs`` / ``sync_runs`` / ``kv_config``
     repositories), the shared ``LibrarySyncStateBox`` (the reporter reads
-    the pending-sync dicts populated by the orchestrator; the run-lifecycle
+    the pending-sync dicts staged by :class:`ChunkDispatcher`; the run-lifecycle
     reset is owned by the orchestrator's terminal ``finally``, not here), an
     orchestrator-supplied ``emit_progress`` callback for the terminal "done"
     event, and the

--- a/py_modules/services/library/service.py
+++ b/py_modules/services/library/service.py
@@ -10,6 +10,7 @@ lifecycle and safety heartbeat, :class:`SyncReporter` for post-apply
 finalisation and the ``roms``-derived callable queries,
 :class:`SessionBudgetMonitor` for Steam's renderer-heap budget,
 :class:`ShortcutLaunchResolver` for each ROM's launch facts,
+:class:`ChunkDispatcher` for one unit's emit → ack → commit round-trips,
 :class:`LocalLibraryReader` for what this device already recorded about the
 library. The façade itself only wires the
 pieces together and delegates — anything that touches RomM or mutates
@@ -23,6 +24,7 @@ from typing import TYPE_CHECKING, Any
 
 from lib.late_binding import LateBinding
 from services.library._state import CollectionMembership, LibrarySyncStateBox
+from services.library.chunk_dispatcher import ChunkDispatcher, ChunkDispatcherConfig
 from services.library.fetcher import LibraryFetcher, LibraryFetcherConfig
 from services.library.local_library_reader import LocalLibraryReader, LocalLibraryReaderConfig
 from services.library.reporter import SyncReporter, SyncReporterConfig
@@ -102,8 +104,9 @@ class LibraryService:
     (post-apply finalisation + the ``roms``-derived callable queries),
     :class:`SessionBudgetMonitor` (Steam's renderer-heap budget),
     :class:`ShortcutLaunchResolver` (each ROM's installed path + active
-    emulator), and :class:`LocalLibraryReader` (this device's own record of
-    the library, read back out of SQLite) over a
+    emulator), :class:`ChunkDispatcher` (one unit's apply, emitted and
+    committed a chunk at a time), and :class:`LocalLibraryReader` (this
+    device's own record of the library, read back out of SQLite) over a
     single shared :class:`LibrarySyncStateBox`. The façade itself owns the box and
     exposes the callable surface; every implementation method lives on
     one of the sub-services.
@@ -165,11 +168,28 @@ class LibraryService:
         )
 
         # The orchestrator dispatches the per-unit pipeline's finalize
-        # step (sync_collections + sync_complete) through the reporter,
-        # but the reporter doesn't exist yet at this point in __init__.
-        # Thread the forward reference through a LateBinding rather than
-        # writing to a sub-service private after the fact.
+        # step (sync_collections + sync_complete) through the reporter, and
+        # the chunk dispatcher commits every chunk through it, but the
+        # reporter doesn't exist yet at this point in __init__. Thread the
+        # forward reference through a LateBinding rather than writing to a
+        # sub-service private after the fact.
         reporter_binding: LateBinding[SyncReporter] = LateBinding("reporter")
+
+        # Sub-service: chunk dispatcher — one work unit's apply, emitted to the
+        # frontend and committed a chunk at a time. Constructed before the
+        # orchestrator, which holds it and hands it each unit's built delta.
+        self._chunk_dispatcher = ChunkDispatcher(
+            config=ChunkDispatcherConfig(
+                logger=config.logger,
+                emit=config.emit,
+                clock=config.clock,
+                sleeper=config.sleeper,
+                sync_state_box=self._box,
+                reporter=reporter_binding,
+                session_budget=self._session_budget,
+            )
+        )
+
         self._orchestrator = SyncOrchestrator(
             config=SyncOrchestratorConfig(
                 settings=config.settings,
@@ -179,7 +199,6 @@ class LibraryService:
                 emit=config.emit,
                 clock=config.clock,
                 uuid_gen=config.uuid_gen,
-                sleeper=config.sleeper,
                 uow_factory=config.uow_factory,
                 sync_state_box=self._box,
                 fetcher=self._fetcher,
@@ -188,6 +207,7 @@ class LibraryService:
                 shortcut_launch_resolver=self._shortcut_launch_resolver,
                 local_library_reader=self._local_library_reader,
                 session_budget=self._session_budget,
+                chunk_dispatcher=self._chunk_dispatcher,
             )
         )
 

--- a/py_modules/services/library/service.py
+++ b/py_modules/services/library/service.py
@@ -155,8 +155,10 @@ class LibraryService:
         # through its own executor.
         self._local_library_reader = LocalLibraryReader(config=LocalLibraryReaderConfig(uow_factory=config.uow_factory))
 
-        # Sub-service: session-budget monitor. Constructed before the
-        # orchestrator, which holds it and calls it at every chunk boundary.
+        # Sub-service: session-budget monitor. Constructed before both holders:
+        # the chunk dispatcher asks it at every chunk boundary, the orchestrator
+        # for the preview prognosis, the run-start baseline and the terminal
+        # memory delta.
         self._session_budget = SessionBudgetMonitor(
             config=SessionBudgetMonitorConfig(
                 loop=config.loop,

--- a/py_modules/services/library/session_budget.py
+++ b/py_modules/services/library/session_budget.py
@@ -2,7 +2,8 @@
 
 Owns every renderer-RSS **reading** the sync subsystem takes, and the verdicts
 drawn from one: the GC-settled measurement itself, the chunk-boundary pause
-decision, the post-preview prognosis, the run-start baseline behind the last-run
+decision, the trim of additive chunk work to whatever headroom that decision
+left, the post-preview prognosis, the run-start baseline behind the last-run
 delta, and the live reading the QAM banners poll. The pure arithmetic behind
 every one of those decisions is :mod:`domain.session_budget`; the ``/proc``
 reader and the CDP garbage-collect trigger are adapters reached through the
@@ -10,13 +11,11 @@ reader and the CDP garbage-collect trigger are adapters reached through the
 orchestration between the two — measure, ask the domain, record the verdict on
 the shared :class:`LibrarySyncStateBox`.
 
-Two sites in :mod:`services.library.sync_orchestrator` still price against the
-budget, from a reading this module handed them rather than one they took:
-``_clip_cover_refreshes`` (trimming the cover-refresh list to a chunk's leftover
-headroom) and the terminal ``session_memory_delta`` / ``post_run_advisory``
-computation in ``_finalize_per_unit``. They sit with the chunk loop and the
-finalize phase they belong to; what never happens outside this module is taking
-a reading.
+One site in :mod:`services.library.sync_orchestrator` still prices against the
+budget, from a reading this module handed it rather than one it took: the
+terminal ``session_memory_delta`` / ``post_run_advisory`` computation in
+``_finalize_per_unit``. It sits with the finalize phase it belongs to; what
+never happens outside this module is taking a reading.
 
 Fail-open is the contract of every path: an unavailable reading, or any seam
 error, degrades to "no verdict" (no pause, no warning, no number) and never
@@ -209,6 +208,40 @@ class SessionBudgetMonitor:
         except Exception as e:  # fail-open: the gate must never fail the run
             self._logger.debug(f"Session-budget gate skipped: {e}")
             return None
+
+    def clip_cover_refreshes(
+        self,
+        cover_refreshes: list[dict[str, int]],
+        *,
+        rss_kb: int | None,
+        creates: int,
+        updates: int,
+        limit_kb: int,
+    ) -> list[dict[str, int]]:
+        """Clip the #1386 cover-refresh list to the chunk's remaining budget headroom.
+
+        Each refresh is a ``SetCustomArtworkForApp`` push costing one transient
+        cover (:data:`domain.session_budget.COVER_TRANSIENT_KB`) of renderer heap
+        at the chunk's peak, on top of the chunk's own projected cost. The clip
+        keeps only as many refreshes as fit under ``limit_kb`` so the refreshes
+        can never push a chunk the gate just approved over the line; the
+        remainder is skipped gracefully — their grid files are already updated,
+        so a Steam restart shows them (the same degradation the budget gate uses
+        elsewhere). ``rss_kb`` ``None`` (measurement unavailable) fails open and
+        keeps the whole list, mirroring the gate itself.
+        """
+        if rss_kb is None:
+            return cover_refreshes
+        headroom_kb = limit_kb - rss_kb - chunk_worst_cost_kb(creates, updates)
+        allowance = max(0, headroom_kb // COVER_TRANSIENT_KB)
+        if allowance >= len(cover_refreshes):
+            return cover_refreshes
+        self._logger.info(
+            f"Session-budget headroom clips cover refreshes: applying {allowance} of "
+            f"{len(cover_refreshes)}; the remaining grid files are already updated and "
+            f"show after a Steam restart"
+        )
+        return cover_refreshes[:allowance]
 
     async def predict_pause_likely(self, *, new_items: int, changed_items: int) -> bool:
         """Whether a run of *new_items* creates + *changed_items* updates would cross the ceiling.

--- a/py_modules/services/library/sync_orchestrator.py
+++ b/py_modules/services/library/sync_orchestrator.py
@@ -2,15 +2,18 @@
 
 Owns every async path the user triggers from the QAM that mutates in-flight
 sync state: starting and cancelling syncs, computing a preview (read-only),
-and dispatching the per-unit sync pipeline on apply. The heartbeat clock —
-refreshed on every progress emission and inspected by per-unit waits — lives
-here too. Progress emission also lives here — sub-services that need to
+and dispatching the per-unit sync pipeline on apply. The heartbeat clock is
+stamped here — when a run is admitted, and by the frontend's ``sync_heartbeat``
+route — while the wait that inspects it moved out with the chunk round-trip it
+guards. Progress emission also lives here — sub-services that need to
 surface progress receive the orchestrator's ``emit_progress`` callback
 through their config. Anything that fetches ROMs belongs in
 :class:`LibraryFetcher`; anything that finalises shortcuts after the apply
 completes belongs in :class:`SyncReporter`; Steam's renderer memory belongs
 in :class:`SessionBudgetMonitor`; a single ROM's launch facts — where its
-file is and what runs it — belong in :class:`ShortcutLaunchResolver`; reading
+file is and what runs it — belong in :class:`ShortcutLaunchResolver`; driving
+one unit's built delta to the frontend and back — emit a chunk, wait for its
+ack, commit it — belongs in :class:`ChunkDispatcher`; reading
 the registry and the completion stamps into the projections these decisions
 are made against belongs in :class:`LocalLibraryReader`. What stayed here of that
 last group is the platform stamp's DELETE — a write, and a step of the apply
@@ -27,22 +30,12 @@ import asyncio
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
-from domain.collection_sync_state import CollectionSyncState
 from domain.cover_refresh import count_cover_refreshes
-from domain.platform_sync_state import PlatformSyncState
 from domain.preview_delta import PreviewDelta
-from domain.session_budget import (
-    CLIFF_KB,
-    COVER_TRANSIENT_KB,
-    EFFECTIVE_CEILING_KB,
-    chunk_worst_cost_kb,
-    post_run_advisory,
-    session_memory_delta,
-)
+from domain.session_budget import post_run_advisory, session_memory_delta
 from domain.shortcut_data import build_shortcuts_data
 from domain.sibling_group import compute_component_group_keys
 from domain.sibling_resolution import AUTO_REGION
-from domain.sync_chunking import build_unit_chunks, wire_shortcuts
 from domain.sync_diff import (
     BIND_ROM_ID_KEY,
     classify_roms,
@@ -64,6 +57,7 @@ if TYPE_CHECKING:
     from domain.work_unit import WorkUnit
     from lib.late_binding import LateBinding
     from services.library._state import LibrarySyncStateBox
+    from services.library.chunk_dispatcher import ChunkDispatcher
     from services.library.fetcher import LibraryFetcher
     from services.library.local_library_reader import LocalLibraryReader
     from services.library.reporter import SyncReporter
@@ -72,7 +66,6 @@ if TYPE_CHECKING:
         ArtworkManager,
         Clock,
         EventEmitter,
-        Sleeper,
         UnitOfWorkFactory,
         UuidGen,
     )
@@ -85,23 +78,6 @@ _SYNC_CANCELLED = "Sync cancelled"
 # report "(interrupted)" instead of "(cancelled)" for a crash.
 _SYNC_INTERRUPTED = "Sync interrupted (Steam UI stopped responding)"
 _PREVIEW_MAX_AGE_SECONDS = 1800  # 30 minutes — preview snapshots stale beyond this
-
-# Per-unit heartbeat-based timeout. If the frontend stops calling
-# ``sync_heartbeat`` for this many seconds while the orchestrator is
-# waiting for ``report_unit_results``, the wait is treated as a
-# recoverable cancellation — the in-flight unit is dropped and the
-# next sync resumes via the incremental-skip path.
-_UNIT_HEARTBEAT_TIMEOUT_SEC = 60.0
-# Polling cadence the wait loop uses while watching the heartbeat
-# clock. Kept short so cancel propagation feels responsive without
-# burning CPU.
-_UNIT_WAIT_POLL_SEC = 1.0
-# Emitted-shortcut count per apply chunk. A unit's emitted shortcuts are split
-# into chunks of about this many entries, each emitted → acked → committed
-# durably before the next, so a mid-unit CEF crash forfeits only the in-flight
-# chunk. A chunk may overflow this to keep a sibling group whole (see
-# :func:`domain.sync_chunking.build_unit_chunks`).
-_APPLY_CHUNK_SIZE = 200
 
 
 def _collection_membership_key(unit: WorkUnit) -> tuple[str, str]:
@@ -121,7 +97,7 @@ class SyncOrchestratorConfig:
     """Frozen wiring bundle handed to ``SyncOrchestrator.__init__``.
 
     Holds runtime infrastructure (loop, logger), event emitter, the
-    Clock/UuidGen/Sleeper test seams, the SQLite Unit-of-Work factory
+    Clock/UuidGen test seams, the SQLite Unit-of-Work factory
     (the transactional seam over the ``roms`` / ``sync_runs`` repositories
     the lifecycle writes through), the plugin-dir reference for shortcut
     data construction, the shared
@@ -140,10 +116,15 @@ class SyncOrchestratorConfig:
     classify baseline, the per-unit bound-row projection, the unstamped-platform
     count, the resident sibling-group keys, and the stale-row scan — each in its
     own short read Unit of Work, where the fetcher asks the same kinds of
-    question of RomM. The ``session_budget`` seam owns every
-    renderer-heap reading and verdict: at each chunk boundary the orchestrator asks
-    it whether applying the chunk would exhaust Steam's per-session heap budget, and
-    the run pauses itself when it would (#1383).
+    question of RomM. The ``chunk_dispatcher`` peer takes the unit's built delta
+    the rest of the way: it emits each chunk to the frontend, waits out the
+    heartbeat clock for the ack, and commits the chunk through the reporter. The
+    ``session_budget`` seam owns every
+    renderer-heap reading and verdict, which the dispatcher asks at each chunk
+    boundary — whether applying the chunk would exhaust Steam's per-session heap
+    budget, and how much headroom is left for the chunk's additive cover work
+    (#1383); the terminal memory delta this module reports is drawn from the same
+    seam.
     """
 
     settings: dict[str, Any]
@@ -153,7 +134,6 @@ class SyncOrchestratorConfig:
     emit: EventEmitter
     clock: Clock
     uuid_gen: UuidGen
-    sleeper: Sleeper
     uow_factory: UnitOfWorkFactory
     sync_state_box: LibrarySyncStateBox
     fetcher: LibraryFetcher
@@ -162,6 +142,7 @@ class SyncOrchestratorConfig:
     shortcut_launch_resolver: ShortcutLaunchResolver
     local_library_reader: LocalLibraryReader
     session_budget: SessionBudgetMonitor
+    chunk_dispatcher: ChunkDispatcher
 
 
 @dataclass(frozen=True)
@@ -193,7 +174,6 @@ class SyncOrchestrator:
         self._emit = config.emit
         self._clock = config.clock
         self._uuid_gen = config.uuid_gen
-        self._sleeper = config.sleeper
         self._uow_factory = config.uow_factory
         self._sync_state = config.sync_state_box
         self._fetcher = config.fetcher
@@ -202,6 +182,7 @@ class SyncOrchestrator:
         self._shortcut_launch_resolver = config.shortcut_launch_resolver
         self._local_library_reader = config.local_library_reader
         self._session_budget = config.session_budget
+        self._chunk_dispatcher = config.chunk_dispatcher
 
     # ── Sync control ─────────────────────────────────────────────
 
@@ -1082,7 +1063,9 @@ class SyncOrchestrator:
         # heartbeat-timeout before the final chunk must leave NO stamp, so the
         # skip gate can't honour a stale one over a half-applied platform (the
         # #1025 silent-gap regression). The final chunk re-writes the stamp on a
-        # clean finish. A fetch that failed raised before here (fetch failure ≠
+        # clean finish, and that half of the pair now lives one module over —
+        # ``ChunkDispatcher._build_final_platform_stamp``, which rides the final
+        # chunk's commit UoW. A fetch that failed raised before here (fetch failure ≠
         # apply started) and a cancel during fetch/artwork returned at a guard
         # above with the old stamp intact, so an unstarted apply keeps it. A
         # skipped platform returned before this point and keeps its stamp. Only
@@ -1115,7 +1098,7 @@ class SyncOrchestrator:
             membership = collection_memberships.get(_collection_membership_key(unit))
             collection_member_ids = membership.rom_ids if membership is not None else None
 
-        applied_count = await self._apply_unit_in_chunks(
+        applied_count = await self._chunk_dispatcher.apply_unit_in_chunks(
             unit,
             unit_index=unit_index,
             total_units=total_units,
@@ -1175,300 +1158,6 @@ class SyncOrchestrator:
             if int(rom["id"]) in cover_paths and (source := rom.get("path_cover_large") or rom.get("path_cover_small"))
         }
 
-    async def _apply_unit_in_chunks(
-        self,
-        unit: WorkUnit,
-        *,
-        unit_index: int,
-        total_units: int,
-        emitted: list[dict[str, Any]],
-        shortcuts_data: list[dict[str, Any]],
-        unit_roms: list[dict[str, Any]],
-        new_ids: set[int],
-        cover_refreshes: list[dict[str, int]] | None = None,
-        collection_member_ids: list[int] | None = None,
-    ) -> int:
-        """Emit → wait → commit the unit's DELTA shortcuts one durable chunk at a time.
-
-        ``emitted`` is the delta (new + changed + rebind) the frontend applies;
-        skipped-unchanged entries never reach here but their rows still ride the
-        chunks' ``rom_ids`` (routed to chunk 0's leftover by ``build_unit_chunks``).
-        The delta shortcuts are split into commit chunks processed one at a time
-        (emit → wait → commit durably → next), so a mid-unit CEF crash forfeits
-        only the in-flight chunk, not every prior chunk. ``chunk.rom_ids`` are the
-        chunk's fetched ROMs (its sibling groups' rows, plus chunk 0's skipped
-        leftover); a keyed lookup into the whole unit's live fetch yields the
-        chunk's commit subset. ``new_ids`` (the classified creates) prices each
-        chunk create-vs-update for the session-budget gate. ``cover_refreshes``
-        (the #1386 invalidation pass's ``{rom_id, app_id}`` list) rides the
-        unit's FIRST chunk payload, clipped to the budget headroom left after
-        that chunk's own projected cost — a big refresh list degrades to fewer
-        in-session tile refreshes (the grid files are already updated; a Steam
-        restart shows the rest), never to a run pause. Returns the running
-        count of shortcuts applied — a cancel or heartbeat timeout returns early
-        with the chunks committed so far.
-        """
-        box = self._sync_state
-        # One generation id per platform fetch. The run id serves: a platform is
-        # fetched at most once per run, so it identifies this platform's fetch
-        # uniquely, and every chunk of the unit shares it — unlike a clock reading,
-        # which differs per chunk and would leave the earlier chunks' rows stamped
-        # before the final chunk's completion stamp (#1504).
-        fetch_id = str(box.current_sync_id or "") if unit.type == "platform" else None
-        chunks = build_unit_chunks(emitted, shortcuts_data, _APPLY_CHUNK_SIZE)
-        roms_by_id = {r["id"]: r for r in unit_roms if "id" in r}
-        chunk_count = len(chunks)
-        applied_count = 0
-        for chunk_index, chunk in enumerate(chunks):
-            # A cancel landing in the inter-chunk window — after the prior chunk's
-            # commit but before this chunk's emit — discards the rest of the unit
-            # here, before any per-chunk mutation or emit. Without this the
-            # frontend would fully process another ~200-shortcut chunk (~2 min)
-            # whose ack the backend then rejects, orphaning those shortcuts until
-            # the next sync. Same cleanup as the mid-wait user-cancel branch.
-            if box.is_cancelling():
-                box.clear_active_unit()
-                return applied_count
-
-            # Session-budget gate (#1383): at every chunk boundary ask the monitor
-            # whether applying this chunk would cross Steam's per-session heap budget,
-            # and pause here — a clean chunk boundary — if it would. On pause the
-            # gate sets ``run_paused`` + ``interrupt_reason`` and requests
-            # cancel, so the check just below returns cleanly with the prior chunks
-            # committed — the terminal finalize then records the resumable ``paused``
-            # state (the deliberate sibling of a heartbeat timeout's
-            # ``interrupted``). Both modes are PREDICTIVE (RSS plus this chunk's
-            # worst-case cost) and differ only in the line the projection is
-            # measured against:
-            #  - Every LATER chunk projects against the effective ceiling
-            #    (``cliff - margin`` ≈ 2.2 GB), keeping the anti-thrash safety margin.
-            #  - The run's very FIRST chunk projects against the CLIFF itself
-            #    (``CLIFF_KB`` ≈ 2.45 GB). Forward progress must be guaranteed — the
-            #    run has to apply at least one chunk or it loops forever on a
-            #    no-progress pause — so the first chunk is allowed to spend into the
-            #    safety margin, but the predictive projection still stops it before
-            #    the crash line. Net effect: a resume proceeds only when this chunk's
-            #    worst-case peak stays below the cliff (≈ 1.95 GB for a full 200-item
-            #    chunk of cover-applying creates, each priced create + cover) and can
-            #    never be projected past it; at/above that it re-pauses with zero
-            #    progress and the banner directs the user to restart Steam.
-            # The chunk is priced by composition, so the gate needs its creates and
-            # updates apart. The frontend decides create-vs-update itself via its
-            # existing-shortcut scan; a small backend/frontend mismatch only ever
-            # overprices (worst-case safe).
-            creates = sum(1 for e in chunk.emitted if e["rom_id"] in new_ids)
-            updates = len(chunk.emitted) - creates
-            budget_limit_kb = CLIFF_KB if box.chunks_emitted_this_run == 0 else EFFECTIVE_CEILING_KB
-            rss_kb = await self._session_budget.maybe_pause_for_budget(
-                creates=creates, updates=updates, limit_kb=budget_limit_kb
-            )
-            if box.is_cancelling():
-                box.clear_active_unit()
-                return applied_count
-
-            # The #1386 cover-refresh list rides the unit's FIRST chunk, clipped to
-            # the budget headroom left after this chunk's own projected cost — the
-            # refreshes must never be the reason a run pauses, so they degrade to
-            # fewer in-session tile refreshes instead (grid files already updated).
-            chunk_cover_refreshes: list[dict[str, int]] = []
-            if chunk_index == 0 and cover_refreshes:
-                chunk_cover_refreshes = self._clip_cover_refreshes(
-                    cover_refreshes, rss_kb=rss_kb, creates=creates, updates=updates, limit_kb=budget_limit_kb
-                )
-
-            chunk_rows = [roms_by_id[rid] for rid in chunk.rom_ids if rid in roms_by_id]
-
-            # Fresh per-chunk coordination: a new event + identity (run + unit +
-            # chunk index) so the reporter validates each chunk's ack.
-            box.unit_complete_event = asyncio.Event()
-            box.last_unit_results = None
-            box.active_unit_id = unit.id
-            box.active_chunk_index = chunk_index
-            box.sync_last_heartbeat = self._clock.monotonic()
-            await self._emit(
-                "sync_apply_unit",
-                {
-                    "run_id": str(box.current_sync_id or ""),
-                    "unit_type": unit.type,
-                    "unit_id": unit.id,
-                    "unit_name": unit.name,
-                    "unit_index": unit_index,
-                    "total_units": total_units,
-                    "chunk_index": chunk_index,
-                    "chunk_count": chunk_count,
-                    "chunk_offset": chunk.offset,
-                    "unit_total": len(emitted),
-                    # Strip backend-internal keys (staged cover path, rebind target)
-                    # from the wire — the frontend fetches a created shortcut's cover
-                    # via get_artwork_base64(rom_id); the commit reads them from
-                    # pending_sync, which keeps the full entries.
-                    "shortcuts": wire_shortcuts(chunk.emitted),
-                    # Existing shortcuts whose server-side cover changed (#1386):
-                    # the frontend re-applies each via SetCustomArtworkForApp so
-                    # the tile refreshes in-session. Non-empty only on chunk 0.
-                    "cover_refreshes": chunk_cover_refreshes,
-                },
-            )
-            # Count this emit so the session-budget gate exempts only the very
-            # first chunk of the run (forward-progress guarantee, #1383).
-            box.chunks_emitted_this_run += 1
-
-            applied = await self._wait_for_unit_complete(unit, box.unit_complete_event)
-            if applied is None:
-                # The wait gave up — the reason (user cancel vs heartbeat timeout)
-                # decides whether this chunk's in-flight work is recoverable. Chunks
-                # committed before this one stay committed either way.
-                self._abandon_active_chunk(box, chunk_rows)
-                return applied_count
-
-            platform_stamp = self._build_final_platform_stamp(unit, chunk_index, chunk_count, fetch_id)
-            collection_stamp = self._build_final_collection_stamp(unit, chunk_index, chunk_count, collection_member_ids)
-
-            # Per-chunk commit: the reporter upserts every fetched ROM of this
-            # chunk into the ``roms`` aggregate (identity + version metadata,
-            # unbound for non-representatives) and binds only the acked
-            # representatives, stamping each ROM's cached ``rom_metadata`` in the
-            # same write UoW (Rom row first, metadata second — FK-safe).
-            # ``chunk_rows`` is this chunk's slice of the live RomM fetch — the
-            # source of ``metadatum`` — so each committed chunk is a crash-safe
-            # checkpoint. The final-chunk ``platform_stamp`` / ``collection_stamp``
-            # (whichever the unit type produces) rides the same UoW.
-            await self._reporter.get().commit_unit_results(
-                applied,
-                chunk_rows,
-                platform_stamp=platform_stamp,
-                collection_stamp=collection_stamp,
-                # The fetch generation for a PLATFORM unit's rows (#1504), passed on
-                # EVERY chunk so the whole unit shares the generation the final
-                # chunk's stamp records. A collection unit passes None — it spans
-                # platforms, and re-marking a foreign platform's row would drop it
-                # from that platform's counted rows.
-                fetch_id=fetch_id,
-            )
-            applied_count += len(applied)
-            # Only a COMMITTED chunk's items count as done (#1383): an emitted chunk
-            # whose ack never landed — a cancel or a heartbeat timeout — returns above,
-            # before this line, so the paused banner never over-reports.
-            box.run_done_items += len(applied)
-
-        box.clear_active_unit()
-        return applied_count
-
-    def _abandon_active_chunk(self, box: LibrarySyncStateBox, chunk_rows: list[dict[str, Any]]) -> None:
-        """Tear down or stash the in-flight chunk after its wait gave up.
-
-        A user cancel (box already CANCELLING) intentionally discards the chunk:
-        drop the whole-unit staging, null the event, and clear the unit + chunk
-        identity so a stray late ack can't commit it. A heartbeat timeout (box
-        still RUNNING) instead stashes THIS chunk (its run/unit/chunk identity +
-        rows) into ``abandoned_chunk`` via ``stash_abandoned_chunk`` — inert data
-        that survives the run's teardown — while leaving the whole-unit staging
-        live, so a late ``report_unit_results`` still commits the delivered
-        bindings instead of leaving orphan shortcuts (#1052 / #1367). It then
-        marks the run ``interrupted`` (the frontend went dark, not the user's
-        Cancel — so the terminal SyncRun write records ``interrupted``) and
-        requests the cancel that stops the chunk loop.
-        """
-        if box.is_cancelling():
-            box.clear_active_unit()
-        else:
-            box.stash_abandoned_chunk(chunk_rows)
-            box.run_interrupted = True
-            box.request_cancel()
-
-    def _clip_cover_refreshes(
-        self,
-        cover_refreshes: list[dict[str, int]],
-        *,
-        rss_kb: int | None,
-        creates: int,
-        updates: int,
-        limit_kb: int,
-    ) -> list[dict[str, int]]:
-        """Clip the #1386 cover-refresh list to the chunk's remaining budget headroom.
-
-        Each refresh is a ``SetCustomArtworkForApp`` push costing one transient
-        cover (:data:`domain.session_budget.COVER_TRANSIENT_KB`) of renderer heap
-        at the chunk's peak, on top of the chunk's own projected cost. The clip
-        keeps only as many refreshes as fit under ``limit_kb`` so the refreshes
-        can never push a chunk the gate just approved over the line; the
-        remainder is skipped gracefully — their grid files are already updated,
-        so a Steam restart shows them (the same degradation the budget gate uses
-        elsewhere). ``rss_kb`` ``None`` (measurement unavailable) fails open and
-        keeps the whole list, mirroring the gate itself.
-        """
-        if rss_kb is None:
-            return cover_refreshes
-        headroom_kb = limit_kb - rss_kb - chunk_worst_cost_kb(creates, updates)
-        allowance = max(0, headroom_kb // COVER_TRANSIENT_KB)
-        if allowance >= len(cover_refreshes):
-            return cover_refreshes
-        self._logger.info(
-            f"Session-budget headroom clips cover refreshes: applying {allowance} of "
-            f"{len(cover_refreshes)}; the remaining grid files are already updated and "
-            f"show after a Steam restart"
-        )
-        return cover_refreshes[:allowance]
-
-    def _build_final_platform_stamp(
-        self, unit: WorkUnit, chunk_index: int, chunk_count: int, fetch_id: str | None = None
-    ) -> PlatformSyncState | None:
-        """Build the completion stamp for a platform unit's FINAL chunk, else ``None``.
-
-        On the final chunk of a PLATFORM unit the stamp rides that chunk's commit
-        UoW so "platform fully synced" ⟺ "stamp exists" is atomic on a crash. The
-        stamp lets the next sync's incremental-skip gate skip this platform even
-        when the whole run is later cancelled (its library-wide ``last_sync`` never
-        advances). Only platform units carry a skip gate — collections have none,
-        so they are never stamped. A cancel or heartbeat timeout mid-unit returns
-        before the final chunk, so an incomplete platform is never stamped
-        (ADR-0023 / #1025).
-        """
-        if unit.type == "platform" and unit.slug and chunk_index == chunk_count - 1:
-            return PlatformSyncState.stamp(
-                platform_slug=unit.slug,
-                at=self._clock.now().isoformat(),
-                rom_count=unit.rom_count,
-                fetch_id=fetch_id,
-            )
-        return None
-
-    def _build_final_collection_stamp(
-        self,
-        unit: WorkUnit,
-        chunk_index: int,
-        chunk_count: int,
-        member_rom_ids: list[int] | None,
-    ) -> CollectionSyncState | None:
-        """Build the completion stamp for a standard/smart collection's FINAL chunk, else ``None``.
-
-        The collection sibling of :meth:`_build_final_platform_stamp` (#742). On
-        the final chunk of a standard/smart collection unit whose listing carried an
-        ``updated_at``, the stamp rides that chunk's commit UoW so "collection
-        fully synced" ⟺ "stamp exists" is atomic on a crash. ``member_rom_ids`` is
-        the collection's FULL membership (every member id, not just the applied
-        new_roms), which a future skip replays to rebuild the Steam-collection
-        map. Virtual collections carry no stamp (no stable
-        ``updated_at``), and a cancel or heartbeat timeout mid-unit returns before
-        the final chunk — an incomplete collection is never stamped (ADR-0023).
-        """
-        if (
-            unit.type == "collection"
-            and unit.collection_kind in ("standard", "smart")
-            and unit.collection_updated_at
-            and member_rom_ids is not None
-            and chunk_index == chunk_count - 1
-        ):
-            return CollectionSyncState.stamp(
-                collection_id=str(unit.id),
-                collection_kind=unit.collection_kind,
-                updated_at=unit.collection_updated_at,
-                completed_at=self._clock.now().isoformat(),
-                rom_count=unit.rom_count,
-                member_rom_ids=tuple(member_rom_ids),
-            )
-        return None
-
     async def _sync_platform_unit(
         self,
         unit: WorkUnit,
@@ -1523,36 +1212,6 @@ class SyncOrchestrator:
                 virtual_type=unit.virtual_type,
             )
         return unit_roms, skipped
-
-    async def _wait_for_unit_complete(self, unit: WorkUnit, event: asyncio.Event) -> dict[str, int] | None:
-        """Heartbeat-based wait for the active unit's frontend callback.
-
-        Returns the frontend-reported ``rom_id_to_app_id`` on success.
-        Returns ``None`` on timeout or cancel — the outer loop maps that
-        onto a recoverable cancellation. The wait poll polls the
-        heartbeat clock rather than ``asyncio.wait_for(timeout=...)``
-        because the frontend sends ``sync_heartbeat`` calls during long
-        per-unit applies (artwork download, Set* calls) and a 60s
-        absolute cap would still race those.
-        """
-        box = self._sync_state
-        while not event.is_set():
-            if box.is_cancelling():
-                self._logger.info(f"Per-unit cancel observed while waiting for unit {unit.name}")
-                return None
-            elapsed = self._clock.monotonic() - box.sync_last_heartbeat
-            if elapsed > _UNIT_HEARTBEAT_TIMEOUT_SEC:
-                self._logger.warning(f"Per-unit timeout: no heartbeat for {elapsed:.0f}s waiting on unit {unit.name}")
-                return None
-            try:
-                await self._sleeper.sleep(_UNIT_WAIT_POLL_SEC)
-            except asyncio.CancelledError:
-                self._logger.info(f"Per-unit wait cancelled for unit {unit.name}")
-                raise
-
-        results = box.last_unit_results or {}
-        box.last_unit_results = None
-        return results
 
     async def _finalize_per_unit(
         self,

--- a/py_modules/services/library/sync_orchestrator.py
+++ b/py_modules/services/library/sync_orchestrator.py
@@ -1,14 +1,16 @@
-"""Preview / apply / per-unit sync lifecycle and the heartbeat clock.
+"""Preview / apply / per-unit sync lifecycle and progress emission.
 
 Owns every async path the user triggers from the QAM that mutates in-flight
 sync state: starting and cancelling syncs, computing a preview (read-only),
-and dispatching the per-unit sync pipeline on apply. The heartbeat clock is
-stamped here — when a run is admitted, and by the frontend's ``sync_heartbeat``
-route — while the wait that inspects it moved out with the chunk round-trip it
-guards. Progress emission also lives here — sub-services that need to
-surface progress receive the orchestrator's ``emit_progress`` callback
-through their config. Anything that fetches ROMs belongs in
-:class:`LibraryFetcher`; anything that finalises shortcuts after the apply
+and dispatching the per-unit sync pipeline on apply. Of the heartbeat clock
+this module holds only two of the three stamps — the one taken when a run is
+admitted, and the frontend's ``sync_heartbeat`` route. The stamp that opens a
+chunk's 60-second window, and the wait that measures against it, belong to
+:class:`ChunkDispatcher`, so the window a timeout is judged by starts at a
+chunk's emit rather than at run admission. Progress emission lives here —
+sub-services that need to surface progress receive the orchestrator's
+``emit_progress`` callback through their config. Anything that fetches ROMs
+belongs in :class:`LibraryFetcher`; anything that finalises shortcuts after the apply
 completes belongs in :class:`SyncReporter`; Steam's renderer memory belongs
 in :class:`SessionBudgetMonitor`; a single ROM's launch facts — where its
 file is and what runs it — belong in :class:`ShortcutLaunchResolver`; driving
@@ -1063,7 +1065,7 @@ class SyncOrchestrator:
         # heartbeat-timeout before the final chunk must leave NO stamp, so the
         # skip gate can't honour a stale one over a half-applied platform (the
         # #1025 silent-gap regression). The final chunk re-writes the stamp on a
-        # clean finish, and that half of the pair now lives one module over —
+        # clean finish; the other half of the pair is
         # ``ChunkDispatcher._build_final_platform_stamp``, which rides the final
         # chunk's commit UoW. A fetch that failed raised before here (fetch failure ≠
         # apply started) and a cancel during fetch/artwork returned at a guard

--- a/py_modules/services/library/sync_orchestrator.py
+++ b/py_modules/services/library/sync_orchestrator.py
@@ -17,10 +17,10 @@ file is and what runs it — belong in :class:`ShortcutLaunchResolver`; driving
 one unit's built delta to the frontend and back — emit a chunk, wait for its
 ack, commit it — belongs in :class:`ChunkDispatcher`; reading
 the registry and the completion stamps into the projections these decisions
-are made against belongs in :class:`LocalLibraryReader`. What stayed here of that
-last group is the platform stamp's DELETE — a write, and a step of the apply
-pipeline rather than a question a run weighs; its ordering is argued at its call
-site — and the pure component-key stamp, which does no I/O at all. Cached
+are made against belongs in :class:`LocalLibraryReader`. Two of that last group
+are this module's deliberately: the platform stamp's DELETE — a write, and a step
+of the apply pipeline rather than a question a run weighs; its ordering is argued
+at its call site — and the pure component-key stamp, which does no I/O at all. Cached
 ``rom_metadata`` is written by the reporter's per-unit commit (the same write
 UoW as the ``roms`` upsert), so preview never persists metadata and an
 interrupted apply leaves only already-committed units' metadata.

--- a/py_modules/services/library/sync_orchestrator.py
+++ b/py_modules/services/library/sync_orchestrator.py
@@ -1077,16 +1077,6 @@ class SyncOrchestrator:
         if unit.type == "platform" and unit.slug:
             await self._loop.run_in_executor(None, self._clear_platform_stamp_io, unit.slug)
 
-        # Stage the DELTA representatives for cover finalise + binding, and the
-        # full built set for the ack-independent identity + version persist (the
-        # reporter upserts a row for every sibling — skipped ones included — and
-        # binds only the delta's acked representatives). Staging stays whole-unit;
-        # the apply is chunked below, so a mid-unit CEF crash forfeits only the
-        # in-flight chunk, not every prior chunk.
-        box.pending_sync = {e["rom_id"]: e for e in apply_emitted}
-        box.pending_all_roms = {sd["rom_id"]: sd for sd in shortcuts_data}
-        box.pending_cover_sources = confirmed_cover_sources
-
         # A collection unit's final chunk stamps a CollectionSyncState over its
         # full membership (the accumulator just populated by the fetch, #742); a
         # platform unit passes None. The full set — not just the applied new_roms —
@@ -1106,6 +1096,7 @@ class SyncOrchestrator:
             shortcuts_data=shortcuts_data,
             unit_roms=unit_roms,
             new_ids=new_ids,
+            confirmed_cover_sources=confirmed_cover_sources,
             cover_refreshes=cover_refreshes,
             collection_member_ids=collection_member_ids,
         )

--- a/scripts/check_module_size.py
+++ b/scripts/check_module_size.py
@@ -79,12 +79,6 @@ SCOPE_DIRS = (
 ALLOWLIST = {
     "py_modules/services/downloads.py": 1119,
     "py_modules/services/library/fetcher.py": 1150,
-    # Raised 1186 -> 1192 by #1777's rename of this module's launch-facts peer
-    # to ShortcutLaunchResolver, for accuracy. The six lines are `ruff format`
-    # re-wraps of three existing call sites that the longer identifier pushed
-    # past the line length; no code was added. This entry has to be deleted once
-    # the module falls under the threshold — the gate fails until it is.
-    "py_modules/services/library/sync_orchestrator.py": 1192,
 }
 
 

--- a/tests/contract/test_cover_refresh.py
+++ b/tests/contract/test_cover_refresh.py
@@ -36,6 +36,10 @@ def _orchestrator(harness):
     return harness.plugin._sync_service._orchestrator
 
 
+def _dispatcher(harness):
+    return harness.plugin._sync_service._chunk_dispatcher
+
+
 def _box(harness):
     return harness.plugin._sync_service._box
 
@@ -124,7 +128,7 @@ async def test_changed_cover_ts_between_runs_re_downloads_and_emits_refresh_entr
     _seed_library(harness, cover=_COVER_OLD)
     harness.romm.download_payloads[f"cover:{_COVER_OLD}"] = b"old cover bytes"
     harness.romm.download_payloads[f"cover:{_COVER_NEW}"] = b"new cover bytes"
-    _orchestrator(harness)._wait_for_unit_complete = _ack_with({"10": 7777})
+    _dispatcher(harness)._wait_for_unit_complete = _ack_with({"10": 7777})
 
     # Run 1: the new ROM's cover downloads into the cache and the fingerprint
     # is recorded at commit.
@@ -164,7 +168,7 @@ async def test_changed_cover_ts_between_runs_re_downloads_and_emits_refresh_entr
 async def test_null_fingerprint_with_cache_adopts_without_download(harness):
     _make_grid_resolvable(harness)
     _seed_library(harness, cover=_COVER_NEW)
-    _orchestrator(harness)._wait_for_unit_complete = _ack_with({})
+    _dispatcher(harness)._wait_for_unit_complete = _ack_with({})
 
     # A pre-#1386 state: a bound row with NO fingerprint whose cache file exists.
     # Identity matches the fetch and the recorded applied "" matches the
@@ -216,7 +220,7 @@ async def test_cover_only_change_flows_from_preview_to_apply_via_callables(harne
     _seed_library(harness, cover=_COVER_OLD)
     harness.romm.download_payloads[f"cover:{_COVER_OLD}"] = b"old cover bytes"
     harness.romm.download_payloads[f"cover:{_COVER_NEW}"] = b"new cover bytes"
-    _orchestrator(harness)._wait_for_unit_complete = _ack_with({"10": 7777})
+    _dispatcher(harness)._wait_for_unit_complete = _ack_with({"10": 7777})
 
     # Seeding run: bind the shortcut and record the OLD fingerprint.
     await _run_sync(harness, "run-seed")
@@ -277,7 +281,7 @@ async def test_cover_asset_404_falls_back_to_url_cover_and_records_it(harness):
     # The RomM-local cover asset 404s; the external url_cover serves real bytes.
     harness.romm.download_cover_side_effect = RommNotFoundError("HTTP 404: Not Found")
     harness.romm.download_payloads[f"cover_url:{_URL_COVER}"] = b"cdn cover bytes"
-    _orchestrator(harness)._wait_for_unit_complete = _ack_with({"10": 7777})
+    _dispatcher(harness)._wait_for_unit_complete = _ack_with({"10": 7777})
 
     await _run_sync(harness, "run-fallback-1")
 
@@ -298,7 +302,7 @@ async def test_pure_no_changes_preview_keeps_zero_cover_count(harness):
     _make_grid_resolvable(harness)
     _seed_library(harness, cover=_COVER_OLD)
     harness.romm.download_payloads[f"cover:{_COVER_OLD}"] = b"old cover bytes"
-    _orchestrator(harness)._wait_for_unit_complete = _ack_with({"10": 7777})
+    _dispatcher(harness)._wait_for_unit_complete = _ack_with({"10": 7777})
     await _run_sync(harness, "run-seed-settled")
     harness.emit.reset_mock()
 
@@ -329,7 +333,7 @@ async def test_ts_only_rescan_revalidates_304_then_second_sync_does_zero_cover_w
     harness.romm.download_payloads[f"cover:{_COVER_OLD}"] = b"the cover bytes"
     # The validator is stable across ?ts= values (the live-probe fact).
     harness.romm.cover_etags[_COVER_ASSET] = '"etag-v1"'
-    _orchestrator(harness)._wait_for_unit_complete = _ack_with({"10": 7777})
+    _dispatcher(harness)._wait_for_unit_complete = _ack_with({"10": 7777})
 
     # Run 1: fresh download seeds the cache, the cover_source, AND the validator sidecar.
     await _run_sync(harness, "run-reval-1")

--- a/tests/contract/test_sync_cancel_scope.py
+++ b/tests/contract/test_sync_cancel_scope.py
@@ -20,6 +20,10 @@ def _orchestrator(harness):
     return harness.plugin._sync_service._orchestrator
 
 
+def _dispatcher(harness):
+    return harness.plugin._sync_service._chunk_dispatcher
+
+
 async def _ack_immediately(_unit, event):
     """Stand-in for ``_wait_for_unit_complete``: ack with an empty map.
 
@@ -60,7 +64,7 @@ async def test_cancel_sync_stale_run_does_not_abort_fresh_run(harness):
     harness.plugin.settings["enabled_platforms"] = {"1": True}
 
     orch = _orchestrator(harness)
-    orch._wait_for_unit_complete = _ack_immediately
+    _dispatcher(harness)._wait_for_unit_complete = _ack_immediately
 
     # Run A: start through the real callable. The deterministic FakeUuidGen mints
     # a fixed id, so pin run A's id explicitly to model the cross-run race
@@ -137,7 +141,7 @@ async def test_apply_rejected_while_run_in_flight_emits_single_complete(harness)
     harness.plugin.settings["enabled_platforms"] = {"1": True}
 
     orch = _orchestrator(harness)
-    orch._wait_for_unit_complete = _ack_immediately
+    _dispatcher(harness)._wait_for_unit_complete = _ack_immediately
     box = harness.plugin._sync_service._box
 
     # A real preview stages a valid pending_delta (and finalizes to IDLE).

--- a/tests/contract/test_unstamped_platform_rerun.py
+++ b/tests/contract/test_unstamped_platform_rerun.py
@@ -29,6 +29,10 @@ def _orchestrator(harness):
     return harness.plugin._sync_service._orchestrator
 
 
+def _dispatcher(harness):
+    return harness.plugin._sync_service._chunk_dispatcher
+
+
 def _ack_with(bindings):
     """A ``_wait_for_unit_complete`` stand-in acking with *bindings*."""
 
@@ -75,7 +79,7 @@ async def test_unstamped_platform_rerun_restamps_and_heals_run_status(harness):
     _seed_library(harness)
 
     # Seeding run at t0: the platform is stamped and the ROM bound.
-    _orchestrator(harness)._wait_for_unit_complete = _ack_with({"10": 7777})
+    _dispatcher(harness)._wait_for_unit_complete = _ack_with({"10": 7777})
     await _run_sync(harness, "run-seed")
     with harness.uow_factory() as uow:
         assert uow.platform_sync_state.get("n64") is not None
@@ -112,7 +116,7 @@ async def test_unstamped_platform_rerun_restamps_and_heals_run_status(harness):
 
     # The gated apply's empty chunk re-stamps the platform and records a fresh
     # completed SyncRun. The empty chunk acks nothing (no shortcut to bind).
-    _orchestrator(harness)._wait_for_unit_complete = _ack_with({})
+    _dispatcher(harness)._wait_for_unit_complete = _ack_with({})
     apply_result = await harness.plugin.sync_apply_delta(preview["preview_id"])
     assert apply_result == {"success": True, "message": "Applying changes"}
     await _drain_apply(harness)

--- a/tests/services/library/_helpers.py
+++ b/tests/services/library/_helpers.py
@@ -7,7 +7,8 @@ used across :class:`TestFetchCollectionRoms`,
 collection tests, plus the shared-UoW seeders the sub-service test
 files drive their fixtures with — including ``_seed_rom_row``, which the
 orchestrator and registry-query suites both build their bound-row baselines
-from.
+from, and the fake-RomM seeders the orchestrator and chunk-dispatcher suites
+drive their end-to-end runs through.
 """
 
 from unittest.mock import AsyncMock, MagicMock
@@ -21,9 +22,10 @@ def rebind_loop(library_service, loop):
     Four of the façade's sub-services (fetcher, orchestrator, reporter,
     session-budget monitor) hold their own ctor-bound ``_loop``. Tests that
     swap in a mock loop must propagate it to all four so async calls land on
-    the override. ``ShortcutLaunchResolver`` and ``LocalLibraryReader`` hold
-    none — their methods are synchronous workers the orchestrator offloads
-    through *its* loop.
+    the override. ``ShortcutLaunchResolver``, ``LocalLibraryReader`` and
+    ``ChunkDispatcher`` hold none — the first two are synchronous workers the
+    orchestrator offloads through *its* loop, and the dispatcher offloads
+    nothing at all.
     """
     library_service._fetcher._loop = loop
     library_service._orchestrator._loop = loop
@@ -172,3 +174,50 @@ def _seed_rom_row(
     with plugin._uow:
         plugin._uow.roms.save(rom)
         plugin._uow.roms.set_applied_launch_options(rom_id, applied_launch_options)
+
+
+def _use_fake_romm(plugin, fake_romm_api):
+    """Swap the plugin's MagicMock ``_romm_api`` for the seeded fake.
+
+    The library-suite plugin fixture wires ``_romm_api`` as a
+    ``MagicMock()`` (kept for the test_fetcher.py tests that match
+    callables by identity). Each test that wants the end-to-end path
+    drives through this helper, which rebinds the fake onto every
+    sub-service holding a stale reference.
+    """
+    plugin._romm_api = fake_romm_api
+    plugin._sync_service._fetcher._romm_api = fake_romm_api
+    plugin._artwork_service._romm_api = fake_romm_api
+    plugin._shortcut_removal_service._romm_api = fake_romm_api
+    return fake_romm_api
+
+
+def _seed_platform(fake_romm_api, *, platform_id, name, slug, roms):
+    """Seed a platform plus its ROMs on the fake.
+
+    ROMs are dicts with at least ``id``/``name``; ``platform_id`` and
+    ``platform_slug``/``platform_name`` are stamped automatically so the
+    fetcher's enrichment loop sees consistent data.
+    """
+    fake_romm_api.platforms.append({"id": platform_id, "name": name, "slug": slug, "rom_count": len(roms)})
+    for rom in roms:
+        rom_id = rom["id"]
+        full_rom = {
+            "platform_id": platform_id,
+            "platform_name": name,
+            "platform_slug": slug,
+            **rom,
+        }
+        fake_romm_api.roms[rom_id] = full_rom
+
+
+async def _fake_wait_set_event(_unit, event):
+    """Default ``_wait_for_unit_complete`` stand-in: set the event and
+    return an empty rom_id_to_app_id map.
+
+    The frontend's ``report_unit_results`` callback never runs in tests.
+    The dispatcher's per-chunk loop requires the event to fire and a
+    mapping to come back — this helper provides both.
+    """
+    event.set()
+    return {}

--- a/tests/services/library/test_chunk_dispatcher.py
+++ b/tests/services/library/test_chunk_dispatcher.py
@@ -551,3 +551,141 @@ class TestFinalChunkCollectionStamp:
 
         assert stamps == [None], "only the first chunk committed, and it carries no stamp"
         assert box.abandoned_chunk is not None
+
+
+class TestAckIdentityPrecedesTheEmit:
+    """The per-chunk ack identity is stamped BEFORE the frame goes out (#1041).
+
+    The reporter validates a frontend ack against ``current_sync_id`` /
+    ``active_unit_id`` / ``active_chunk_index`` and signals the wait through
+    ``unit_complete_event``. A frontend can ack within milliseconds of receiving
+    the frame, so all four have to be in place at the moment the emit is made:
+    stamp them after and a fast ack is rejected as stray, the event is never set,
+    and the chunk dies of a heartbeat timeout a silent minute later with the
+    shortcuts already applied.
+
+    Nothing else in the suite sees that ordering — every other test lets the emit
+    mock swallow the call — so this one wraps the dispatcher's own emitter and
+    records the box AT CALL TIME.
+    """
+
+    @pytest.mark.asyncio
+    async def test_identity_and_event_are_live_at_emit_time(self, plugin, monkeypatch):
+        from services.library import chunk_dispatcher
+
+        monkeypatch.setattr(chunk_dispatcher, "_APPLY_CHUNK_SIZE", 1)
+        dispatcher = plugin._sync_service._chunk_dispatcher
+        box = plugin._sync_service._box
+        emitted = [
+            {"rom_id": 1, "sibling_group_key": None},
+            {"rom_id": 2, "sibling_group_key": None},
+        ]
+
+        # What the reporter would see if an ack landed while the emit is in flight.
+        seen: list[tuple[str | None, int | str | None, int | None, bool]] = []
+        inner_emit = dispatcher._emit
+
+        async def recording_emit(event, payload):
+            seen.append(
+                (
+                    box.current_sync_id,
+                    box.active_unit_id,
+                    box.active_chunk_index,
+                    box.unit_complete_event is not None,
+                )
+            )
+            return await inner_emit(event, payload)
+
+        dispatcher._emit = recording_emit
+        plugin._sync_service._reporter.commit_unit_results = AsyncMock()  # type: ignore[method-assign]
+        dispatcher._wait_for_unit_complete = _fake_wait_set_event
+        box.sync_state = SyncState.RUNNING
+        box.current_sync_id = "run-ack-identity"
+
+        unit = WorkUnit(type="platform", id=7, name="N64", slug="n64", rom_count=2)
+        await dispatcher.apply_unit_in_chunks(
+            unit,
+            unit_index=0,
+            total_units=1,
+            emitted=emitted,
+            shortcuts_data=list(emitted),
+            unit_roms=[{"id": 1}, {"id": 2}],
+            new_ids=set(),
+            confirmed_cover_sources={},
+        )
+
+        assert seen == [
+            ("run-ack-identity", 7, 0, True),
+            ("run-ack-identity", 7, 1, True),
+        ], "each chunk's ack identity and its event must already be live when its frame is emitted"
+
+
+class TestInterChunkCancelGuard:
+    """A cancel at a chunk boundary stays a cancel, not a budget pause.
+
+    The guard at the top of the loop runs BEFORE the session-budget gate, and
+    that ordering is what the run's terminal status depends on: the gate sets
+    ``run_paused`` + ``interrupt_reason`` before requesting its own cancel, so a
+    user cancel landing in the inter-chunk window while renderer RSS sits near
+    the ceiling would be recorded as a resumable ``paused`` run — the wrong
+    story, and a resumable one at that. Read through the terminal ``SyncRun``
+    because that is where the confusion would surface.
+    """
+
+    @pytest.mark.asyncio
+    async def test_cancel_near_the_ceiling_is_recorded_as_cancelled(self, plugin, fake_romm_api, monkeypatch):
+        import decky
+
+        from services.library import chunk_dispatcher
+
+        decky.emit.reset_mock()
+        plugin.loop = asyncio.get_event_loop()
+        _use_fake_romm(plugin, fake_romm_api)
+        _seed_platform(
+            fake_romm_api,
+            platform_id=1,
+            name="N64",
+            slug="n64",
+            roms=[{"id": 10, "name": "Alpha"}, {"id": 11, "name": "Beta"}],
+        )
+        plugin.settings["enabled_platforms"] = {"1": True}
+        plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
+        monkeypatch.setattr(chunk_dispatcher, "_APPLY_CHUNK_SIZE", 1)
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = _fake_wait_set_event
+
+        # Just under the ceiling: the run's first chunk projects against the cliff
+        # and proceeds, a second chunk would project against the ceiling and pause.
+        plugin._renderer_gc.result = True
+        plugin._renderer_rss.rss_kb = 2_199_000
+
+        box = plugin._sync_service._box
+        commit = plugin._sync_service._reporter.commit_unit_results
+        commits = 0
+
+        async def cancel_after_first_commit(*args, **kwargs):
+            nonlocal commits
+            result = await commit(*args, **kwargs)
+            commits += 1
+            if commits == 1:
+                # The user's Cancel lands the instant chunk 0's commit resolves —
+                # before the loop returns to the top for chunk 1.
+                box.request_cancel()
+            return result
+
+        plugin._sync_service._reporter.commit_unit_results = cancel_after_first_commit  # type: ignore[method-assign]
+        box.sync_state = SyncState.RUNNING
+        box.current_sync_id = "run-cancel-near-ceiling"
+
+        await plugin._sync_service._orchestrator._do_sync_per_unit()
+
+        with plugin._uow as uow:
+            run = uow.sync_runs.get("run-cancel-near-ceiling")
+        assert run is not None
+        assert run.status == "cancelled", "a user cancel must not be recorded as a resumable budget pause"
+        assert box.run_paused is False
+        assert box.interrupt_reason is None
+        # The guard returned at the top of the loop, so chunk 1 was never emitted
+        # and the gate it would have passed through never ran for it.
+        apply_events = [c[0][1] for c in decky.emit.call_args_list if c[0][0] == "sync_apply_unit"]
+        assert len(apply_events) == 1
+        assert apply_events[0]["chunk_index"] == 0

--- a/tests/services/library/test_chunk_dispatcher.py
+++ b/tests/services/library/test_chunk_dispatcher.py
@@ -440,3 +440,114 @@ class TestWholeUnitStaging:
         assert box.pending_sync == {}
         assert box.pending_all_roms == {}
         assert box.pending_cover_sources == {}
+
+
+class TestFinalChunkCollectionStamp:
+    """A standard/smart collection is stamped on its FINAL chunk only (#742).
+
+    Driven through ``apply_unit_in_chunks`` directly rather than the whole
+    pipeline: the condition reads only the unit and its position in the chunk
+    sequence, so a fetch and a collapse in front of it would add setup without
+    adding evidence. The stamp's atomicity with the chunk's row upserts is the
+    reporter's, and is pinned in ``tests/services/library/test_reporter.py``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_stamp_rides_only_the_last_chunk(self, plugin, monkeypatch):
+        from services.library import chunk_dispatcher
+
+        monkeypatch.setattr(chunk_dispatcher, "_APPLY_CHUNK_SIZE", 1)
+        emitted = [
+            {"rom_id": 1, "sibling_group_key": None},
+            {"rom_id": 2, "sibling_group_key": None},
+        ]
+
+        stamps = []
+
+        async def capture_commit(_rid_to_aid, _chunk_rows, platform_stamp=None, collection_stamp=None, fetch_id=None):
+            stamps.append(collection_stamp)
+
+        plugin._sync_service._reporter.commit_unit_results = capture_commit  # type: ignore[method-assign]
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = _fake_wait_set_event
+        box = plugin._sync_service._box
+        box.sync_state = SyncState.RUNNING
+        box.current_sync_id = "run-collection-stamp"
+
+        unit = WorkUnit(
+            type="collection",
+            id="7",
+            name="Faves",
+            slug="faves",
+            rom_count=2,
+            collection_kind="standard",
+            collection_updated_at="2025-01-01T00:00:00",
+        )
+        await plugin._sync_service._chunk_dispatcher.apply_unit_in_chunks(
+            unit,
+            unit_index=0,
+            total_units=1,
+            emitted=emitted,
+            shortcuts_data=list(emitted),
+            unit_roms=[{"id": 1}, {"id": 2}],
+            new_ids=set(),
+            confirmed_cover_sources={},
+            collection_member_ids=[1, 2],
+        )
+
+        assert len(stamps) == 2, "one commit per chunk"
+        assert stamps[0] is None, "an incomplete collection is never stamped"
+        assert stamps[1] is not None
+        assert stamps[1].collection_id == "7"
+        assert stamps[1].member_rom_ids == (1, 2), "the FULL membership, not the chunk's slice"
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_timeout_before_the_last_chunk_leaves_no_stamp(self, plugin, monkeypatch):
+        """The wait giving up returns before the final chunk, so nothing is stamped."""
+        from services.library import chunk_dispatcher
+
+        monkeypatch.setattr(chunk_dispatcher, "_APPLY_CHUNK_SIZE", 1)
+        emitted = [
+            {"rom_id": 1, "sibling_group_key": None},
+            {"rom_id": 2, "sibling_group_key": None},
+        ]
+
+        stamps = []
+        box = plugin._sync_service._box
+
+        async def capture_commit(_rid_to_aid, _chunk_rows, platform_stamp=None, collection_stamp=None, fetch_id=None):
+            stamps.append(collection_stamp)
+
+        async def wait(_unit, event):
+            if box.active_chunk_index == 0:
+                event.set()
+                return {}
+            return None  # heartbeat timeout on the final chunk
+
+        plugin._sync_service._reporter.commit_unit_results = capture_commit  # type: ignore[method-assign]
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = wait
+        box.sync_state = SyncState.RUNNING
+        box.current_sync_id = "run-collection-timeout"
+
+        unit = WorkUnit(
+            type="collection",
+            id="7",
+            name="Faves",
+            slug="faves",
+            rom_count=2,
+            collection_kind="standard",
+            collection_updated_at="2025-01-01T00:00:00",
+        )
+        await plugin._sync_service._chunk_dispatcher.apply_unit_in_chunks(
+            unit,
+            unit_index=0,
+            total_units=1,
+            emitted=emitted,
+            shortcuts_data=list(emitted),
+            unit_roms=[{"id": 1}, {"id": 2}],
+            new_ids=set(),
+            confirmed_cover_sources={},
+            collection_member_ids=[1, 2],
+        )
+
+        assert stamps == [None], "only the first chunk committed, and it carries no stamp"
+        assert box.abandoned_chunk is not None

--- a/tests/services/library/test_chunk_dispatcher.py
+++ b/tests/services/library/test_chunk_dispatcher.py
@@ -1,0 +1,373 @@
+"""Tests for ChunkDispatcher — the per-unit emit → ack → commit round-trip.
+
+The dispatcher is reached through the library façade
+(``plugin._sync_service._chunk_dispatcher``) so every test drives the same
+instance the orchestrator holds, over the shared state box the chunk
+coordination lands on.
+
+Two levels are covered here. The chunk **loop** is driven end-to-end through
+``SyncOrchestrator._sync_one_unit`` against the seeded ``FakeRommApi`` — the
+loop's inputs are a whole unit's fetch, collapse and delta, so entering below
+that would mean hand-building them and asserting against a shape rather than
+against what the pipeline produces. What each test then observes is the
+dispatcher's own output: the ``sync_apply_unit`` frames, the per-chunk commits,
+and what the box holds after a cancel or a timeout. The heartbeat **wait** is
+called directly, because its whole behaviour is a function of the clock and the
+box.
+
+``_wait_for_unit_complete`` stands in for a frontend ``report_unit_results``
+callback no test exercises; ``_download_artwork`` stands in for the SteamGridDB
+pipeline. The exact chunk partition maths is pinned in
+``tests/domain/test_sync_chunking.py``.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from domain.sync_state import SyncState
+from domain.work_unit import WorkUnit
+
+# conftest.py patches decky before this import
+from tests.services.library._helpers import _fake_wait_set_event, _seed_platform, _use_fake_romm
+
+
+class TestApplyChunking:
+    """A unit's apply is split into durable commit chunks (#1025).
+
+    Each chunk is emitted → acked → committed on its own, so a mid-unit CEF
+    crash forfeits only the in-flight chunk. These tests drive ``_sync_one_unit``
+    directly with a shrunk ``_APPLY_CHUNK_SIZE`` so a handful of singleton ROMs
+    exercises the multi-chunk loop; the exact partition maths is pinned in
+    ``tests/domain/test_sync_chunking.py``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_large_unit_emits_one_event_and_commit_per_chunk(self, plugin, fake_romm_api, monkeypatch):
+        """Five singletons at chunk size 2 → three ``sync_apply_unit`` events with
+        continuous unit-wide chunk fields, and one commit per chunk carrying only
+        that chunk's rows."""
+        import decky
+
+        from services.library import chunk_dispatcher
+
+        decky.emit.reset_mock()
+        plugin.loop = asyncio.get_event_loop()
+        _use_fake_romm(plugin, fake_romm_api)
+        monkeypatch.setattr(chunk_dispatcher, "_APPLY_CHUNK_SIZE", 2)
+
+        _seed_platform(
+            fake_romm_api,
+            platform_id=1,
+            name="N64",
+            slug="n64",
+            roms=[{"id": i, "name": f"Game {i}"} for i in range(1, 6)],
+        )
+
+        commit_rows: list[list[int]] = []
+
+        async def capture_commit(_rid_to_aid, chunk_rows, platform_stamp=None, collection_stamp=None, fetch_id=None):
+            commit_rows.append([r["id"] for r in chunk_rows])
+
+        plugin._sync_service._reporter.commit_unit_results = capture_commit  # type: ignore[method-assign]
+        plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = _fake_wait_set_event
+        plugin._sync_service._box.sync_state = SyncState.RUNNING
+        plugin._sync_service._box.current_sync_id = "run-chunk"
+
+        unit = WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=5)
+        await plugin._sync_service._orchestrator._sync_one_unit(
+            unit,
+            unit_index=0,
+            total_units=1,
+            synced_rom_ids=set(),
+            collection_memberships={},
+            platform_rom_ids=set(),
+        )
+
+        unit_events = [c[0][1] for c in decky.emit.call_args_list if c[0][0] == "sync_apply_unit"]
+        assert len(unit_events) == 3
+        assert [e["chunk_index"] for e in unit_events] == [0, 1, 2]
+        assert all(e["chunk_count"] == 3 for e in unit_events)
+        assert [e["chunk_offset"] for e in unit_events] == [0, 2, 4]
+        assert all(e["unit_total"] == 5 for e in unit_events)
+        assert [len(e["shortcuts"]) for e in unit_events] == [2, 2, 1]
+        # One commit per chunk, each with only its chunk's rows.
+        assert commit_rows == [[1, 2], [3, 4], [5]]
+
+    @pytest.mark.asyncio
+    async def test_small_unit_emits_exactly_one_chunk(self, plugin, fake_romm_api):
+        """A unit under the chunk size emits a single chunk — regression guard that
+        the chunk fields collapse to the today's one-shot behaviour."""
+        import decky
+
+        decky.emit.reset_mock()
+        plugin.loop = asyncio.get_event_loop()
+        _use_fake_romm(plugin, fake_romm_api)
+
+        _seed_platform(
+            fake_romm_api,
+            platform_id=1,
+            name="N64",
+            slug="n64",
+            roms=[{"id": i, "name": f"G{i}"} for i in range(1, 4)],
+        )
+
+        plugin._sync_service._reporter.commit_unit_results = AsyncMock()  # type: ignore[method-assign]
+        plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = _fake_wait_set_event
+        plugin._sync_service._box.sync_state = SyncState.RUNNING
+        plugin._sync_service._box.current_sync_id = "run-single"
+
+        unit = WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=3)
+        await plugin._sync_service._orchestrator._sync_one_unit(
+            unit,
+            unit_index=0,
+            total_units=1,
+            synced_rom_ids=set(),
+            collection_memberships={},
+            platform_rom_ids=set(),
+        )
+
+        unit_events = [c[0][1] for c in decky.emit.call_args_list if c[0][0] == "sync_apply_unit"]
+        assert len(unit_events) == 1
+        event = unit_events[0]
+        assert event["chunk_index"] == 0
+        assert event["chunk_count"] == 1
+        assert event["chunk_offset"] == 0
+        assert event["unit_total"] == 3
+        assert len(event["shortcuts"]) == 3
+
+    @pytest.mark.asyncio
+    async def test_user_cancel_between_chunks_keeps_committed_chunks(self, plugin, fake_romm_api, monkeypatch):
+        """A user cancel during chunk 1's wait discards the rest but leaves chunk 0
+        committed — the whole point of chunking (#1025)."""
+        from services.library import chunk_dispatcher
+
+        plugin.loop = asyncio.get_event_loop()
+        _use_fake_romm(plugin, fake_romm_api)
+        monkeypatch.setattr(chunk_dispatcher, "_APPLY_CHUNK_SIZE", 2)
+
+        _seed_platform(
+            fake_romm_api,
+            platform_id=1,
+            name="N64",
+            slug="n64",
+            roms=[{"id": i, "name": f"G{i}"} for i in range(1, 6)],
+        )
+
+        commit_rows: list[list[int]] = []
+
+        async def capture_commit(_rid_to_aid, chunk_rows, platform_stamp=None, collection_stamp=None, fetch_id=None):
+            commit_rows.append([r["id"] for r in chunk_rows])
+
+        plugin._sync_service._reporter.commit_unit_results = capture_commit  # type: ignore[method-assign]
+        plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
+        box = plugin._sync_service._box
+
+        async def wait(_unit, event):
+            if box.active_chunk_index == 0:
+                event.set()
+                return {}
+            box.sync_state = SyncState.CANCELLING  # user cancel during chunk 1
+            return None
+
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = wait
+        box.sync_state = SyncState.RUNNING
+        box.current_sync_id = "run-cancel-chunk"
+
+        unit = WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=5)
+        await plugin._sync_service._orchestrator._sync_one_unit(
+            unit,
+            unit_index=0,
+            total_units=1,
+            synced_rom_ids=set(),
+            collection_memberships={},
+            platform_rom_ids=set(),
+        )
+
+        # Only chunk 0 committed; the cancel discarded chunk 1 onward.
+        assert commit_rows == [[1, 2]]
+        # Staging + chunk identity cleared so a stray late ack can't commit.
+        assert box.pending_sync == {}
+        assert box.unit_complete_event is None
+        assert box.active_chunk_index is None
+        assert box.abandoned_chunk is None
+
+    @pytest.mark.asyncio
+    async def test_cancel_in_inter_chunk_window_never_emits_next_chunk(self, plugin, fake_romm_api, monkeypatch):
+        """A cancel landing AFTER chunk 0's commit but BEFORE chunk 1's emit stops
+        the unit at the top of the loop: chunk 1 is never emitted, chunk 0's commit
+        persists, staging cleared. Complements
+        ``test_user_cancel_between_chunks_keeps_committed_chunks`` (cancel DURING
+        the wait) — this is the inter-chunk window, where an un-guarded loop would
+        still emit chunk 1 and leave ~200 shortcuts orphaned until the next sync
+        (#1025)."""
+        import decky
+
+        from services.library import chunk_dispatcher
+
+        decky.emit.reset_mock()
+        plugin.loop = asyncio.get_event_loop()
+        _use_fake_romm(plugin, fake_romm_api)
+        monkeypatch.setattr(chunk_dispatcher, "_APPLY_CHUNK_SIZE", 2)
+
+        _seed_platform(
+            fake_romm_api,
+            platform_id=1,
+            name="N64",
+            slug="n64",
+            roms=[{"id": i, "name": f"G{i}"} for i in range(1, 6)],
+        )
+
+        commit_rows: list[list[int]] = []
+        box = plugin._sync_service._box
+
+        async def capture_commit(_rid_to_aid, chunk_rows, platform_stamp=None, collection_stamp=None, fetch_id=None):
+            commit_rows.append([r["id"] for r in chunk_rows])
+            # Cancel lands the instant chunk 0's commit resolves — before the loop
+            # returns to the top to emit chunk 1.
+            if len(commit_rows) == 1:
+                box.sync_state = SyncState.CANCELLING
+
+        plugin._sync_service._reporter.commit_unit_results = capture_commit  # type: ignore[method-assign]
+        plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = _fake_wait_set_event
+        box.sync_state = SyncState.RUNNING
+        box.current_sync_id = "run-inter-chunk"
+
+        unit = WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=5)
+        await plugin._sync_service._orchestrator._sync_one_unit(
+            unit,
+            unit_index=0,
+            total_units=1,
+            synced_rom_ids=set(),
+            collection_memberships={},
+            platform_rom_ids=set(),
+        )
+
+        # Chunk 1 is never emitted — the loop stopped at its top before any emit —
+        # so the frontend has no orphaned chunk to churn and later fail the ack on.
+        unit_events = [c[0][1] for c in decky.emit.call_args_list if c[0][0] == "sync_apply_unit"]
+        assert len(unit_events) == 1
+        assert unit_events[0]["chunk_index"] == 0
+        # Chunk 0's commit persists.
+        assert commit_rows == [[1, 2]]
+        # Staging + chunk identity cleared so a stray late ack can't commit.
+        assert box.pending_sync == {}
+        assert box.pending_all_roms == {}
+        assert box.unit_complete_event is None
+        assert box.active_unit_id is None
+        assert box.active_chunk_index is None
+        assert box.abandoned_chunk is None
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_timeout_on_chunk_stashes_only_that_chunk(self, plugin, fake_romm_api, monkeypatch):
+        """A heartbeat timeout on chunk 1 stashes ONLY chunk 1's rows (not the whole
+        unit) under chunk 1's identity, so a late ack commits just that chunk."""
+        from services.library import chunk_dispatcher
+
+        plugin.loop = asyncio.get_event_loop()
+        _use_fake_romm(plugin, fake_romm_api)
+        monkeypatch.setattr(chunk_dispatcher, "_APPLY_CHUNK_SIZE", 2)
+
+        _seed_platform(
+            fake_romm_api,
+            platform_id=1,
+            name="N64",
+            slug="n64",
+            roms=[{"id": i, "name": f"G{i}"} for i in range(1, 6)],
+        )
+
+        plugin._sync_service._reporter.commit_unit_results = AsyncMock()  # type: ignore[method-assign]
+        plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
+        box = plugin._sync_service._box
+
+        async def wait(_unit, event):
+            if box.active_chunk_index == 0:
+                event.set()
+                return {}
+            return None  # heartbeat timeout on chunk 1 (no cancel)
+
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = wait
+        box.sync_state = SyncState.RUNNING
+        box.current_sync_id = "run-timeout-chunk"
+
+        unit = WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=5)
+        await plugin._sync_service._orchestrator._sync_one_unit(
+            unit,
+            unit_index=0,
+            total_units=1,
+            synced_rom_ids=set(),
+            collection_memberships={},
+            platform_rom_ids=set(),
+        )
+
+        assert box.abandoned_chunk is not None
+        # The dispatch identity is cleared; the chunk index lives on the stash.
+        assert box.active_chunk_index is None
+        assert box.abandoned_chunk.chunk_index == 1
+        # Only chunk 1's rows are stashed for the late ack, not the whole unit.
+        assert [r["id"] for r in box.abandoned_chunk.chunk_rows] == [3, 4]
+        # The timeout requested cancel so the outer loop stops.
+        assert box.sync_state == SyncState.CANCELLING
+
+
+class TestWaitForUnitComplete:
+    """Heartbeat-based per-unit timeout."""
+
+    @pytest.mark.asyncio
+    async def test_returns_results_when_event_set(self, plugin):
+        unit = WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=1)
+        event = asyncio.Event()
+        event.set()
+        plugin._sync_service._box.sync_state = SyncState.RUNNING
+        plugin._sync_service._sync_last_heartbeat = plugin._sync_service._chunk_dispatcher._clock.monotonic()
+        plugin._sync_service._box.last_unit_results = {"10": 9000}
+
+        results = await plugin._sync_service._chunk_dispatcher._wait_for_unit_complete(unit, event)
+        assert results == {"10": 9000}
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_cancel(self, plugin):
+        unit = WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=1)
+        event = asyncio.Event()
+        plugin._sync_service._box.sync_state = SyncState.CANCELLING
+        plugin._sync_service._sync_last_heartbeat = plugin._sync_service._chunk_dispatcher._clock.monotonic()
+
+        results = await plugin._sync_service._chunk_dispatcher._wait_for_unit_complete(unit, event)
+        assert results is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_heartbeat_timeout(self, plugin):
+        unit = WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=1)
+        event = asyncio.Event()
+        plugin._sync_service._box.sync_state = SyncState.RUNNING
+        # Heartbeat is way too old — should timeout immediately on first loop check
+        plugin._sync_service._sync_last_heartbeat = plugin._sync_service._chunk_dispatcher._clock.monotonic() - 999.0
+
+        results = await plugin._sync_service._chunk_dispatcher._wait_for_unit_complete(unit, event)
+        assert results is None
+
+
+class TestWaitForUnitCompleteCancelled:
+    """Tests for asyncio.CancelledError in _wait_for_unit_complete."""
+
+    @pytest.mark.asyncio
+    async def test_cancelled_error_during_sleep_is_logged_and_reraised(self, plugin):
+        """If the inner sleep is cancelled, log + re-raise so the outer loop sees the cancel."""
+
+        class _CancellingSleeper:
+            async def sleep(self, _seconds: float) -> None:
+                raise asyncio.CancelledError()
+
+        plugin._sync_service._chunk_dispatcher._sleeper = _CancellingSleeper()
+        plugin._sync_service._box.sync_state = SyncState.RUNNING
+        plugin._sync_service._sync_last_heartbeat = plugin._sync_service._chunk_dispatcher._clock.monotonic()
+
+        unit = WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=1)
+        event = asyncio.Event()  # never set — wait will enter the sleep path
+
+        with pytest.raises(asyncio.CancelledError):
+            await plugin._sync_service._chunk_dispatcher._wait_for_unit_complete(unit, event)

--- a/tests/services/library/test_chunk_dispatcher.py
+++ b/tests/services/library/test_chunk_dispatcher.py
@@ -30,7 +30,7 @@ from domain.sync_state import SyncState
 from domain.work_unit import WorkUnit
 
 # conftest.py patches decky before this import
-from tests.services.library._helpers import _fake_wait_set_event, _seed_platform, _use_fake_romm
+from tests.services.library._helpers import _fake_wait_set_event, _seed_platform, _seed_rom_row, _use_fake_romm
 
 
 class TestApplyChunking:
@@ -371,3 +371,72 @@ class TestWaitForUnitCompleteCancelled:
 
         with pytest.raises(asyncio.CancelledError):
             await plugin._sync_service._chunk_dispatcher._wait_for_unit_complete(unit, event)
+
+
+class TestWholeUnitStaging:
+    """The three whole-unit staging dicts the reporter's commit reads.
+
+    They are written here, once per unit, before the first chunk goes out — one
+    production writer module from the moment they are staged to
+    ``clear_active_unit``'s teardown. ``pending_sync`` and ``pending_all_roms``
+    hold deliberately different sets and are the same shape, so the swap is
+    silent everywhere except here: ``pending_sync`` is the DELTA the frontend
+    applies, ``pending_all_roms`` the FULL built set every sibling's identity row
+    is upserted from.
+    """
+
+    @pytest.mark.asyncio
+    async def test_delta_and_full_set_are_staged_into_their_own_fields(self, plugin, fake_romm_api):
+        plugin.loop = asyncio.get_event_loop()
+        _use_fake_romm(plugin, fake_romm_api)
+        # rom 10 is content-unchanged (skipped from the delta); rom 11 changed its
+        # name, so the delta is {11} while the built set is {10, 11}.
+        _seed_platform(
+            fake_romm_api,
+            platform_id=1,
+            name="N64",
+            slug="n64",
+            roms=[
+                {"id": 10, "name": "Keep", "fs_name": "keep.z64"},
+                {"id": 11, "name": "New Name", "fs_name": "changed.z64", "path_cover_large": "cover-11.png"},
+            ],
+        )
+        plugin.settings["enabled_platforms"] = {"1": True}
+        _seed_rom_row(plugin, 10, app_id=1010, platform_slug="n64", name="Keep", fs_name="keep.z64")
+        _seed_rom_row(plugin, 11, app_id=1011, platform_slug="n64", name="Old Name", fs_name="changed.z64")
+        plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={11: "/covers/11.png"})
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = _fake_wait_set_event
+        box = plugin._sync_service._box
+        box.sync_state = SyncState.RUNNING
+        box.current_sync_id = "run-staging"
+
+        # Snapshot the staging as the commit sees it — ``clear_active_unit`` wipes
+        # all three the moment the unit finishes.
+        staged: list[tuple[set[int], set[int], dict[int, str]]] = []
+        commit = plugin._sync_service._reporter.commit_unit_results
+
+        async def capture_commit(*args, **kwargs):
+            staged.append((set(box.pending_sync), set(box.pending_all_roms), dict(box.pending_cover_sources)))
+            return await commit(*args, **kwargs)
+
+        plugin._sync_service._reporter.commit_unit_results = capture_commit  # type: ignore[method-assign]
+
+        unit = WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=2)
+        await plugin._sync_service._orchestrator._sync_one_unit(
+            unit,
+            unit_index=0,
+            total_units=1,
+            synced_rom_ids=set(),
+            collection_memberships={},
+            platform_rom_ids=set(),
+        )
+
+        assert len(staged) == 1
+        pending_sync, pending_all_roms, cover_sources = staged[0]
+        assert pending_sync == {11}, "pending_sync is the DELTA the frontend applies"
+        assert pending_all_roms == {10, 11}, "pending_all_roms is the FULL built set, skipped siblings included"
+        assert cover_sources == {11: "cover-11.png"}
+        # Teardown clears all three, so a late ack after the unit finished stages nothing.
+        assert box.pending_sync == {}
+        assert box.pending_all_roms == {}
+        assert box.pending_cover_sources == {}

--- a/tests/services/library/test_session_budget.py
+++ b/tests/services/library/test_session_budget.py
@@ -293,3 +293,59 @@ class TestSessionBudgetMonitor:
 
         assert result["rss_kb"] == 1_234_000
         assert result["memory_delta_kb"] == 800_000
+
+
+class TestClipCoverRefreshes:
+    """Trimming a chunk's additive cover work to the headroom the gate left (#1386)."""
+
+    def test_clip_fails_open_when_rss_unavailable(self, plugin):
+        budget = plugin._sync_service._session_budget
+        refreshes = [{"rom_id": 1, "app_id": 10}, {"rom_id": 2, "app_id": 20}]
+        assert (
+            budget.clip_cover_refreshes(refreshes, rss_kb=None, creates=0, updates=0, limit_kb=1_000_000) == refreshes
+        )
+
+    def test_clip_keeps_all_with_headroom(self, plugin):
+        from domain.session_budget import COVER_TRANSIENT_KB, EFFECTIVE_CEILING_KB
+
+        budget = plugin._sync_service._session_budget
+        refreshes = [{"rom_id": 1, "app_id": 10}, {"rom_id": 2, "app_id": 20}]
+        rss = EFFECTIVE_CEILING_KB - 10 * COVER_TRANSIENT_KB
+        assert (
+            budget.clip_cover_refreshes(refreshes, rss_kb=rss, creates=0, updates=0, limit_kb=EFFECTIVE_CEILING_KB)
+            == refreshes
+        )
+
+    def test_clip_accounts_for_the_chunks_own_cost(self, plugin):
+        from domain.session_budget import EFFECTIVE_CEILING_KB, chunk_worst_cost_kb
+
+        budget = plugin._sync_service._session_budget
+        refreshes = [{"rom_id": i, "app_id": i * 10} for i in range(1, 6)]
+        # Headroom of exactly the chunk's own cost → zero left for refreshes.
+        rss = EFFECTIVE_CEILING_KB - chunk_worst_cost_kb(3, 2)
+        assert (
+            budget.clip_cover_refreshes(refreshes, rss_kb=rss, creates=3, updates=2, limit_kb=EFFECTIVE_CEILING_KB)
+            == []
+        )
+
+    def test_clip_negative_headroom_yields_empty(self, plugin):
+        from domain.session_budget import EFFECTIVE_CEILING_KB
+
+        budget = plugin._sync_service._session_budget
+        refreshes = [{"rom_id": 1, "app_id": 10}]
+        assert (
+            budget.clip_cover_refreshes(
+                refreshes, rss_kb=EFFECTIVE_CEILING_KB + 1, creates=0, updates=0, limit_kb=EFFECTIVE_CEILING_KB
+            )
+            == []
+        )
+
+    def test_clip_keeps_list_order(self, plugin):
+        from domain.session_budget import COVER_TRANSIENT_KB, EFFECTIVE_CEILING_KB
+
+        budget = plugin._sync_service._session_budget
+        refreshes = [{"rom_id": i, "app_id": i * 10} for i in range(1, 6)]
+        rss = EFFECTIVE_CEILING_KB - 2 * COVER_TRANSIENT_KB
+        assert budget.clip_cover_refreshes(
+            refreshes, rss_kb=rss, creates=0, updates=0, limit_kb=EFFECTIVE_CEILING_KB
+        ) == [{"rom_id": 1, "app_id": 10}, {"rom_id": 2, "app_id": 20}]

--- a/tests/services/library/test_sync_orchestrator.py
+++ b/tests/services/library/test_sync_orchestrator.py
@@ -9,8 +9,9 @@ counts.
 
 Two production seams remain mockable per test:
 
-* ``_wait_for_unit_complete`` — waits on a frontend ``report_unit_results``
-  callback that no test exercises. Replaced with a ``fake_wait`` helper.
+* ``ChunkDispatcher._wait_for_unit_complete`` — waits on a frontend
+  ``report_unit_results`` callback that no test exercises. Replaced with a
+  ``fake_wait`` helper.
 * ``_download_artwork`` — delegates to the SteamGridDB pipeline; the
   orchestrator tests do not exercise artwork I/O. Replaced with an
   ``AsyncMock``.
@@ -41,44 +42,15 @@ from domain.work_unit import WorkUnit
 from lib.romm_paging import LIST_PAGE_SIZE
 
 # conftest.py patches decky before this import
-from tests.services.library._helpers import _seed_install, _seed_rom_row
+from tests.services.library._helpers import (
+    _fake_wait_set_event,
+    _seed_install,
+    _seed_platform,
+    _seed_rom_row,
+    _use_fake_romm,
+)
 
 # ── Test helpers ─────────────────────────────────────────────────
-
-
-def _use_fake_romm(plugin, fake_romm_api):
-    """Swap the plugin's MagicMock ``_romm_api`` for the seeded fake.
-
-    The library-suite plugin fixture wires ``_romm_api`` as a
-    ``MagicMock()`` (kept for the test_fetcher.py tests that match
-    callables by identity). Each orchestrator test that wants the
-    end-to-end path drives through this helper, which rebinds the fake
-    onto every sub-service holding a stale reference.
-    """
-    plugin._romm_api = fake_romm_api
-    plugin._sync_service._fetcher._romm_api = fake_romm_api
-    plugin._artwork_service._romm_api = fake_romm_api
-    plugin._shortcut_removal_service._romm_api = fake_romm_api
-    return fake_romm_api
-
-
-def _seed_platform(fake_romm_api, *, platform_id, name, slug, roms):
-    """Seed a platform plus its ROMs on the fake.
-
-    ROMs are dicts with at least ``id``/``name``; ``platform_id`` and
-    ``platform_slug``/``platform_name`` are stamped automatically so the
-    fetcher's enrichment loop sees consistent data.
-    """
-    fake_romm_api.platforms.append({"id": platform_id, "name": name, "slug": slug, "rom_count": len(roms)})
-    for rom in roms:
-        rom_id = rom["id"]
-        full_rom = {
-            "platform_id": platform_id,
-            "platform_name": name,
-            "platform_slug": slug,
-            **rom,
-        }
-        fake_romm_api.roms[rom_id] = full_rom
 
 
 def _seed_collection(
@@ -132,22 +104,10 @@ def _seed_platform_stamp(plugin, slug, *, at, rom_count):
         plugin._uow.platform_sync_state.save(PlatformSyncState.stamp(platform_slug=slug, at=at, rom_count=rom_count))
 
 
-async def _fake_wait_set_event(_unit, event):
-    """Default ``_wait_for_unit_complete`` stand-in: set the event and
-    return an empty rom_id_to_app_id map.
-
-    The frontend's ``report_unit_results`` callback never runs in tests.
-    The orchestrator's per-unit driver requires the event to fire and a
-    mapping to come back — this helper provides both.
-    """
-    event.set()
-    return {}
-
-
 class _ClockAdvancingSleeper:
     """A ``Sleeper`` that advances a ``FakeClock`` on each sleep, so the real
-    heartbeat-clocked ``_wait_for_unit_complete`` times out deterministically
-    without any wall-clock wait (#1367)."""
+    heartbeat-clocked ``ChunkDispatcher._wait_for_unit_complete`` times out
+    deterministically without any wall-clock wait (#1367)."""
 
     def __init__(self, clock, step: float) -> None:
         self._clock = clock
@@ -163,7 +123,8 @@ def _stash_abandoned_and_wind_down(plugin, *, run_id, unit_id, chunk_index, pend
     """Drive the box into the production post-heartbeat-timeout state via the
     real box verbs, then wind the run down — no hand-forced internals (#1367).
 
-    Mirrors exactly what ``_abandon_active_chunk`` (stash the chunk: null the
+    Mirrors exactly what ``ChunkDispatcher._abandon_active_chunk`` (stash the
+    chunk: null the
     event, clear the dispatch identity) followed by the run's terminal
     ``finally: finish_run(run_id)`` (null ``current_sync_id``) leave behind, so a
     late ``report_unit_results`` arriving now must recover the binding through
@@ -1218,7 +1179,7 @@ class TestDoSyncPerUnit:
         plugin.settings["enabled_platforms"] = {"1": True}
 
         plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
-        plugin._sync_service._orchestrator._wait_for_unit_complete = _fake_wait_set_event
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = _fake_wait_set_event
         plugin._sync_service._box.sync_state = SyncState.RUNNING
         plugin._sync_service._box.current_sync_id = "run-plan"
 
@@ -1263,7 +1224,7 @@ class TestDoSyncPerUnit:
         plugin.settings["enabled_collections"] = {"standard": {"7": True}, "smart": {}, "virtual": {}}
 
         plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
-        plugin._sync_service._orchestrator._wait_for_unit_complete = _fake_wait_set_event
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = _fake_wait_set_event
         plugin._sync_service._box.sync_state = SyncState.RUNNING
         plugin._sync_service._box.current_sync_id = "run-est"
 
@@ -1316,7 +1277,7 @@ class TestDoSyncPerUnit:
             assert uow.platform_sync_state.get("n64") is None
 
         plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
-        plugin._sync_service._orchestrator._wait_for_unit_complete = _fake_wait_set_event
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = _fake_wait_set_event
         plugin._sync_service._box.sync_state = SyncState.RUNNING
         plugin._sync_service._box.current_sync_id = "run-restamp"
 
@@ -1370,7 +1331,7 @@ class TestDoSyncPerUnit:
             event.set()
             return {str(_unit.id * 10): 9000 + int(_unit.id)}
 
-        plugin._sync_service._orchestrator._wait_for_unit_complete = fake_wait
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = fake_wait
         plugin._sync_service._box.sync_state = SyncState.RUNNING
 
         await plugin._sync_service._orchestrator._do_sync_per_unit()
@@ -1412,7 +1373,7 @@ class TestDoSyncPerUnit:
         plugin.settings["enabled_platforms"] = {"1": True, "2": True}
 
         plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
-        plugin._sync_service._orchestrator._wait_for_unit_complete = _fake_wait_set_event
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = _fake_wait_set_event
         plugin._sync_service._reporter.commit_unit_results = AsyncMock()  # type: ignore[method-assign]
         plugin._sync_service._box.sync_state = SyncState.RUNNING
         plugin._sync_service._box.current_sync_id = "run-abc"
@@ -1449,7 +1410,7 @@ class TestDoSyncPerUnit:
         _seed_install(plugin, 10, file_path="/roms/n64/installed.z64", platform_slug="n64")
 
         plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
-        plugin._sync_service._orchestrator._wait_for_unit_complete = _fake_wait_set_event
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = _fake_wait_set_event
         plugin._sync_service._reporter.commit_unit_results = AsyncMock()  # type: ignore[method-assign]
         plugin._sync_service._box.sync_state = SyncState.RUNNING
 
@@ -1492,7 +1453,7 @@ class TestDoSyncPerUnit:
             plugin._uow.roms.set_emulator_override(10, "PCSX ReARMed")
 
         plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
-        plugin._sync_service._orchestrator._wait_for_unit_complete = _fake_wait_set_event
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = _fake_wait_set_event
         plugin._sync_service._reporter.commit_unit_results = AsyncMock()  # type: ignore[method-assign]
         plugin._sync_service._box.sync_state = SyncState.RUNNING
 
@@ -1534,7 +1495,7 @@ class TestDoSyncPerUnit:
             plugin._uow.roms.set_emulator_override(10, "Removed Core")
 
         plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
-        plugin._sync_service._orchestrator._wait_for_unit_complete = _fake_wait_set_event
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = _fake_wait_set_event
         plugin._sync_service._reporter.commit_unit_results = AsyncMock()  # type: ignore[method-assign]
         plugin._sync_service._box.sync_state = SyncState.RUNNING
 
@@ -1577,7 +1538,7 @@ class TestDoSyncPerUnit:
         download_artwork = AsyncMock(return_value={})
         plugin._sync_service._orchestrator._download_artwork = download_artwork
         wait_mock = AsyncMock(return_value={})
-        plugin._sync_service._orchestrator._wait_for_unit_complete = wait_mock
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = wait_mock
         commit_mock = AsyncMock()
         plugin._sync_service._reporter.commit_unit_results = commit_mock  # type: ignore[method-assign]
         plugin._sync_service._box.sync_state = SyncState.RUNNING
@@ -1634,7 +1595,7 @@ class TestDoSyncPerUnit:
         plugin.settings["enabled_platforms"] = {"1": True}
 
         plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
-        plugin._sync_service._orchestrator._wait_for_unit_complete = AsyncMock(return_value={})
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = AsyncMock(return_value={})
         plugin._sync_service._reporter.commit_unit_results = AsyncMock()  # type: ignore[method-assign]
         plugin._sync_service._box.sync_state = SyncState.RUNNING
 
@@ -1681,7 +1642,7 @@ class TestDoSyncPerUnit:
         plugin.settings["enabled_platforms"] = {"1": True}
 
         plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
-        plugin._sync_service._orchestrator._wait_for_unit_complete = AsyncMock(return_value={})
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = AsyncMock(return_value={})
         plugin._sync_service._reporter.commit_unit_results = AsyncMock()  # type: ignore[method-assign]
         plugin._sync_service._box.sync_state = SyncState.RUNNING
 
@@ -1731,7 +1692,7 @@ class TestDoSyncPerUnit:
             event.set()
             return {"2": 5000}
 
-        plugin._sync_service._orchestrator._wait_for_unit_complete = ack_same_appid
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = ack_same_appid
         plugin._sync_service._box.sync_state = SyncState.RUNNING
 
         await plugin._sync_service._orchestrator._do_sync_per_unit()
@@ -1778,7 +1739,7 @@ class TestDoSyncPerUnit:
             event.set()
             return {"2": 5000}
 
-        plugin._sync_service._orchestrator._wait_for_unit_complete = ack_same_appid
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = ack_same_appid
         plugin._sync_service._box.sync_state = SyncState.RUNNING
 
         await plugin._sync_service._orchestrator._do_sync_per_unit()
@@ -1822,7 +1783,7 @@ class TestDoSyncPerUnit:
             event.set()
             return {str(rid): 9000 + rid for rid in plugin._sync_service._box.pending_sync}
 
-        plugin._sync_service._orchestrator._wait_for_unit_complete = ack_reps
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = ack_reps
         plugin._sync_service._box.sync_state = SyncState.RUNNING
 
         await plugin._sync_service._orchestrator._do_sync_per_unit()
@@ -1856,7 +1817,7 @@ class TestDoSyncPerUnit:
             event.set()
             return {str(rid): 9000 + rid for rid in plugin._sync_service._box.pending_sync}
 
-        plugin._sync_service._orchestrator._wait_for_unit_complete = ack_reps
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = ack_reps
         plugin._sync_service._box.sync_state = SyncState.RUNNING
         await plugin._sync_service._orchestrator._do_sync_per_unit()
 
@@ -1971,7 +1932,7 @@ class TestDoSyncPerUnit:
             # its rom_id — the emitted rebind entry is keyed to rom 1.
             return {str(rid): 5000 for rid in plugin._sync_service._box.pending_sync}
 
-        plugin._sync_service._orchestrator._wait_for_unit_complete = ack_reuse
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = ack_reuse
         plugin._sync_service._box.sync_state = SyncState.RUNNING
 
         await plugin._sync_service._orchestrator._do_sync_per_unit()
@@ -2059,7 +2020,7 @@ class TestDoSyncPerUnit:
         )
 
         plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
-        plugin._sync_service._orchestrator._wait_for_unit_complete = _fake_wait_set_event
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = _fake_wait_set_event
         plugin._sync_service._box.sync_state = SyncState.RUNNING
 
         await plugin._sync_service._orchestrator._do_sync_per_unit()
@@ -2141,7 +2102,7 @@ class TestDoSyncPerUnit:
         )
 
         plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
-        plugin._sync_service._orchestrator._wait_for_unit_complete = _fake_wait_set_event
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = _fake_wait_set_event
         plugin._sync_service._box.sync_state = SyncState.RUNNING
 
         await plugin._sync_service._orchestrator._do_sync_per_unit()
@@ -2182,7 +2143,7 @@ class TestDoSyncPerUnit:
 
         download_artwork = AsyncMock(return_value={10: "/grid/a.png"})
         plugin._sync_service._orchestrator._download_artwork = download_artwork
-        plugin._sync_service._orchestrator._wait_for_unit_complete = _fake_wait_set_event
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = _fake_wait_set_event
         plugin._sync_service._box.sync_state = SyncState.RUNNING
 
         await plugin._sync_service._orchestrator._do_sync_per_unit()
@@ -2229,7 +2190,7 @@ class TestDoSyncPerUnit:
             plugin._sync_service._box.sync_state = SyncState.CANCELLING
             return {}
 
-        plugin._sync_service._orchestrator._wait_for_unit_complete = fake_wait
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = fake_wait
         plugin._sync_service._box.sync_state = SyncState.RUNNING
 
         await plugin._sync_service._orchestrator._do_sync_per_unit()
@@ -2260,7 +2221,7 @@ class TestDoSyncPerUnit:
         plugin.settings["enabled_platforms"] = {"1": True}
 
         plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
-        plugin._sync_service._orchestrator._wait_for_unit_complete = _fake_wait_set_event
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = _fake_wait_set_event
         plugin._sync_service._box.sync_state = SyncState.RUNNING
 
         await plugin._sync_service._orchestrator._do_sync_per_unit()
@@ -2314,7 +2275,7 @@ class TestDoSyncPerUnit:
             plugin._sync_service._box.sync_state = SyncState.CANCELLING
             return {}
 
-        plugin._sync_service._orchestrator._wait_for_unit_complete = fake_wait
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = fake_wait
         plugin._sync_service._box.sync_state = SyncState.RUNNING
 
         await plugin._sync_service._orchestrator._do_sync_per_unit()
@@ -2348,7 +2309,7 @@ class TestSyncRunLifecycle:
             event.set()
             return {"10": 9001}
 
-        plugin._sync_service._orchestrator._wait_for_unit_complete = fake_wait
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = fake_wait
         plugin._sync_service._box.sync_state = SyncState.RUNNING
         plugin._sync_service._box.current_sync_id = "run-clean"
 
@@ -2408,7 +2369,7 @@ class TestSyncRunLifecycle:
             plugin._sync_service._box.sync_state = SyncState.CANCELLING
             return {}
 
-        plugin._sync_service._orchestrator._wait_for_unit_complete = fake_wait
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = fake_wait
         plugin._sync_service._box.sync_state = SyncState.RUNNING
         plugin._sync_service._box.current_sync_id = "run-cancel"
 
@@ -2440,7 +2401,7 @@ class TestSyncRunLifecycle:
         async def wait_timeout(_u, _event):
             return
 
-        plugin._sync_service._orchestrator._wait_for_unit_complete = wait_timeout
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = wait_timeout
         plugin._sync_service._box.sync_state = SyncState.RUNNING
         plugin._sync_service._box.current_sync_id = "run-interrupted"
 
@@ -2497,7 +2458,7 @@ class TestSyncRunLifecycle:
             event.set()
             return {"10": 9001}
 
-        plugin._sync_service._orchestrator._wait_for_unit_complete = fake_wait
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = fake_wait
 
         # The terminal completed-write raises (e.g. a SQLite lock during the
         # short write UoW) AFTER finalize has already nulled current_sync_id.
@@ -2540,43 +2501,6 @@ class TestSyncRunLifecycle:
         assert after.status == "completed"
         assert after.platforms_completed == ["N64"]
         assert after.collections_completed == []
-
-
-class TestWaitForUnitComplete:
-    """Heartbeat-based per-unit timeout."""
-
-    @pytest.mark.asyncio
-    async def test_returns_results_when_event_set(self, plugin):
-        unit = WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=1)
-        event = asyncio.Event()
-        event.set()
-        plugin._sync_service._box.sync_state = SyncState.RUNNING
-        plugin._sync_service._sync_last_heartbeat = plugin._sync_service._orchestrator._clock.monotonic()
-        plugin._sync_service._box.last_unit_results = {"10": 9000}
-
-        results = await plugin._sync_service._orchestrator._wait_for_unit_complete(unit, event)
-        assert results == {"10": 9000}
-
-    @pytest.mark.asyncio
-    async def test_returns_none_on_cancel(self, plugin):
-        unit = WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=1)
-        event = asyncio.Event()
-        plugin._sync_service._box.sync_state = SyncState.CANCELLING
-        plugin._sync_service._sync_last_heartbeat = plugin._sync_service._orchestrator._clock.monotonic()
-
-        results = await plugin._sync_service._orchestrator._wait_for_unit_complete(unit, event)
-        assert results is None
-
-    @pytest.mark.asyncio
-    async def test_returns_none_on_heartbeat_timeout(self, plugin):
-        unit = WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=1)
-        event = asyncio.Event()
-        plugin._sync_service._box.sync_state = SyncState.RUNNING
-        # Heartbeat is way too old — should timeout immediately on first loop check
-        plugin._sync_service._sync_last_heartbeat = plugin._sync_service._orchestrator._clock.monotonic() - 999.0
-
-        results = await plugin._sync_service._orchestrator._wait_for_unit_complete(unit, event)
-        assert results is None
 
 
 class TestReportUnitResults:
@@ -2909,8 +2833,8 @@ class TestRealOrchestratorLateAckRecovery:
     """The #1367 acceptance path end-to-end through the REAL orchestrator.
 
     Drives a real ``_do_sync_per_unit`` whose only frontend ack never arrives, so
-    the real heartbeat-clocked wait times out, the real ``_abandon_active_chunk``
-    stashes the chunk, and the run's terminal ``finally`` winds the run down
+    the real heartbeat-clocked wait times out, the real
+    ``ChunkDispatcher._abandon_active_chunk`` stashes the chunk, and the run's terminal ``finally`` winds the run down
     (``finish_run`` nulls ``current_sync_id``). Then the real
     ``report_unit_results`` — carrying the identity captured from the emitted
     ``sync_apply_unit`` event — recovers the stash and commits the binding. No box
@@ -2938,7 +2862,8 @@ class TestRealOrchestratorLateAckRecovery:
         # clock-advancing sleeper pushes it past the heartbeat timeout on the
         # second poll — a genuine timeout, no cancel, no stubbed wait.
         orch = plugin._sync_service._orchestrator
-        orch._sleeper = _ClockAdvancingSleeper(orch._clock, 999.0)
+        dispatcher = plugin._sync_service._chunk_dispatcher
+        dispatcher._sleeper = _ClockAdvancingSleeper(dispatcher._clock, 999.0)
 
         # Real run start (claims the slot + stamps current_sync_id).
         assert plugin._sync_service._box.try_begin_run("run-headline") is True
@@ -2998,7 +2923,8 @@ class TestRealOrchestratorLateAckRecovery:
 
         plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
         orch = plugin._sync_service._orchestrator
-        orch._sleeper = _ClockAdvancingSleeper(orch._clock, 999.0)
+        dispatcher = plugin._sync_service._chunk_dispatcher
+        dispatcher._sleeper = _ClockAdvancingSleeper(dispatcher._clock, 999.0)
 
         assert plugin._sync_service._box.try_begin_run("run-1") is True
         plugin._sync_service._box.sync_last_heartbeat = orch._clock.monotonic()
@@ -3456,7 +3382,7 @@ class TestSyncOneUnitCollectionAndCancel:
         plugin.settings["enabled_collections"] = {"standard": {"7": True}, "smart": {}, "virtual": {}}
 
         plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
-        plugin._sync_service._orchestrator._wait_for_unit_complete = _fake_wait_set_event
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = _fake_wait_set_event
         plugin._sync_service._box.sync_state = SyncState.RUNNING
 
         await plugin._sync_service._orchestrator._do_sync_per_unit()
@@ -3688,7 +3614,7 @@ class TestSyncOneUnitCollectionAndCancel:
             plugin._sync_service._box.sync_state = SyncState.CANCELLING
             return
 
-        plugin._sync_service._orchestrator._wait_for_unit_complete = wait_user_cancel
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = wait_user_cancel
         plugin._sync_service._box.sync_state = SyncState.RUNNING
 
         unit = WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=1)
@@ -3736,7 +3662,7 @@ class TestSyncOneUnitCollectionAndCancel:
         async def wait_timeout(_unit, _event):
             return
 
-        plugin._sync_service._orchestrator._wait_for_unit_complete = wait_timeout
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = wait_timeout
         plugin._sync_service._box.sync_state = SyncState.RUNNING
 
         unit = WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=1)
@@ -3762,287 +3688,6 @@ class TestSyncOneUnitCollectionAndCancel:
         assert box.abandoned_chunk is not None
         assert (box.abandoned_chunk.unit_id, box.abandoned_chunk.chunk_index) == (1, 0)
         assert [r["id"] for r in box.abandoned_chunk.chunk_rows] == [1]
-
-
-class TestApplyChunking:
-    """A unit's apply is split into durable commit chunks (#1025).
-
-    Each chunk is emitted → acked → committed on its own, so a mid-unit CEF
-    crash forfeits only the in-flight chunk. These tests drive ``_sync_one_unit``
-    directly with a shrunk ``_APPLY_CHUNK_SIZE`` so a handful of singleton ROMs
-    exercises the multi-chunk loop; the exact partition maths is pinned in
-    ``tests/domain/test_sync_chunking.py``.
-    """
-
-    @pytest.mark.asyncio
-    async def test_large_unit_emits_one_event_and_commit_per_chunk(self, plugin, fake_romm_api, monkeypatch):
-        """Five singletons at chunk size 2 → three ``sync_apply_unit`` events with
-        continuous unit-wide chunk fields, and one commit per chunk carrying only
-        that chunk's rows."""
-        import decky
-
-        from services.library import sync_orchestrator
-
-        decky.emit.reset_mock()
-        plugin.loop = asyncio.get_event_loop()
-        _use_fake_romm(plugin, fake_romm_api)
-        monkeypatch.setattr(sync_orchestrator, "_APPLY_CHUNK_SIZE", 2)
-
-        _seed_platform(
-            fake_romm_api,
-            platform_id=1,
-            name="N64",
-            slug="n64",
-            roms=[{"id": i, "name": f"Game {i}"} for i in range(1, 6)],
-        )
-
-        commit_rows: list[list[int]] = []
-
-        async def capture_commit(_rid_to_aid, chunk_rows, platform_stamp=None, collection_stamp=None, fetch_id=None):
-            commit_rows.append([r["id"] for r in chunk_rows])
-
-        plugin._sync_service._reporter.commit_unit_results = capture_commit  # type: ignore[method-assign]
-        plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
-        plugin._sync_service._orchestrator._wait_for_unit_complete = _fake_wait_set_event
-        plugin._sync_service._box.sync_state = SyncState.RUNNING
-        plugin._sync_service._box.current_sync_id = "run-chunk"
-
-        unit = WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=5)
-        await plugin._sync_service._orchestrator._sync_one_unit(
-            unit,
-            unit_index=0,
-            total_units=1,
-            synced_rom_ids=set(),
-            collection_memberships={},
-            platform_rom_ids=set(),
-        )
-
-        unit_events = [c[0][1] for c in decky.emit.call_args_list if c[0][0] == "sync_apply_unit"]
-        assert len(unit_events) == 3
-        assert [e["chunk_index"] for e in unit_events] == [0, 1, 2]
-        assert all(e["chunk_count"] == 3 for e in unit_events)
-        assert [e["chunk_offset"] for e in unit_events] == [0, 2, 4]
-        assert all(e["unit_total"] == 5 for e in unit_events)
-        assert [len(e["shortcuts"]) for e in unit_events] == [2, 2, 1]
-        # One commit per chunk, each with only its chunk's rows.
-        assert commit_rows == [[1, 2], [3, 4], [5]]
-
-    @pytest.mark.asyncio
-    async def test_small_unit_emits_exactly_one_chunk(self, plugin, fake_romm_api):
-        """A unit under the chunk size emits a single chunk — regression guard that
-        the chunk fields collapse to the today's one-shot behaviour."""
-        import decky
-
-        decky.emit.reset_mock()
-        plugin.loop = asyncio.get_event_loop()
-        _use_fake_romm(plugin, fake_romm_api)
-
-        _seed_platform(
-            fake_romm_api,
-            platform_id=1,
-            name="N64",
-            slug="n64",
-            roms=[{"id": i, "name": f"G{i}"} for i in range(1, 4)],
-        )
-
-        plugin._sync_service._reporter.commit_unit_results = AsyncMock()  # type: ignore[method-assign]
-        plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
-        plugin._sync_service._orchestrator._wait_for_unit_complete = _fake_wait_set_event
-        plugin._sync_service._box.sync_state = SyncState.RUNNING
-        plugin._sync_service._box.current_sync_id = "run-single"
-
-        unit = WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=3)
-        await plugin._sync_service._orchestrator._sync_one_unit(
-            unit,
-            unit_index=0,
-            total_units=1,
-            synced_rom_ids=set(),
-            collection_memberships={},
-            platform_rom_ids=set(),
-        )
-
-        unit_events = [c[0][1] for c in decky.emit.call_args_list if c[0][0] == "sync_apply_unit"]
-        assert len(unit_events) == 1
-        event = unit_events[0]
-        assert event["chunk_index"] == 0
-        assert event["chunk_count"] == 1
-        assert event["chunk_offset"] == 0
-        assert event["unit_total"] == 3
-        assert len(event["shortcuts"]) == 3
-
-    @pytest.mark.asyncio
-    async def test_user_cancel_between_chunks_keeps_committed_chunks(self, plugin, fake_romm_api, monkeypatch):
-        """A user cancel during chunk 1's wait discards the rest but leaves chunk 0
-        committed — the whole point of chunking (#1025)."""
-        from services.library import sync_orchestrator
-
-        plugin.loop = asyncio.get_event_loop()
-        _use_fake_romm(plugin, fake_romm_api)
-        monkeypatch.setattr(sync_orchestrator, "_APPLY_CHUNK_SIZE", 2)
-
-        _seed_platform(
-            fake_romm_api,
-            platform_id=1,
-            name="N64",
-            slug="n64",
-            roms=[{"id": i, "name": f"G{i}"} for i in range(1, 6)],
-        )
-
-        commit_rows: list[list[int]] = []
-
-        async def capture_commit(_rid_to_aid, chunk_rows, platform_stamp=None, collection_stamp=None, fetch_id=None):
-            commit_rows.append([r["id"] for r in chunk_rows])
-
-        plugin._sync_service._reporter.commit_unit_results = capture_commit  # type: ignore[method-assign]
-        plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
-        box = plugin._sync_service._box
-
-        async def wait(_unit, event):
-            if box.active_chunk_index == 0:
-                event.set()
-                return {}
-            box.sync_state = SyncState.CANCELLING  # user cancel during chunk 1
-            return None
-
-        plugin._sync_service._orchestrator._wait_for_unit_complete = wait
-        box.sync_state = SyncState.RUNNING
-        box.current_sync_id = "run-cancel-chunk"
-
-        unit = WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=5)
-        await plugin._sync_service._orchestrator._sync_one_unit(
-            unit,
-            unit_index=0,
-            total_units=1,
-            synced_rom_ids=set(),
-            collection_memberships={},
-            platform_rom_ids=set(),
-        )
-
-        # Only chunk 0 committed; the cancel discarded chunk 1 onward.
-        assert commit_rows == [[1, 2]]
-        # Staging + chunk identity cleared so a stray late ack can't commit.
-        assert box.pending_sync == {}
-        assert box.unit_complete_event is None
-        assert box.active_chunk_index is None
-        assert box.abandoned_chunk is None
-
-    @pytest.mark.asyncio
-    async def test_cancel_in_inter_chunk_window_never_emits_next_chunk(self, plugin, fake_romm_api, monkeypatch):
-        """A cancel landing AFTER chunk 0's commit but BEFORE chunk 1's emit stops
-        the unit at the top of the loop: chunk 1 is never emitted, chunk 0's commit
-        persists, staging cleared. Complements
-        ``test_user_cancel_between_chunks_keeps_committed_chunks`` (cancel DURING
-        the wait) — this is the inter-chunk window, where an un-guarded loop would
-        still emit chunk 1 and leave ~200 shortcuts orphaned until the next sync
-        (#1025)."""
-        import decky
-
-        from services.library import sync_orchestrator
-
-        decky.emit.reset_mock()
-        plugin.loop = asyncio.get_event_loop()
-        _use_fake_romm(plugin, fake_romm_api)
-        monkeypatch.setattr(sync_orchestrator, "_APPLY_CHUNK_SIZE", 2)
-
-        _seed_platform(
-            fake_romm_api,
-            platform_id=1,
-            name="N64",
-            slug="n64",
-            roms=[{"id": i, "name": f"G{i}"} for i in range(1, 6)],
-        )
-
-        commit_rows: list[list[int]] = []
-        box = plugin._sync_service._box
-
-        async def capture_commit(_rid_to_aid, chunk_rows, platform_stamp=None, collection_stamp=None, fetch_id=None):
-            commit_rows.append([r["id"] for r in chunk_rows])
-            # Cancel lands the instant chunk 0's commit resolves — before the loop
-            # returns to the top to emit chunk 1.
-            if len(commit_rows) == 1:
-                box.sync_state = SyncState.CANCELLING
-
-        plugin._sync_service._reporter.commit_unit_results = capture_commit  # type: ignore[method-assign]
-        plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
-        plugin._sync_service._orchestrator._wait_for_unit_complete = _fake_wait_set_event
-        box.sync_state = SyncState.RUNNING
-        box.current_sync_id = "run-inter-chunk"
-
-        unit = WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=5)
-        await plugin._sync_service._orchestrator._sync_one_unit(
-            unit,
-            unit_index=0,
-            total_units=1,
-            synced_rom_ids=set(),
-            collection_memberships={},
-            platform_rom_ids=set(),
-        )
-
-        # Chunk 1 is never emitted — the loop stopped at its top before any emit —
-        # so the frontend has no orphaned chunk to churn and later fail the ack on.
-        unit_events = [c[0][1] for c in decky.emit.call_args_list if c[0][0] == "sync_apply_unit"]
-        assert len(unit_events) == 1
-        assert unit_events[0]["chunk_index"] == 0
-        # Chunk 0's commit persists.
-        assert commit_rows == [[1, 2]]
-        # Staging + chunk identity cleared so a stray late ack can't commit.
-        assert box.pending_sync == {}
-        assert box.pending_all_roms == {}
-        assert box.unit_complete_event is None
-        assert box.active_unit_id is None
-        assert box.active_chunk_index is None
-        assert box.abandoned_chunk is None
-
-    @pytest.mark.asyncio
-    async def test_heartbeat_timeout_on_chunk_stashes_only_that_chunk(self, plugin, fake_romm_api, monkeypatch):
-        """A heartbeat timeout on chunk 1 stashes ONLY chunk 1's rows (not the whole
-        unit) under chunk 1's identity, so a late ack commits just that chunk."""
-        from services.library import sync_orchestrator
-
-        plugin.loop = asyncio.get_event_loop()
-        _use_fake_romm(plugin, fake_romm_api)
-        monkeypatch.setattr(sync_orchestrator, "_APPLY_CHUNK_SIZE", 2)
-
-        _seed_platform(
-            fake_romm_api,
-            platform_id=1,
-            name="N64",
-            slug="n64",
-            roms=[{"id": i, "name": f"G{i}"} for i in range(1, 6)],
-        )
-
-        plugin._sync_service._reporter.commit_unit_results = AsyncMock()  # type: ignore[method-assign]
-        plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
-        box = plugin._sync_service._box
-
-        async def wait(_unit, event):
-            if box.active_chunk_index == 0:
-                event.set()
-                return {}
-            return None  # heartbeat timeout on chunk 1 (no cancel)
-
-        plugin._sync_service._orchestrator._wait_for_unit_complete = wait
-        box.sync_state = SyncState.RUNNING
-        box.current_sync_id = "run-timeout-chunk"
-
-        unit = WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=5)
-        await plugin._sync_service._orchestrator._sync_one_unit(
-            unit,
-            unit_index=0,
-            total_units=1,
-            synced_rom_ids=set(),
-            collection_memberships={},
-            platform_rom_ids=set(),
-        )
-
-        assert box.abandoned_chunk is not None
-        # The dispatch identity is cleared; the chunk index lives on the stash.
-        assert box.active_chunk_index is None
-        assert box.abandoned_chunk.chunk_index == 1
-        # Only chunk 1's rows are stashed for the late ack, not the whole unit.
-        assert [r["id"] for r in box.abandoned_chunk.chunk_rows] == [3, 4]
-        # The timeout requested cancel so the outer loop stops.
-        assert box.sync_state == SyncState.CANCELLING
 
 
 class TestPerUnitMetadataStamping:
@@ -4080,7 +3725,7 @@ class TestPerUnitMetadataStamping:
             event.set()
             return {"10": 5001}
 
-        plugin._sync_service._orchestrator._wait_for_unit_complete = fake_wait
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = fake_wait
         plugin._sync_service._box.sync_state = SyncState.RUNNING
 
         unit = WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=1)
@@ -4128,7 +3773,7 @@ class TestPerUnitMetadataStamping:
             event.set()
             return {"10": 5001}
 
-        plugin._sync_service._orchestrator._wait_for_unit_complete = fake_wait
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = fake_wait
         plugin._sync_service._box.sync_state = SyncState.RUNNING
 
         unit = WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=1)
@@ -4180,7 +3825,7 @@ class TestPerUnitMetadataStamping:
             event.set()
             return {"1": 5001, "3": 5003, "5": 5005}
 
-        plugin._sync_service._orchestrator._wait_for_unit_complete = fake_wait
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = fake_wait
         plugin._sync_service._box.sync_state = SyncState.RUNNING
 
         unit = WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=5)
@@ -4231,7 +3876,7 @@ class TestPlatformCompletionStamp:
             event.set()
             return {"1": 5001, "2": 5002}
 
-        plugin._sync_service._orchestrator._wait_for_unit_complete = fake_wait
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = fake_wait
         plugin._sync_service._box.sync_state = SyncState.RUNNING
 
         unit = WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=2)
@@ -4255,11 +3900,11 @@ class TestPlatformCompletionStamp:
     async def test_stamp_only_on_final_chunk_carries_unit_rom_count(self, plugin, fake_romm_api, monkeypatch):
         """Across a multi-chunk platform, only the FINAL chunk's commit carries the
         stamp, and it records the unit's whole ``rom_count`` (not the chunk size)."""
-        from services.library import sync_orchestrator
+        from services.library import chunk_dispatcher
 
         plugin.loop = asyncio.get_event_loop()
         _use_fake_romm(plugin, fake_romm_api)
-        monkeypatch.setattr(sync_orchestrator, "_APPLY_CHUNK_SIZE", 2)
+        monkeypatch.setattr(chunk_dispatcher, "_APPLY_CHUNK_SIZE", 2)
 
         _seed_platform(
             fake_romm_api,
@@ -4276,7 +3921,7 @@ class TestPlatformCompletionStamp:
 
         plugin._sync_service._reporter.commit_unit_results = capture_commit  # type: ignore[method-assign]
         plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
-        plugin._sync_service._orchestrator._wait_for_unit_complete = _fake_wait_set_event
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = _fake_wait_set_event
         plugin._sync_service._box.sync_state = SyncState.RUNNING
 
         unit = WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=5)
@@ -4301,11 +3946,11 @@ class TestPlatformCompletionStamp:
     async def test_no_stamp_on_user_cancel_mid_unit(self, plugin, fake_romm_api, monkeypatch):
         """A user cancel before a platform's last chunk leaves NO stamp — the platform
         is only partially applied, so the next run must re-fetch it."""
-        from services.library import sync_orchestrator
+        from services.library import chunk_dispatcher
 
         plugin.loop = asyncio.get_event_loop()
         _use_fake_romm(plugin, fake_romm_api)
-        monkeypatch.setattr(sync_orchestrator, "_APPLY_CHUNK_SIZE", 2)
+        monkeypatch.setattr(chunk_dispatcher, "_APPLY_CHUNK_SIZE", 2)
 
         _seed_platform(
             fake_romm_api,
@@ -4325,7 +3970,7 @@ class TestPlatformCompletionStamp:
             box.sync_state = SyncState.CANCELLING  # user cancel during chunk 1
             return None
 
-        plugin._sync_service._orchestrator._wait_for_unit_complete = wait
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = wait
         box.sync_state = SyncState.RUNNING
 
         unit = WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=5)
@@ -4361,7 +4006,7 @@ class TestPlatformCompletionStamp:
         async def timeout_wait(_unit, _event):
             return None  # heartbeat timeout — box is NOT cancelling
 
-        plugin._sync_service._orchestrator._wait_for_unit_complete = timeout_wait
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = timeout_wait
         plugin._sync_service._box.sync_state = SyncState.RUNNING
 
         unit = WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=2)
@@ -4405,7 +4050,7 @@ class TestPlatformCompletionStamp:
             event.set()
             return {"1": 5001, "2": 5002}
 
-        plugin._sync_service._orchestrator._wait_for_unit_complete = fake_wait
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = fake_wait
         plugin._sync_service._box.sync_state = SyncState.RUNNING
 
         unit = WorkUnit(type="collection", id="7", name="Favs", slug="favs", rom_count=2, collection_kind="standard")
@@ -4431,11 +4076,11 @@ class TestPlatformCompletionStamp:
         rows on a generation the stamp never names, so the next skip would count
         only the last chunk and wedge itself off permanently.
         """
-        from services.library import sync_orchestrator
+        from services.library import chunk_dispatcher
 
         plugin.loop = asyncio.get_event_loop()
         _use_fake_romm(plugin, fake_romm_api)
-        monkeypatch.setattr(sync_orchestrator, "_APPLY_CHUNK_SIZE", 2)
+        monkeypatch.setattr(chunk_dispatcher, "_APPLY_CHUNK_SIZE", 2)
 
         _seed_platform(
             fake_romm_api,
@@ -4452,7 +4097,7 @@ class TestPlatformCompletionStamp:
 
         plugin._sync_service._reporter.commit_unit_results = capture_commit  # type: ignore[method-assign]
         plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
-        plugin._sync_service._orchestrator._wait_for_unit_complete = _fake_wait_set_event
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = _fake_wait_set_event
         plugin._sync_service._box.sync_state = SyncState.RUNNING
         plugin._sync_service._box.current_sync_id = "run-abc"
 
@@ -4502,7 +4147,7 @@ class TestPlatformCompletionStamp:
             event.set()
             return {"1": 5001, "2": 5002}
 
-        plugin._sync_service._orchestrator._wait_for_unit_complete = fake_wait
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = fake_wait
         plugin._sync_service._box.sync_state = SyncState.RUNNING
         plugin._sync_service._box.current_sync_id = "run-abc"
 
@@ -4529,11 +4174,11 @@ class TestPlatformCompletionStamp:
         let the next sync skip the half-applied platform, dropping every game the
         cancelled run never re-bound.
         """
-        from services.library import sync_orchestrator
+        from services.library import chunk_dispatcher
 
         plugin.loop = asyncio.get_event_loop()
         _use_fake_romm(plugin, fake_romm_api)
-        monkeypatch.setattr(sync_orchestrator, "_APPLY_CHUNK_SIZE", 2)
+        monkeypatch.setattr(chunk_dispatcher, "_APPLY_CHUNK_SIZE", 2)
 
         _seed_platform(
             fake_romm_api,
@@ -4555,7 +4200,7 @@ class TestPlatformCompletionStamp:
             box.sync_state = SyncState.CANCELLING  # user cancel during chunk 1
             return None
 
-        plugin._sync_service._orchestrator._wait_for_unit_complete = wait
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = wait
         box.sync_state = SyncState.RUNNING
 
         unit = WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=5)
@@ -4593,7 +4238,7 @@ class TestPlatformCompletionStamp:
         async def timeout_wait(_unit, _event):
             return None  # heartbeat timeout — box is NOT cancelling
 
-        plugin._sync_service._orchestrator._wait_for_unit_complete = timeout_wait
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = timeout_wait
         plugin._sync_service._box.sync_state = SyncState.RUNNING
 
         unit = WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=2)
@@ -4631,7 +4276,7 @@ class TestPlatformCompletionStamp:
             event.set()
             return {"1": 5001, "2": 5002}
 
-        plugin._sync_service._orchestrator._wait_for_unit_complete = fake_wait
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = fake_wait
         plugin._sync_service._box.sync_state = SyncState.RUNNING
 
         unit = WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=2)
@@ -4801,7 +4446,7 @@ class TestRegression738CacheCorruption:
             event.set()
             return {"1": 1001, "2": 1002, "3": 1003}
 
-        plugin._sync_service._orchestrator._wait_for_unit_complete = fake_wait
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = fake_wait
         plugin._sync_service._box.sync_state = SyncState.RUNNING
 
         await plugin._sync_service._orchestrator._do_sync_per_unit()
@@ -4811,28 +4456,6 @@ class TestRegression738CacheCorruption:
         with plugin._uow as uow:
             for rid, meta in seeds.items():
                 assert uow.rom_metadata.get(rid) == meta
-
-
-class TestWaitForUnitCompleteCancelled:
-    """Tests for asyncio.CancelledError in _wait_for_unit_complete."""
-
-    @pytest.mark.asyncio
-    async def test_cancelled_error_during_sleep_is_logged_and_reraised(self, plugin):
-        """If the inner sleep is cancelled, log + re-raise so the outer loop sees the cancel."""
-
-        class _CancellingSleeper:
-            async def sleep(self, _seconds: float) -> None:
-                raise asyncio.CancelledError()
-
-        plugin._sync_service._orchestrator._sleeper = _CancellingSleeper()
-        plugin._sync_service._box.sync_state = SyncState.RUNNING
-        plugin._sync_service._sync_last_heartbeat = plugin._sync_service._orchestrator._clock.monotonic()
-
-        unit = WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=1)
-        event = asyncio.Event()  # never set — wait will enter the sleep path
-
-        with pytest.raises(asyncio.CancelledError):
-            await plugin._sync_service._orchestrator._wait_for_unit_complete(unit, event)
 
 
 class TestDownloadArtworkDelegation:
@@ -4895,7 +4518,7 @@ class TestFetchNarrationInterplay:
         _seed_platform(fake_romm_api, platform_id=1, name="N64", slug="n64", roms=[{"id": 10, "name": "A"}])
         plugin.settings["enabled_platforms"] = {"1": True}
         plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
-        plugin._sync_service._orchestrator._wait_for_unit_complete = _fake_wait_set_event
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = _fake_wait_set_event
         plugin._sync_service._box.sync_state = SyncState.RUNNING
 
         await plugin._sync_service._orchestrator._do_sync_per_unit()
@@ -4925,7 +4548,7 @@ class TestFetchNarrationInterplay:
         )
         plugin.settings["enabled_platforms"] = {"1": True}
         plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
-        plugin._sync_service._orchestrator._wait_for_unit_complete = _fake_wait_set_event
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = _fake_wait_set_event
         plugin._sync_service._box.sync_state = SyncState.RUNNING
 
         await plugin._sync_service._orchestrator._do_sync_per_unit()
@@ -4976,7 +4599,7 @@ class TestComponentGroupKeyStamping:
         )
         plugin.settings["enabled_platforms"] = {"1": True}
         plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
-        plugin._sync_service._orchestrator._wait_for_unit_complete = _fake_wait_set_event
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = _fake_wait_set_event
         plugin._sync_service._box.sync_state = SyncState.RUNNING
 
         await plugin._sync_service._orchestrator._do_sync_per_unit()
@@ -5015,7 +4638,7 @@ class TestDeltaRestrictedApply:
         plugin.loop = asyncio.get_event_loop()
         _use_fake_romm(plugin, fake_romm_api)
         plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
-        plugin._sync_service._orchestrator._wait_for_unit_complete = _fake_wait_set_event
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = _fake_wait_set_event
         plugin._sync_service._box.sync_state = SyncState.RUNNING
         plugin._sync_service._box.current_sync_id = "run-delta"
 
@@ -5132,7 +4755,7 @@ class TestCoverRefreshPass:
         plugin.loop = asyncio.get_event_loop()
         _use_fake_romm(plugin, fake_romm_api)
         plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
-        plugin._sync_service._orchestrator._wait_for_unit_complete = _fake_wait_set_event
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = _fake_wait_set_event
         plugin._sync_service._box.sync_state = SyncState.RUNNING
         plugin._sync_service._box.current_sync_id = "run-cover"
 
@@ -5211,10 +4834,10 @@ class TestCoverRefreshPass:
     async def test_refreshes_ride_only_the_first_chunk(self, plugin, fake_romm_api, monkeypatch):
         # Four changed items at chunk size 2 → two chunks; rom 1's cover also
         # changed. The refresh entry rides chunk 0 only; chunk 1 carries [].
-        from services.library import sync_orchestrator
+        from services.library import chunk_dispatcher
 
         self._apply_setup(plugin, fake_romm_api)
-        monkeypatch.setattr(sync_orchestrator, "_APPLY_CHUNK_SIZE", 2)
+        monkeypatch.setattr(chunk_dispatcher, "_APPLY_CHUNK_SIZE", 2)
         _seed_platform(
             fake_romm_api,
             platform_id=1,
@@ -5289,57 +4912,6 @@ class TestCoverRefreshPass:
             assert uow.roms.get(1).cover_source == "/a.png?ts=2026-07-11 12:00:00"
             assert uow.roms.get(2).cover_source == "/b.png?ts=2026-07-11 12:00:00"
 
-    # ── _clip_cover_refreshes (the clip primitive) ───────────────
-
-    def test_clip_fails_open_when_rss_unavailable(self, plugin):
-        orch = plugin._sync_service._orchestrator
-        refreshes = [{"rom_id": 1, "app_id": 10}, {"rom_id": 2, "app_id": 20}]
-        assert orch._clip_cover_refreshes(refreshes, rss_kb=None, creates=0, updates=0, limit_kb=1_000_000) == refreshes
-
-    def test_clip_keeps_all_with_headroom(self, plugin):
-        from domain.session_budget import COVER_TRANSIENT_KB, EFFECTIVE_CEILING_KB
-
-        orch = plugin._sync_service._orchestrator
-        refreshes = [{"rom_id": 1, "app_id": 10}, {"rom_id": 2, "app_id": 20}]
-        rss = EFFECTIVE_CEILING_KB - 10 * COVER_TRANSIENT_KB
-        assert (
-            orch._clip_cover_refreshes(refreshes, rss_kb=rss, creates=0, updates=0, limit_kb=EFFECTIVE_CEILING_KB)
-            == refreshes
-        )
-
-    def test_clip_accounts_for_the_chunks_own_cost(self, plugin):
-        from domain.session_budget import EFFECTIVE_CEILING_KB, chunk_worst_cost_kb
-
-        orch = plugin._sync_service._orchestrator
-        refreshes = [{"rom_id": i, "app_id": i * 10} for i in range(1, 6)]
-        # Headroom of exactly the chunk's own cost → zero left for refreshes.
-        rss = EFFECTIVE_CEILING_KB - chunk_worst_cost_kb(3, 2)
-        assert (
-            orch._clip_cover_refreshes(refreshes, rss_kb=rss, creates=3, updates=2, limit_kb=EFFECTIVE_CEILING_KB) == []
-        )
-
-    def test_clip_negative_headroom_yields_empty(self, plugin):
-        from domain.session_budget import EFFECTIVE_CEILING_KB
-
-        orch = plugin._sync_service._orchestrator
-        refreshes = [{"rom_id": 1, "app_id": 10}]
-        assert (
-            orch._clip_cover_refreshes(
-                refreshes, rss_kb=EFFECTIVE_CEILING_KB + 1, creates=0, updates=0, limit_kb=EFFECTIVE_CEILING_KB
-            )
-            == []
-        )
-
-    def test_clip_keeps_list_order(self, plugin):
-        from domain.session_budget import COVER_TRANSIENT_KB, EFFECTIVE_CEILING_KB
-
-        orch = plugin._sync_service._orchestrator
-        refreshes = [{"rom_id": i, "app_id": i * 10} for i in range(1, 6)]
-        rss = EFFECTIVE_CEILING_KB - 2 * COVER_TRANSIENT_KB
-        assert orch._clip_cover_refreshes(
-            refreshes, rss_kb=rss, creates=0, updates=0, limit_kb=EFFECTIVE_CEILING_KB
-        ) == [{"rom_id": 1, "app_id": 10}, {"rom_id": 2, "app_id": 20}]
-
     # ── delegation ───────────────────────────────────────────────
 
     @pytest.mark.asyncio
@@ -5375,7 +4947,7 @@ class TestSessionBudgetGate:
     @staticmethod
     def _arm_two_chunk_apply(plugin, fake_romm_api, monkeypatch):
         """Seed a 2-ROM platform and force one shortcut per chunk (2 chunks)."""
-        from services.library import sync_orchestrator
+        from services.library import chunk_dispatcher
 
         plugin.loop = asyncio.get_event_loop()
         _use_fake_romm(plugin, fake_romm_api)
@@ -5388,13 +4960,13 @@ class TestSessionBudgetGate:
         )
         plugin.settings["enabled_platforms"] = {"1": True}
         plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
-        monkeypatch.setattr(sync_orchestrator, "_APPLY_CHUNK_SIZE", 1)
+        monkeypatch.setattr(chunk_dispatcher, "_APPLY_CHUNK_SIZE", 1)
 
         async def fake_wait(_u, event):
             event.set()
             return {}
 
-        plugin._sync_service._orchestrator._wait_for_unit_complete = fake_wait
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = fake_wait
         plugin._sync_service._box.sync_state = SyncState.RUNNING
         plugin._sync_service._box.current_sync_id = "run-budget"
 
@@ -5435,20 +5007,20 @@ class TestSessionBudgetGate:
     @staticmethod
     def _arm_single_chunk_apply(plugin, fake_romm_api, monkeypatch, *, run_id):
         """Seed a 1-ROM platform (→ one chunk = the run's first chunk)."""
-        from services.library import sync_orchestrator
+        from services.library import chunk_dispatcher
 
         plugin.loop = asyncio.get_event_loop()
         _use_fake_romm(plugin, fake_romm_api)
         _seed_platform(fake_romm_api, platform_id=1, name="N64", slug="n64", roms=[{"id": 10, "name": "Solo"}])
         plugin.settings["enabled_platforms"] = {"1": True}
         plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
-        monkeypatch.setattr(sync_orchestrator, "_APPLY_CHUNK_SIZE", 1)
+        monkeypatch.setattr(chunk_dispatcher, "_APPLY_CHUNK_SIZE", 1)
 
         async def fake_wait(_u, event):
             event.set()
             return {}
 
-        plugin._sync_service._orchestrator._wait_for_unit_complete = fake_wait
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = fake_wait
         plugin._sync_service._box.sync_state = SyncState.RUNNING
         plugin._sync_service._box.current_sync_id = run_id
 
@@ -5612,7 +5184,7 @@ class TestSessionBudgetGate:
             event.set()
             return {"10": 9001}
 
-        plugin._sync_service._orchestrator._wait_for_unit_complete = fake_wait
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = fake_wait
         plugin._sync_service._box.sync_state = SyncState.RUNNING
         plugin._sync_service._box.current_sync_id = "run-restart"
 
@@ -5796,11 +5368,11 @@ class TestRunProgressCounters:
             event.set()
             return pending.pop(0) if pending else {}
 
-        plugin._sync_service._orchestrator._wait_for_unit_complete = fake_wait
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = fake_wait
 
     @pytest.mark.asyncio
     async def test_committed_chunks_count_toward_done(self, plugin, fake_romm_api, monkeypatch):
-        from services.library import sync_orchestrator
+        from services.library import chunk_dispatcher
 
         # Two brand-new ROMs, one shortcut per chunk → two chunks, both acked and
         # committed. The plan's ROM total is the denominator.
@@ -5813,7 +5385,7 @@ class TestRunProgressCounters:
             roms=[{"id": 10, "name": "Alpha"}, {"id": 11, "name": "Beta"}],
         )
         plugin.settings["enabled_platforms"] = {"1": True}
-        monkeypatch.setattr(sync_orchestrator, "_APPLY_CHUNK_SIZE", 1)
+        monkeypatch.setattr(chunk_dispatcher, "_APPLY_CHUNK_SIZE", 1)
         self._acks(plugin, {"10": 1010}, {"11": 1011})
 
         await plugin._sync_service._orchestrator._do_sync_per_unit()
@@ -5824,7 +5396,7 @@ class TestRunProgressCounters:
 
     @pytest.mark.asyncio
     async def test_emitted_but_uncommitted_chunk_does_not_count(self, plugin, fake_romm_api, monkeypatch):
-        from services.library import sync_orchestrator
+        from services.library import chunk_dispatcher
 
         # The first chunk is emitted, then the user cancels mid-wait: the wait gives
         # up (None), the chunk never commits, and its item must NOT be reported done.
@@ -5837,7 +5409,7 @@ class TestRunProgressCounters:
             roms=[{"id": 10, "name": "Alpha"}, {"id": 11, "name": "Beta"}],
         )
         plugin.settings["enabled_platforms"] = {"1": True}
-        monkeypatch.setattr(sync_orchestrator, "_APPLY_CHUNK_SIZE", 1)
+        monkeypatch.setattr(chunk_dispatcher, "_APPLY_CHUNK_SIZE", 1)
         box = plugin._sync_service._box
 
         async def cancel_mid_wait(_unit, _event) -> dict[str, int] | None:
@@ -5845,7 +5417,7 @@ class TestRunProgressCounters:
             box.request_cancel()
             return None
 
-        plugin._sync_service._orchestrator._wait_for_unit_complete = cancel_mid_wait
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = cancel_mid_wait
 
         await plugin._sync_service._orchestrator._do_sync_per_unit()
 
@@ -5854,7 +5426,7 @@ class TestRunProgressCounters:
 
     @pytest.mark.asyncio
     async def test_paused_run_counts_only_the_committed_chunk(self, plugin, fake_romm_api, monkeypatch):
-        from services.library import sync_orchestrator
+        from services.library import chunk_dispatcher
 
         # The session-budget gate pauses at the second chunk's boundary — before its
         # emit — so exactly one chunk committed. This is the banner's own scenario.
@@ -5867,7 +5439,7 @@ class TestRunProgressCounters:
             roms=[{"id": 10, "name": "Alpha"}, {"id": 11, "name": "Beta"}],
         )
         plugin.settings["enabled_platforms"] = {"1": True}
-        monkeypatch.setattr(sync_orchestrator, "_APPLY_CHUNK_SIZE", 1)
+        monkeypatch.setattr(chunk_dispatcher, "_APPLY_CHUNK_SIZE", 1)
         self._acks(plugin, {"10": 1010}, {"11": 1011})
         plugin._renderer_gc.result = True
         plugin._renderer_rss.rss_kb = 2_199_000  # first chunk passes (vs cliff), second pauses
@@ -6019,7 +5591,7 @@ class TestProcessedGamesNumerator:
             event.set()
             return {"11": 1011}
 
-        plugin._sync_service._orchestrator._wait_for_unit_complete = fake_wait
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = fake_wait
 
         await plugin._sync_service._orchestrator._do_sync_per_unit()
 
@@ -6035,7 +5607,7 @@ class TestProcessedGamesNumerator:
         (and agrees with the paused banner's ``run_done_items``)."""
         import decky
 
-        from services.library import sync_orchestrator
+        from services.library import chunk_dispatcher
 
         self._arm(plugin, fake_romm_api, run_id="run-resume-interrupt")
 
@@ -6064,7 +5636,7 @@ class TestProcessedGamesNumerator:
         _seed_rom_row(plugin, 21, app_id=1021, platform_slug="gba", name="Old Name", fs_name="changed.gba")
         _seed_rom_row(plugin, 22, app_id=1022, platform_slug="gba", name="Old Other", fs_name="other.gba")
         plugin.settings["enabled_platforms"] = {"1": True, "2": True}
-        monkeypatch.setattr(sync_orchestrator, "_APPLY_CHUNK_SIZE", 1)
+        monkeypatch.setattr(chunk_dispatcher, "_APPLY_CHUNK_SIZE", 1)
 
         acks: list[dict[str, int] | None] = [{"21": 1021}, None]
 
@@ -6075,7 +5647,7 @@ class TestProcessedGamesNumerator:
                 return ack
             return None  # heartbeat timeout — the box is still RUNNING
 
-        plugin._sync_service._orchestrator._wait_for_unit_complete = wait_ack_then_timeout
+        plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = wait_ack_then_timeout
 
         await plugin._sync_service._orchestrator._do_sync_per_unit()
 


### PR DESCRIPTION
The apply pipeline's chunk round-trip moves into `services/library/chunk_dispatcher.py`. `ChunkDispatcher` drives one work unit's apply as a sequence of durable round-trips: emit a chunk to the frontend, wait for its acknowledgement against the heartbeat clock, commit it through the reporter, and decide what becomes of a chunk whose acknowledgement never comes.

Six methods and three constants move. The three the issue named — the loop, the wait, and the give-up — plus the two that decide when a platform or collection gets its completion stamp, because those are final-**chunk** facts evaluated inside the loop, not the run's finalisation. The issue's grouping was wrong there: "final stamps" conflated the last chunk of a unit with the last phase of a run, and `_finalize_per_unit` genuinely is the latter and stays.

`_clip_cover_refreshes` moves too, but to `session_budget.py`. It touches no cover and downloads nothing; every symbol in it is renderer-budget arithmetic and its input is a reading the monitor produced a few lines earlier. The loop now asks the monitor two plain questions instead of doing the sums itself.

The whole-unit staging writes move with the loop, so `pending_sync`, `pending_all_roms` and `pending_cover_sources` have one production writer module from the moment they are filled to the moment a heartbeat timeout deliberately leaves them alone for a late acknowledgement.

What the new config does **not** take is the contract: no unit-of-work factory, no event loop, no settings, and none of the four confined seams. It opens no transaction and performs no I/O of its own — every durable write goes through the reporter, every message through the emitter. It may ask a run to stop; it may never begin or end one. Those stay the orchestrator's.

Bodies moved verbatim. The one pair worth naming: `pending_sync` holds the delta and `pending_all_roms` the full built set, and swapping them compiles, type-checks, and silently writes the wrong recorded launch command for every skipped sibling — the one path to a later sync wrongly skipping a ROM. They are character-identical to their origin and now pinned apart by a test that fails on the swap.

**Two rules that lived only in comments are now tests.** The chunk's identity must be stamped before its emit; taken after, a fast acknowledgement is rejected as stray, the wait stalls for the full sixty-second window, and the run ends by stashing a chunk the frontend had already applied — slow, plausible, and silent. Nothing observed that ordering before, because every test stubs the wait. It now has a test, and the invariant register carries the rule with its three-module span and the limit of what the test can see: a mock's call-time state, not a real round-trip.

The second is the cancel check between chunks, which turned out to be load-bearing in a way its own comment did not claim. Without it the budget gate runs first and records the run as paused before requesting the cancel — so a cancel landing on a chunk boundary near the memory ceiling would come back as a resumable pause instead of a cancellation. That is now pinned too.

One pre-existing hole closed on the way: the condition that stamps a collection only on its final chunk had no test at all. Deleting it left the suite green, which means a collection could be marked fully synced mid-unit and the next sync's skip gate would honour it.

`sync_orchestrator.py` goes 1192 → 956 counted lines, so its module-size allowlist entry is **deleted** rather than lowered — the gate insists on that once a module falls back under the threshold.

What this does not claim: the service layer is not thin now. A loop that blocks on another program for minutes is not thin orchestration, and moving it does not make it so. What the cut buys is that the coordination is one small module with a stateable dependency surface, and that naming the frontend round-trip as a seam — #1785, where ~74 test sites currently monkeypatch a private method to stand in for the frontend — becomes a change to one module instead of to twelve hundred lines.

Step of #1777.
