### PR TITLE
feat(sync): keep a computed preview alive when you leave the page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -327,6 +327,14 @@ Format: **invariant** — tier — enforced by.
   mode is why the entry exists rather than being left to the comment: stamp after the emit and a fast ack is rejected as
   stray, the wait then stalls the full 60-second heartbeat window, and the run ends by stashing a chunk the frontend had
   already applied — slow, plausible-looking, and silent (#1052 / #1367)
+- **Every path on which the user answers the preview question leaves a live snapshot on neither side — the
+  pending-preview store (`src/utils/pendingPreviewStore.ts`) and the backend's `pending_delta`** — prompt-only — three
+  paths clear the store and tell the backend (`handleDismiss`, `handleApply`, a fresh `handleSync` press); the fourth is
+  the cancel that lands just after a preview was staged, which never adopted it into the store and so discharges the
+  rule by discarding server-side alone. Nothing mechanical can tell: an answer path is a `MainPage` handler, and neither
+  the store nor the backend can know that a call it never received was an answer. Forget the store and a card stands
+  over a decision already made; forget the backend and the terminal-stage re-ask fetches that card back a round trip
+  later
 - **A prune run's claim reservation and its refusal of every conflicting callable happen in one atomic gate hold (the
   preview rebuild does not), and frontend-owned Steam work holds a heartbeated, generation-tombstoned lease through
   every continuation's final write** — test + prompt-only — prune service/gate race tests + contract callable-entry

--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -288,7 +288,7 @@ The library sync subsystem is a façade over seven sub-services that coordinate 
 | `reporter.py`                 | `SyncReporter` — post-apply finalisation (artwork filenames, per-unit `roms` upsert + `SyncRun` lifecycle) and the `roms`-derived queries                                                                                                                                                                                                  |
 | `session_budget.py`           | `SessionBudgetMonitor` — Steam's per-session renderer-heap budget: the GC-settled RSS measurement, the chunk-boundary pause verdict, the headroom clip that trims a chunk's additive cover work to what that verdict left, the post-preview prognosis, the run-start baseline, and the `get_session_budget_status` payload                 |
 | `shortcut_launch_resolver.py` | `ShortcutLaunchResolver` — resolves each ROM's launch facts for the shortcut bake: the disc-resolved installed path and the active emulator, both handed to `build_shortcuts_data`                                                                                                                                                         |
-| `_state.py`                   | `LibrarySyncStateBox` — shared mutable in-flight sync state; single source of truth threaded through every sub-service, and the **sole owner** of the run-lifecycle pair (`sync_state` / `current_sync_id`) and of the staged preview snapshot (`pending_delta`, TTL included) via its verb methods                                        |
+| `_state.py`                   | `LibrarySyncStateBox` — shared mutable in-flight sync state; single source of truth threaded through every sub-service, and the **sole owner** of the run-lifecycle pair (`sync_state` / `current_sync_id`) and of the staged preview snapshot (`pending_delta`, TTL and the run-in-flight withholding included) via its verb methods      |
 
 The pipeline is split **fetch (read-only) / apply (owns persistence)**: the fetcher never mutates the `roms` registry or
 `rom_metadata`, and the reporter's per-unit commit upserts each acked ROM's `roms` row and stamps its cached
@@ -786,17 +786,32 @@ the snapshot for its full 30-minute TTL, so a user who steps into a submenu used
 perfectly valid. Storing the answer rather than re-assembling one is what guarantees the restored card is what the user
 was shown. The answer also carries `expires_at` — an absolute epoch — which the card counts down against; absolute
 rather than a remaining-seconds count because plugin and panel share a clock and a deadline survives a suspend.
-`get_pending_preview` is a pure read plus one lazy clear: nothing staged (or a snapshot past its TTL, dropped on the
-spot) answers `{"success": True, "preview": None}` — "no preview" is a normal answer, not a failure.
+`get_pending_preview` answers `{"success": True, "preview": None}` for all three of nothing staged, a snapshot past its
+TTL (dropped on the spot), and **a run in flight** — "no preview" is a normal answer, not a failure.
 
-**`pending_delta` is box-owned, like the run-lifecycle pair.** The staged snapshot's whole lifetime runs through four
-`LibrarySyncStateBox` verbs — `stage_preview` / `read_fresh_preview` / `matches_preview` / `discard_preview` — and no
-module outside `_state.py` assigns the field (the façade exposes a getter only). The TTL lives with them:
-`PREVIEW_MAX_AGE_SECONDS` and the `preview_deadline` the answer's `expires_at` comes from are the box's, so the number
-the card counts down to and the verdict `read_fresh_preview` reaches cannot drift apart. "Too old" has exactly one
-expression, `PreviewDelta.is_expired`, reached only from `read_fresh_preview` — which both the pending read and
-`sync_apply_delta`'s age refusal go through, so the read can never offer an Apply the apply would reject. Unlike the
-run-lifecycle pair this has no CI gate; it is prose plus the box's own tests.
+That third case is a backend guarantee rather than a frontend courtesy, because the panel cannot get it right on its
+own. It derives "a run is live" from the `sync_progress` store, and `abortOptimisticSync` retracts the optimistic
+`running: true` on **every** failed apply — including the `sync_in_progress` rejection, which is exactly the branch
+where the backend deliberately **keeps** the staged delta (#1202). The store therefore reads idle during a live run, and
+a panel remounting there would render the restored card over the run's own progress rows (its `preview` branch outranks
+its `syncing` branch), with the next Apply retracting the live run's UI a second time. A plugin reload mid-run reaches
+the same state through an empty store racing the `get_sync_status` seed. So the run-in-flight case is refused where the
+truth is: `LibrarySyncStateBox.read_restorable_preview`. The frontend keeps its own check as belt-and-braces.
+
+**Withheld, not discarded.** A run in flight suppresses the snapshot for the duration and nothing else — the same
+payload is handed back on the next mount after the run ends, as long as it is still inside its TTL. And the withholding
+belongs to that reader alone: `sync_apply_delta`'s age check goes through the run-blind `read_fresh_preview`, so an
+overlapping apply is still refused by the run-slot claim with `sync_in_progress` instead of being rewritten into a
+staleness verdict.
+
+**`pending_delta` is box-owned, like the run-lifecycle pair.** The staged snapshot's whole lifetime runs through the
+`LibrarySyncStateBox` verbs — `stage_preview` / `read_fresh_preview` / `read_restorable_preview` / `matches_preview` /
+`discard_preview` — and no module outside `_state.py` assigns the field (the façade exposes a getter only). The TTL
+lives with them: `PREVIEW_MAX_AGE_SECONDS` and the `preview_deadline` the answer's `expires_at` comes from are the
+box's, so the number the card counts down to and the verdict `read_fresh_preview` reaches cannot drift apart. "Too old"
+has exactly one expression, `PreviewDelta.is_expired`, reached only from `read_fresh_preview` — which both the pending
+read and `sync_apply_delta`'s age refusal go through, so the read can never offer an Apply the apply would reject.
+Unlike the run-lifecycle pair this has no CI gate; it is prose plus the box's own tests.
 
 In `sync_apply_delta` the ordering is load-bearing and deliberately left as three visible steps — identity check,
 run-slot claim, then discard — rather than one atomic "take" verb: a rapid second apply, or one landing while a run is

--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -837,21 +837,35 @@ includes an additive `runId: str` field — `str(current_sync_id or "")` — so 
 the authoritative backend store rather than minting or threading its own. The idle default snapshot carries `runId: ""`.
 
 **The snapshot describes an in-flight run only.** `finish_run` puts `sync_progress` back to the idle default as part of
-ending a run — after the terminal frame has been emitted, since every path emits it before reaching the
-`finally: finish_run(run_id)` that lands there. It exists so a remounting QAM can pick up a **live** run; a finished
-run's ending already reached the panel as an event, and a panel that merely _finds_ a terminal frame on a later mount is
-required to ignore it (#1019). Left in place, the frame answered every later mount with a run that had ended — message
-and run id included — and the panel took it for the state of the run it was actually watching: pressing Sync, then
-returning during the window before the new run's first frame, showed a green "Preview ready" over a preview that was
-still going, and dropped the panel back to the idle buttons in the meantime. The reset is not itself a frame: nothing
-emits it, so no `running: false` reaches the panel from it.
+ending a run — after the terminal frame has gone out, since every path emits **or schedules** it before reaching the
+`finally: finish_run(run_id)` that lands there. (The per-unit error path schedules its emit through `create_task`, so
+that one may run _after_ the reset; it is safe because the coroutine binds the ERROR frame by value and the reset
+rebinds the attribute rather than mutating the dict a pending task is holding.) It exists so a remounting QAM can pick
+up a **live** run; a finished run's ending already reached the panel as an event, and a panel that merely _finds_ a
+terminal frame on a later mount is required to ignore it (#1019). Left in place, the frame answered every later mount
+with a run that had ended — message and run id included — and the panel took it for the state of the run it was actually
+watching: pressing Sync, then returning during the window before the new run's first frame, showed a green "Preview
+ready" over a preview that was still going, and dropped the panel back to the idle buttons in the meantime. The reset is
+not itself a frame: nothing emits it, so no `running: false` reaches the panel from it.
 
-The panel closes the same gap from its side, because the reset only helps a backend that has one: a `get_sync_status`
-answer reporting **nothing** in flight may not retract a run the module store is currently tracking unless it names that
-same run. The optimistic frame carries no run id, so nothing can name it during the start window — which is correct,
-because in that window the store knows about a run the backend has not reported yet. The residual risk is stated at the
-call site: a genuinely missed terminal frame leaves the panel believing a run is live until the next frame or the next
-run, which is the better failure — a panel wrongly showing the idle buttons invites a second run on top of a live one.
+**`get_sync_status` answers with the run lifecycle too.** The payload carries an additive `inFlight: bool` —
+`box.is_in_flight()`, the lifecycle state itself, not a re-reading of the frame. It rides this answer only, never an
+emitted `sync_progress` event, and the two legitimately disagree: during a cancel drain the CANCELLED frame already
+reads `running: False` while the run still owns the slot.
+
+The panel needs it because a frame alone cannot separate two questions it must answer differently. When the module store
+says a run is live and the answer says nothing is running, retracting is right if the run really ended (its terminal
+frame was lost) and wrong if the backend simply has not heard of it yet — which is exactly the start window, where the
+panel has written an optimistic frame and `sync_preview` has not yet claimed the run slot. So the seed retracts only
+where the answer is evidence about _that_ run: either it names it, or `inFlight` is explicitly `false` **and** the
+store's run carries a backend-stamped id. An idle answer against the panel's own unstamped optimistic frame is refused,
+and that cannot wedge, because the handler that wrote that frame always retracts it itself — from a dead instance too.
+
+Inferring the lifecycle from the frame instead would wedge the panel: with the snapshot reset above, a finished run and
+a run that never started are the same answer, so a lost terminal frame would leave every later mount believing a run is
+live. Nothing recovers from that state — the start controls all live in the idle branch, "Cancel Sync" for an unknown
+run is answered `{"success": True, "message": "No sync in progress"}` with no terminal to follow, and DangerZone and
+RemovedGamesCleanup gate four more actions on the same flag.
 
 The same `sync_plan` capture point also clears the frontend's per-run cancel flag (`_cancelRequested`). The per-unit
 handler resets that flag at its own start, but an incrementally-**skipped** unit never runs that handler, so a skip-only

--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -793,10 +793,24 @@ That third case is a backend guarantee rather than a frontend courtesy, because 
 own. It derives "a run is live" from the `sync_progress` store, and `abortOptimisticSync` retracts the optimistic
 `running: true` on **every** failed apply — including the `sync_in_progress` rejection, which is exactly the branch
 where the backend deliberately **keeps** the staged delta (#1202). The store therefore reads idle during a live run, and
-a panel remounting there would render the restored card over the run's own progress rows (its `preview` branch outranks
-its `syncing` branch), with the next Apply retracting the live run's UI a second time. A plugin reload mid-run reaches
-the same state through an empty store racing the `get_sync_status` seed. So the run-in-flight case is refused where the
-truth is: `LibrarySyncStateBox.read_restorable_preview`. The frontend keeps its own check as belt-and-braces.
+a panel that let the restored card decide the body would render it over the run's own progress rows, with the next Apply
+retracting the live run's UI a second time. A plugin reload mid-run reaches the same state through an empty store racing
+the `get_sync_status` seed. So the run-in-flight case is refused where the truth is:
+`LibrarySyncStateBox.read_restorable_preview`. The panel's own defence is a rendering rule rather than a second check on
+the read: a run in flight owns the body, so a preview held while one is going is **kept and not shown**, and its card
+appears the moment the run ends.
+
+**Frontend side: the pending preview is a module store, not panel state.** `src/utils/pendingPreviewStore.ts` owns it.
+The reason is the same lifetime mismatch from the other end — `sync_preview` is an awaited callable, so its answer is
+delivered to the closure of whichever `MainPage` pressed Sync, and leaving the main page unmounts that instance while
+the run carries on. The card then never appeared for the instance actually on screen: the panel showed the idle Sync
+buttons over a preview the backend was holding, and only the _next_ mount's `get_pending_preview` recovered it. The
+store is not a second source of truth — it holds the backend's answer verbatim, is only ever filled from `sync_preview`
+/ `get_pending_preview`, and never derives or repairs one. Its ordering rule (a write takes a ticket when its
+information was issued; an answer applies only if no later-issued write already has; a read only ever fills, because
+`preview: None` conflates three different situations) is stated in full in that module's docstring. Two triggers fill it
+— the panel's mount, and a preview run reaching its terminal stage with the store still empty — and, because both write
+to the same destination, the race between them is "who writes first", not "which copy wins".
 
 **Withheld, not discarded.** A run in flight suppresses the snapshot for the duration and nothing else — the same
 payload is handed back on the next mount after the run ends, as long as it is still inside its TTL. And the withholding
@@ -821,6 +835,23 @@ legitimate apply (#1202).
 **`sync_progress` carries `runId`.** Every `sync_progress` event (and the persisted `get_sync_status` snapshot) now
 includes an additive `runId: str` field — `str(current_sync_id or "")` — so the frontend reads the active run id from
 the authoritative backend store rather than minting or threading its own. The idle default snapshot carries `runId: ""`.
+
+**The snapshot describes an in-flight run only.** `finish_run` puts `sync_progress` back to the idle default as part of
+ending a run — after the terminal frame has been emitted, since every path emits it before reaching the
+`finally: finish_run(run_id)` that lands there. It exists so a remounting QAM can pick up a **live** run; a finished
+run's ending already reached the panel as an event, and a panel that merely _finds_ a terminal frame on a later mount is
+required to ignore it (#1019). Left in place, the frame answered every later mount with a run that had ended — message
+and run id included — and the panel took it for the state of the run it was actually watching: pressing Sync, then
+returning during the window before the new run's first frame, showed a green "Preview ready" over a preview that was
+still going, and dropped the panel back to the idle buttons in the meantime. The reset is not itself a frame: nothing
+emits it, so no `running: false` reaches the panel from it.
+
+The panel closes the same gap from its side, because the reset only helps a backend that has one: a `get_sync_status`
+answer reporting **nothing** in flight may not retract a run the module store is currently tracking unless it names that
+same run. The optimistic frame carries no run id, so nothing can name it during the start window — which is correct,
+because in that window the store knows about a run the backend has not reported yet. The residual risk is stated at the
+call site: a genuinely missed terminal frame leaves the panel believing a run is live until the next frame or the next
+run, which is the better failure — a panel wrongly showing the idle buttons invites a second run on top of a live one.
 
 The same `sync_plan` capture point also clears the frontend's per-run cancel flag (`_cancelRequested`). The per-unit
 handler resets that flag at its own start, but an incrementally-**skipped** unit never runs that handler, so a skip-only

--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -288,7 +288,7 @@ The library sync subsystem is a façade over seven sub-services that coordinate 
 | `reporter.py`                 | `SyncReporter` — post-apply finalisation (artwork filenames, per-unit `roms` upsert + `SyncRun` lifecycle) and the `roms`-derived queries                                                                                                                                                                                                  |
 | `session_budget.py`           | `SessionBudgetMonitor` — Steam's per-session renderer-heap budget: the GC-settled RSS measurement, the chunk-boundary pause verdict, the headroom clip that trims a chunk's additive cover work to what that verdict left, the post-preview prognosis, the run-start baseline, and the `get_session_budget_status` payload                 |
 | `shortcut_launch_resolver.py` | `ShortcutLaunchResolver` — resolves each ROM's launch facts for the shortcut bake: the disc-resolved installed path and the active emulator, both handed to `build_shortcuts_data`                                                                                                                                                         |
-| `_state.py`                   | `LibrarySyncStateBox` — shared mutable in-flight sync state; single source of truth threaded through every sub-service, and the **sole owner** of the run-lifecycle pair (`sync_state` / `current_sync_id`) via its verb methods                                                                                                           |
+| `_state.py`                   | `LibrarySyncStateBox` — shared mutable in-flight sync state; single source of truth threaded through every sub-service, and the **sole owner** of the run-lifecycle pair (`sync_state` / `current_sync_id`) and of the staged preview snapshot (`pending_delta`, TTL included) via its verb methods                                        |
 
 The pipeline is split **fetch (read-only) / apply (owns persistence)**: the fetcher never mutates the `roms` registry or
 `rom_metadata`, and the reporter's per-unit commit upserts each acked ROM's `roms` row and stamps its cached
@@ -576,7 +576,7 @@ recording the requested `run_id`, the active `current_sync_id`, and the `sync_st
 the run id from the backend-fed `sync_progress` store — its additive `runId` field (see below) — and passes it on the
 Cancel click; in the pre-run "Fetching library…" window the store's `runId` is still `""`, which maps to the
 unconditional cancel path rather than a stale prior-run id the backend would reject as a cross-run mismatch.
-`sync_cancel_preview` is **not** run-scoped: it only clears the pending preview delta (`pending_delta`), never touches
+`sync_cancel_preview` is **not** run-scoped: it only discards the pending preview delta (`pending_delta`), never touches
 `sync_state`, and `sync_apply_delta` independently validates the `preview_id`, so a stale preview-cancel cannot abort a
 fresh sync.
 
@@ -784,12 +784,24 @@ the window the checkpoint closes cannot reopen. The confinement is enforced by `
 returned, and `get_pending_preview` hands it back verbatim — the QAM card dies with its render, while the backend holds
 the snapshot for its full 30-minute TTL, so a user who steps into a submenu used to lose an Apply that was still
 perfectly valid. Storing the answer rather than re-assembling one is what guarantees the restored card is what the user
-was shown. The answer also carries `expires_at` — `created_at + _PREVIEW_MAX_AGE_SECONDS`, an absolute epoch — which the
-card counts down against; absolute rather than a remaining-seconds count because plugin and panel share a clock and a
-deadline survives a suspend. `get_pending_preview` is a pure read plus one lazy clear: nothing staged (or a snapshot
-past its TTL, dropped on the spot) answers `{"success": True, "preview": None}` — "no preview" is a normal answer, not a
-failure. "Too old" has exactly one expression, `PreviewDelta.is_expired`, shared by that read and by
-`sync_apply_delta`'s refusal, so the read can never offer an Apply the apply would reject.
+was shown. The answer also carries `expires_at` — an absolute epoch — which the card counts down against; absolute
+rather than a remaining-seconds count because plugin and panel share a clock and a deadline survives a suspend.
+`get_pending_preview` is a pure read plus one lazy clear: nothing staged (or a snapshot past its TTL, dropped on the
+spot) answers `{"success": True, "preview": None}` — "no preview" is a normal answer, not a failure.
+
+**`pending_delta` is box-owned, like the run-lifecycle pair.** The staged snapshot's whole lifetime runs through four
+`LibrarySyncStateBox` verbs — `stage_preview` / `read_fresh_preview` / `matches_preview` / `discard_preview` — and no
+module outside `_state.py` assigns the field (the façade exposes a getter only). The TTL lives with them:
+`PREVIEW_MAX_AGE_SECONDS` and the `preview_deadline` the answer's `expires_at` comes from are the box's, so the number
+the card counts down to and the verdict `read_fresh_preview` reaches cannot drift apart. "Too old" has exactly one
+expression, `PreviewDelta.is_expired`, reached only from `read_fresh_preview` — which both the pending read and
+`sync_apply_delta`'s age refusal go through, so the read can never offer an Apply the apply would reject. Unlike the
+run-lifecycle pair this has no CI gate; it is prose plus the box's own tests.
+
+In `sync_apply_delta` the ordering is load-bearing and deliberately left as three visible steps — identity check,
+run-slot claim, then discard — rather than one atomic "take" verb: a rapid second apply, or one landing while a run is
+in flight, is refused by `try_begin_run` **before** `discard_preview` runs, so the still-valid preview survives for the
+legitimate apply (#1202).
 
 **`sync_progress` carries `runId`.** Every `sync_progress` event (and the persisted `get_sync_status` snapshot) now
 includes an additive `runId: str` field — `str(current_sync_id or "")` — so the frontend reads the active run id from

--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -775,9 +775,21 @@ a fresh run's start and leave a half-reset id:
 
 `sync_preview` adds a final cancel checkpoint **after** the unit loop, immediately before it stages `pending_delta`, so
 a cancel landing in that last window routes into the cancelled branch (`{success: False, reason: "cancelled"}`,
-`pending_delta` left `None`) rather than staging a delta the user already cancelled. The confinement is enforced by
-`scripts/check_sync_lifecycle_owner.py` (an AST gate that fails CI if `sync_state` / `current_sync_id` is assigned
-anywhere outside `_state.py`).
+`pending_delta` left `None`) rather than staging a delta the user already cancelled. Nothing awaits between that
+checkpoint and the staging — the session-budget prognosis is taken before it, and the `done` frame emitted after it — so
+the window the checkpoint closes cannot reopen. The confinement is enforced by `scripts/check_sync_lifecycle_owner.py`
+(an AST gate that fails CI if `sync_state` / `current_sync_id` is assigned anywhere outside `_state.py`).
+
+**The preview outlives the panel that asked for it.** `PreviewDelta` carries the exact answer dict `sync_preview`
+returned, and `get_pending_preview` hands it back verbatim — the QAM card dies with its render, while the backend holds
+the snapshot for its full 30-minute TTL, so a user who steps into a submenu used to lose an Apply that was still
+perfectly valid. Storing the answer rather than re-assembling one is what guarantees the restored card is what the user
+was shown. The answer also carries `expires_at` — `created_at + _PREVIEW_MAX_AGE_SECONDS`, an absolute epoch — which the
+card counts down against; absolute rather than a remaining-seconds count because plugin and panel share a clock and a
+deadline survives a suspend. `get_pending_preview` is a pure read plus one lazy clear: nothing staged (or a snapshot
+past its TTL, dropped on the spot) answers `{"success": True, "preview": None}` — "no preview" is a normal answer, not a
+failure. "Too old" has exactly one expression, `PreviewDelta.is_expired`, shared by that read and by
+`sync_apply_delta`'s refusal, so the read can never offer an Apply the apply would reject.
 
 **`sync_progress` carries `runId`.** Every `sync_progress` event (and the persisted `get_sync_status` snapshot) now
 includes an additive `runId: str` field — `str(current_sync_id or "")` — so the frontend reads the active run id from
@@ -1555,7 +1567,7 @@ documented in [Database Design](database-design.md). Selected modules:
 | `sync_action.py`                                                                  | The `SyncAction` union (`Skip` / `Upload` / `Download` / `Conflict`) the whole vertical dispatches on and the compiled core answers in. The decisions themselves are made in the core, not here. See [Save File Sync Architecture](save-file-sync-architecture.md).                                                            |
 | `sync_diff.py`                                                                    | ROM classification and platform/collection diff computation for the sync preview                                                                                                                                                                                                                                               |
 | `cover_refresh.py`                                                                | cover-fingerprint compare kernel (#1386) — `scan_cover_refresh_candidates` / `count_cover_refreshes`, shared by the apply-path invalidation pass and the preview's cover-work count so the two can never diverge                                                                                                               |
-| `preview_delta.py`                                                                | `PreviewDelta` shape for the sync preview                                                                                                                                                                                                                                                                                      |
+| `preview_delta.py`                                                                | `PreviewDelta` shape for the sync preview (the staged answer included) plus `is_expired` / `preview_expires_at`, the one expression of its TTL                                                                                                                                                                                 |
 | `work_unit.py`                                                                    | `WorkUnit` — the per-unit sync work item                                                                                                                                                                                                                                                                                       |
 | `rom_save_sync_state.py`                                                          | `RomSaveSyncState` aggregate + `FileSyncState` value object — per-ROM save-sync state, backed by `rom_save_sync_states` + `rom_save_files`                                                                                                                                                                                     |
 | `save_path.py` / `save_attribution.py` / `save_status*.py` / `save_extensions.py` | save path resolution, uploader attribution, status DTO building                                                                                                                                                                                                                                                                |

--- a/docs/user-guide/syncing-your-library.md
+++ b/docs/user-guide/syncing-your-library.md
@@ -49,11 +49,13 @@ the shortcuts. Only when there is truly nothing to do does the preview read "Eve
 
 A preview stays good for **30 minutes**, and it belongs to the plugin rather than to the page you are looking at: you
 can leave the main page for the settings or a submenu, come back, and the same preview is still there with **Apply
-Sync** ready. The card tells you how long that has left — "Expires in 26 min" just above the button, counting down. If
-you leave it sitting past the half hour, the card stays where it is and says "Expired — run the preview again"; the
-change list remains readable, **Apply Sync** goes away, and the card only disappears when you tap **Dismiss**. Nothing
-you were shown is discarded behind your back. Tapping **Sync Library** again works out a fresh preview against whatever
-your server holds now.
+Sync** ready. That holds while it is still being worked out, too — leave while the plugin is comparing your library and
+come back, and you get the progress bar for the comparison that is still running, then its card the moment it finishes,
+whether you were watching or not. The card tells you how long that has left — "Expires in 26 min" just above the button,
+counting down. If you leave it sitting past the half hour, the card stays where it is and says "Expired — run the
+preview again"; the change list remains readable, **Apply Sync** goes away, and the card only disappears when you tap
+**Dismiss**. Nothing you were shown is discarded behind your back. Tapping **Sync Library** again works out a fresh
+preview against whatever your server holds now.
 
 That starting estimate is **skip-aware**: when the run is planned, the plugin already knows which platforms haven't
 changed since their last sync and expects to skip them wholesale, so they don't inflate the number — an incremental

--- a/docs/user-guide/syncing-your-library.md
+++ b/docs/user-guide/syncing-your-library.md
@@ -17,8 +17,10 @@ games appear in the Steam Library with cover art, metadata, and organized into c
 
 1. Open the QAM and navigate to the plugin
 2. Tap **Sync Library** on the main page
-3. A progress bar shows the sync status
-4. When complete, a toast reports what actually changed — the true delta, not the total in your library. It shows the
+3. The plugin works out what would change and shows you a preview; tap **Apply Sync** to start the run, or **Cancel** to
+   throw the preview away (with **Skip Preview** switched on, the run starts straight away instead)
+4. A progress bar shows the sync status
+5. When complete, a toast reports what actually changed — the true delta, not the total in your library. It shows the
    number of shortcuts added and/or removed this run (e.g. "Sync complete — 42 added, 3 removed."), omitting a part that
    is zero. If nothing changed, it reads "Library up to date."
 
@@ -44,6 +46,14 @@ line, shown as "up to X min".
 Cover changes count too: if you replaced a game's cover on the server but nothing else changed, the preview reads "No
 shortcut changes — N cover updates" and still offers **Apply Sync** — applying refreshes those tiles without touching
 the shortcuts. Only when there is truly nothing to do does the preview read "Everything is up to date."
+
+A preview stays good for **30 minutes**, and it belongs to the plugin rather than to the page you are looking at: you
+can leave the main page for the settings or a submenu, come back, and the same preview is still there with **Apply
+Sync** ready. The card tells you how long that has left — "Expires in 26 min" next to the button, counting down. If you
+leave it sitting past the half hour, the card stays where it is and says "Expired — run the preview again"; the change
+list remains readable, **Apply Sync** goes away, and the card only disappears when you tap **Dismiss**. Nothing you were
+shown is discarded behind your back. Tapping **Sync Library** again works out a fresh preview against whatever your
+server holds now.
 
 That starting estimate is **skip-aware**: when the run is planned, the plugin already knows which platforms haven't
 changed since their last sync and expects to skip them wholesale, so they don't inflate the number — an incremental

--- a/docs/user-guide/syncing-your-library.md
+++ b/docs/user-guide/syncing-your-library.md
@@ -49,11 +49,11 @@ the shortcuts. Only when there is truly nothing to do does the preview read "Eve
 
 A preview stays good for **30 minutes**, and it belongs to the plugin rather than to the page you are looking at: you
 can leave the main page for the settings or a submenu, come back, and the same preview is still there with **Apply
-Sync** ready. The card tells you how long that has left — "Expires in 26 min" next to the button, counting down. If you
-leave it sitting past the half hour, the card stays where it is and says "Expired — run the preview again"; the change
-list remains readable, **Apply Sync** goes away, and the card only disappears when you tap **Dismiss**. Nothing you were
-shown is discarded behind your back. Tapping **Sync Library** again works out a fresh preview against whatever your
-server holds now.
+Sync** ready. The card tells you how long that has left — "Expires in 26 min" just above the button, counting down. If
+you leave it sitting past the half hour, the card stays where it is and says "Expired — run the preview again"; the
+change list remains readable, **Apply Sync** goes away, and the card only disappears when you tap **Dismiss**. Nothing
+you were shown is discarded behind your back. Tapping **Sync Library** again works out a fresh preview against whatever
+your server holds now.
 
 That starting estimate is **skip-aware**: when the run is planned, the plugin already knows which platforms haven't
 changed since their last sync and expects to skip them wholesale, so they don't inflate the number — an incremental

--- a/main.py
+++ b/main.py
@@ -500,6 +500,9 @@ class Plugin:
     async def sync_cancel_preview(self):
         return self._sync_service.sync_cancel_preview()
 
+    async def get_pending_preview(self):
+        return self._sync_service.get_pending_preview()
+
     async def get_sync_status(self):
         return self._sync_service.get_sync_status()
 

--- a/py_modules/domain/preview_delta.py
+++ b/py_modules/domain/preview_delta.py
@@ -27,11 +27,8 @@ class PreviewDelta:
     ``preview_id`` ties the snapshot to the frontend's apply call; mismatched
     ids cause the apply to be rejected as stale. ``created_at`` is the wall
     clock at preview time so apply can reject snapshots older than the TTL.
-    ``platforms_count`` and ``total_roms`` are persisted into ``sync_stats``
-    on apply so ``get_sync_stats`` and the stale-removal pass see the
-    apply's intended counts. The apply phase fetches ROM data live per
-    unit; this snapshot carries only the pre-flight counts, never ROM
-    payloads.
+    The apply phase rebuilds the work queue and fetches ROM data live per
+    unit, so this snapshot carries no counts and no ROM payloads.
 
     ``answer`` is the exact dict ``sync_preview`` returned to the frontend, so
     a panel that was navigated away from and remounted can be handed back what
@@ -41,8 +38,6 @@ class PreviewDelta:
 
     preview_id: str
     created_at: float
-    platforms_count: int
-    total_roms: int
     answer: Mapping[str, Any]
 
     def is_expired(self, now: float, max_age_seconds: float) -> bool:

--- a/py_modules/domain/preview_delta.py
+++ b/py_modules/domain/preview_delta.py
@@ -1,13 +1,23 @@
 """Pending sync-preview snapshot held between ``sync_preview`` and ``sync_apply_delta``.
 
 Owns the typed shape of the data ``LibraryService`` stashes after a preview
-run so the subsequent apply call can act on the exact snapshot the user saw.
-Pure data — construction, attribute reads, no I/O, no clock or randomness.
+run so the subsequent apply call can act on the exact snapshot the user saw,
+and so a panel that lost its card can ask for it back. Pure data —
+construction, attribute reads, the TTL predicate; no I/O, no clock.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+
+def preview_expires_at(created_at: float, max_age_seconds: float) -> float:
+    """The absolute wall-clock epoch a snapshot taken at *created_at* stops being appliable."""
+    return created_at + max_age_seconds
 
 
 @dataclass(frozen=True)
@@ -22,9 +32,24 @@ class PreviewDelta:
     apply's intended counts. The apply phase fetches ROM data live per
     unit; this snapshot carries only the pre-flight counts, never ROM
     payloads.
+
+    ``answer`` is the exact dict ``sync_preview`` returned to the frontend, so
+    a panel that was navigated away from and remounted can be handed back what
+    the user was shown rather than a second assembly of it that can drift from
+    the first.
     """
 
     preview_id: str
     created_at: float
     platforms_count: int
     total_roms: int
+    answer: Mapping[str, Any]
+
+    def is_expired(self, now: float, max_age_seconds: float) -> bool:
+        """Whether the snapshot is past its TTL at wall-clock *now*.
+
+        The single expression of "this delta is too old" — the apply path
+        refuses an expired snapshot, and the pending-preview read drops one, on
+        this one predicate.
+        """
+        return now > preview_expires_at(self.created_at, max_age_seconds)

--- a/py_modules/services/library/_state.py
+++ b/py_modules/services/library/_state.py
@@ -370,6 +370,21 @@ class LibrarySyncStateBox:
             return None
         return delta
 
+    def read_restorable_preview(self, now: float) -> PreviewDelta | None:
+        """The staged snapshot a returning panel may put back on screen, else ``None``.
+
+        Everything :meth:`read_fresh_preview` refuses, plus one more: while a
+        run is in flight the snapshot is **withheld, never discarded**. A panel
+        that remounts mid-run must show that run, not a card that would render
+        over its progress rows — and the same snapshot is handed back on the
+        next mount after the run ends, as long as it is still inside its TTL.
+        Withholding is this reader's alone: the apply path must keep answering
+        an overlapping apply with its own refusal, not this one's silence.
+        """
+        if self.is_in_flight():
+            return None
+        return self.read_fresh_preview(now)
+
     def matches_preview(self, preview_id: str) -> bool:
         """Whether the staged snapshot is the one ``preview_id`` names.
 

--- a/py_modules/services/library/_state.py
+++ b/py_modules/services/library/_state.py
@@ -323,10 +323,15 @@ class LibrarySyncStateBox:
             return False
         self.sync_state = SyncState.IDLE
         self.current_sync_id = None
-        # Ordering: every run emits its terminal frame before reaching the
-        # ``finally: finish_run(run_id)`` that lands here, so this drops a
-        # snapshot the frontend has already been sent as an event — never one it
-        # is still waiting for. Not itself a frame: nothing emits it, so no
+        # Ordering: every run emits or SCHEDULES its terminal frame before
+        # reaching the ``finally: finish_run(run_id)`` that lands here, so this
+        # drops a snapshot the frontend has already been sent as an event — never
+        # one it is still waiting for. The per-unit error path schedules its emit
+        # through ``create_task``, which may run after this line; that is safe
+        # only because the coroutine binds the ERROR frame BY VALUE and this
+        # rebinds the attribute rather than mutating the dict it holds. A future
+        # in-place edit here would corrupt a frame already handed to a pending
+        # task. Not itself a frame either way: nothing emits this one, so no
         # ``running: False`` reaches the panel mid-run from this line.
         self.sync_progress = _default_progress()
         return True

--- a/py_modules/services/library/_state.py
+++ b/py_modules/services/library/_state.py
@@ -330,8 +330,6 @@ class LibrarySyncStateBox:
         *,
         preview_id: str,
         created_at: float,
-        platforms_count: int,
-        total_roms: int,
         answer: Mapping[str, Any],
     ) -> None:
         """Hold the computed preview for the apply — and for a panel that comes back to it.
@@ -343,8 +341,6 @@ class LibrarySyncStateBox:
         self.pending_delta = PreviewDelta(
             preview_id=preview_id,
             created_at=created_at,
-            platforms_count=platforms_count,
-            total_roms=total_roms,
             answer=answer,
         )
 

--- a/py_modules/services/library/_state.py
+++ b/py_modules/services/library/_state.py
@@ -114,6 +114,14 @@ class LibrarySyncStateBox:
     sync_state: SyncState = SyncState.IDLE
     current_sync_id: str | None = None
     sync_last_heartbeat: float = 0.0
+    # The latest progress frame, which ``get_sync_status`` hands a remounting
+    # QAM so it can recover a live run without waiting for the next event. It
+    # describes an IN-FLIGHT run only: ``finish_run`` puts it back to the idle
+    # default, because a finished run's terminal frame is an event the panel was
+    # already sent, and a panel that merely FINDS one on a later mount is
+    # required to ignore it (#1019) — so leaving it here answered every mount
+    # with a run that ended, message and run id included, for as long as the
+    # plugin stayed loaded.
     sync_progress: dict[str, Any] = field(default_factory=_default_progress)
     pending_sync: dict[int, dict[str, Any]] = field(default_factory=dict)
     # Every fetched ROM of the active unit (built shortcut-shape, keyed by
@@ -307,12 +315,20 @@ class LibrarySyncStateBox:
         Resets to IDLE + nulls ``current_sync_id`` only when ``run_id`` equals
         the active ``current_sync_id``; a late, foreign, or doubled terminal is
         a no-op and can never null a freshly-started run. Returns ``True`` when
-        it reset.
+        it reset. The progress snapshot goes back to the idle default with it,
+        so ``get_sync_status`` answers a finished run the way it answers a
+        plugin that has never run — see :attr:`sync_progress`.
         """
         if str(run_id) != str(self.current_sync_id):
             return False
         self.sync_state = SyncState.IDLE
         self.current_sync_id = None
+        # Ordering: every run emits its terminal frame before reaching the
+        # ``finally: finish_run(run_id)`` that lands here, so this drops a
+        # snapshot the frontend has already been sent as an event — never one it
+        # is still waiting for. Not itself a frame: nothing emits it, so no
+        # ``running: False`` reaches the panel mid-run from this line.
+        self.sync_progress = _default_progress()
         return True
 
     def is_in_flight(self) -> bool:

--- a/py_modules/services/library/_state.py
+++ b/py_modules/services/library/_state.py
@@ -14,6 +14,13 @@ field assignment from a sub-service. Confining those two writes to the box
 keeps run admission, cancellation, and termination a single
 compare-and-swap on the one event loop, so a rapid Sync/Cancel can't leave
 a half-reset run id (#1202). Enforced by ``scripts/check_sync_lifecycle_owner.py``.
+
+``pending_delta`` is held to the same discipline, unenforced: the staged
+preview snapshot is written only through ``stage_preview`` /
+``read_fresh_preview`` / ``discard_preview``, so its whole lifetime — when it
+appears, when it ages out, when it is consumed — is readable in one place
+rather than inferred from assignments scattered across the orchestrator. The
+TTL lives here with it.
 """
 
 from __future__ import annotations
@@ -21,12 +28,15 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
+from domain.preview_delta import PreviewDelta, preview_expires_at
 from domain.sync_state import SyncState
 
 if TYPE_CHECKING:
     import asyncio
+    from collections.abc import Mapping
 
-    from domain.preview_delta import PreviewDelta
+
+PREVIEW_MAX_AGE_SECONDS = 1800  # 30 minutes — preview snapshots stale beyond this
 
 
 def _default_progress() -> dict[str, Any]:
@@ -123,6 +133,8 @@ class LibrarySyncStateBox:
     # ``ChunkDispatcher`` and reset with it; kept across the heartbeat-timeout
     # abandon window so a late ack still stamps the confirmed values.
     pending_cover_sources: dict[int, str] = field(default_factory=dict)
+    # The staged preview snapshot, between ``sync_preview`` and the apply that
+    # consumes it. Written only through the preview-lifecycle verbs below.
     pending_delta: PreviewDelta | None = None
     # Per-run collection-membership accumulator, keyed by a collision-free
     # ``(collection_kind, collection_id)`` identity (never the display name), so
@@ -310,6 +322,64 @@ class LibrarySyncStateBox:
     def is_cancelling(self) -> bool:
         """True while a cancel has been requested for the in-flight run."""
         return self.sync_state is SyncState.CANCELLING
+
+    # ── Preview snapshot — the only writers of pending_delta ──
+
+    def stage_preview(
+        self,
+        *,
+        preview_id: str,
+        created_at: float,
+        platforms_count: int,
+        total_roms: int,
+        answer: Mapping[str, Any],
+    ) -> None:
+        """Hold the computed preview for the apply — and for a panel that comes back to it.
+
+        ``answer`` is the exact dict ``sync_preview`` returned; a restored card
+        is that payload, never a second assembly of it. Replaces any snapshot
+        already staged: only the newest preview is appliable.
+        """
+        self.pending_delta = PreviewDelta(
+            preview_id=preview_id,
+            created_at=created_at,
+            platforms_count=platforms_count,
+            total_roms=total_roms,
+            answer=answer,
+        )
+
+    def preview_deadline(self, created_at: float) -> float:
+        """The wall clock this box stops accepting a snapshot taken at ``created_at``.
+
+        The frontend counts down against it, so the number it shows and the
+        verdict :meth:`read_fresh_preview` reaches come from the same TTL.
+        """
+        return preview_expires_at(created_at, PREVIEW_MAX_AGE_SECONDS)
+
+    def read_fresh_preview(self, now: float) -> PreviewDelta | None:
+        """The staged snapshot while it is still appliable, else ``None``.
+
+        A snapshot past its TTL at wall-clock ``now`` is discarded here rather
+        than returned, so no caller can be handed one the apply would refuse.
+        """
+        delta = self.pending_delta
+        if delta is None:
+            return None
+        if delta.is_expired(now, PREVIEW_MAX_AGE_SECONDS):
+            self.pending_delta = None
+            return None
+        return delta
+
+    def matches_preview(self, preview_id: str) -> bool:
+        """Whether the staged snapshot is the one ``preview_id`` names.
+
+        Identity only — a match says nothing about the snapshot's age.
+        """
+        return self.pending_delta is not None and self.pending_delta.preview_id == preview_id
+
+    def discard_preview(self) -> None:
+        """Drop the staged snapshot — consumed by an apply, cancelled, or failed."""
+        self.pending_delta = None
 
     # ── Abandoned-chunk stash — the heartbeat-timeout recovery seam ──
 

--- a/py_modules/services/library/service.py
+++ b/py_modules/services/library/service.py
@@ -378,6 +378,9 @@ class LibraryService:
     def sync_cancel_preview(self):
         return self._orchestrator.sync_cancel_preview()
 
+    def get_pending_preview(self):
+        return self._orchestrator.get_pending_preview()
+
     def get_sync_status(self):
         return self._orchestrator.get_sync_status()
 

--- a/py_modules/services/library/service.py
+++ b/py_modules/services/library/service.py
@@ -267,7 +267,9 @@ class LibraryService:
     # run-lifecycle pair (``_sync_state`` / ``_current_sync_id``) is read-only
     # here: those two fields are written **only** through the box's verb
     # methods (``try_begin_run`` / ``request_cancel`` / ``finish_run``), so no
-    # setter is exposed (#1202).
+    # setter is exposed (#1202). ``_pending_delta`` is read-only for the same
+    # reason — the staged preview is written only through ``stage_preview`` /
+    # ``read_fresh_preview`` / ``discard_preview``.
 
     @property
     def _sync_state(self) -> SyncState:
@@ -284,10 +286,6 @@ class LibraryService:
     @property
     def _pending_delta(self) -> PreviewDelta | None:
         return self._box.pending_delta
-
-    @_pending_delta.setter
-    def _pending_delta(self, value: PreviewDelta | None) -> None:
-        self._box.pending_delta = value
 
     @property
     def _pending_collection_memberships(self) -> dict[tuple[str, str], CollectionMembership]:

--- a/py_modules/services/library/sync_orchestrator.py
+++ b/py_modules/services/library/sync_orchestrator.py
@@ -33,7 +33,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from domain.cover_refresh import count_cover_refreshes
-from domain.preview_delta import PreviewDelta
+from domain.preview_delta import PreviewDelta, preview_expires_at
 from domain.session_budget import post_run_advisory, session_memory_delta
 from domain.shortcut_data import build_shortcuts_data
 from domain.sibling_group import compute_component_group_keys
@@ -338,6 +338,16 @@ class SyncOrchestrator:
             # short-circuit the apply and strand a changed cover forever.
             cover_refresh_count = count_cover_refreshes(all_roms, registry)
 
+            # Post-preview session-budget prognosis (#1383): warn up front when the
+            # planned work would walk the renderer heap past the budget ceiling. The
+            # gate is fail-open, so an unreadable renderer simply yields no warning.
+            #
+            # Taken here rather than after the DONE frame so that nothing awaits
+            # between the cancel checkpoint below and the staging that follows it.
+            pause_likely = await self._session_budget.predict_pause_likely(
+                new_items=len(new), changed_items=len(changed)
+            )
+
             # Final cancel checkpoint: a cancel can land after the unit loop's
             # last per-unit check but before the preview is staged. Re-check
             # here so a late cancel routes into the SyncCancelled branch (which
@@ -347,25 +357,11 @@ class SyncOrchestrator:
                 raise SyncCancelled(_SYNC_CANCELLED)
 
             preview_id = self._uuid_gen.uuid4()
+            created_at = self._clock.time()
             platforms_count = sum(1 for u in work_queue if u.type == "platform")
             collections_count = sum(1 for u in work_queue if u.type == "collection")
-            box.pending_delta = PreviewDelta(
-                preview_id=preview_id,
-                created_at=self._clock.time(),
-                platforms_count=platforms_count,
-                total_roms=len(all_roms),
-            )
 
-            await self.emit_progress(SyncStage.DONE, message="Preview ready", running=False)
-
-            # Post-preview session-budget prognosis (#1383): warn up front when the
-            # planned work would walk the renderer heap past the budget ceiling. The
-            # gate is fail-open, so an unreadable renderer simply yields no warning.
-            pause_likely = await self._session_budget.predict_pause_likely(
-                new_items=len(new), changed_items=len(changed)
-            )
-
-            return {
+            answer = {
                 "success": True,
                 "pause_likely": pause_likely,
                 "summary": {
@@ -406,7 +402,26 @@ class SyncOrchestrator:
                 "new_names": [s["name"] for s in new[:10]],
                 "changed_names": [s["name"] for s in changed[:10]],
                 "preview_id": preview_id,
+                # Absolute wall-clock deadline (epoch seconds) the backend stops
+                # accepting this snapshot at. Absolute rather than a remaining-
+                # seconds count because the panel runs on the same machine and the
+                # same clock, and a deadline survives the Deck suspending where a
+                # locally counted-down number does not.
+                "expires_at": preview_expires_at(created_at, _PREVIEW_MAX_AGE_SECONDS),
             }
+            # Stage the answer itself, so a panel that lost its card is handed
+            # back exactly what the user was shown rather than a re-assembly.
+            box.pending_delta = PreviewDelta(
+                preview_id=preview_id,
+                created_at=created_at,
+                platforms_count=platforms_count,
+                total_roms=len(all_roms),
+                answer=answer,
+            )
+
+            await self.emit_progress(SyncStage.DONE, message="Preview ready", running=False)
+
+            return answer
         except SyncCancelled:
             # sync_preview is a Decky callable — the frontend awaits its return.
             # Re-raising leaves that promise unsettled, so a user-initiated
@@ -481,8 +496,7 @@ class SyncOrchestrator:
                 "reason": ErrorCode.STALE_PREVIEW.value,
                 "message": "Preview expired, please re-sync",
             }
-        age = self._clock.time() - box.pending_delta.created_at
-        if age > _PREVIEW_MAX_AGE_SECONDS:
+        if box.pending_delta.is_expired(self._clock.time(), _PREVIEW_MAX_AGE_SECONDS):
             box.pending_delta = None
             return {
                 "success": False,
@@ -506,6 +520,26 @@ class SyncOrchestrator:
     def sync_cancel_preview(self):
         self._sync_state.pending_delta = None
         return {"success": True}
+
+    def get_pending_preview(self):
+        """Hand back the staged preview answer, so a remounted panel can show its card again.
+
+        ``{"success": True, "preview": None}`` when nothing is staged — "no
+        preview" is a normal answer, not a failure, so it never takes the
+        failure shape. A staged snapshot past its TTL answers the same way and
+        is dropped on the spot: the apply would refuse it anyway, and clearing
+        it here keeps the read and the apply on one verdict.
+
+        A pure read plus that lazy clear — it starts, cancels and touches no run.
+        """
+        box = self._sync_state
+        delta = box.pending_delta
+        if delta is None:
+            return {"success": True, "preview": None}
+        if delta.is_expired(self._clock.time(), _PREVIEW_MAX_AGE_SECONDS):
+            box.pending_delta = None
+            return {"success": True, "preview": None}
+        return {"success": True, "preview": dict(delta.answer)}
 
     # ── Progress & safety ────────────────────────────────────────
 

--- a/py_modules/services/library/sync_orchestrator.py
+++ b/py_modules/services/library/sync_orchestrator.py
@@ -564,12 +564,23 @@ class SyncOrchestrator:
         await self._emit("sync_progress", self._sync_state.sync_progress)
 
     def get_sync_status(self) -> dict[str, Any]:
-        """Return the persisted progress snapshot — the authoritative sync state.
+        """Return the latest progress frame plus whether a run is actually in flight.
 
         Idle returns the default ``running: False`` snapshot; a live run
         returns the latest snapshot written by :meth:`emit_progress`.
+
+        ``inFlight`` is the run-lifecycle state itself, not a re-reading of the
+        frame, and it rides only this answer — never an emitted ``sync_progress``
+        event. The two can disagree, legitimately: during a cancel drain the
+        CANCELLED frame already says ``running: False`` while the slot is still
+        owned, and between ``try_begin_run`` and the run's first frame the
+        opposite holds. It exists because the frontend cannot tell "the backend
+        has no run" from "the backend has not said anything about this run yet"
+        by looking at a frame — and the difference decides whether a panel may
+        retract a run it believes is live. See ``src/components/MainPage.tsx``.
         """
-        return self._sync_state.sync_progress
+        box = self._sync_state
+        return {**box.sync_progress, "inFlight": box.is_in_flight()}
 
     # ── Sync termination ─────────────────────────────────────────
 

--- a/py_modules/services/library/sync_orchestrator.py
+++ b/py_modules/services/library/sync_orchestrator.py
@@ -521,11 +521,11 @@ class SyncOrchestrator:
     def get_pending_preview(self):
         """Hand back the staged preview answer, so a remounted panel can show its card again.
 
-        ``preview: None`` — nothing staged, or a snapshot the read aged out —
-        is a normal answer, never the failure shape. Starts, cancels and
-        touches no run.
+        ``preview: None`` — nothing staged, a snapshot the read aged out, or a
+        run in flight (which withholds it rather than discarding it) — is a
+        normal answer, never the failure shape. Starts and cancels no run.
         """
-        delta = self._sync_state.read_fresh_preview(self._clock.time())
+        delta = self._sync_state.read_restorable_preview(self._clock.time())
         return {"success": True, "preview": dict(delta.answer) if delta else None}
 
     # ── Progress & safety ────────────────────────────────────────

--- a/py_modules/services/library/sync_orchestrator.py
+++ b/py_modules/services/library/sync_orchestrator.py
@@ -410,8 +410,6 @@ class SyncOrchestrator:
             box.stage_preview(
                 preview_id=preview_id,
                 created_at=created_at,
-                platforms_count=platforms_count,
-                total_roms=len(all_roms),
                 answer=answer,
             )
 

--- a/py_modules/services/library/sync_orchestrator.py
+++ b/py_modules/services/library/sync_orchestrator.py
@@ -33,7 +33,6 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from domain.cover_refresh import count_cover_refreshes
-from domain.preview_delta import PreviewDelta, preview_expires_at
 from domain.session_budget import post_run_advisory, session_memory_delta
 from domain.shortcut_data import build_shortcuts_data
 from domain.sibling_group import compute_component_group_keys
@@ -79,7 +78,6 @@ _SYNC_CANCELLED = "Sync cancelled"
 # ``sync_runs.error`` via ``mark_interrupted``; the status split lets the UI
 # report "(interrupted)" instead of "(cancelled)" for a crash.
 _SYNC_INTERRUPTED = "Sync interrupted (Steam UI stopped responding)"
-_PREVIEW_MAX_AGE_SECONDS = 1800  # 30 minutes — preview snapshots stale beyond this
 
 
 def _collection_membership_key(unit: WorkUnit) -> tuple[str, str]:
@@ -407,11 +405,9 @@ class SyncOrchestrator:
                 # seconds count because the panel runs on the same machine and the
                 # same clock, and a deadline survives the Deck suspending where a
                 # locally counted-down number does not.
-                "expires_at": preview_expires_at(created_at, _PREVIEW_MAX_AGE_SECONDS),
+                "expires_at": box.preview_deadline(created_at),
             }
-            # Stage the answer itself, so a panel that lost its card is handed
-            # back exactly what the user was shown rather than a re-assembly.
-            box.pending_delta = PreviewDelta(
+            box.stage_preview(
                 preview_id=preview_id,
                 created_at=created_at,
                 platforms_count=platforms_count,
@@ -430,14 +426,14 @@ class SyncOrchestrator:
             # SyncCancelled is a BaseException (not Exception), so it skips the
             # generic ``except Exception`` below and lands here as a distinct
             # cooperative signal — never conflated with a real asyncio cancel.
-            box.pending_delta = None
+            box.discard_preview()
             await self._finish_sync(_SYNC_CANCELLED)
             return {"success": False, "reason": "cancelled", "message": _SYNC_CANCELLED}
         except Exception as e:
             import traceback
 
             self._logger.error(f"Sync preview failed: {e}\n{traceback.format_exc()}")
-            box.pending_delta = None
+            box.discard_preview()
             _reason, _msg = classify_error(e)
             await self.emit_progress(SyncStage.ERROR, message=_msg, running=False)
             return {"success": False, "reason": _reason, "message": _msg}
@@ -490,14 +486,15 @@ class SyncOrchestrator:
 
     async def sync_apply_delta(self, preview_id):
         box = self._sync_state
-        if not box.pending_delta or box.pending_delta.preview_id != preview_id:
+        if not box.matches_preview(preview_id):
             return {
                 "success": False,
                 "reason": ErrorCode.STALE_PREVIEW.value,
                 "message": "Preview expired, please re-sync",
             }
-        if box.pending_delta.is_expired(self._clock.time(), _PREVIEW_MAX_AGE_SECONDS):
-            box.pending_delta = None
+        # The read drops an over-age snapshot on its way out, so a repeat apply
+        # can't pick it up.
+        if box.read_fresh_preview(self._clock.time()) is None:
             return {
                 "success": False,
                 "reason": ErrorCode.STALE_PREVIEW.value,
@@ -506,11 +503,11 @@ class SyncOrchestrator:
         # Admission guard: a rapid second apply (or an apply landing while a
         # sync is already in flight) must be rejected without consuming the
         # staged delta, so the still-valid preview survives for the legitimate
-        # apply (#1202). Claim the run slot before nulling ``pending_delta``.
+        # apply (#1202). Claim the run slot BEFORE discarding the preview.
         run_id = self._uuid_gen.uuid4()
         if not box.try_begin_run(run_id):
             return {"success": False, "reason": "sync_in_progress", "message": "Sync already in progress"}
-        box.pending_delta = None
+        box.discard_preview()
         box.sync_last_heartbeat = self._clock.monotonic()
 
         self._loop.create_task(self._do_sync_per_unit())
@@ -518,28 +515,18 @@ class SyncOrchestrator:
         return {"success": True, "message": "Applying changes"}
 
     def sync_cancel_preview(self):
-        self._sync_state.pending_delta = None
+        self._sync_state.discard_preview()
         return {"success": True}
 
     def get_pending_preview(self):
         """Hand back the staged preview answer, so a remounted panel can show its card again.
 
-        ``{"success": True, "preview": None}`` when nothing is staged — "no
-        preview" is a normal answer, not a failure, so it never takes the
-        failure shape. A staged snapshot past its TTL answers the same way and
-        is dropped on the spot: the apply would refuse it anyway, and clearing
-        it here keeps the read and the apply on one verdict.
-
-        A pure read plus that lazy clear — it starts, cancels and touches no run.
+        ``preview: None`` — nothing staged, or a snapshot the read aged out —
+        is a normal answer, never the failure shape. Starts, cancels and
+        touches no run.
         """
-        box = self._sync_state
-        delta = box.pending_delta
-        if delta is None:
-            return {"success": True, "preview": None}
-        if delta.is_expired(self._clock.time(), _PREVIEW_MAX_AGE_SECONDS):
-            box.pending_delta = None
-            return {"success": True, "preview": None}
-        return {"success": True, "preview": dict(delta.answer)}
+        delta = self._sync_state.read_fresh_preview(self._clock.time())
+        return {"success": True, "preview": dict(delta.answer) if delta else None}
 
     # ── Progress & safety ────────────────────────────────────────
 

--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -24,6 +24,7 @@ import type {
   SyncConflict,
   RommErrorCode,
   SyncPreview,
+  PendingPreviewAnswer,
   SessionBudgetStatus,
   AchievementSummary,
   AchievementList,
@@ -238,6 +239,13 @@ export const syncHeartbeat = callable<[], { success: boolean }>("sync_heartbeat"
 export const syncPreview = callable<[], SyncPreview>("sync_preview");
 export const syncApplyDelta = callable<[string], BackendResult>("sync_apply_delta");
 export const syncCancelPreview = callable<[], BackendResult>("sync_cancel_preview");
+/**
+ * The preview the backend is still holding, if any — how a panel that was
+ * navigated away from gets its card back. `preview: null` is the normal
+ * "nothing pending" answer; the backend also drops (and reports as null) a
+ * snapshot past its 30-minute TTL, which the apply would refuse anyway.
+ */
+export const getPendingPreview = callable<[], PendingPreviewAnswer>("get_pending_preview");
 export const getSyncStatus = callable<[], SyncProgress>("get_sync_status");
 export const getSessionBudgetStatus = callable<[], SessionBudgetStatus>("get_session_budget_status");
 export const clearSyncCache = callable<[], BackendResult>("clear_sync_cache");

--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -3,7 +3,7 @@ import { detach } from "../utils/detach";
 import type {
   PluginSettings,
   SyncStats,
-  SyncProgress,
+  SyncStatusAnswer,
   DownloadItem,
   InstalledRom,
   PlatformSyncSetting,
@@ -246,7 +246,7 @@ export const syncCancelPreview = callable<[], BackendResult>("sync_cancel_previe
  * snapshot past its 30-minute TTL, which the apply would refuse anyway.
  */
 export const getPendingPreview = callable<[], PendingPreviewAnswer>("get_pending_preview");
-export const getSyncStatus = callable<[], SyncProgress>("get_sync_status");
+export const getSyncStatus = callable<[], SyncStatusAnswer>("get_sync_status");
 export const getSessionBudgetStatus = callable<[], SessionBudgetStatus>("get_session_budget_status");
 export const clearSyncCache = callable<[], BackendResult>("clear_sync_cache");
 export const getSyncStats = callable<[], SyncStats>("get_sync_stats");

--- a/src/components/MainPage.test.tsx
+++ b/src/components/MainPage.test.tsx
@@ -66,6 +66,7 @@ import type {
   MigrationStatus,
   SaveSortMigrationStatus,
   SyncStats,
+  SyncStatusAnswer,
   SyncPreview,
   SyncPreviewSummary,
   SessionBudgetStatus,
@@ -5358,8 +5359,10 @@ describe("MainPage", () => {
      *  panel remounting during the start window read it as the state of the run
      *  it was actually watching. The backend now resets the snapshot when a run
      *  finishes; this is the same answer arriving from an older backend, or from
-     *  a run whose reset this read raced. */
-    function lingeringDoneSnapshot(): SyncProgress {
+     *  a run whose reset this read raced. `inFlight: false` is truthful here and
+     *  is the point: during the start window the backend genuinely has no run,
+     *  because `sync_preview` has not claimed the slot yet. */
+    function lingeringDoneSnapshot(): SyncStatusAnswer {
       return {
         running: false,
         stage: "done",
@@ -5367,6 +5370,23 @@ describe("MainPage", () => {
         total: 0,
         message: "Preview ready",
         runId: "run-previous",
+        inFlight: false,
+      };
+    }
+
+    /** Stats that let EVERY start control render, so an assertion that none of
+     *  them is on screen is carried by four absences rather than one. Without a
+     *  recorded attempt "Force Full Sync" is hidden anyway, and without an
+     *  incomplete one plus bound shortcuts the sync button reads "Sync Library"
+     *  rather than "Resume Sync". */
+    function statsWithEveryStartControl(): SyncStats {
+      return {
+        last_sync: null,
+        platforms: 1,
+        collections: 0,
+        roms: 12,
+        total_shortcuts: 12,
+        last_attempt: { finished_at: "2026-06-01T17:48:00", status: "cancelled" },
       };
     }
 
@@ -5390,14 +5410,35 @@ describe("MainPage", () => {
       return container.querySelector('[data-testid="sync-changes"]')?.textContent ?? "";
     }
 
-    /** Every control that offers to START a run. */
+    /**
+     * Every control on the idle body that offers to START a run. The sync button
+     * (labelled "Sync Library" or "Resume Sync") and "Force Full Sync" are
+     * ButtonItems; "Skip Preview" is a ToggleField, which the `@decky/ui` stub
+     * renders as a plain field, so it is matched by its label text rather than by
+     * role. `statsWithEveryStartControl` is what lets all four appear at once —
+     * `rendersEveryStartControl` below pins that the helper really sees them, so
+     * an empty result means absence rather than a query that cannot match.
+     */
     function startControls(container: HTMLElement): string[] {
-      return ["Sync Library", "Resume Sync", "Skip Preview", "Force Full Sync"].filter(
+      const buttons = ["Sync Library", "Resume Sync", "Force Full Sync"].filter(
         (label) => buttonByExactText(container, label) !== null,
       );
+      const skipPreview = container.textContent?.includes("Skip Preview") ? ["Skip Preview"] : [];
+      return [...buttons, ...skipPreview];
     }
 
+    it("the helper sees every start control when the idle body offers them", async () => {
+      // Guards the assertions below: an empty `startControls` has to mean the
+      // page is not offering a run, not that three of the four can never match.
+      vi.mocked(backend.getSyncStats).mockResolvedValue(statsWithEveryStartControl());
+      const { container } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+
+      expect(startControls(container)).toEqual(["Resume Sync", "Force Full Sync", "Skip Preview"]);
+    });
+
     it("a remount mid-start keeps the in-progress view", async () => {
+      vi.mocked(backend.getSyncStats).mockResolvedValue(statsWithEveryStartControl());
       setSyncProgress(optimisticStart());
       vi.mocked(backend.getSyncStatus).mockResolvedValue(lingeringDoneSnapshot());
 
@@ -5442,6 +5483,96 @@ describe("MainPage", () => {
 
       expect(container.querySelector('[data-testid="sync-stage"]')).toBeNull();
       expect(container.querySelector('[data-testid="sync-status"]')?.textContent).toBe("Sync complete: 4 games");
+    });
+
+    it("recovers when a run's terminal frame was lost and the backend says nothing is running", async () => {
+      // The wedge the run-id rule alone would create. The store holds a live
+      // frame for a run that has really ended — its terminal frame never
+      // arrived — and the reset means the backend's own frame no longer names
+      // that run either. `inFlight: false` is the only thing left that can say
+      // so, and it has to be enough: no start control lives outside the idle
+      // body, "Cancel Sync" for an unknown run is answered "No sync in progress"
+      // with no terminal to follow, and DangerZone gates four more actions on the
+      // same flag — so a panel that cannot leave this state is stuck until a
+      // plugin reload.
+      vi.mocked(backend.getSyncStats).mockResolvedValue(statsWithEveryStartControl());
+      setSyncProgress({
+        running: true,
+        stage: "applying",
+        current: 40,
+        total: 100,
+        message: "GBA: 40/100",
+        runId: "run-lost",
+      });
+      vi.mocked(backend.getSyncStatus).mockResolvedValue({
+        running: false,
+        stage: "",
+        current: 0,
+        total: 0,
+        message: "",
+        runId: "",
+        inFlight: false,
+      });
+
+      const { container } = render(<MainPage onNavigate={vi.fn()} />);
+      expect(container.querySelector('[data-testid="sync-stage"]')).not.toBeNull();
+      await flushAsync();
+
+      expect(container.querySelector('[data-testid="sync-stage"]')).toBeNull();
+      expect(startControls(container)).toEqual(["Resume Sync", "Force Full Sync", "Skip Preview"]);
+      expect(getSyncProgress().running).toBe(false);
+    });
+
+    it("a cancel that lands after the preview was staged discards it server-side", async () => {
+      // RC-CANCEL-PREVIEW (#1202): the backend staged the snapshot just before
+      // the cancel reached it, so the run answers success and only the local flag
+      // knows the user pressed Cancel. Without telling the backend, the staged
+      // snapshot survives — and the terminal-stage re-ask would fetch it a round
+      // trip later and put up the card the user just cancelled.
+      vi.mocked(syncManager.isCancelRequested).mockReturnValue(true);
+      vi.mocked(backend.syncPreview).mockResolvedValue(previewWithChanges("staged-then-cancelled"));
+      const { container } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+
+      await act(async () => {
+        fireEvent.click(buttonByExactText(container, "Sync Library")!);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(vi.mocked(backend.syncCancelPreview)).toHaveBeenCalled();
+      expect(buttonByExactText(container, "Apply Sync")).toBeNull();
+      expect(container.querySelector('[data-testid="sync-status"]')?.textContent).toBe("Sync cancelled");
+    });
+
+    it("Cancel Sync cancels the run, even while the store is holding a preview", async () => {
+      // A run in flight hides the card but does not drop it, so the store can
+      // hold a preview while the syncing body is up. That body's only button is
+      // Cancel Sync, and it must cancel the RUN — dismissing the preview instead
+      // would leave the run going with nothing left on screen to stop it.
+      adoptPreview(previewWithChanges("held-under-a-run"));
+      setSyncProgress({ running: true, stage: "applying", message: "GBA: 1/2", runId: "run-live" });
+      vi.mocked(backend.getSyncStatus).mockResolvedValue({
+        running: true,
+        stage: "applying",
+        current: 1,
+        total: 2,
+        message: "GBA: 1/2",
+        runId: "run-live",
+        inFlight: true,
+      });
+      const { container } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+      expect(buttonByExactText(container, "Apply Sync")).toBeNull();
+
+      await act(async () => {
+        fireEvent.click(buttonByExactText(container, "Cancel Sync")!);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(vi.mocked(backend.cancelSync)).toHaveBeenCalledWith("run-live");
+      expect(vi.mocked(backend.syncCancelPreview)).not.toHaveBeenCalled();
     });
 
     it("a preview that finishes while the panel is back on screen puts its card up", async () => {
@@ -5575,6 +5706,7 @@ describe("MainPage", () => {
         // The mount lands in the start window, where the backend has not yet
         // reported the run the store already knows about — the device case that
         // put the idle buttons over a live preview.
+        vi.mocked(backend.getSyncStats).mockResolvedValue(statsWithEveryStartControl());
         setSyncProgress(optimisticStart());
         vi.mocked(backend.getSyncStatus).mockResolvedValue(lingeringDoneSnapshot());
 
@@ -5586,6 +5718,7 @@ describe("MainPage", () => {
       });
 
       it("not while a preview run the backend confirms is in flight, on a fresh mount", async () => {
+        vi.mocked(backend.getSyncStats).mockResolvedValue(statsWithEveryStartControl());
         setSyncProgress({ running: true, stage: "fetching", message: "Fetching library...", runId: "run-live" });
         vi.mocked(backend.getSyncStatus).mockResolvedValue({
           running: true,
@@ -5604,6 +5737,7 @@ describe("MainPage", () => {
       });
 
       it("not while a preview result stands, on a fresh mount", async () => {
+        vi.mocked(backend.getSyncStats).mockResolvedValue(statsWithEveryStartControl());
         vi.mocked(backend.getPendingPreview).mockResolvedValue({
           success: true,
           preview: previewWithChanges("held"),
@@ -5619,6 +5753,7 @@ describe("MainPage", () => {
       it("not while a preview result stands that the panel adopted before this mount", async () => {
         // Nothing to fetch and nothing in flight: the card is on screen at first
         // paint because the store, not the instance, is holding it.
+        vi.mocked(backend.getSyncStats).mockResolvedValue(statsWithEveryStartControl());
         adoptPreview(previewWithChanges("held-across-mounts"));
         vi.mocked(backend.getPendingPreview).mockResolvedValue({ success: true, preview: null });
 

--- a/src/components/MainPage.test.tsx
+++ b/src/components/MainPage.test.tsx
@@ -58,6 +58,7 @@ import { NEW_ITEM_SEC, UPDATED_ITEM_SEC, COVER_DOWNLOAD_SEC, FETCH_ALLOWANCE_SEC
 import { setDownloads } from "../utils/downloadStore";
 import { resetConnectionProbeForTests } from "../utils/connectionProbe";
 import { resetSyncStatsStoreForTests } from "../utils/syncStatsStore";
+import { resetPendingPreviewStoreForTests, adoptPreview } from "../utils/pendingPreviewStore";
 import { showModal } from "@decky/ui";
 import * as syncManager from "../utils/syncManager";
 import * as connectionState from "../utils/connectionState";
@@ -300,6 +301,10 @@ describe("MainPage", () => {
     // Same for the sync stats and session budget: both the stored answers and
     // any read still open outlive the render that issued them.
     resetSyncStatsStoreForTests();
+    // The pending preview outlives the panel by design — that is the whole point
+    // of the store — so a card one test leaves standing would render over the
+    // next test's idle page.
+    resetPendingPreviewStoreForTests();
     setSyncProgress({
       running: false,
       stage: "",
@@ -4007,14 +4012,14 @@ describe("MainPage", () => {
       expect(vi.mocked(backend.syncApplyDelta)).toHaveBeenCalledWith("preview-fresh");
     });
 
-    it("is dropped when a run started while the read was in flight", async () => {
+    it("waits for a run that started while the read was in flight, then shows", async () => {
       const held = deferred<{ success: boolean; preview: SyncPreview | null }>();
       vi.mocked(backend.getPendingPreview).mockReturnValue(held.promise);
       const { container } = render(<MainPage onNavigate={vi.fn()} />);
       await flushAsync();
 
       await act(async () => {
-        setSyncProgress({ running: true, stage: "fetching", message: "Fetching library..." });
+        setSyncProgress({ running: true, stage: "fetching", message: "Fetching library...", runId: "run-live" });
         await Promise.resolve();
       });
       await act(async () => {
@@ -4023,9 +4028,23 @@ describe("MainPage", () => {
         await Promise.resolve();
       });
 
-      // The run owns the panel — no card, and its progress rows stand.
+      // The run owns the panel — no card over its progress rows.
       expect(buttonByExactText(container, "Apply Sync")).toBeNull();
       expect(buttonByExactText(container, "Cancel Sync")).not.toBeNull();
+
+      // But it is held, not dropped: the card is there the moment the run ends.
+      await act(async () => {
+        setSyncProgress({
+          running: false,
+          stage: "done",
+          current: 0,
+          total: 0,
+          message: "Sync complete",
+          runId: "run-live",
+        });
+        await Promise.resolve();
+      });
+      expect(buttonByExactText(container, "Apply Sync")).not.toBeNull();
     });
 
     it("counts down the time left and advances as the clock runs", async () => {
@@ -5322,22 +5341,24 @@ describe("MainPage", () => {
       expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("Failed to query RetroDECK status"));
     });
   });
+
   // ===========================================================================
-  // PHASE-1 DIAGNOSIS — device-observed defects, reproduced. EXPECTED TO FAIL.
-  // Remove or re-point these once the fix lands.
+  // The preview survives leaving the main page
   // ===========================================================================
-  describe("PHASE-1 DIAGNOSIS (expected to fail)", () => {
+  describe("the preview survives leaving the main page", () => {
     /** What handleSync writes into the module store the moment Sync Library is
-     *  pressed: running, no run id yet (the backend has not stamped one). */
+     *  pressed: running, and carrying no run id — the backend has not stamped
+     *  one yet, and will not until a reconcile and a round trip later. */
     function optimisticStart(): SyncProgress {
       return { running: true, stage: "fetching", current: 0, total: 0, message: "Fetching library..." };
     }
 
-    /** The backend's persisted snapshot after a PREVIOUS preview completed.
-     *  ``finish_run`` never resets ``sync_progress``, so this is what
-     *  ``get_sync_status`` keeps answering until the next run's first
-     *  ``emit_progress`` — and handleSync awaits reconcileStaleShortcuts before
-     *  it ever calls sync_preview, so that window is seconds wide. */
+    /** The frame a previous preview run left behind. It used to be what
+     *  `get_sync_status` answered with until the NEXT run overwrote it, so a
+     *  panel remounting during the start window read it as the state of the run
+     *  it was actually watching. The backend now resets the snapshot when a run
+     *  finishes; this is the same answer arriving from an older backend, or from
+     *  a run whose reset this read raced. */
     function lingeringDoneSnapshot(): SyncProgress {
       return {
         running: false,
@@ -5349,7 +5370,34 @@ describe("MainPage", () => {
       };
     }
 
-    it("A: a remount mid-start keeps the in-progress view (stale snapshot must not retract it)", async () => {
+    function previewWithChanges(id: string): SyncPreview {
+      return {
+        success: true,
+        summary: {
+          new_count: 2,
+          changed_count: 0,
+          unchanged_count: 0,
+          remove_count: 0,
+          disabled_platform_remove_count: 0,
+        },
+        new_names: ["a", "b"],
+        changed_names: [],
+        preview_id: id,
+      };
+    }
+
+    function cardChangesText(container: HTMLElement): string {
+      return container.querySelector('[data-testid="sync-changes"]')?.textContent ?? "";
+    }
+
+    /** Every control that offers to START a run. */
+    function startControls(container: HTMLElement): string[] {
+      return ["Sync Library", "Resume Sync", "Skip Preview", "Force Full Sync"].filter(
+        (label) => buttonByExactText(container, label) !== null,
+      );
+    }
+
+    it("a remount mid-start keeps the in-progress view", async () => {
       setSyncProgress(optimisticStart());
       vi.mocked(backend.getSyncStatus).mockResolvedValue(lingeringDoneSnapshot());
 
@@ -5359,24 +5407,46 @@ describe("MainPage", () => {
 
       await flushAsync();
 
-      // ...and then the stale snapshot lands and the panel falls back to idle.
-      expect(buttonByExactText(container, "Sync Library")).toBeNull();
+      // ...and the snapshot, which describes a run that is not the one the store
+      // is tracking, may not retract it.
+      expect(startControls(container)).toEqual([]);
       expect(container.querySelector('[data-testid="sync-stage"]')).not.toBeNull();
     });
 
-    it("C: a remount mid-start does not announce the PREVIOUS run's terminal frame", async () => {
+    it("a remount mid-start does not announce the previous run's terminal frame", async () => {
       setSyncProgress(optimisticStart());
       vi.mocked(backend.getSyncStatus).mockResolvedValue(lingeringDoneSnapshot());
 
       const { container } = render(<MainPage onNavigate={vi.fn()} />);
       await flushAsync();
 
-      const statusEl = container.querySelector('[data-testid="sync-status"]');
-      expect(statusEl?.textContent ?? null).not.toBe("Preview ready");
+      expect(container.querySelector('[data-testid="sync-status"]')?.textContent ?? null).not.toBe("Preview ready");
     });
 
-    it("B: a preview that finishes while the panel is back on screen puts its card up", async () => {
-      // Instance 1 starts the preview, then the user leaves the main page.
+    it("a snapshot that names the very run the store is tracking still ends it", async () => {
+      // The retraction is refused only where the answer cannot be shown to be
+      // about this run. One that names it is the panel's correction path — a run
+      // whose terminal frame the panel missed while it was away.
+      setSyncProgress({ running: true, stage: "fetching", message: "Fetching library...", runId: "run-live" });
+      vi.mocked(backend.getSyncStatus).mockResolvedValue({
+        running: false,
+        stage: "done",
+        current: 0,
+        total: 0,
+        message: "Sync complete: 4 games",
+        runId: "run-live",
+      });
+
+      const { container } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+
+      expect(container.querySelector('[data-testid="sync-stage"]')).toBeNull();
+      expect(container.querySelector('[data-testid="sync-status"]')?.textContent).toBe("Sync complete: 4 games");
+    });
+
+    it("a preview that finishes while the panel is back on screen puts its card up", async () => {
+      // Instance 1 starts the preview, then the user leaves the main page. The
+      // `sync_preview` promise stays with the instance that is about to die.
       const previewCall = deferred<SyncPreview>();
       vi.mocked(backend.syncPreview).mockReturnValue(previewCall.promise);
       const first = render(<MainPage onNavigate={vi.fn()} />);
@@ -5389,8 +5459,9 @@ describe("MainPage", () => {
       expect(getSyncProgress().running).toBe(true);
       first.unmount();
 
-      // The user comes back while the run is still going. The backend WITHHOLDS
-      // the staged preview while a run is in flight, so the mount read gets nothing.
+      // The user comes back while the run is still going. The backend withholds
+      // a staged preview while a run is in flight, so this mount read gets
+      // nothing — and there is nothing staged yet anyway.
       vi.mocked(backend.getPendingPreview).mockResolvedValue({ success: true, preview: null });
       vi.mocked(backend.getSyncStatus).mockResolvedValue({
         running: true,
@@ -5404,21 +5475,9 @@ describe("MainPage", () => {
       await flushAsync();
       expect(second.container.querySelector('[data-testid="sync-stage"]')).not.toBeNull();
 
-      // The preview finishes HERE. Its promise belongs to the unmounted instance.
+      // The preview finishes HERE, and its answer goes to the dead instance.
       await act(async () => {
-        previewCall.resolve({
-          success: true,
-          summary: {
-            new_count: 2,
-            changed_count: 0,
-            unchanged_count: 0,
-            remove_count: 0,
-            disabled_platform_remove_count: 0,
-          },
-          new_names: ["a", "b"],
-          changed_names: [],
-          preview_id: "preview-finished-offscreen",
-        });
+        previewCall.resolve(previewWithChanges("preview-finished-offscreen"));
         await Promise.resolve();
         await Promise.resolve();
       });
@@ -5435,9 +5494,126 @@ describe("MainPage", () => {
         await Promise.resolve();
       });
 
-      // What the device shows: the status line, and no card.
-      expect(second.container.querySelector('[data-testid="sync-status"]')?.textContent).toBe("Preview ready");
+      // The card is on screen for the instance that is actually mounted.
       expect(buttonByExactText(second.container, "Apply Sync")).not.toBeNull();
+      expect(startControls(second.container)).toEqual([]);
+      await act(async () => {
+        fireEvent.click(buttonByExactText(second.container, "Apply Sync")!);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(vi.mocked(backend.syncApplyDelta)).toHaveBeenCalledWith("preview-finished-offscreen");
+    });
+
+    it("asks the backend when a preview run ends having staged something this panel never saw", async () => {
+      // The other order: the run ends for a panel holding nothing — the answer to
+      // `sync_preview` was lost with the instance that asked for it (a QAM close,
+      // a reload). The terminal frame is the cue to go and ask.
+      vi.mocked(backend.getPendingPreview).mockResolvedValue({ success: true, preview: null });
+      setSyncProgress({ running: true, stage: "fetching", message: "Fetching library...", runId: "run-live" });
+      vi.mocked(backend.getSyncStatus).mockResolvedValue({
+        running: true,
+        stage: "fetching",
+        current: 0,
+        total: 0,
+        message: "Fetching Game Boy...",
+        runId: "run-live",
+      });
+      const { container } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+
+      vi.mocked(backend.getPendingPreview).mockResolvedValue({
+        success: true,
+        preview: previewWithChanges("preview-staged-while-away"),
+      });
+      await act(async () => {
+        setSyncProgress({
+          running: false,
+          stage: "done",
+          current: 0,
+          total: 0,
+          message: "Preview ready",
+          runId: "run-live",
+        });
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(buttonByExactText(container, "Apply Sync")).not.toBeNull();
+      expect(cardChangesText(container)).toContain("Games: 2 new");
+    });
+
+    it("does not re-ask when the store already holds the run's preview", async () => {
+      setSyncProgress({ running: true, stage: "fetching", message: "Fetching library...", runId: "run-live" });
+      const { container } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+      vi.mocked(backend.getPendingPreview).mockClear();
+
+      await act(async () => {
+        adoptPreview(previewWithChanges("already-here"));
+        setSyncProgress({
+          running: false,
+          stage: "done",
+          current: 0,
+          total: 0,
+          message: "Preview ready",
+          runId: "run-live",
+        });
+        await Promise.resolve();
+      });
+
+      expect(vi.mocked(backend.getPendingPreview)).not.toHaveBeenCalled();
+      expect(buttonByExactText(container, "Apply Sync")).not.toBeNull();
+    });
+
+    // -------------------------------------------------------------------------
+    // The rule, directly: neither a running preview nor a preview result may
+    // leave the panel offering to start another one.
+    // -------------------------------------------------------------------------
+    describe("the controls that start a preview never appear over one", () => {
+      it("not while a preview run is in flight, on a fresh mount", async () => {
+        setSyncProgress({ running: true, stage: "fetching", message: "Fetching library...", runId: "run-live" });
+        vi.mocked(backend.getSyncStatus).mockResolvedValue({
+          running: true,
+          stage: "fetching",
+          current: 0,
+          total: 0,
+          message: "Fetching Game Boy...",
+          runId: "run-live",
+        });
+
+        const { container } = render(<MainPage onNavigate={vi.fn()} />);
+        expect(startControls(container)).toEqual([]);
+        await flushAsync();
+        expect(startControls(container)).toEqual([]);
+        expect(buttonByExactText(container, "Cancel Sync")).not.toBeNull();
+      });
+
+      it("not while a preview result stands, on a fresh mount", async () => {
+        vi.mocked(backend.getPendingPreview).mockResolvedValue({
+          success: true,
+          preview: previewWithChanges("held"),
+        });
+
+        const { container } = render(<MainPage onNavigate={vi.fn()} />);
+        await flushAsync();
+
+        expect(startControls(container)).toEqual([]);
+        expect(buttonByExactText(container, "Apply Sync")).not.toBeNull();
+      });
+
+      it("not while a preview result stands that the panel adopted before this mount", async () => {
+        // Nothing to fetch and nothing in flight: the card is on screen at first
+        // paint because the store, not the instance, is holding it.
+        adoptPreview(previewWithChanges("held-across-mounts"));
+        vi.mocked(backend.getPendingPreview).mockResolvedValue({ success: true, preview: null });
+
+        const { container } = render(<MainPage onNavigate={vi.fn()} />);
+        expect(startControls(container)).toEqual([]);
+        expect(buttonByExactText(container, "Apply Sync")).not.toBeNull();
+        await flushAsync();
+        expect(startControls(container)).toEqual([]);
+      });
     });
   });
 });

--- a/src/components/MainPage.test.tsx
+++ b/src/components/MainPage.test.tsx
@@ -4153,29 +4153,40 @@ describe("MainPage", () => {
       expect(changesText(container)).toBe("");
     });
 
-    it("shows no countdown on a preview with nothing to apply", async () => {
-      vi.mocked(backend.getPendingPreview).mockResolvedValue({
-        success: true,
-        preview: heldPreview({
-          summary: {
-            new_count: 0,
-            changed_count: 0,
-            unchanged_count: 4,
-            remove_count: 0,
-            disabled_platform_remove_count: 0,
-          },
-          new_names: [],
-          expires_at: 1800,
-        }),
-      });
-      const { container } = render(<MainPage onNavigate={vi.fn()} />);
-      await flushAsync();
+    it("shows no countdown on a preview with nothing to apply, and arms no timer for it", async () => {
+      vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout", "setInterval", "clearInterval"] });
+      try {
+        vi.setSystemTime(0);
+        const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+        vi.mocked(backend.getPendingPreview).mockResolvedValue({
+          success: true,
+          preview: heldPreview({
+            summary: {
+              new_count: 0,
+              changed_count: 0,
+              unchanged_count: 4,
+              remove_count: 0,
+              disabled_platform_remove_count: 0,
+            },
+            new_names: [],
+            expires_at: 1800,
+          }),
+        });
+        const { container } = render(<MainPage onNavigate={vi.fn()} />);
+        await flushAsync();
 
-      // Nothing to apply, so there is no deadline worth counting down to —
-      // only the Dismiss the empty card already had.
-      expect(changesText(container)).toContain("Everything is up to date.");
-      expect(expiryText(container)).toBeNull();
-      expect(buttonByExactText(container, "Dismiss")).not.toBeNull();
+        // Nothing to apply, so there is no deadline worth counting down to —
+        // only the Dismiss the empty card already had.
+        expect(changesText(container)).toContain("Everything is up to date.");
+        expect(expiryText(container)).toBeNull();
+        expect(buttonByExactText(container, "Dismiss")).not.toBeNull();
+        // And nothing ticks for it: the panel's only 1 Hz timer is the
+        // countdown's, so an armed one would re-render the whole page every
+        // second with nothing on screen that could change.
+        expect(setIntervalSpy.mock.calls.filter((call) => call[1] === 1000)).toEqual([]);
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it("tears the countdown timer down when the preview goes away, and on unmount", async () => {

--- a/src/components/MainPage.test.tsx
+++ b/src/components/MainPage.test.tsx
@@ -5572,6 +5572,20 @@ describe("MainPage", () => {
     // -------------------------------------------------------------------------
     describe("the controls that start a preview never appear over one", () => {
       it("not while a preview run is in flight, on a fresh mount", async () => {
+        // The mount lands in the start window, where the backend has not yet
+        // reported the run the store already knows about — the device case that
+        // put the idle buttons over a live preview.
+        setSyncProgress(optimisticStart());
+        vi.mocked(backend.getSyncStatus).mockResolvedValue(lingeringDoneSnapshot());
+
+        const { container } = render(<MainPage onNavigate={vi.fn()} />);
+        expect(startControls(container)).toEqual([]);
+        await flushAsync();
+        expect(startControls(container)).toEqual([]);
+        expect(buttonByExactText(container, "Cancel Sync")).not.toBeNull();
+      });
+
+      it("not while a preview run the backend confirms is in flight, on a fresh mount", async () => {
         setSyncProgress({ running: true, stage: "fetching", message: "Fetching library...", runId: "run-live" });
         vi.mocked(backend.getSyncStatus).mockResolvedValue({
           running: true,

--- a/src/components/MainPage.test.tsx
+++ b/src/components/MainPage.test.tsx
@@ -4120,6 +4120,108 @@ describe("MainPage", () => {
       expect(expiryText(container)).toBeNull();
       expect(buttonByExactText(container, "Apply Sync")).not.toBeNull();
     });
+
+    it("loses to a preview the user dismissed while the read was in flight", async () => {
+      // A dismissal told the backend to discard the snapshot, so restoring it
+      // would put back a card whose Apply can only answer stale_preview.
+      const held = deferred<{ success: boolean; preview: SyncPreview | null }>();
+      vi.mocked(backend.getPendingPreview).mockReturnValue(held.promise);
+      vi.mocked(backend.syncPreview).mockResolvedValue(heldPreview({ preview_id: "preview-fresh" }));
+      const { container } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+      await act(async () => {
+        fireEvent.click(buttonByExactText(container, "Sync Library")!);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      await act(async () => {
+        fireEvent.click(buttonByExactText(container, "Cancel")!);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(vi.mocked(backend.syncCancelPreview)).toHaveBeenCalled();
+
+      await act(async () => {
+        held.resolve({ success: true, preview: heldPreview({ preview_id: "preview-held" }) });
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      // Back to the idle page — no card came back.
+      expect(buttonByExactText(container, "Sync Library")).not.toBeNull();
+      expect(buttonByExactText(container, "Apply Sync")).toBeNull();
+      expect(changesText(container)).toBe("");
+    });
+
+    it("shows no countdown on a preview with nothing to apply", async () => {
+      vi.mocked(backend.getPendingPreview).mockResolvedValue({
+        success: true,
+        preview: heldPreview({
+          summary: {
+            new_count: 0,
+            changed_count: 0,
+            unchanged_count: 4,
+            remove_count: 0,
+            disabled_platform_remove_count: 0,
+          },
+          new_names: [],
+          expires_at: 1800,
+        }),
+      });
+      const { container } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+
+      // Nothing to apply, so there is no deadline worth counting down to —
+      // only the Dismiss the empty card already had.
+      expect(changesText(container)).toContain("Everything is up to date.");
+      expect(expiryText(container)).toBeNull();
+      expect(buttonByExactText(container, "Dismiss")).not.toBeNull();
+    });
+
+    it("tears the countdown timer down when the preview goes away, and on unmount", async () => {
+      vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout", "setInterval", "clearInterval"] });
+      try {
+        vi.setSystemTime(0);
+        const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+        const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval");
+        vi.mocked(backend.getPendingPreview).mockResolvedValue({
+          success: true,
+          preview: heldPreview({ expires_at: 1800 }),
+        });
+        const { container, unmount } = render(<MainPage onNavigate={vi.fn()} />);
+        await flushAsync();
+        expect(expiryText(container)).toBe("Expires in 30 min");
+
+        // The panel's only 1 Hz timer is the countdown's.
+        const armed = setIntervalSpy.mock.calls.findIndex((call) => call[1] === 1000);
+        expect(armed).toBeGreaterThanOrEqual(0);
+        const countdownTimer = setIntervalSpy.mock.results[armed]?.value;
+
+        await act(async () => {
+          fireEvent.click(buttonByExactText(container, "Cancel")!);
+          await Promise.resolve();
+          await Promise.resolve();
+        });
+        expect(clearIntervalSpy).toHaveBeenCalledWith(countdownTimer);
+
+        // …and a card still on screen at unmount leaves nothing ticking either.
+        clearIntervalSpy.mockClear();
+        vi.mocked(backend.getPendingPreview).mockResolvedValue({
+          success: true,
+          preview: heldPreview({ expires_at: 1800 }),
+        });
+        const second = render(<MainPage onNavigate={vi.fn()} />);
+        await flushAsync();
+        expect(expiryText(second.container)).toBe("Expires in 30 min");
+
+        second.unmount();
+        unmount();
+        expect(clearIntervalSpy).toHaveBeenCalled();
+        expect(vi.getTimerCount()).toBe(0);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
   });
 
   // ===========================================================================

--- a/src/components/MainPage.test.tsx
+++ b/src/components/MainPage.test.tsx
@@ -5423,7 +5423,7 @@ describe("MainPage", () => {
       const buttons = ["Sync Library", "Resume Sync", "Force Full Sync"].filter(
         (label) => buttonByExactText(container, label) !== null,
       );
-      const skipPreview = container.textContent?.includes("Skip Preview") ? ["Skip Preview"] : [];
+      const skipPreview = container.textContent.includes("Skip Preview") ? ["Skip Preview"] : [];
       return [...buttons, ...skipPreview];
     }
 

--- a/src/components/MainPage.test.tsx
+++ b/src/components/MainPage.test.tsx
@@ -4153,6 +4153,38 @@ describe("MainPage", () => {
       expect(changesText(container)).toBe("");
     });
 
+    it("loses to a preview the user superseded with a Sync press whose own preview failed", async () => {
+      // The Sync press answers the preview question too: the backend discards
+      // the staged snapshot when this run's preview fails, and the retracted
+      // running flag leaves the late answer nothing else to notice that by — so
+      // restoring it would put back a card whose Apply can only answer
+      // stale_preview.
+      const held = deferred<{ success: boolean; preview: SyncPreview | null }>();
+      vi.mocked(backend.getPendingPreview).mockReturnValue(held.promise);
+      vi.mocked(backend.syncPreview).mockResolvedValue(
+        heldPreview({ success: false, message: "Cannot reach RomM server" }),
+      );
+      const { container } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+      await act(async () => {
+        fireEvent.click(buttonByExactText(container, "Sync Library")!);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      // The failed preview retracted the optimistic run, so the panel is idle
+      // again — the state the late answer arrives into.
+      expect(buttonByExactText(container, "Sync Library")).not.toBeNull();
+
+      await act(async () => {
+        held.resolve({ success: true, preview: heldPreview({ preview_id: "preview-held" }) });
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(buttonByExactText(container, "Apply Sync")).toBeNull();
+      expect(changesText(container)).toBe("");
+    });
+
     it("shows no countdown on a preview with nothing to apply, and arms no timer for it", async () => {
       vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout", "setInterval", "clearInterval"] });
       try {

--- a/src/components/MainPage.test.tsx
+++ b/src/components/MainPage.test.tsx
@@ -391,6 +391,8 @@ describe("MainPage", () => {
       success: true,
       message: "",
     });
+    // Nothing staged is the default; the restore tests opt into a preview.
+    vi.mocked(backend.getPendingPreview).mockResolvedValue({ success: true, preview: null });
     vi.mocked(backend.getSyncStatus).mockResolvedValue({
       running: false,
       stage: "",
@@ -3908,6 +3910,215 @@ describe("MainPage", () => {
 
       expect(buttonByExactText(container, "Cancel Sync")).not.toBeNull();
       expect(fieldLabels(container)).not.toContain("Preview ready");
+    });
+  });
+
+  // ===========================================================================
+  // G2. A preview outlives the panel that computed it
+  // ===========================================================================
+  describe("pending preview restored on mount", () => {
+    /** A preview with a real delta, so the card offers Apply Sync. */
+    function heldPreview(overrides: Partial<SyncPreview> = {}): SyncPreview {
+      return {
+        success: true,
+        summary: {
+          new_count: 2,
+          changed_count: 0,
+          unchanged_count: 0,
+          remove_count: 0,
+          disabled_platform_remove_count: 0,
+        },
+        new_names: ["a", "b"],
+        changed_names: [],
+        preview_id: "preview-held",
+        ...overrides,
+      };
+    }
+
+    function changesText(container: HTMLElement): string {
+      return container.querySelector('[data-testid="sync-changes"]')?.textContent ?? "";
+    }
+
+    function expiryText(container: HTMLElement): string | null {
+      return container.querySelector('[data-testid="preview-expiry"]')?.textContent ?? null;
+    }
+
+    it("shows the card again on mount and applies the preview the backend still holds", async () => {
+      vi.mocked(backend.getPendingPreview).mockResolvedValue({ success: true, preview: heldPreview() });
+      vi.mocked(backend.syncApplyDelta).mockResolvedValue({ success: true, message: "" });
+      const { container } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+
+      expect(changesText(container)).toContain("Games: 2 new");
+      await act(async () => {
+        fireEvent.click(buttonByExactText(container, "Apply Sync")!);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(vi.mocked(backend.syncApplyDelta)).toHaveBeenCalledWith("preview-held");
+    });
+
+    it("nothing pending leaves the idle page untouched", async () => {
+      vi.mocked(backend.getPendingPreview).mockResolvedValue({ success: true, preview: null });
+      const { container } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+
+      expect(buttonByExactText(container, "Sync Library")).not.toBeNull();
+      expect(buttonByExactText(container, "Apply Sync")).toBeNull();
+    });
+
+    it("logs the failure when getPendingPreview rejects, and the idle page stands", async () => {
+      vi.mocked(backend.getPendingPreview).mockRejectedValue(new Error("boom"));
+      const logSpy = vi.spyOn(backend, "logError").mockImplementation(() => {});
+      const { container } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("Failed to query pending preview"));
+      expect(buttonByExactText(container, "Sync Library")).not.toBeNull();
+      logSpy.mockRestore();
+    });
+
+    it("loses to a preview the user produced while the read was in flight", async () => {
+      // The answer describes the world as it was when the read was issued; the
+      // preview the user is looking at was computed after it.
+      const held = deferred<{ success: boolean; preview: SyncPreview | null }>();
+      vi.mocked(backend.getPendingPreview).mockReturnValue(held.promise);
+      vi.mocked(backend.syncPreview).mockResolvedValue(heldPreview({ preview_id: "preview-fresh" }));
+      vi.mocked(backend.syncApplyDelta).mockResolvedValue({ success: true, message: "" });
+      const { container } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+      await act(async () => {
+        fireEvent.click(buttonByExactText(container, "Sync Library")!);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      await act(async () => {
+        held.resolve({ success: true, preview: heldPreview({ preview_id: "preview-held" }) });
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      await act(async () => {
+        fireEvent.click(buttonByExactText(container, "Apply Sync")!);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(vi.mocked(backend.syncApplyDelta)).toHaveBeenCalledWith("preview-fresh");
+    });
+
+    it("is dropped when a run started while the read was in flight", async () => {
+      const held = deferred<{ success: boolean; preview: SyncPreview | null }>();
+      vi.mocked(backend.getPendingPreview).mockReturnValue(held.promise);
+      const { container } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+
+      await act(async () => {
+        setSyncProgress({ running: true, stage: "fetching", message: "Fetching library..." });
+        await Promise.resolve();
+      });
+      await act(async () => {
+        held.resolve({ success: true, preview: heldPreview() });
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      // The run owns the panel — no card, and its progress rows stand.
+      expect(buttonByExactText(container, "Apply Sync")).toBeNull();
+      expect(buttonByExactText(container, "Cancel Sync")).not.toBeNull();
+    });
+
+    it("counts down the time left and advances as the clock runs", async () => {
+      vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout", "setInterval", "clearInterval"] });
+      try {
+        vi.setSystemTime(0);
+        vi.mocked(backend.getPendingPreview).mockResolvedValue({
+          success: true,
+          preview: heldPreview({ expires_at: 1800 }),
+        });
+        const { container } = render(<MainPage onNavigate={vi.fn()} />);
+        await flushAsync();
+
+        expect(expiryText(container)).toBe("Expires in 30 min");
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(60_000);
+        });
+        expect(expiryText(container)).toBe("Expires in 29 min");
+        // Floored, so the readout never promises more time than remains.
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(1000);
+        });
+        expect(expiryText(container)).toBe("Expires in 28 min");
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("at zero the card stays, says it expired, and drops Apply Sync for Dismiss", async () => {
+      vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout", "setInterval", "clearInterval"] });
+      try {
+        vi.setSystemTime(0);
+        // A five-second deadline: the same expiry the 30-minute one reaches,
+        // without ticking the interval 1800 times to get there.
+        vi.mocked(backend.getPendingPreview).mockResolvedValue({
+          success: true,
+          preview: heldPreview({ expires_at: 5 }),
+        });
+        const { container } = render(<MainPage onNavigate={vi.fn()} />);
+        await flushAsync();
+        expect(expiryText(container)).toBe("Expires in < 1 min");
+
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(6000);
+        });
+
+        expect(expiryText(container)).toBe("Expired — run the preview again");
+        // Nothing disappeared or moved on its own: the change list is still there
+        // and only the user's Dismiss takes the card away.
+        expect(changesText(container)).toContain("Games: 2 new");
+        expect(buttonByExactText(container, "Apply Sync")).toBeNull();
+        expect(buttonByExactText(container, "Dismiss")).not.toBeNull();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("an expired preview cannot be applied by a press that beat the tick", async () => {
+      vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout", "setInterval", "clearInterval"] });
+      try {
+        vi.setSystemTime(0);
+        vi.mocked(backend.getPendingPreview).mockResolvedValue({
+          success: true,
+          preview: heldPreview({ expires_at: 5 }),
+        });
+        const { container } = render(<MainPage onNavigate={vi.fn()} />);
+        await flushAsync();
+        const apply = buttonByExactText(container, "Apply Sync")!;
+
+        // The clock passes the deadline without the interval having ticked, so
+        // the button the user presses is one the render still believes in.
+        vi.setSystemTime(6000);
+        await act(async () => {
+          fireEvent.click(apply);
+          await Promise.resolve();
+          await Promise.resolve();
+        });
+
+        expect(vi.mocked(backend.syncApplyDelta)).not.toHaveBeenCalled();
+        expect(expiryText(container)).toBe("Expired — run the preview again");
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("shows no countdown at all when the backend sends no deadline", async () => {
+      vi.mocked(backend.getPendingPreview).mockResolvedValue({ success: true, preview: heldPreview() });
+      vi.mocked(backend.syncApplyDelta).mockResolvedValue({ success: true, message: "" });
+      const { container } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+
+      expect(expiryText(container)).toBeNull();
+      expect(buttonByExactText(container, "Apply Sync")).not.toBeNull();
     });
   });
 

--- a/src/components/MainPage.test.tsx
+++ b/src/components/MainPage.test.tsx
@@ -5322,4 +5322,122 @@ describe("MainPage", () => {
       expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("Failed to query RetroDECK status"));
     });
   });
+  // ===========================================================================
+  // PHASE-1 DIAGNOSIS — device-observed defects, reproduced. EXPECTED TO FAIL.
+  // Remove or re-point these once the fix lands.
+  // ===========================================================================
+  describe("PHASE-1 DIAGNOSIS (expected to fail)", () => {
+    /** What handleSync writes into the module store the moment Sync Library is
+     *  pressed: running, no run id yet (the backend has not stamped one). */
+    function optimisticStart(): SyncProgress {
+      return { running: true, stage: "fetching", current: 0, total: 0, message: "Fetching library..." };
+    }
+
+    /** The backend's persisted snapshot after a PREVIOUS preview completed.
+     *  ``finish_run`` never resets ``sync_progress``, so this is what
+     *  ``get_sync_status`` keeps answering until the next run's first
+     *  ``emit_progress`` — and handleSync awaits reconcileStaleShortcuts before
+     *  it ever calls sync_preview, so that window is seconds wide. */
+    function lingeringDoneSnapshot(): SyncProgress {
+      return {
+        running: false,
+        stage: "done",
+        current: 0,
+        total: 0,
+        message: "Preview ready",
+        runId: "run-previous",
+      };
+    }
+
+    it("A: a remount mid-start keeps the in-progress view (stale snapshot must not retract it)", async () => {
+      setSyncProgress(optimisticStart());
+      vi.mocked(backend.getSyncStatus).mockResolvedValue(lingeringDoneSnapshot());
+
+      const { container } = render(<MainPage onNavigate={vi.fn()} />);
+      // First paint is right — the seed reads the module store.
+      expect(container.querySelector('[data-testid="sync-stage"]')).not.toBeNull();
+
+      await flushAsync();
+
+      // ...and then the stale snapshot lands and the panel falls back to idle.
+      expect(buttonByExactText(container, "Sync Library")).toBeNull();
+      expect(container.querySelector('[data-testid="sync-stage"]')).not.toBeNull();
+    });
+
+    it("C: a remount mid-start does not announce the PREVIOUS run's terminal frame", async () => {
+      setSyncProgress(optimisticStart());
+      vi.mocked(backend.getSyncStatus).mockResolvedValue(lingeringDoneSnapshot());
+
+      const { container } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+
+      const statusEl = container.querySelector('[data-testid="sync-status"]');
+      expect(statusEl?.textContent ?? null).not.toBe("Preview ready");
+    });
+
+    it("B: a preview that finishes while the panel is back on screen puts its card up", async () => {
+      // Instance 1 starts the preview, then the user leaves the main page.
+      const previewCall = deferred<SyncPreview>();
+      vi.mocked(backend.syncPreview).mockReturnValue(previewCall.promise);
+      const first = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+      await act(async () => {
+        fireEvent.click(buttonByExactText(first.container, "Sync Library")!);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(getSyncProgress().running).toBe(true);
+      first.unmount();
+
+      // The user comes back while the run is still going. The backend WITHHOLDS
+      // the staged preview while a run is in flight, so the mount read gets nothing.
+      vi.mocked(backend.getPendingPreview).mockResolvedValue({ success: true, preview: null });
+      vi.mocked(backend.getSyncStatus).mockResolvedValue({
+        running: true,
+        stage: "fetching",
+        current: 0,
+        total: 0,
+        message: "Fetching Game Boy...",
+        runId: "run-live",
+      });
+      const second = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+      expect(second.container.querySelector('[data-testid="sync-stage"]')).not.toBeNull();
+
+      // The preview finishes HERE. Its promise belongs to the unmounted instance.
+      await act(async () => {
+        previewCall.resolve({
+          success: true,
+          summary: {
+            new_count: 2,
+            changed_count: 0,
+            unchanged_count: 0,
+            remove_count: 0,
+            disabled_platform_remove_count: 0,
+          },
+          new_names: ["a", "b"],
+          changed_names: [],
+          preview_id: "preview-finished-offscreen",
+        });
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      // ...followed by the backend's own terminal frame for the run.
+      await act(async () => {
+        setSyncProgress({
+          running: false,
+          stage: "done",
+          current: 0,
+          total: 0,
+          message: "Preview ready",
+          runId: "run-live",
+        });
+        await Promise.resolve();
+      });
+
+      // What the device shows: the status line, and no card.
+      expect(second.container.querySelector('[data-testid="sync-status"]')?.textContent).toBe("Preview ready");
+      expect(buttonByExactText(second.container, "Apply Sync")).not.toBeNull();
+    });
+  });
 });

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -21,6 +21,7 @@ import {
   syncPreview,
   syncApplyDelta,
   syncCancelPreview,
+  getPendingPreview,
   clearSyncCache,
   refreshMigrationState,
   getSyncStatus,
@@ -29,7 +30,7 @@ import {
 } from "../api/backend";
 import { formatTimeAgo } from "../utils/formatters";
 import { pluralize } from "../utils/pluralize";
-import { formatDuration, previewApplySeconds } from "../utils/syncEstimate";
+import { formatDuration, formatTimeRemaining, previewApplySeconds } from "../utils/syncEstimate";
 import {
   observeApplyProgress,
   displayedEtaSeconds,
@@ -352,6 +353,25 @@ function formatLibraryLine(stats: SyncStats): string {
 const LONG_SYNC_HINT_THRESHOLD_SEC = 600;
 
 /**
+ * Seconds left before the backend stops accepting *preview*, measured against
+ * *nowMs*, or `null` when the preview carries no deadline (an older backend) —
+ * the card then shows no countdown at all. Never negative: past the deadline it
+ * is 0, which the card reads as expired.
+ *
+ * `nowMs` is passed in rather than read here: the value ticks from an interval
+ * into state, so render stays pure.
+ */
+function previewSecondsLeft(preview: SyncPreview, nowMs: number): number | null {
+  if (preview.expires_at === undefined) return null;
+  return Math.max(0, preview.expires_at - nowMs / 1000);
+}
+
+/** How often the preview card's expiry countdown re-reads the clock. The readout
+ *  itself is minute-coarse; the second-level cadence is what makes the switch to
+ *  the expired notice land promptly rather than up to a minute late. */
+const PREVIEW_COUNTDOWN_TICK_MS = 1000;
+
+/**
  * Thin horizontal rule dividing the panel's blocks (status | sync | menu).
  * The panel carries no section headings — these rules are the only block
  * boundaries.
@@ -461,6 +481,10 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
   const [liveEtaDisplay, setLiveEtaDisplay] = useState<number | null>(null);
   const [status, setStatus] = useState<TransientStatus | null>(null);
   const [preview, setPreview] = useState<SyncPreview | null>(null);
+  // Clock mirror for the preview card's expiry countdown, written from the
+  // interval below (never read during render, same rule as the live-ETA row).
+  // `null` while no preview is up, or when the preview carries no deadline.
+  const [previewNowMs, setPreviewNowMs] = useState<number | null>(null);
   const [skipPreview, setSkipPreview] = useState(false);
   const [retroarchWarning, setRetroarchWarning] = useState<{ warning: boolean; current?: string } | null>(null);
   const [retrodeckBanner, setRetrodeckBanner] = useState<RetroDeckBanner | null>(null);
@@ -520,6 +544,25 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
     getRetroDeckStatus()
       .then((s) => setRetrodeckBanner(retroDeckBanner(s.status, s)))
       .catch((e) => logError(`Failed to query RetroDECK status: ${e}`));
+
+    // The backend holds a computed preview for 30 minutes, but this panel's card
+    // dies with the render — leaving the main page for a submenu used to strand a
+    // preview that was still perfectly appliable. Ask for it back on every mount.
+    getPendingPreview()
+      .then((answer) => {
+        if (!answer.success || !answer.preview) return;
+        const restored = answer.preview;
+        // Same reasoning as the getSyncStatus seed above: this answer describes
+        // the world as it was when the read was ISSUED, so anything that happened
+        // since outranks it. A run started in that window owns the panel — the
+        // store, not this read, is authoritative about a sync being in flight —
+        // and a preview the user produced or dismissed in it is the one they are
+        // looking at, so the functional update lets the restored one lose.
+        if (getSyncProgress().running) return;
+        setPreviewNowMs(Date.now());
+        setPreview((cur) => cur ?? restored);
+      })
+      .catch((e) => logError(`Failed to query pending preview: ${e}`));
 
     // Cross-device playtime scope notice. The backend sets a durable flag when a
     // playtime reconcile is rejected for a token missing `roms.user.read`; it
@@ -674,6 +717,19 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
     };
   }, []);
 
+  // Drive the preview card's expiry countdown. The deadline is absolute, so the
+  // only thing that has to tick is the current time — mirrored into state here
+  // rather than read in render, which must stay pure. The first value is stamped
+  // by whoever adopts the preview (both are handlers); this only keeps it moving,
+  // and is torn down when the preview goes away (dismissed, applied, or the panel
+  // unmounting). A preview without a deadline (older backend) arms nothing.
+  const previewExpiresAt = preview?.expires_at;
+  useEffect(() => {
+    if (previewExpiresAt === undefined) return;
+    const id = setInterval(() => setPreviewNowMs(Date.now()), PREVIEW_COUNTDOWN_TICK_MS);
+    return () => clearInterval(id);
+  }, [previewExpiresAt]);
+
   // Poll the live renderer-heap reading while it can still change: during a sync (so
   // the "Steam memory" row tracks the climbing RSS mid-apply) AND while the last run
   // is paused (so the paused banner notices once a Steam restart frees memory and
@@ -756,6 +812,9 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
         abortOptimisticSync("Sync cancelled");
         return;
       }
+      // Stamp the clock the card's expiry countdown reads from — an impure read,
+      // so it belongs here rather than in render or in the interval's effect body.
+      setPreviewNowMs(Date.now());
       setPreview(result);
       // The preview run is over — retract the optimistic running:true rather than
       // waiting for the backend's own terminal frame for it. That frame can be
@@ -770,6 +829,14 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
 
   const handleApply = async () => {
     if (!preview) return;
+    // A press that beat the countdown's tick to the expired state. The backend
+    // would refuse this apply, so don't spend the user's press on a failure they
+    // could not have avoided — re-read the clock instead, which flips the card to
+    // its expired form and takes the button with it.
+    if (previewSecondsLeft(preview, Date.now()) === 0) {
+      setPreviewNowMs(Date.now());
+      return;
+    }
     const previewId = preview.preview_id;
     // Seed the apply ETA from the walk cost (shared with the preview row via
     // previewApplySeconds) so the number the user approved is the run's seed. It
@@ -966,6 +1033,13 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
     // omits the scope counts leaves scopeText empty; the duration line then
     // stands alone.
     const scopeText = formatSyncScope(preview.summary);
+    // Time left before the backend stops accepting this preview. `null` when the
+    // backend sent no deadline (older backend) — no countdown, no expiry, the
+    // card behaves exactly as it did before. At zero the card STAYS: nothing is
+    // allowed to disappear or move on its own, so the countdown is replaced by
+    // the expired notice, Apply goes away, and only Dismiss remains.
+    const secondsLeft = previewNowMs === null ? null : previewSecondsLeft(preview, previewNowMs);
+    const expired = secondsLeft === 0;
     // The sleep-pause caveat is only worth the extra line for a genuinely long run.
     const hintText =
       "Progress is saved about every 200 games — cancelling is safe." +
@@ -1027,7 +1101,23 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
             </Focusable>
           </PanelSectionRow>
         ) : null}
-        {hasChanges ? (
+        {hasChanges && secondsLeft !== null && (
+          <PanelSectionRow>
+            <Focusable>
+              <div
+                data-testid="preview-expiry"
+                style={{
+                  fontSize: "12px",
+                  color: expired ? "#e5b93c" : "rgba(255, 255, 255, 0.6)",
+                  padding: "4px 0",
+                }}
+              >
+                {expired ? "Expired — run the preview again" : `Expires in ${formatTimeRemaining(secondsLeft)}`}
+              </div>
+            </Focusable>
+          </PanelSectionRow>
+        )}
+        {hasChanges && !expired ? (
           <>
             <PanelSectionRow>
               <ButtonItem

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -353,6 +353,29 @@ function formatLibraryLine(stats: SyncStats): string {
 const LONG_SYNC_HINT_THRESHOLD_SEC = 600;
 
 /**
+ * Whether *preview* has anything for Apply Sync to do — the condition the card's
+ * Apply button, its coverage/estimate lines and its expiry countdown all hang
+ * off. A preview with nothing to apply is still a card ("Everything is up to
+ * date."), just one with no work and therefore no deadline worth showing.
+ */
+function previewHasChanges(preview: SyncPreview): boolean {
+  const s = preview.summary;
+  return (
+    s.new_count + s.changed_count + s.remove_count > 0 ||
+    !!(s.collection_diff?.added.length || s.collection_diff?.removed.length) ||
+    !!s.platform_collection_diff?.has_changes ||
+    // Cover-only work (#1386): the refresh pass runs inside the apply, so an
+    // empty shortcut delta with pending cover updates must still offer Apply —
+    // the old "no changes" short-circuit stranded changed covers forever.
+    (s.cover_refresh_count ?? 0) > 0 ||
+    // Unstamped platforms (#1416): a late-ack-recovered platform needs a
+    // 0-delta apply run to re-stamp itself and heal the lingering
+    // "interrupted" status, so offer Apply even when every change count is zero.
+    (s.restamp_platform_count ?? 0) > 0
+  );
+}
+
+/**
  * Seconds left before the backend stops accepting *preview*, measured against
  * *nowMs*, or `null` when the preview carries no deadline (an older backend) —
  * the card then shows no countdown at all. Never negative: past the deadline it
@@ -741,13 +764,16 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
   // rather than read in render, which must stay pure. The first value is stamped
   // by whoever adopts the preview (both are handlers); this only keeps it moving,
   // and is torn down when the preview goes away (dismissed, applied, or the panel
-  // unmounting). A preview without a deadline (older backend) arms nothing.
-  const previewExpiresAt = preview?.expires_at;
+  // unmounting). The condition is the countdown row's own: a preview without a
+  // deadline (older backend) and one with nothing to apply both show no
+  // countdown, and a tick that nothing on screen can consume is a wasted
+  // re-render of the whole page every second.
+  const previewCountdownDeadline = preview && previewHasChanges(preview) ? preview.expires_at : undefined;
   useEffect(() => {
-    if (previewExpiresAt === undefined) return;
+    if (previewCountdownDeadline === undefined) return;
     const id = setInterval(() => setPreviewNowMs(Date.now()), PREVIEW_COUNTDOWN_TICK_MS);
     return () => clearInterval(id);
-  }, [previewExpiresAt]);
+  }, [previewCountdownDeadline]);
 
   // Poll the live renderer-heap reading while it can still change: during a sync (so
   // the "Steam memory" row tracks the climbing RSS mid-apply) AND while the last run
@@ -1033,18 +1059,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
 
   let syncBody: ReactNode;
   if (preview) {
-    const hasChanges =
-      preview.summary.new_count + preview.summary.changed_count + preview.summary.remove_count > 0 ||
-      !!(preview.summary.collection_diff?.added.length || preview.summary.collection_diff?.removed.length) ||
-      preview.summary.platform_collection_diff?.has_changes ||
-      // Cover-only work (#1386): the refresh pass runs inside the apply, so an
-      // empty shortcut delta with pending cover updates must still offer Apply —
-      // the old "no changes" short-circuit stranded changed covers forever.
-      (preview.summary.cover_refresh_count ?? 0) > 0 ||
-      // Unstamped platforms (#1416): a late-ack-recovered platform needs a
-      // 0-delta apply run to re-stamp itself and heal the lingering
-      // "interrupted" status, so offer Apply even when every change count is zero.
-      (preview.summary.restamp_platform_count ?? 0) > 0;
+    const hasChanges = previewHasChanges(preview);
     // Walk cost, shared with the handleApply seed (previewApplySeconds) so the
     // approved number equals the run's seed. Delta-only pricing here read "2 min"
     // for a resume whose apply walked ~3100 items.

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -674,6 +674,81 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
       })
       .catch((e) => logError(`Failed to query sync status: ${e}`));
 
+    /**
+     * The terminal half of the sync-progress subscriber: a run's once-per-run
+     * teardown, and — for the frame that follows it — the run's own account of how
+     * it ended. Called only from that subscriber, and only for a frame whose stage
+     * is terminal.
+     *
+     * WHICH of the two a frame is stays with the caller and is NOT re-derived
+     * here. Those verdicts are taken from the run refs before the refs move on and
+     * outside the caller's try, so a throw in here can never leave the panel
+     * believing a finished run is still live; recomputing them here would put that
+     * decision back inside the guarded region. The two cases are also never
+     * merged: the first frame ends the run, the second only replaces the text that
+     * ending left behind.
+     */
+    const applyTerminalFrame = (progress: SyncProgress, runEndedNow: boolean, laterTerminalFrame: boolean) => {
+      if (runEndedNow) {
+        // Tear down the run's live-ETA state (deadline included) so the next run
+        // measures fresh, and clear the display mirror.
+        resetEta();
+        setLiveEtaDisplay(null);
+        // True terminal reached — re-arm the button out of any "Cancelling…"
+        // drain state (#1202, RC-B).
+        setCancelling(false);
+        showTransientStatus(progress.message || "Sync finished", terminalStatusTone(progress.stage));
+        // A preview run that just ended may have staged a card this panel never
+        // received: `sync_preview` answers the instance that pressed Sync, and that
+        // instance is gone whenever the user left the page mid-run. Ask for it —
+        // unless the store already has it, which is the same run answering through
+        // the other door. A run that staged nothing (an apply, a cancel, Skip
+        // Preview) is answered `preview: null` and the store is left as it stands.
+        // Stamp the countdown's clock either way: this is where a preview can
+        // appear without this instance adopting it, and the impure now-read
+        // belongs in a handler.
+        setPreviewNowMs(Date.now());
+        if (getPendingPreviewSnapshot() === null) detach(refreshPendingPreview());
+        // Both re-reads are provoked by the run ending, so neither may join a read
+        // issued while it was still going — see the two AfterChange functions.
+        detach(refreshSyncStatsAfterChange());
+        // Refresh the live heap reading so the paused / high-heap banner reflects
+        // the run's end state (a pause leaves it high; a completed run may too).
+        detach(refreshSessionBudgetAfterChange());
+      } else if (laterTerminalFrame && progress.message) {
+        // The same run's second terminal signal. Everything above has already
+        // happened for this run; what this frame adds is the run's own account of
+        // how it ended, which replaces the text the merged sync_complete frame
+        // carried over from mid-run. A frame with no message of its own changes
+        // nothing rather than blanking the one already shown.
+        showTransientStatus(progress.message, terminalStatusTone(progress.stage));
+      }
+    };
+
+    /**
+     * The non-terminal half: keep the live-rate ETA moving. Called only from the
+     * subscriber, and only for a frame whose stage is not terminal.
+     *
+     * Feeds the estimator from applying frames that carry ITEM progress only —
+     * fetch frames carry page/cover counters, and an applying-stage cover-refresh
+     * frame (``coverRefresh``, #1456) carries a cover counter, not item progress,
+     * so both must be skipped. syncEta re-anchors its sticky deadline internally;
+     * the countdown is then mirrored into state here. Both now-reads are impure
+     * and so must stay on this side of the render boundary, which they do — this
+     * runs from an event handler, never from render.
+     */
+    const advanceLiveEta = (progress: SyncProgress) => {
+      if (
+        progress.stage === "applying" &&
+        progress.step !== undefined &&
+        progress.current !== undefined &&
+        !progress.coverRefresh
+      ) {
+        observeApplyProgress(progress.step, progress.current, Date.now());
+      }
+      setLiveEtaDisplay(displayedEtaSeconds(Date.now()));
+    };
+
     // Subscribe to the module store — every backend sync_progress event and
     // every frontend updateSyncProgress notifies, driving a re-render. What the
     // end-of-run work keys on is the watched RUN reaching a terminal stage, not a
@@ -722,57 +797,13 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
         setCarriedFineDetail(progress.message);
       }
       try {
-        if (runEndedNow) {
-          // Tear down the run's live-ETA state (deadline included) so the next run
-          // measures fresh, and clear the display mirror.
-          resetEta();
-          setLiveEtaDisplay(null);
-          // True terminal reached — re-arm the button out of any "Cancelling…"
-          // drain state (#1202, RC-B).
-          setCancelling(false);
-          showTransientStatus(progress.message || "Sync finished", terminalStatusTone(progress.stage));
-          // A preview run that just ended may have staged a card this panel never
-          // received: `sync_preview` answers the instance that pressed Sync, and
-          // that instance is gone whenever the user left the page mid-run. Ask
-          // for it — unless the store already has it, which is the same run
-          // answering through the other door. A run that staged nothing (an
-          // apply, a cancel, Skip Preview) is answered `preview: null` and the
-          // store is left as it stands. Stamp the countdown's clock either way:
-          // this is where a preview can appear without this instance adopting it,
-          // and the impure now-read belongs in a handler.
-          setPreviewNowMs(Date.now());
-          if (getPendingPreviewSnapshot() === null) detach(refreshPendingPreview());
-          // Both re-reads are provoked by the run ending, so neither may join a
-          // read issued while it was still going — see the two AfterChange
-          // functions.
-          detach(refreshSyncStatsAfterChange());
-          // Refresh the live heap reading so the paused / high-heap banner reflects
-          // the run's end state (a pause leaves it high; a completed run may too).
-          detach(refreshSessionBudgetAfterChange());
-        } else if (laterTerminalFrame && progress.message) {
-          // The same run's second terminal signal. Everything above has already
-          // happened for this run; what this frame adds is the run's own account of
-          // how it ended, which replaces the text the merged sync_complete frame
-          // carried over from mid-run. A frame with no message of its own changes
-          // nothing rather than blanking the one already shown.
-          showTransientStatus(progress.message, terminalStatusTone(progress.stage));
-        } else if (!terminal) {
-          // Feed the live-rate estimator from applying frames that carry ITEM
-          // progress only — fetch frames carry page/cover counters, and an
-          // applying-stage cover-refresh frame (``coverRefresh``, #1456) carries a
-          // cover counter, not item progress, so both must be skipped. syncEta
-          // re-anchors its sticky deadline internally; then mirror the current
-          // countdown into state here — the impure now-read must live in this
-          // subscriber (an event handler), never in render, which must stay pure.
-          if (
-            progress.stage === "applying" &&
-            progress.step !== undefined &&
-            progress.current !== undefined &&
-            !progress.coverRefresh
-          ) {
-            observeApplyProgress(progress.step, progress.current, Date.now());
-          }
-          setLiveEtaDisplay(displayedEtaSeconds(Date.now()));
+        if (terminal) {
+          // A terminal frame that is neither verdict — the stored one a mount
+          // merely finds, watching nothing (#1019) — reaches this call and does
+          // nothing, exactly as it fell out of the chain this replaced.
+          applyTerminalFrame(progress, runEndedNow, laterTerminalFrame);
+        } else {
+          advanceLiveEta(progress);
         }
       } catch (e) {
         logError(`sync-progress subscriber failed: ${e}`);

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -21,7 +21,6 @@ import {
   syncPreview,
   syncApplyDelta,
   syncCancelPreview,
-  getPendingPreview,
   clearSyncCache,
   refreshMigrationState,
   getSyncStatus,
@@ -45,6 +44,13 @@ import {
   withinUnitFraction,
 } from "../utils/syncProgress";
 import { useDownloads } from "../utils/downloadStore";
+import {
+  usePendingPreview,
+  getPendingPreviewSnapshot,
+  adoptPreview,
+  clearPendingPreview,
+  refreshPendingPreview,
+} from "../utils/pendingPreviewStore";
 import {
   refreshSessionBudget,
   refreshSessionBudgetAfterChange,
@@ -503,16 +509,19 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
   // so the countdown ticks per frame exactly as before.
   const [liveEtaDisplay, setLiveEtaDisplay] = useState<number | null>(null);
   const [status, setStatus] = useState<TransientStatus | null>(null);
-  const [preview, setPreview] = useState<SyncPreview | null>(null);
+  // The preview lives in a module store, not here: the answer to `sync_preview`
+  // is delivered to the instance that pressed Sync, and leaving the main page
+  // mid-run unmounts that instance while the run carries on
+  // (`utils/pendingPreviewStore.ts` states the whole rule).
+  const preview = usePendingPreview();
   // Clock mirror for the preview card's expiry countdown, written from the
-  // interval below and from each site that adopts a preview — never read during
-  // render, same rule as the live-ETA row. `null` only until the first preview
-  // of this mount is adopted: nothing resets it afterwards, because the reset
-  // would have to live in the countdown effect and a setState there is a lint
-  // error (react-hooks/set-state-in-effect). That costs nothing while EVERY
-  // adopter stamps it first — the invariant a third adopter must keep — since it
-  // is read only through `previewSecondsLeft`, i.e. only while a preview is up,
-  // and the interval refreshes it every second from then on.
+  // interval below and from the handlers through which a preview can reach this
+  // instance — never read during render, same rule as the live-ETA row. `null`
+  // only until the first of those runs: nothing resets it afterwards, because
+  // the reset would have to live in the countdown effect and a setState there is
+  // a lint error (react-hooks/set-state-in-effect). That costs nothing, since it
+  // is read only through `previewSecondsLeft` — only while a preview is up — and
+  // the interval refreshes it every second from then on.
   const [previewNowMs, setPreviewNowMs] = useState<number | null>(null);
   const [skipPreview, setSkipPreview] = useState(false);
   const [retroarchWarning, setRetroarchWarning] = useState<{ warning: boolean; current?: string } | null>(null);
@@ -523,12 +532,6 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
   const saveSortMigration = useSaveSortMigrationState();
   const downloads = useDownloads();
   const statusTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  // Whether the user has answered the preview question since this mount —
-  // dismissed the card, or pressed Sync (which asks the backend for a fresh
-  // preview and, on failure, has it discard the staged one). Read by the
-  // pending-preview restore, which cannot see any of that in state: an answered
-  // preview and one that never existed both leave `preview` null.
-  const previewAnsweredRef = useRef(false);
   // The run this panel is watching, by id, and whether its end has been handled.
   // Seeded at first render — BEFORE the subscription below exists, so the mount
   // seed's own write is measured against the state it replaced rather than against
@@ -583,31 +586,11 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
     // The backend holds a computed preview for 30 minutes, but this panel's card
     // dies with the render — leaving the main page for a submenu used to strand a
     // preview that was still perfectly appliable. Ask for it back on every mount.
-    getPendingPreview()
-      .then((answer) => {
-        if (!answer.success || !answer.preview) return;
-        const restored = answer.preview;
-        // Same reasoning as the getSyncStatus seed above: this answer describes
-        // the world as it was when the read was ISSUED, so anything the user did
-        // since outranks it. A preview they produced in that window is the one
-        // they are looking at (the functional update below lets the restored one
-        // lose), and a preview they have ANSWERED — dismissed, or superseded by a
-        // Sync press whose own preview failed — is one the backend has already
-        // been told to discard: restoring it would put back a card whose Apply
-        // can only answer stale_preview, which is the failure this whole change
-        // exists to remove. State cannot tell the two apart (both leave `cur`
-        // null), so the answer is recorded in a ref.
-        //
-        // The run check is belt-and-braces: the backend withholds a staged
-        // preview while a run is in flight, precisely because this store can be
-        // wrong here — an apply refused with sync_in_progress retracts the
-        // optimistic running flag while the backend keeps the delta (#1202).
-        if (previewAnsweredRef.current) return;
-        if (getSyncProgress().running) return;
-        setPreviewNowMs(Date.now());
-        setPreview((cur) => cur ?? restored);
-      })
-      .catch((e) => logError(`Failed to query pending preview: ${e}`));
+    // The store decides whether the answer still stands: it loses to anything the
+    // user answered while it was open, and its own failure is logged there.
+    // Stamping the countdown's clock is this side's job — an impure read, so it
+    // belongs in a handler rather than in render or in the interval's effect.
+    detach(refreshPendingPreview().then(() => setPreviewNowMs(Date.now())));
 
     // Cross-device playtime scope notice. The backend sets a durable flag when a
     // playtime reconcile is rejected for a token missing `roms.user.read`; it
@@ -638,6 +621,28 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
         // it existed, so applying it would retract a run that has just started
         // (#751). The store's own frames then carry the run from here.
         if (!backendProgress.running && stored !== storeAtIssue) return;
+        // Nor over a run the store is tracking right now. The backend keeps
+        // answering with a snapshot until the NEXT run overwrites it, and the
+        // next run's first frame is a reconcile plus a round trip away — so
+        // between pressing Sync and the backend's first frame, this read answers
+        // with the PREVIOUS run: not running, and carrying that run's terminal
+        // stage and message. Adopting it retracted the run the panel was showing
+        // (idle buttons over a live preview) and handed the subscriber below a
+        // terminal stage it announced as this run's ending. A retraction is
+        // therefore allowed only from an answer that names the very run the store
+        // is tracking; the optimistic frame carries no run id, so during that
+        // window nothing can name it — which is correct, because in that window
+        // the store knows about a run the backend has not reported yet.
+        //
+        // The residual risk, stated honestly: if a run's terminal frame were ever
+        // missed entirely, the panel would go on believing the run is live rather
+        // than being corrected by the next mount. That is the better failure. A
+        // panel wrongly showing progress is corrected by the next frame or the
+        // next run and blocks nothing in the meantime; a panel wrongly showing
+        // the idle buttons invites a second run on top of a live one, which is
+        // the failure users actually hit.
+        const namesStoredRun = !!stored.runId && stored.runId === backendProgress.runId;
+        if (!backendProgress.running && stored.running && !namesStoredRun) return;
         const sameRun = backendProgress.runId && stored.runId ? backendProgress.runId === stored.runId : true;
         const isSameLiveRun = backendProgress.running && stored.running && sameRun;
         // Same live run: spread the store (keeping its fine fields + etaSeconds)
@@ -719,6 +724,17 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
           // drain state (#1202, RC-B).
           setCancelling(false);
           showTransientStatus(progress.message || "Sync finished", terminalStatusTone(progress.stage));
+          // A preview run that just ended may have staged a card this panel never
+          // received: `sync_preview` answers the instance that pressed Sync, and
+          // that instance is gone whenever the user left the page mid-run. Ask
+          // for it — unless the store already has it, which is the same run
+          // answering through the other door. A run that staged nothing (an
+          // apply, a cancel, Skip Preview) is answered `preview: null` and the
+          // store is left as it stands. Stamp the countdown's clock either way:
+          // this is where a preview can appear without this instance adopting it,
+          // and the impure now-read belongs in a handler.
+          setPreviewNowMs(Date.now());
+          if (getPendingPreviewSnapshot() === null) detach(refreshPendingPreview());
           // Both re-reads are provoked by the run ending, so neither may join a
           // read issued while it was still going — see the two AfterChange
           // functions.
@@ -771,7 +787,13 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
   // deadline (older backend) and one with nothing to apply both show no
   // countdown, and a tick that nothing on screen can consume is a wasted
   // re-render of the whole page every second.
-  const previewCountdownDeadline = preview && previewHasChanges(preview) ? preview.expires_at : undefined;
+  // A run in flight owns the panel. A preview held while one is going is not
+  // dropped — the store keeps it and the card comes back the moment the run
+  // ends — but it must not render over the progress rows, which are the true
+  // state of the machine at that moment. The two only ever overlap for the
+  // instant between a preview being staged and its run's terminal frame.
+  const previewCard = syncing ? null : preview;
+  const previewCountdownDeadline = previewCard && previewHasChanges(previewCard) ? previewCard.expires_at : undefined;
   useEffect(() => {
     if (previewCountdownDeadline === undefined) return;
     const id = setInterval(() => setPreviewNowMs(Date.now()), PREVIEW_COUNTDOWN_TICK_MS);
@@ -825,10 +847,10 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
     setCancelling(false);
     setStatus(null);
     // Pressing Sync answers the preview question too: the backend discards the
-    // staged snapshot the moment this run's own preview fails, and the retracted
-    // running flag leaves an in-flight mount read nothing else to notice that by.
-    previewAnsweredRef.current = true;
-    setPreview(null);
+    // staged snapshot the moment this run's own preview fails, and this answer
+    // outranks any pending-preview read still open, which would otherwise put the
+    // card the user just replaced back on screen.
+    clearPendingPreview();
     setStoredSyncProgress({ running: true, stage: "fetching", message: "Fetching library..." });
     try {
       // Reconcile shortcuts the user deleted via Steam's own UI BEFORE the work
@@ -867,7 +889,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
       // Stamp the clock the card's expiry countdown reads from — an impure read,
       // so it belongs here rather than in render or in the interval's effect body.
       setPreviewNowMs(Date.now());
-      setPreview(result);
+      adoptPreview(result);
       // The preview run is over — retract the optimistic running:true rather than
       // waiting for the backend's own terminal frame for it. That frame can be
       // dropped or raced (the reason index.tsx also drives teardown from
@@ -900,7 +922,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
     // backend stamps the run id, which the backend treats as an unconditional
     // cancel (#1202).
     resetSyncCancel();
-    setPreview(null);
+    clearPendingPreview();
     // The preview's own "Preview ready" line is still armed for its 15s lifetime,
     // hidden only by the preview it belongs to; clearing the preview without it
     // would carry a finished run's status into this one's progress rows.
@@ -919,10 +941,9 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
   };
 
   const handleDismiss = async () => {
-    // The user has answered the preview question: whatever the mount read is
-    // still holding is a snapshot the backend is being told to discard.
-    previewAnsweredRef.current = true;
-    setPreview(null);
+    // The user has answered the preview question: whatever a read still open is
+    // about to hand back is a snapshot the backend is being told to discard.
+    clearPendingPreview();
     setStatus(null);
     try {
       await syncCancelPreview();
@@ -1065,24 +1086,24 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
   }
 
   let syncBody: ReactNode;
-  if (preview) {
-    const hasChanges = previewHasChanges(preview);
+  if (previewCard) {
+    const hasChanges = previewHasChanges(previewCard);
     // Walk cost, shared with the handleApply seed (previewApplySeconds) so the
     // approved number equals the run's seed. Delta-only pricing here read "2 min"
     // for a resume whose apply walked ~3100 items.
-    const applySeconds = previewApplySeconds(preview.summary);
+    const applySeconds = previewApplySeconds(previewCard.summary);
     const estimateText = formatDuration(applySeconds);
     // Coverage and duration each own a line — at the QAM width they wrapped as
     // one row anyway, and the break landed mid-phrase. An older backend that
     // omits the scope counts leaves scopeText empty; the duration line then
     // stands alone.
-    const scopeText = formatSyncScope(preview.summary);
+    const scopeText = formatSyncScope(previewCard.summary);
     // Time left before the backend stops accepting this preview. `null` when the
     // backend sent no deadline (older backend) — no countdown, no expiry, the
     // card behaves exactly as it did before. At zero the card STAYS: nothing is
     // allowed to disappear or move on its own, so the countdown is replaced by
     // the expired notice, Apply goes away, and only Dismiss remains.
-    const secondsLeft = previewNowMs === null ? null : previewSecondsLeft(preview, previewNowMs);
+    const secondsLeft = previewNowMs === null ? null : previewSecondsLeft(previewCard, previewNowMs);
     const expired = secondsLeft === 0;
     // The sleep-pause caveat is only worth the extra line for a genuinely long run.
     const hintText =
@@ -1100,7 +1121,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
             description={
               <>
                 <div data-testid="sync-changes">
-                  <PreviewChanges summary={preview.summary} />
+                  <PreviewChanges summary={previewCard.summary} />
                 </div>
                 {hasChanges && scopeText && (
                   <div data-testid="sync-scope" style={{ marginTop: "4px" }}>
@@ -1125,7 +1146,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
             </Focusable>
           </PanelSectionRow>
         )}
-        {preview.pause_likely ? (
+        {previewCard.pause_likely ? (
           <PanelSectionRow>
             <Focusable>
               <div
@@ -1534,7 +1555,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
             is set by a path that has already ended its run — but a status OUTLIVES
             the run that set it (15s), so the two paths that start a run clear it
             rather than let it ride into the next one. */}
-        {status?.text && !preview && (
+        {status?.text && !previewCard && (
           <PanelSectionRow>
             <Field
               label={

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -523,10 +523,12 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
   const saveSortMigration = useSaveSortMigrationState();
   const downloads = useDownloads();
   const statusTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  // Whether the user has dismissed a preview since this mount. Read by the
-  // pending-preview restore, which cannot see the difference in state: a
-  // dismissed preview and one that never existed both leave `preview` null.
-  const previewDismissedRef = useRef(false);
+  // Whether the user has answered the preview question since this mount —
+  // dismissed the card, or pressed Sync (which asks the backend for a fresh
+  // preview and, on failure, has it discard the staged one). Read by the
+  // pending-preview restore, which cannot see any of that in state: an answered
+  // preview and one that never existed both leave `preview` null.
+  const previewAnsweredRef = useRef(false);
   // The run this panel is watching, by id, and whether its end has been handled.
   // Seeded at first render — BEFORE the subscription below exists, so the mount
   // seed's own write is measured against the state it replaced rather than against
@@ -589,17 +591,18 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
         // the world as it was when the read was ISSUED, so anything the user did
         // since outranks it. A preview they produced in that window is the one
         // they are looking at (the functional update below lets the restored one
-        // lose), and a preview they DISMISSED is one the backend has already been
-        // told to discard — restoring it would put back a card whose Apply can
-        // only answer stale_preview, which is the failure this whole change
+        // lose), and a preview they have ANSWERED — dismissed, or superseded by a
+        // Sync press whose own preview failed — is one the backend has already
+        // been told to discard: restoring it would put back a card whose Apply
+        // can only answer stale_preview, which is the failure this whole change
         // exists to remove. State cannot tell the two apart (both leave `cur`
-        // null), so the dismissal is recorded in a ref.
+        // null), so the answer is recorded in a ref.
         //
         // The run check is belt-and-braces: the backend withholds a staged
         // preview while a run is in flight, precisely because this store can be
         // wrong here — an apply refused with sync_in_progress retracts the
         // optimistic running flag while the backend keeps the delta (#1202).
-        if (previewDismissedRef.current) return;
+        if (previewAnsweredRef.current) return;
         if (getSyncProgress().running) return;
         setPreviewNowMs(Date.now());
         setPreview((cur) => cur ?? restored);
@@ -821,6 +824,10 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
     // reads), not a shadowing local state.
     setCancelling(false);
     setStatus(null);
+    // Pressing Sync answers the preview question too: the backend discards the
+    // staged snapshot the moment this run's own preview fails, and the retracted
+    // running flag leaves an in-flight mount read nothing else to notice that by.
+    previewAnsweredRef.current = true;
     setPreview(null);
     setStoredSyncProgress({ running: true, stage: "fetching", message: "Fetching library..." });
     try {
@@ -914,7 +921,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
   const handleDismiss = async () => {
     // The user has answered the preview question: whatever the mount read is
     // still holding is a snapshot the backend is being told to discard.
-    previewDismissedRef.current = true;
+    previewAnsweredRef.current = true;
     setPreview(null);
     setStatus(null);
     try {

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -613,7 +613,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
     // replace behavior (the store holds nothing worth preserving).
     const storeAtIssue = getSyncProgress();
     getSyncStatus()
-      .then((backendProgress) => {
+      .then(({ inFlight, ...backendProgress }) => {
         const stored = getSyncProgress();
         // An answer reporting nothing in flight has no authority over a write
         // that landed after the read was issued: a Sync click in that window
@@ -621,28 +621,35 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
         // it existed, so applying it would retract a run that has just started
         // (#751). The store's own frames then carry the run from here.
         if (!backendProgress.running && stored !== storeAtIssue) return;
-        // Nor over a run the store is tracking right now. The backend keeps
-        // answering with a snapshot until the NEXT run overwrites it, and the
-        // next run's first frame is a reconcile plus a round trip away — so
-        // between pressing Sync and the backend's first frame, this read answers
-        // with the PREVIOUS run: not running, and carrying that run's terminal
-        // stage and message. Adopting it retracted the run the panel was showing
-        // (idle buttons over a live preview) and handed the subscriber below a
-        // terminal stage it announced as this run's ending. A retraction is
-        // therefore allowed only from an answer that names the very run the store
-        // is tracking; the optimistic frame carries no run id, so during that
-        // window nothing can name it — which is correct, because in that window
-        // the store knows about a run the backend has not reported yet.
+        // Retracting a run the store is tracking is a separate question from
+        // reading the frame, and the answer carries both. `inFlight` is the
+        // backend's run-lifecycle state; the frame is the last thing a run said.
+        // Between pressing Sync and the new run's first frame — a reconcile plus
+        // a round trip — the frame belongs to the PREVIOUS run, so taking it for
+        // this one both retracted the run the panel was showing (idle buttons
+        // over a live preview) and handed the subscriber below a terminal stage
+        // it announced as this run's ending.
         //
-        // The residual risk, stated honestly: if a run's terminal frame were ever
-        // missed entirely, the panel would go on believing the run is live rather
-        // than being corrected by the next mount. That is the better failure. A
-        // panel wrongly showing progress is corrected by the next frame or the
-        // next run and blocks nothing in the meantime; a panel wrongly showing
-        // the idle buttons invites a second run on top of a live one, which is
-        // the failure users actually hit.
+        // A retraction is therefore allowed only where the answer is evidence
+        // about the run the store is tracking, which is one of two things: the
+        // answer NAMES that run (its own ending, e.g. a terminal frame this panel
+        // missed while it was away), or the backend reports the lifecycle
+        // explicitly idle AND the store's run carries a backend-stamped id, so it
+        // is a run the backend has seen and is now telling us is over. That
+        // second clause is what keeps a lost terminal frame from wedging the
+        // panel on a run that is not running: the next mount corrects it.
+        //
+        // What is refused is an idle answer against the panel's OWN optimistic
+        // start, which carries no run id because the backend has not stamped one
+        // — there the backend is not silent about the run, it has not heard of it
+        // yet. That frame is not a wedge: the handler that wrote it always
+        // retracts it itself (a preview answered, a failure aborted, or a
+        // per-unit run whose frames stamp a real id), even from an instance the
+        // user has already navigated away from.
+        const backendRunIdle = inFlight === false;
         const namesStoredRun = !!stored.runId && stored.runId === backendProgress.runId;
-        if (!backendProgress.running && stored.running && !namesStoredRun) return;
+        const backendKnowsStoredRun = backendRunIdle && !!stored.runId;
+        if (!backendProgress.running && stored.running && !namesStoredRun && !backendKnowsStoredRun) return;
         const sameRun = backendProgress.runId && stored.runId ? backendProgress.runId === stored.runId : true;
         const isSameLiveRun = backendProgress.running && stored.running && sameRun;
         // Same live run: spread the store (keeping its fine fields + etaSeconds)
@@ -884,6 +891,14 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
       // (so the next sync doesn't start pre-cancelled) and abort to idle.
       if (isCancelRequested()) {
         resetSyncCancel();
+        // The backend staged this snapshot before the cancel reached it, and a
+        // cancel that lands after the preview is computed never travels far
+        // enough to discard it. Say so explicitly: otherwise the terminal frame's
+        // re-ask fetches it a round trip later and puts up the card the user just
+        // cancelled, which reads as the plugin ignoring the press. Best-effort —
+        // a failed discard leaves a snapshot the user can only meet again by
+        // coming back to the page, and must not turn a cancel into an error.
+        detach(syncCancelPreview());
         abortOptimisticSync("Sync cancelled");
         return;
       }
@@ -954,10 +969,14 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
   };
 
   const handleCancel = async () => {
-    if (preview) {
-      await handleDismiss();
-      return;
-    }
+    // No preview branch here. This handler is wired to one button — "Cancel
+    // Sync", in the body a run in flight owns — and that body renders only where
+    // `previewCard` is null, so a preview cannot be what the press is about. The
+    // card's own Cancel calls `handleDismiss` directly. A branch reading the
+    // STORE's preview would fire exactly where the store holds one while a run is
+    // going, dismissing the card and leaving the run untouched with no other way
+    // out of the syncing body.
+    //
     // RC-B (#1202): do NOT re-arm the Sync button here. The backend drains
     // RUNNING → CANCELLING → IDLE asynchronously; flipping back to enabled now
     // lets a quick re-press hit the sync_in_progress reject and look like an

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -482,8 +482,14 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
   const [status, setStatus] = useState<TransientStatus | null>(null);
   const [preview, setPreview] = useState<SyncPreview | null>(null);
   // Clock mirror for the preview card's expiry countdown, written from the
-  // interval below (never read during render, same rule as the live-ETA row).
-  // `null` while no preview is up, or when the preview carries no deadline.
+  // interval below and from each site that adopts a preview — never read during
+  // render, same rule as the live-ETA row. `null` only until the first preview
+  // of this mount is adopted: nothing resets it afterwards, because the reset
+  // would have to live in the countdown effect and a setState there is a lint
+  // error (react-hooks/set-state-in-effect). That costs nothing while EVERY
+  // adopter stamps it first — the invariant a third adopter must keep — since it
+  // is read only through `previewSecondsLeft`, i.e. only while a preview is up,
+  // and the interval refreshes it every second from then on.
   const [previewNowMs, setPreviewNowMs] = useState<number | null>(null);
   const [skipPreview, setSkipPreview] = useState(false);
   const [retroarchWarning, setRetroarchWarning] = useState<{ warning: boolean; current?: string } | null>(null);
@@ -494,6 +500,10 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
   const saveSortMigration = useSaveSortMigrationState();
   const downloads = useDownloads();
   const statusTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Whether the user has dismissed a preview since this mount. Read by the
+  // pending-preview restore, which cannot see the difference in state: a
+  // dismissed preview and one that never existed both leave `preview` null.
+  const previewDismissedRef = useRef(false);
   // The run this panel is watching, by id, and whether its end has been handled.
   // Seeded at first render — BEFORE the subscription below exists, so the mount
   // seed's own write is measured against the state it replaced rather than against
@@ -553,11 +563,20 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
         if (!answer.success || !answer.preview) return;
         const restored = answer.preview;
         // Same reasoning as the getSyncStatus seed above: this answer describes
-        // the world as it was when the read was ISSUED, so anything that happened
-        // since outranks it. A run started in that window owns the panel — the
-        // store, not this read, is authoritative about a sync being in flight —
-        // and a preview the user produced or dismissed in it is the one they are
-        // looking at, so the functional update lets the restored one lose.
+        // the world as it was when the read was ISSUED, so anything the user did
+        // since outranks it. A preview they produced in that window is the one
+        // they are looking at (the functional update below lets the restored one
+        // lose), and a preview they DISMISSED is one the backend has already been
+        // told to discard — restoring it would put back a card whose Apply can
+        // only answer stale_preview, which is the failure this whole change
+        // exists to remove. State cannot tell the two apart (both leave `cur`
+        // null), so the dismissal is recorded in a ref.
+        //
+        // The run check is belt-and-braces: the backend withholds a staged
+        // preview while a run is in flight, precisely because this store can be
+        // wrong here — an apply refused with sync_in_progress retracts the
+        // optimistic running flag while the backend keeps the delta (#1202).
+        if (previewDismissedRef.current) return;
         if (getSyncProgress().running) return;
         setPreviewNowMs(Date.now());
         setPreview((cur) => cur ?? restored);
@@ -867,6 +886,9 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
   };
 
   const handleDismiss = async () => {
+    // The user has answered the preview question: whatever the mount read is
+    // still holding is a snapshot the backend is being told to discard.
+    previewDismissedRef.current = true;
     setPreview(null);
     setStatus(null);
     try {

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -778,21 +778,22 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
     };
   }, []);
 
-  // Drive the preview card's expiry countdown. The deadline is absolute, so the
-  // only thing that has to tick is the current time — mirrored into state here
-  // rather than read in render, which must stay pure. The first value is stamped
-  // by whoever adopts the preview (both are handlers); this only keeps it moving,
-  // and is torn down when the preview goes away (dismissed, applied, or the panel
-  // unmounting). The condition is the countdown row's own: a preview without a
-  // deadline (older backend) and one with nothing to apply both show no
-  // countdown, and a tick that nothing on screen can consume is a wasted
-  // re-render of the whole page every second.
   // A run in flight owns the panel. A preview held while one is going is not
   // dropped — the store keeps it and the card comes back the moment the run
   // ends — but it must not render over the progress rows, which are the true
   // state of the machine at that moment. The two only ever overlap for the
   // instant between a preview being staged and its run's terminal frame.
   const previewCard = syncing ? null : preview;
+  // Drive the card's expiry countdown. The deadline is absolute, so the only
+  // thing that has to tick is the current time — mirrored into state here rather
+  // than read in render, which must stay pure. The first value is stamped by the
+  // handlers a preview can reach this instance through (the Sync press, the mount
+  // read, the terminal frame); this only keeps it moving, and is torn down when
+  // the card goes away (dismissed, applied, hidden by a run, or the panel
+  // unmounting). The condition is the countdown row's own: a preview without a
+  // deadline (older backend) and one with nothing to apply both show no
+  // countdown, and a tick that nothing on screen can consume is a wasted
+  // re-render of the whole page every second.
   const previewCountdownDeadline = previewCard && previewHasChanges(previewCard) ? previewCard.expires_at : undefined;
   useEffect(() => {
     if (previewCountdownDeadline === undefined) return;

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -675,54 +675,57 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
       .catch((e) => logError(`Failed to query sync status: ${e}`));
 
     /**
-     * The terminal half of the sync-progress subscriber: a run's once-per-run
-     * teardown, and — for the frame that follows it — the run's own account of how
-     * it ended. Called only from that subscriber, and only for a frame whose stage
-     * is terminal.
+     * The watched run has ended: everything that happens once per run.
      *
-     * WHICH of the two a frame is stays with the caller and is NOT re-derived
-     * here. Those verdicts are taken from the run refs before the refs move on and
-     * outside the caller's try, so a throw in here can never leave the panel
-     * believing a finished run is still live; recomputing them here would put that
-     * decision back inside the guarded region. The two cases are also never
-     * merged: the first frame ends the run, the second only replaces the text that
-     * ending left behind.
+     * Which of the three actions below a frame calls for is decided at the call
+     * site and never re-derived in any of them. Those verdicts are taken from the
+     * run refs before the refs move on and OUTSIDE the subscriber's try, so a
+     * throw in here can never leave the panel believing a finished run is still
+     * live; recomputing them inside would put that decision back into the guarded
+     * region. This is also why the run's ending and the correction that follows
+     * it are two functions rather than one with a mode: they are different
+     * actions, not one action told which way to behave.
      */
-    const applyTerminalFrame = (progress: SyncProgress, runEndedNow: boolean, laterTerminalFrame: boolean) => {
-      if (runEndedNow) {
-        // Tear down the run's live-ETA state (deadline included) so the next run
-        // measures fresh, and clear the display mirror.
-        resetEta();
-        setLiveEtaDisplay(null);
-        // True terminal reached — re-arm the button out of any "Cancelling…"
-        // drain state (#1202, RC-B).
-        setCancelling(false);
-        showTransientStatus(progress.message || "Sync finished", terminalStatusTone(progress.stage));
-        // A preview run that just ended may have staged a card this panel never
-        // received: `sync_preview` answers the instance that pressed Sync, and that
-        // instance is gone whenever the user left the page mid-run. Ask for it —
-        // unless the store already has it, which is the same run answering through
-        // the other door. A run that staged nothing (an apply, a cancel, Skip
-        // Preview) is answered `preview: null` and the store is left as it stands.
-        // Stamp the countdown's clock either way: this is where a preview can
-        // appear without this instance adopting it, and the impure now-read
-        // belongs in a handler.
-        setPreviewNowMs(Date.now());
-        if (getPendingPreviewSnapshot() === null) detach(refreshPendingPreview());
-        // Both re-reads are provoked by the run ending, so neither may join a read
-        // issued while it was still going — see the two AfterChange functions.
-        detach(refreshSyncStatsAfterChange());
-        // Refresh the live heap reading so the paused / high-heap banner reflects
-        // the run's end state (a pause leaves it high; a completed run may too).
-        detach(refreshSessionBudgetAfterChange());
-      } else if (laterTerminalFrame && progress.message) {
-        // The same run's second terminal signal. Everything above has already
-        // happened for this run; what this frame adds is the run's own account of
-        // how it ended, which replaces the text the merged sync_complete frame
-        // carried over from mid-run. A frame with no message of its own changes
-        // nothing rather than blanking the one already shown.
-        showTransientStatus(progress.message, terminalStatusTone(progress.stage));
-      }
+    const endWatchedRun = (progress: SyncProgress) => {
+      // Tear down the run's live-ETA state (deadline included) so the next run
+      // measures fresh, and clear the display mirror.
+      resetEta();
+      setLiveEtaDisplay(null);
+      // True terminal reached — re-arm the button out of any "Cancelling…"
+      // drain state (#1202, RC-B).
+      setCancelling(false);
+      showTransientStatus(progress.message || "Sync finished", terminalStatusTone(progress.stage));
+      // A preview run that just ended may have staged a card this panel never
+      // received: `sync_preview` answers the instance that pressed Sync, and that
+      // instance is gone whenever the user left the page mid-run. Ask for it —
+      // unless the store already has it, which is the same run answering through
+      // the other door. A run that staged nothing (an apply, a cancel, Skip
+      // Preview) is answered `preview: null` and the store is left as it stands.
+      // Stamp the countdown's clock either way: this is where a preview can
+      // appear without this instance adopting it, and the impure now-read
+      // belongs in a handler.
+      setPreviewNowMs(Date.now());
+      if (getPendingPreviewSnapshot() === null) detach(refreshPendingPreview());
+      // Both re-reads are provoked by the run ending, so neither may join a read
+      // issued while it was still going — see the two AfterChange functions.
+      detach(refreshSyncStatsAfterChange());
+      // Refresh the live heap reading so the paused / high-heap banner reflects
+      // the run's end state (a pause leaves it high; a completed run may too).
+      detach(refreshSessionBudgetAfterChange());
+    };
+
+    /**
+     * The same run's SECOND terminal signal, which ends nothing — {@link
+     * endWatchedRun} has already run for this run. What this frame adds is the
+     * run's own account of how it ended, replacing the text the merged
+     * sync_complete frame carried over from mid-run. A frame with no message of
+     * its own changes nothing rather than blanking what is already shown, which
+     * is why the message is a required argument: the caller's guard is the only
+     * place that decision is taken, and the signature makes calling without one
+     * impossible rather than merely wrong.
+     */
+    const correctTerminalWording = (message: string, stage: SyncProgress["stage"]) => {
+      showTransientStatus(message, terminalStatusTone(stage));
     };
 
     /**
@@ -796,13 +799,15 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
       } else if (progress.message && (progress.total || progress.totalSteps)) {
         setCarriedFineDetail(progress.message);
       }
+      // A terminal frame that is neither verdict — the stored one a mount merely
+      // finds, watching nothing (#1019) — matches no arm and does nothing, which
+      // is the whole of what it should do.
       try {
-        if (terminal) {
-          // A terminal frame that is neither verdict — the stored one a mount
-          // merely finds, watching nothing (#1019) — reaches this call and does
-          // nothing, exactly as it fell out of the chain this replaced.
-          applyTerminalFrame(progress, runEndedNow, laterTerminalFrame);
-        } else {
+        if (runEndedNow) {
+          endWatchedRun(progress);
+        } else if (laterTerminalFrame && progress.message) {
+          correctTerminalWording(progress.message, progress.stage);
+        } else if (!terminal) {
           advanceLiveEta(progress);
         }
       } catch (e) {

--- a/src/types/sync.ts
+++ b/src/types/sync.ts
@@ -272,6 +272,22 @@ export interface SyncPreview {
 }
 
 /**
+ * Answer of ``get_sync_status``: the latest progress frame, plus the backend's
+ * run-lifecycle state as a fact of its own.
+ *
+ * `inFlight` rides this answer only — never an emitted `sync_progress` event —
+ * and it is not a re-reading of the frame's `running`. The two disagree by
+ * design: during a cancel drain the terminal frame already reads
+ * `running: false` while the run still owns the slot. A panel needs the
+ * distinction because a frame cannot tell it "the backend has no run" apart from
+ * "the backend has not said anything about this run yet", and only the first of
+ * those licenses retracting a run the panel believes is live.
+ */
+export interface SyncStatusAnswer extends SyncProgress {
+  inFlight?: boolean;
+}
+
+/**
  * Answer of ``get_pending_preview`` — the preview the backend is still holding,
  * which is how a panel that was navigated away from gets its card back. A
  * ``null`` preview is the normal "nothing pending" answer (including a snapshot

--- a/src/types/sync.ts
+++ b/src/types/sync.ts
@@ -260,6 +260,26 @@ export interface SyncPreview {
    * ``false`` when the reading is unavailable or the run fits under the budget.
    */
   pause_likely?: boolean;
+  /**
+   * Absolute wall-clock deadline (epoch SECONDS) the backend stops accepting
+   * this preview at — 30 minutes after it was computed. Absolute rather than a
+   * remaining-seconds count because the plugin and the panel share a machine
+   * and a clock, and a deadline survives the Deck suspending where a locally
+   * counted-down number does not. Absent on older backends; the card then shows
+   * no countdown and behaves exactly as it did before.
+   */
+  expires_at?: number;
+}
+
+/**
+ * Answer of ``get_pending_preview`` — the preview the backend is still holding,
+ * which is how a panel that was navigated away from gets its card back. A
+ * ``null`` preview is the normal "nothing pending" answer (including a snapshot
+ * the backend dropped as expired), not a failure.
+ */
+export interface PendingPreviewAnswer {
+  success: boolean;
+  preview: SyncPreview | null;
 }
 
 export interface SyncPlanUnit {

--- a/src/utils/pendingPreviewStore.test.tsx
+++ b/src/utils/pendingPreviewStore.test.tsx
@@ -1,0 +1,204 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, act } from "@testing-library/react";
+import { createElement } from "react";
+import {
+  usePendingPreview,
+  getPendingPreviewSnapshot,
+  onPendingPreviewChange,
+  adoptPreview,
+  clearPendingPreview,
+  refreshPendingPreview,
+  resetPendingPreviewStoreForTests,
+} from "./pendingPreviewStore";
+import * as backend from "../api/backend";
+import type { SyncPreview } from "../types";
+
+vi.mock("../api/backend", () => ({
+  getPendingPreview: vi.fn(),
+  logError: vi.fn(),
+}));
+
+function preview(id: string): SyncPreview {
+  return {
+    success: true,
+    summary: {
+      new_count: 1,
+      changed_count: 0,
+      unchanged_count: 0,
+      remove_count: 0,
+      disabled_platform_remove_count: 0,
+    },
+    new_names: ["a"],
+    changed_names: [],
+    preview_id: id,
+  };
+}
+
+/** A promise plus the handle to settle it, so a test can hold a read open
+ *  across a user answer and decide when it lands. */
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void; reject: (e: unknown) => void } {
+  let resolve!: (value: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("pendingPreviewStore", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    resetPendingPreviewStoreForTests();
+    vi.mocked(backend.getPendingPreview).mockResolvedValue({ success: true, preview: null });
+  });
+
+  it("starts empty and hands the same snapshot back until it changes", () => {
+    // The useSyncExternalStore contract: React compares snapshots by identity,
+    // so a getter that allocates per call re-renders forever.
+    expect(getPendingPreviewSnapshot()).toBeNull();
+    const held = preview("p1");
+    adoptPreview(held);
+    expect(getPendingPreviewSnapshot()).toBe(held);
+    expect(getPendingPreviewSnapshot()).toBe(getPendingPreviewSnapshot());
+  });
+
+  it("notifies subscribers on a change and stops on unsubscribe", () => {
+    const seen = vi.fn();
+    const unsubscribe = onPendingPreviewChange(seen);
+    adoptPreview(preview("p1"));
+    expect(seen).toHaveBeenCalledTimes(1);
+    clearPendingPreview();
+    expect(seen).toHaveBeenCalledTimes(2);
+    unsubscribe();
+    adoptPreview(preview("p2"));
+    expect(seen).toHaveBeenCalledTimes(2);
+  });
+
+  it("stays silent when a write installs the value already stored", () => {
+    const held = preview("p1");
+    adoptPreview(held);
+    const seen = vi.fn();
+    onPendingPreviewChange(seen);
+    adoptPreview(held);
+    expect(seen).not.toHaveBeenCalled();
+    clearPendingPreview();
+    clearPendingPreview();
+    expect(seen).toHaveBeenCalledTimes(1);
+  });
+
+  it("fills from the backend's staged snapshot", async () => {
+    vi.mocked(backend.getPendingPreview).mockResolvedValue({ success: true, preview: preview("staged") });
+    await refreshPendingPreview();
+    expect(getPendingPreviewSnapshot()?.preview_id).toBe("staged");
+  });
+
+  it("a read cannot restore a card the user answered while it was open", async () => {
+    // The ordering rule: the read describes a world in which the dismiss had not
+    // happened, so the dismiss — issued later — outranks it.
+    const read = deferred<{ success: boolean; preview: SyncPreview | null }>();
+    vi.mocked(backend.getPendingPreview).mockReturnValue(read.promise);
+    const inFlight = refreshPendingPreview();
+
+    clearPendingPreview();
+    read.resolve({ success: true, preview: preview("dismissed") });
+    await inFlight;
+
+    expect(getPendingPreviewSnapshot()).toBeNull();
+  });
+
+  it("a read cannot overwrite a preview produced while it was open", async () => {
+    const read = deferred<{ success: boolean; preview: SyncPreview | null }>();
+    vi.mocked(backend.getPendingPreview).mockReturnValue(read.promise);
+    const inFlight = refreshPendingPreview();
+
+    adoptPreview(preview("fresh"));
+    read.resolve({ success: true, preview: preview("older") });
+    await inFlight;
+
+    expect(getPendingPreviewSnapshot()?.preview_id).toBe("fresh");
+  });
+
+  it("between two reads the one asked for last wins, whichever answers first", async () => {
+    const first = deferred<{ success: boolean; preview: SyncPreview | null }>();
+    const second = deferred<{ success: boolean; preview: SyncPreview | null }>();
+    vi.mocked(backend.getPendingPreview).mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
+    const a = refreshPendingPreview();
+    const b = refreshPendingPreview();
+
+    second.resolve({ success: true, preview: preview("newer") });
+    await b;
+    first.resolve({ success: true, preview: preview("older") });
+    await a;
+
+    expect(getPendingPreviewSnapshot()?.preview_id).toBe("newer");
+  });
+
+  it("a null answer never drops a preview the store holds", async () => {
+    // `preview: null` conflates nothing-staged, aged-out and withheld-while-a-
+    // run-is-in-flight, so it is not evidence that this card is gone.
+    adoptPreview(preview("held"));
+    vi.mocked(backend.getPendingPreview).mockResolvedValue({ success: true, preview: null });
+
+    await refreshPendingPreview();
+
+    expect(getPendingPreviewSnapshot()?.preview_id).toBe("held");
+  });
+
+  it("an unsuccessful answer never drops a preview the store holds", async () => {
+    adoptPreview(preview("held"));
+    vi.mocked(backend.getPendingPreview).mockResolvedValue({ success: false, preview: preview("ignored") });
+
+    await refreshPendingPreview();
+
+    expect(getPendingPreviewSnapshot()?.preview_id).toBe("held");
+  });
+
+  it("logs a rejected read and leaves the store as it stands", async () => {
+    adoptPreview(preview("held"));
+    vi.mocked(backend.getPendingPreview).mockRejectedValue(new Error("boom"));
+
+    await expect(refreshPendingPreview()).resolves.toBeUndefined();
+
+    expect(vi.mocked(backend.logError)).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to query pending preview"),
+    );
+    expect(getPendingPreviewSnapshot()?.preview_id).toBe("held");
+  });
+
+  it("a failed read is not an answer — a later read still applies", async () => {
+    const failing = deferred<{ success: boolean; preview: SyncPreview | null }>();
+    vi.mocked(backend.getPendingPreview).mockReturnValueOnce(failing.promise);
+    const rejected = refreshPendingPreview();
+    failing.reject(new Error("boom"));
+    await rejected;
+
+    vi.mocked(backend.getPendingPreview).mockResolvedValue({ success: true, preview: preview("after") });
+    await refreshPendingPreview();
+
+    expect(getPendingPreviewSnapshot()?.preview_id).toBe("after");
+  });
+
+  it("re-renders a subscribed component once per change, and never loops", () => {
+    // The snapshot-identity discipline, observed from React's side: a getter that
+    // allocated per call would re-render without end here rather than twice.
+    let renders = 0;
+    const Probe = () => {
+      renders += 1;
+      return createElement("div", null, usePendingPreview()?.preview_id ?? "none");
+    };
+    const { container, unmount } = render(createElement(Probe));
+    expect(container.textContent).toBe("none");
+    const atStart = renders;
+
+    act(() => adoptPreview(preview("p1")));
+    expect(container.textContent).toBe("p1");
+    act(() => clearPendingPreview());
+    expect(container.textContent).toBe("none");
+    expect(renders).toBe(atStart + 2);
+
+    unmount();
+    adoptPreview(preview("p2"));
+    expect(renders).toBe(atStart + 2);
+  });
+});

--- a/src/utils/pendingPreviewStore.ts
+++ b/src/utils/pendingPreviewStore.ts
@@ -32,6 +32,13 @@
  * them. Between two reads the same rule holds: the one asked for last wins,
  * whichever answers first.
  *
+ * The answer verbs are not absolute, and must not be: a read ISSUED AFTER a
+ * discard legitimately outranks it, because by then the backend has been told
+ * and is answering about what it holds now — a fresh preview computed since, or
+ * nothing. So what protects a dismissal is not the verb being privileged, it is
+ * the ordering: no read that was already open when the user answered can apply.
+ * A verb that stopped taking a ticket would lose to every read in flight.
+ *
  * **A read only ever FILLS, never clears.** `get_pending_preview` answers
  * `preview: null` for three different situations — nothing is staged, the
  * snapshot aged out, and it is being withheld because a run is in flight — and

--- a/src/utils/pendingPreviewStore.ts
+++ b/src/utils/pendingPreviewStore.ts
@@ -1,0 +1,129 @@
+/**
+ * Module-level owner of the pending sync preview — the delta the backend has
+ * computed and is holding, between the preview run that produced it and the
+ * answer the user gives it (Apply, Dismiss, or a fresh Sync press).
+ *
+ * **Why this fact is not component state, when panel rendering state normally
+ * is.** The preview outlives the panel instance that asked for it. `sync_preview`
+ * is an awaited callable, so its answer is delivered to the closure of whichever
+ * `MainPage` pressed Sync — and leaving the main page unmounts that instance
+ * while the run keeps going. A `setPreview` in that closure then lands on a dead
+ * component, and the instance actually on screen shows the idle Sync buttons
+ * over a preview the backend is holding, inviting a second run on top of the
+ * first. Storing the answer where the backend's own lifetime can reach it — a
+ * module store, outliving every mount — is what makes the card survive.
+ *
+ * **This is not a second source of truth.** The backend owns the preview; this
+ * store holds its answer verbatim and is only ever filled from it. Nothing here
+ * derives, re-assembles, merges or repairs a preview, and no value that
+ * `sync_preview` or `get_pending_preview` did not hand over can enter. What was
+ * wrong was never that the panel rendered from state — it is that the *rendering*
+ * state was frozen inside one component instance while the fact it renders is
+ * owned by a process that outlives it.
+ *
+ * **Ordering.** Two kinds of writer meet here. A READ of the backend's staged
+ * snapshot ({@link refreshPendingPreview}) answers a round trip after it was
+ * issued, so it describes the world as it was at issue time. An ANSWER the user
+ * just produced ({@link adoptPreview}, {@link clearPendingPreview}) is true the
+ * moment it is written. Every write takes a ticket when its information was
+ * ISSUED and applies only if no later-issued write has already applied. So a
+ * dismiss beats a read already open — that read describes a world in which the
+ * user had not answered yet — and the read can never put the card back behind
+ * them. Between two reads the same rule holds: the one asked for last wins,
+ * whichever answers first.
+ *
+ * **A read only ever FILLS, never clears.** `get_pending_preview` answers
+ * `preview: null` for three different situations — nothing is staged, the
+ * snapshot aged out, and it is being withheld because a run is in flight — and
+ * the wire cannot tell them apart. A null answer is therefore not evidence that
+ * a preview this store holds is gone. Dropping one is the job of the explicit
+ * answer verbs alone; expiry is carried on screen by the card's own countdown.
+ */
+
+import { useSyncExternalStore } from "react";
+import { getPendingPreview, logError } from "../api/backend";
+import type { SyncPreview } from "../types";
+
+/** The stored answer, or `null` when nothing is pending. Handed out as the
+ *  `useSyncExternalStore` snapshot, which React compares by identity, so it is
+ *  only ever REPLACED and the getter never allocates — a getter handing back a
+ *  fresh object per call re-renders forever, and an in-place write would leave a
+ *  subscriber unable to tell that the preview moved. */
+let _preview: SyncPreview | null = null;
+/** Ticket of the most recently issued write. */
+let _issued = 0;
+/** Ticket of the newest write whose value has been applied. */
+let _applied = 0;
+const _listeners = new Set<() => void>();
+
+function notify(): void {
+  _listeners.forEach((fn) => fn());
+}
+
+/** Install a value unless a later-issued write has already applied one. */
+function apply(seq: number, value: SyncPreview | null): void {
+  if (seq <= _applied) return;
+  _applied = seq;
+  if (_preview === value) return;
+  _preview = value;
+  notify();
+}
+
+/** The preview as it stands, or `null` when nothing is pending. */
+export function getPendingPreviewSnapshot(): SyncPreview | null {
+  return _preview;
+}
+
+export function onPendingPreviewChange(fn: () => void): () => void {
+  _listeners.add(fn);
+  return () => {
+    _listeners.delete(fn);
+  };
+}
+
+/** Subscribe a component to the pending preview. Renders what is pending
+ *  immediately — the store outlives the panel, so a preview computed before this
+ *  mount, or answered to an instance that is already gone, is on screen at first
+ *  paint rather than a round trip later. */
+export function usePendingPreview(): SyncPreview | null {
+  return useSyncExternalStore(onPendingPreviewChange, getPendingPreviewSnapshot);
+}
+
+/** Hold a preview the backend has just handed back through `sync_preview`. True
+ *  the moment it is written, so it outranks every read already open. */
+export function adoptPreview(preview: SyncPreview): void {
+  apply(++_issued, preview);
+}
+
+/** The user has answered the preview question — dismissed the card, started its
+ *  apply, or pressed Sync for a fresh one. Also outranks every open read, which
+ *  is what keeps a mount read from restoring a card they just answered. */
+export function clearPendingPreview(): void {
+  apply(++_issued, null);
+}
+
+/**
+ * Ask the backend whether it is holding a preview for us, and hold it if so.
+ *
+ * Never rejects and never clears: a failed read is not an answer, and neither is
+ * a `null` one (see the module docstring). The failure is logged here, so a
+ * caller can fire this and forget it.
+ */
+export function refreshPendingPreview(): Promise<void> {
+  const seq = ++_issued;
+  return getPendingPreview().then(
+    (answer) => {
+      if (!answer.success || !answer.preview) return;
+      apply(seq, answer.preview);
+    },
+    (e) => logError(`Failed to query pending preview: ${e}`),
+  );
+}
+
+/** Reset the module state between tests. Not for production use. */
+export function resetPendingPreviewStoreForTests(): void {
+  _preview = null;
+  _issued = 0;
+  _applied = 0;
+  _listeners.clear();
+}

--- a/src/utils/syncEstimate.test.ts
+++ b/src/utils/syncEstimate.test.ts
@@ -7,6 +7,7 @@ import {
   estimateApplySeconds,
   estimatePlanSeconds,
   formatDuration,
+  formatTimeRemaining,
 } from "./syncEstimate";
 import type { SyncPlanUnit } from "../types/sync";
 
@@ -222,5 +223,30 @@ describe("formatDuration", () => {
 
   it("omits the minutes part on a whole-hour value", () => {
     expect(formatDuration(7200)).toBe("2 h");
+  });
+});
+
+describe("formatTimeRemaining", () => {
+  it("shows '< 1 min' for anything under a minute", () => {
+    expect(formatTimeRemaining(0)).toBe("< 1 min");
+    expect(formatTimeRemaining(59)).toBe("< 1 min");
+  });
+
+  it("floors to the minute rather than rounding, so it never promises more time than remains", () => {
+    // 89s = 1.48 min — formatDuration rounds this to "1 min" too, but 90s
+    // (exactly 1.5 min) is where the two part: rounding reads "2 min" for a
+    // deadline that is 90 seconds away.
+    expect(formatTimeRemaining(89)).toBe("1 min");
+    expect(formatTimeRemaining(90)).toBe("1 min");
+    expect(formatDuration(90)).toBe("2 min");
+    // 3599s is one second short of the hour and must not read "1 h".
+    expect(formatTimeRemaining(3599)).toBe("59 min");
+    expect(formatDuration(3599)).toBe("1 h");
+  });
+
+  it("renders the full TTL and the hour boundary", () => {
+    expect(formatTimeRemaining(1800)).toBe("30 min");
+    expect(formatTimeRemaining(3600)).toBe("1 h");
+    expect(formatTimeRemaining(4200)).toBe("1 h 10 min");
   });
 });

--- a/src/utils/syncEstimate.ts
+++ b/src/utils/syncEstimate.ts
@@ -168,3 +168,13 @@ export function formatApproxDuration(seconds: number, roundMinutes: (n: number) 
 export function formatDuration(seconds: number): string {
   return formatApproxDuration(seconds, Math.round, "");
 }
+
+/**
+ * Render the time left before a deadline — ``"< 1 min"``, ``"29 min"``,
+ * ``"1 h 10 min"``. Minutes are FLOORED, which is what separates this from
+ * ``formatDuration``: a readout counting down to a hard cutoff must never
+ * promise more time than remains, so 89 seconds reads "1 min", not "2 min".
+ */
+export function formatTimeRemaining(seconds: number): string {
+  return formatApproxDuration(seconds, Math.floor, "");
+}

--- a/src/utils/syncEstimate.ts
+++ b/src/utils/syncEstimate.ts
@@ -142,13 +142,25 @@ export function estimatePlanSeconds(units: readonly SyncPlanUnit[]): number {
 }
 
 /**
- * Shared coarse-duration renderer for the sync UI's two readouts. Renders
- * *seconds* as ``"< 1 min"`` under a minute, ``"N min"`` under an hour, and
- * ``"H h M min"`` / ``"H h"`` (on the hour) beyond, appending *suffix* to every
- * branch. *roundMinutes* controls the minute rounding: ``Math.round`` for the
- * neutral estimate, ``Math.ceil`` for the live countdown (which must never promise
- * less time than it expects). No ``~`` prefix — the coarse minute rounding already
- * reads as an estimate, and the tilde read as noise on-device.
+ * Shared coarse-duration renderer for the sync UI's three duration readouts.
+ * Renders *seconds* as ``"< 1 min"`` under a minute, ``"N min"`` under an hour,
+ * and ``"H h M min"`` / ``"H h"`` (on the hour) beyond, appending *suffix* to
+ * every branch. No ``~`` prefix — the coarse minute rounding already reads as an
+ * estimate, and the tilde read as noise on-device.
+ *
+ * *roundMinutes* is where the three part company, and the direction follows what
+ * the number would cost the reader if it were wrong:
+ *
+ * - ``Math.round`` (`formatDuration`) — the neutral estimate of how long a run
+ *   will take. Nothing depends on the error's sign, so it rounds to whichever
+ *   minute is nearer.
+ * - ``Math.ceil`` (`formatEtaCountdown`) — the live countdown of a run in
+ *   progress. It is a FORECAST, so it must never promise less time than it
+ *   expects: a run that outlives its own countdown reads as stuck.
+ * - ``Math.floor`` (`formatTimeRemaining`) — the time left before a hard cutoff,
+ *   which the preview card counts down to. The deadline is a fact rather than a
+ *   forecast, so the honest error is the opposite one: never promise more time
+ *   than remains, or the card offers an Apply that is already refused.
  */
 export function formatApproxDuration(seconds: number, roundMinutes: (n: number) => number, suffix: string): string {
   if (seconds < 60) return `< 1 min${suffix}`;
@@ -173,7 +185,7 @@ export function formatDuration(seconds: number): string {
  * Render the time left before a deadline — ``"< 1 min"``, ``"29 min"``,
  * ``"1 h 10 min"``. Minutes are FLOORED, which is what separates this from
  * ``formatDuration``: a readout counting down to a hard cutoff must never
- * promise more time than remains, so 89 seconds reads "1 min", not "2 min".
+ * promise more time than remains, so 90 seconds reads "1 min", not "2 min".
  */
 export function formatTimeRemaining(seconds: number): string {
   return formatApproxDuration(seconds, Math.floor, "");

--- a/tests/contract/test_pending_preview.py
+++ b/tests/contract/test_pending_preview.py
@@ -1,0 +1,72 @@
+"""Contract tests for ``get_pending_preview`` — the preview a remounted panel asks for.
+
+The QAM panel loses its preview card whenever the user navigates into a
+submenu, while the backend goes on holding the staged snapshot for its full
+TTL. This callable is how the panel gets the card back, so what it returns has
+to be exactly the payload ``sync_preview`` answered with — including the
+absolute ``expires_at`` deadline the card counts down against — and "nothing
+pending" has to read as a normal answer rather than a failure.
+
+Driven through the real callables over the real wired plugin.
+"""
+
+from __future__ import annotations
+
+
+def _seed_one_platform(harness):
+    harness.romm.platforms = [{"id": 1, "name": "N64", "slug": "n64", "rom_count": 1}]
+    harness.romm.roms[10] = {
+        "id": 10,
+        "name": "Game",
+        "platform_id": 1,
+        "platform_name": "N64",
+        "platform_slug": "n64",
+    }
+    harness.plugin.settings["enabled_platforms"] = {"1": True}
+
+
+async def test_nothing_pending_is_a_success_not_a_failure(harness):
+    """No preview staged is a normal answer — the failure shape is for failures."""
+    assert await harness.plugin.get_pending_preview() == {"success": True, "preview": None}
+
+
+async def test_restores_the_payload_sync_preview_answered_with(harness):
+    _seed_one_platform(harness)
+
+    fresh = await harness.plugin.sync_preview()
+    restored = await harness.plugin.get_pending_preview()
+
+    assert fresh["success"] is True
+    assert restored == {"success": True, "preview": fresh}
+    # The restored card counts down against the same absolute deadline the
+    # fresh one did, so both render identically.
+    preview = restored["preview"]
+    assert preview is not None
+    assert preview["expires_at"] == fresh["expires_at"]
+
+
+async def test_restored_preview_id_still_applies(harness):
+    """The point of restoring the card: its Apply Sync must still be honoured."""
+    _seed_one_platform(harness)
+    await harness.plugin.sync_preview()
+
+    restored = await harness.plugin.get_pending_preview()
+    preview = restored["preview"]
+    assert preview is not None
+
+    applied = await harness.plugin.sync_apply_delta(preview["preview_id"])
+    assert applied == {"success": True, "message": "Applying changes"}
+
+
+async def test_over_age_snapshot_is_dropped(harness):
+    """Past the TTL the read answers "nothing pending" and clears the staged
+    snapshot, on the same rule the apply refuses it by."""
+    _seed_one_platform(harness)
+    await harness.plugin.sync_preview()
+    box = harness.plugin._sync_service._box
+    assert box.pending_delta is not None
+
+    harness.plugin._sync_service._orchestrator._clock.advance(1801)
+
+    assert await harness.plugin.get_pending_preview() == {"success": True, "preview": None}
+    assert box.pending_delta is None

--- a/tests/contract/test_pending_preview.py
+++ b/tests/contract/test_pending_preview.py
@@ -58,6 +58,32 @@ async def test_restored_preview_id_still_applies(harness):
     assert applied == {"success": True, "message": "Applying changes"}
 
 
+async def test_withheld_while_a_run_is_in_flight_then_handed_back(harness):
+    """A run in flight owns the panel: the callable answers "nothing pending"
+    rather than a card the frontend would render over the run's progress rows.
+
+    The frontend cannot be the authority here — an apply refused with
+    ``sync_in_progress`` retracts its optimistic running flag while the backend
+    deliberately keeps the delta (#1202), so its store says idle during a live
+    run. Withheld, not discarded: once the run ends the same payload comes back.
+    """
+    _seed_one_platform(harness)
+    fresh = await harness.plugin.sync_preview()
+    box = harness.plugin._sync_service._box
+    assert box.try_begin_run("run-1") is True
+
+    assert await harness.plugin.get_pending_preview() == {"success": True, "preview": None}
+    assert box.pending_delta is not None
+
+    # An overlapping apply keeps its own refusal — the withholding is the
+    # restore reader's alone and must not leak into the apply's verdict.
+    rejected = await harness.plugin.sync_apply_delta(fresh["preview_id"])
+    assert rejected == {"success": False, "reason": "sync_in_progress", "message": "Sync already in progress"}
+
+    box.finish_run("run-1")
+    assert await harness.plugin.get_pending_preview() == {"success": True, "preview": fresh}
+
+
 async def test_over_age_snapshot_is_dropped(harness):
     """Past the TTL the read answers "nothing pending" and clears the staged
     snapshot, on the same rule the apply refuses it by."""

--- a/tests/contract/test_sync_read.py
+++ b/tests/contract/test_sync_read.py
@@ -28,7 +28,12 @@ from ._seed import seed_platform_stamp, seed_rom
 
 
 async def test_get_sync_status_idle_shape(harness):
-    """Idle: every progress field present; running is False."""
+    """Idle: every progress field present; running is False; the lifecycle says so too.
+
+    ``inFlight`` is the run-lifecycle state carried alongside the frame, and the
+    frontend reads it as evidence rather than inferring "no run" from a frame
+    that may be a leftover — so it belongs in the pinned wire shape.
+    """
     result = await harness.plugin.get_sync_status()
     assert result == {
         "running": False,
@@ -39,6 +44,7 @@ async def test_get_sync_status_idle_shape(harness):
         "step": 0,
         "totalSteps": 0,
         "runId": "",
+        "inFlight": False,
     }
     assert result["running"] is False
     for key in ("current", "total", "step", "totalSteps"):

--- a/tests/domain/test_preview_delta.py
+++ b/tests/domain/test_preview_delta.py
@@ -1,8 +1,10 @@
 """Unit tests for ``domain.preview_delta.PreviewDelta``.
 
-The dataclass is pure data — its contract is "all 4 fields are required,
-immutable, and exposed as typed attributes". Tests cover construction,
-frozen semantics, and the zero-counts boundary case.
+The dataclass is pure data — its contract is "all fields are required,
+immutable, and exposed as typed attributes", plus the one TTL predicate the
+apply path and the pending-preview read share. Tests cover construction,
+frozen semantics, the zero-counts boundary case, and both sides of the TTL
+boundary.
 """
 
 from __future__ import annotations
@@ -12,7 +14,7 @@ from typing import Any
 
 import pytest
 
-from domain.preview_delta import PreviewDelta
+from domain.preview_delta import PreviewDelta, preview_expires_at
 
 
 def _build(**overrides) -> PreviewDelta:
@@ -21,6 +23,7 @@ def _build(**overrides) -> PreviewDelta:
         "created_at": 1_700_000_000.0,
         "platforms_count": 2,
         "total_roms": 3,
+        "answer": {"success": True, "preview_id": "preview-abc"},
     }
     defaults.update(overrides)
     return PreviewDelta(**defaults)
@@ -32,6 +35,7 @@ def test_construction_exposes_all_fields_as_attributes() -> None:
     assert delta.created_at == 1_700_000_000.0
     assert delta.platforms_count == 2
     assert delta.total_roms == 3
+    assert delta.answer == {"success": True, "preview_id": "preview-abc"}
 
 
 def test_is_frozen_attribute_rebinding_raises() -> None:
@@ -52,3 +56,17 @@ def test_equality_by_field_values() -> None:
     assert a == b
     c = _build(preview_id="preview-xyz")
     assert a != c
+
+
+def test_expires_at_is_creation_plus_max_age() -> None:
+    assert preview_expires_at(1_700_000_000.0, 1800) == 1_700_001_800.0
+
+
+def test_not_expired_at_the_deadline_itself() -> None:
+    delta = _build()
+    assert delta.is_expired(1_700_001_800.0, 1800) is False
+
+
+def test_expired_one_second_past_the_deadline() -> None:
+    delta = _build()
+    assert delta.is_expired(1_700_001_801.0, 1800) is True

--- a/tests/domain/test_preview_delta.py
+++ b/tests/domain/test_preview_delta.py
@@ -3,8 +3,7 @@
 The dataclass is pure data — its contract is "all fields are required,
 immutable, and exposed as typed attributes", plus the one TTL predicate the
 apply path and the pending-preview read share. Tests cover construction,
-frozen semantics, the zero-counts boundary case, and both sides of the TTL
-boundary.
+frozen semantics, equality, and both sides of the TTL boundary.
 """
 
 from __future__ import annotations
@@ -21,8 +20,6 @@ def _build(**overrides) -> PreviewDelta:
     defaults: dict[str, Any] = {
         "preview_id": "preview-abc",
         "created_at": 1_700_000_000.0,
-        "platforms_count": 2,
-        "total_roms": 3,
         "answer": {"success": True, "preview_id": "preview-abc"},
     }
     defaults.update(overrides)
@@ -33,8 +30,6 @@ def test_construction_exposes_all_fields_as_attributes() -> None:
     delta = _build()
     assert delta.preview_id == "preview-abc"
     assert delta.created_at == 1_700_000_000.0
-    assert delta.platforms_count == 2
-    assert delta.total_roms == 3
     assert delta.answer == {"success": True, "preview_id": "preview-abc"}
 
 
@@ -42,12 +37,6 @@ def test_is_frozen_attribute_rebinding_raises() -> None:
     delta = _build()
     with pytest.raises(FrozenInstanceError):
         delta.preview_id = "other"  # type: ignore[misc]
-
-
-def test_zero_counts_are_accepted() -> None:
-    delta = _build(platforms_count=0, total_roms=0)
-    assert delta.platforms_count == 0
-    assert delta.total_roms == 0
 
 
 def test_equality_by_field_values() -> None:

--- a/tests/services/library/test_state.py
+++ b/tests/services/library/test_state.py
@@ -328,6 +328,46 @@ class TestPreviewSnapshot:
         box = LibrarySyncStateBox()
         assert box.read_fresh_preview(self._CREATED_AT) is None
 
+    def test_restorable_read_withholds_while_a_run_is_in_flight(self):
+        """A panel remounting mid-run must show the run, not a card that would
+        render over its progress rows — but the snapshot is only withheld."""
+        box = self._staged_box()
+        box.try_begin_run("run-1")
+
+        assert box.read_restorable_preview(self._CREATED_AT) is None
+        # Withheld, NOT discarded.
+        assert box.pending_delta is not None
+        # A cancelling run is still in flight, so it withholds too.
+        box.request_cancel("run-1")
+        assert box.read_restorable_preview(self._CREATED_AT) is None
+        assert box.pending_delta is not None
+
+    def test_restorable_read_hands_the_snapshot_back_once_the_run_ends(self):
+        box = self._staged_box()
+        box.try_begin_run("run-1")
+        box.read_restorable_preview(self._CREATED_AT)
+
+        box.finish_run("run-1")
+
+        delta = box.read_restorable_preview(self._CREATED_AT)
+        assert delta is not None
+        assert delta.preview_id == "pv-1"
+
+    def test_restorable_read_still_refuses_an_over_age_snapshot(self):
+        box = self._staged_box()
+
+        assert box.read_restorable_preview(self._CREATED_AT + PREVIEW_MAX_AGE_SECONDS + 1) is None
+        assert box.pending_delta is None
+
+    def test_in_flight_withholding_does_not_reach_the_apply_path_read(self):
+        """``read_fresh_preview`` is the apply's age check and must stay
+        run-blind: an overlapping apply is refused by the run-slot claim with
+        its own reason, never rewritten into a staleness verdict."""
+        box = self._staged_box()
+        box.try_begin_run("run-1")
+
+        assert box.read_fresh_preview(self._CREATED_AT) is not None
+
     def test_matches_is_identity_only_and_ignores_age(self):
         box = self._staged_box()
 

--- a/tests/services/library/test_state.py
+++ b/tests/services/library/test_state.py
@@ -1,10 +1,13 @@
-"""Tests for the ``LibrarySyncStateBox`` run-lifecycle verb methods.
+"""Tests for the ``LibrarySyncStateBox`` verb methods.
 
-The box's four verbs (``try_begin_run`` / ``request_cancel`` / ``finish_run`` /
-``is_in_flight``) are the only writers of the run-lifecycle pair
-(``sync_state`` / ``current_sync_id``). These tests pin the compare-and-swap
-admission, the run-scoped cancel routing, and the compare-and-reset terminal so
-a rapid Sync/Cancel can't leave a half-reset run id (#1202).
+The box's four run-lifecycle verbs (``try_begin_run`` / ``request_cancel`` /
+``finish_run`` / ``is_in_flight``) are the only writers of the run-lifecycle
+pair (``sync_state`` / ``current_sync_id``). These tests pin the
+compare-and-swap admission, the run-scoped cancel routing, and the
+compare-and-reset terminal so a rapid Sync/Cancel can't leave a half-reset run
+id (#1202). The preview-snapshot verbs (``stage_preview`` /
+``read_fresh_preview`` / ``matches_preview`` / ``discard_preview``) are the
+only writers of ``pending_delta``, and carry the TTL with it.
 """
 
 from __future__ import annotations
@@ -12,7 +15,7 @@ from __future__ import annotations
 import asyncio
 
 from domain.sync_state import SyncState
-from services.library._state import AbandonedChunk, LibrarySyncStateBox
+from services.library._state import PREVIEW_MAX_AGE_SECONDS, AbandonedChunk, LibrarySyncStateBox
 
 
 class TestTryBeginRun:
@@ -255,6 +258,109 @@ class TestAbandonedChunkStash:
     def test_take_returns_none_when_no_stash(self):
         box = LibrarySyncStateBox()
         assert box.take_abandoned_chunk("run-1", 5, 2) is None
+
+
+class TestPreviewSnapshot:
+    """The staged preview's whole lifetime: stage, read-if-fresh, match, discard.
+
+    These four verbs are the only writers of ``pending_delta``. The TTL is the
+    box's (``PREVIEW_MAX_AGE_SECONDS``), applied against a caller-supplied
+    ``now`` so the box stays clock-free.
+    """
+
+    _CREATED_AT = 1_700_000_000.0
+
+    def _staged_box(self, preview_id: str = "pv-1") -> LibrarySyncStateBox:
+        box = LibrarySyncStateBox()
+        box.stage_preview(
+            preview_id=preview_id,
+            created_at=self._CREATED_AT,
+            platforms_count=2,
+            total_roms=7,
+            answer={"success": True, "preview_id": preview_id},
+        )
+        return box
+
+    def test_stage_holds_every_field_including_the_answer(self):
+        box = self._staged_box()
+
+        delta = box.pending_delta
+        assert delta is not None
+        assert delta.preview_id == "pv-1"
+        assert delta.created_at == self._CREATED_AT
+        assert delta.platforms_count == 2
+        assert delta.total_roms == 7
+        assert delta.answer == {"success": True, "preview_id": "pv-1"}
+
+    def test_stage_replaces_an_earlier_snapshot(self):
+        box = self._staged_box("pv-old")
+
+        box.stage_preview(
+            preview_id="pv-new",
+            created_at=self._CREATED_AT,
+            platforms_count=0,
+            total_roms=0,
+            answer={"success": True, "preview_id": "pv-new"},
+        )
+
+        assert box.matches_preview("pv-new") is True
+        assert box.matches_preview("pv-old") is False
+
+    def test_read_returns_the_snapshot_inside_the_ttl(self):
+        box = self._staged_box()
+
+        delta = box.read_fresh_preview(self._CREATED_AT + PREVIEW_MAX_AGE_SECONDS)
+
+        assert delta is not None
+        assert delta.preview_id == "pv-1"
+        # A read inside the window consumes nothing.
+        assert box.pending_delta is delta
+
+    def test_read_discards_the_snapshot_past_the_ttl(self):
+        box = self._staged_box()
+
+        assert box.read_fresh_preview(self._CREATED_AT + PREVIEW_MAX_AGE_SECONDS + 1) is None
+        # Dropped on the way out, so no later caller is handed one the apply
+        # would refuse.
+        assert box.pending_delta is None
+
+    def test_read_returns_none_when_nothing_staged(self):
+        box = LibrarySyncStateBox()
+        assert box.read_fresh_preview(self._CREATED_AT) is None
+
+    def test_matches_is_identity_only_and_ignores_age(self):
+        box = self._staged_box()
+
+        assert box.matches_preview("pv-1") is True
+        assert box.matches_preview("pv-other") is False
+        # Still a match long past the TTL — age is the read's verdict, not this one.
+        assert box.matches_preview("pv-1") is True
+        assert box.pending_delta is not None
+
+    def test_matches_is_false_when_nothing_staged(self):
+        box = LibrarySyncStateBox()
+        assert box.matches_preview("pv-1") is False
+
+    def test_discard_drops_the_snapshot_and_is_idempotent(self):
+        box = self._staged_box()
+
+        box.discard_preview()
+        assert box.pending_delta is None
+        box.discard_preview()
+        assert box.pending_delta is None
+
+    def test_preview_verbs_leave_the_run_lifecycle_alone(self):
+        """The staged preview is not run state: staging or dropping it must never
+        admit, cancel or end a run."""
+        box = self._staged_box()
+        assert box.sync_state is SyncState.IDLE
+        assert box.current_sync_id is None
+
+        box.read_fresh_preview(self._CREATED_AT)
+        box.discard_preview()
+
+        assert box.sync_state is SyncState.IDLE
+        assert box.current_sync_id is None
 
 
 class TestIsInFlight:

--- a/tests/services/library/test_state.py
+++ b/tests/services/library/test_state.py
@@ -275,8 +275,6 @@ class TestPreviewSnapshot:
         box.stage_preview(
             preview_id=preview_id,
             created_at=self._CREATED_AT,
-            platforms_count=2,
-            total_roms=7,
             answer={"success": True, "preview_id": preview_id},
         )
         return box
@@ -288,8 +286,6 @@ class TestPreviewSnapshot:
         assert delta is not None
         assert delta.preview_id == "pv-1"
         assert delta.created_at == self._CREATED_AT
-        assert delta.platforms_count == 2
-        assert delta.total_roms == 7
         assert delta.answer == {"success": True, "preview_id": "pv-1"}
 
     def test_stage_replaces_an_earlier_snapshot(self):
@@ -298,8 +294,6 @@ class TestPreviewSnapshot:
         box.stage_preview(
             preview_id="pv-new",
             created_at=self._CREATED_AT,
-            platforms_count=0,
-            total_roms=0,
             answer={"success": True, "preview_id": "pv-new"},
         )
 

--- a/tests/services/library/test_state.py
+++ b/tests/services/library/test_state.py
@@ -17,7 +17,12 @@ from __future__ import annotations
 import asyncio
 
 from domain.sync_state import SyncState
-from services.library._state import PREVIEW_MAX_AGE_SECONDS, AbandonedChunk, LibrarySyncStateBox
+from services.library._state import (
+    PREVIEW_MAX_AGE_SECONDS,
+    AbandonedChunk,
+    LibrarySyncStateBox,
+    _default_progress,
+)
 
 
 class TestTryBeginRun:
@@ -118,6 +123,37 @@ class TestFinishRun:
         assert box.finish_run("run-A") is False
         assert box.sync_state is SyncState.RUNNING
         assert box.current_sync_id == "run-B"
+
+    def test_owner_puts_the_progress_snapshot_back_to_the_idle_default(self):
+        """A finished run stops being answerable by ``get_sync_status``.
+
+        The snapshot exists so a remounting QAM can pick up an IN-FLIGHT run. A
+        terminal frame left in it answered every later mount with a run that
+        ended — message and run id included — which the panel then took for the
+        state of whatever run it was actually watching.
+        """
+        box = LibrarySyncStateBox()
+        box.try_begin_run("run-1")
+        box.sync_progress = {"running": False, "stage": "done", "message": "Preview ready", "runId": "run-1"}
+
+        assert box.finish_run("run-1") is True
+
+        assert box.sync_progress == _default_progress()
+        assert box.sync_progress["stage"] == ""
+        assert box.sync_progress["message"] == ""
+        assert box.sync_progress["runId"] == ""
+
+    def test_a_foreign_finish_leaves_the_live_run_s_snapshot_alone(self):
+        """The reset is the owner's alone — a late terminal from a previous run
+        must not blank the frame a remounting panel needs for the live one."""
+        box = LibrarySyncStateBox()
+        box.try_begin_run("run-B")
+        live = {"running": True, "stage": "fetching", "message": "Fetching GBA...", "runId": "run-B"}
+        box.sync_progress = live
+
+        assert box.finish_run("run-A") is False
+
+        assert box.sync_progress == live
 
     def test_try_begin_run_clears_a_prior_abandoned_chunk_stash(self):
         """A heartbeat-timed-out chunk whose late ack never arrived is dropped

--- a/tests/services/library/test_state.py
+++ b/tests/services/library/test_state.py
@@ -5,9 +5,11 @@ The box's four run-lifecycle verbs (``try_begin_run`` / ``request_cancel`` /
 pair (``sync_state`` / ``current_sync_id``). These tests pin the
 compare-and-swap admission, the run-scoped cancel routing, and the
 compare-and-reset terminal so a rapid Sync/Cancel can't leave a half-reset run
-id (#1202). The preview-snapshot verbs (``stage_preview`` /
-``read_fresh_preview`` / ``matches_preview`` / ``discard_preview``) are the
-only writers of ``pending_delta``, and carry the TTL with it.
+id (#1202). The preview-snapshot verbs cover the staged snapshot's whole
+lifetime — ``stage_preview`` / ``read_fresh_preview`` /
+``read_restorable_preview`` / ``matches_preview`` / ``discard_preview`` — of
+which the three that write ``pending_delta`` (stage, the age-dropping read,
+discard) are its only writers, and carry the TTL with it.
 """
 
 from __future__ import annotations
@@ -261,11 +263,14 @@ class TestAbandonedChunkStash:
 
 
 class TestPreviewSnapshot:
-    """The staged preview's whole lifetime: stage, read-if-fresh, match, discard.
+    """The staged preview's whole lifetime: stage, read-if-fresh, read-if-restorable, match, discard.
 
-    These four verbs are the only writers of ``pending_delta``. The TTL is the
-    box's (``PREVIEW_MAX_AGE_SECONDS``), applied against a caller-supplied
-    ``now`` so the box stays clock-free.
+    ``stage_preview``, ``read_fresh_preview`` (which drops an over-age
+    snapshot on its way out) and ``discard_preview`` are the only writers of
+    ``pending_delta``; ``read_restorable_preview`` reaches the field through
+    the fresh read, and ``matches_preview`` only reads. The TTL is the box's
+    (``PREVIEW_MAX_AGE_SECONDS``), applied against a caller-supplied ``now``
+    so the box stays clock-free.
     """
 
     _CREATED_AT = 1_700_000_000.0
@@ -362,13 +367,13 @@ class TestPreviewSnapshot:
 
         assert box.read_fresh_preview(self._CREATED_AT) is not None
 
-    def test_matches_is_identity_only_and_ignores_age(self):
+    def test_matches_is_identity_only_and_consumes_nothing(self):
         box = self._staged_box()
 
         assert box.matches_preview("pv-1") is True
         assert box.matches_preview("pv-other") is False
-        # Still a match long past the TTL — age is the read's verdict, not this one.
-        assert box.matches_preview("pv-1") is True
+        # The verb takes no ``now`` at all: age is the read's verdict, never
+        # this one's, so a match is a signature comparison and nothing else.
         assert box.pending_delta is not None
 
     def test_matches_is_false_when_nothing_staged(self):

--- a/tests/services/library/test_sync_orchestrator.py
+++ b/tests/services/library/test_sync_orchestrator.py
@@ -225,6 +225,46 @@ class TestSyncPreview:
         assert "preview_id" in result
 
     @pytest.mark.asyncio
+    async def test_terminal_frame_is_emitted_before_the_snapshot_goes_idle(self, plugin, fake_romm_api):
+        """The run's ending reaches the panel as an EVENT; what it leaves behind is idle.
+
+        Ordering, not merely outcome: the terminal frame is emitted while the run
+        still owns the slot, and only the ``finally: finish_run`` that follows it
+        puts the snapshot back to the idle default. A panel remounting after this
+        run must not be handed its terminal frame as the state of whatever run it
+        is watching now — that frame's message and run id were what turned a live
+        preview into a green "Preview ready" over its own progress rows.
+        """
+        import decky
+
+        plugin.loop = asyncio.get_event_loop()
+        decky.emit.reset_mock()
+        _use_fake_romm(plugin, fake_romm_api)
+        _seed_platform(
+            fake_romm_api,
+            platform_id=1,
+            name="N64",
+            slug="n64",
+            roms=[{"id": 1, "name": "Game A", "fs_name": "a.z64"}],
+        )
+        plugin.settings["enabled_platforms"] = {"1": True}
+
+        result = await plugin.sync_preview()
+        assert result["success"] is True
+
+        frames = [c[0][1] for c in decky.emit.call_args_list if c[0][0] == "sync_progress"]
+        assert frames[-1]["stage"] == "done"
+        assert frames[-1]["message"] == "Preview ready"
+        assert frames[-1]["running"] is False
+        # ...and the run id it named is gone from what the next mount reads.
+        assert frames[-1]["runId"] != ""
+        status = plugin._sync_service.get_sync_status()
+        assert status["running"] is False
+        assert status["stage"] == ""
+        assert status["message"] == ""
+        assert status["runId"] == ""
+
+    @pytest.mark.asyncio
     async def test_populates_pending_delta(self, plugin, fake_romm_api):
         import decky
 
@@ -5771,7 +5811,9 @@ class TestProcessedGamesNumerator:
         complete = [c[0][1] for c in decky.emit.call_args_list if c[0][0] == "sync_complete"]
         assert complete[-1]["total_games"] == 3, "1 wholesale-skipped + 1 delta-skipped + 1 committed"
         assert complete[-1]["interrupted"] is True
-        progress = plugin._sync_service._sync_progress
+        # The terminal frame as EMITTED — the snapshot the box holds is back at
+        # the idle default by now, because the run has finished (``finish_run``).
+        progress = [c[0][1] for c in decky.emit.call_args_list if c[0][0] == "sync_progress"][-1]
         assert progress["stage"] == "cancelled"
         assert progress["message"] == "Sync interrupted: 3 of 4 games processed"
         assert progress["current"] == 3

--- a/tests/services/library/test_sync_orchestrator.py
+++ b/tests/services/library/test_sync_orchestrator.py
@@ -569,6 +569,7 @@ class TestSyncApplyDelta:
             created_at=plugin._sync_service._orchestrator._clock.time(),
             platforms_count=1,
             total_roms=3,
+            answer={"success": True, "preview_id": preview_id},
         )
 
     @pytest.mark.asyncio
@@ -713,6 +714,7 @@ class TestSyncCancelPreview:
             created_at=plugin._sync_service._orchestrator._clock.time(),
             platforms_count=0,
             total_roms=0,
+            answer={"success": True, "preview_id": "some-id"},
         )
         result = await plugin.sync_cancel_preview()
         assert plugin._sync_service._pending_delta is None
@@ -722,6 +724,99 @@ class TestSyncCancelPreview:
     async def test_returns_success(self, plugin):
         result = await plugin.sync_cancel_preview()
         assert result == {"success": True}
+
+
+class TestGetPendingPreview:
+    """Tests for get_pending_preview().
+
+    The staged snapshot is what a panel that was navigated away from asks
+    for on its next mount, so the read hands back the preview answer
+    verbatim, answers "nothing pending" as a success, and drops a snapshot
+    the apply would refuse anyway.
+    """
+
+    @staticmethod
+    def _preview_setup(plugin, fake_romm_api):
+        import decky
+
+        plugin.loop = asyncio.get_event_loop()
+        decky.emit.reset_mock()
+        _use_fake_romm(plugin, fake_romm_api)
+        _seed_platform(
+            fake_romm_api,
+            platform_id=1,
+            name="N64",
+            slug="n64",
+            roms=[{"id": 1, "name": "Game A", "fs_name": "a.z64"}],
+        )
+        plugin.settings["enabled_platforms"] = {"1": True}
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_nothing_pending(self, plugin):
+        assert plugin._sync_service._pending_delta is None
+        assert await plugin.get_pending_preview() == {"success": True, "preview": None}
+
+    @pytest.mark.asyncio
+    async def test_hands_back_the_exact_answer_sync_preview_returned(self, plugin, fake_romm_api):
+        """The restored card must be what the user was shown — the same payload,
+        not a second assembly of it that can drift from the first."""
+        self._preview_setup(plugin, fake_romm_api)
+
+        fresh = await plugin.sync_preview()
+        restored = await plugin.get_pending_preview()
+
+        assert fresh["success"] is True
+        assert restored == {"success": True, "preview": fresh}
+
+    @pytest.mark.asyncio
+    async def test_answer_carries_the_absolute_expiry_deadline(self, plugin, fake_romm_api):
+        self._preview_setup(plugin, fake_romm_api)
+        clock = plugin._sync_service._orchestrator._clock
+
+        fresh = await plugin.sync_preview()
+
+        assert fresh["expires_at"] == clock.time() + 1800
+
+    @pytest.mark.asyncio
+    async def test_over_age_snapshot_is_dropped_and_answered_as_none(self, plugin, fake_romm_api):
+        """Past the TTL the read answers "nothing pending" AND clears the box —
+        the apply refuses the same snapshot, so leaving it staged would only
+        offer the user an Apply that cannot succeed."""
+        self._preview_setup(plugin, fake_romm_api)
+        await plugin.sync_preview()
+        assert plugin._sync_service._pending_delta is not None
+        plugin._sync_service._orchestrator._clock.advance(1801)
+
+        assert await plugin.get_pending_preview() == {"success": True, "preview": None}
+        assert plugin._sync_service._pending_delta is None
+
+    @pytest.mark.asyncio
+    async def test_just_under_the_ttl_is_still_handed_back(self, plugin, fake_romm_api):
+        self._preview_setup(plugin, fake_romm_api)
+        fresh = await plugin.sync_preview()
+        plugin._sync_service._orchestrator._clock.advance(1799)
+
+        assert await plugin.get_pending_preview() == {"success": True, "preview": fresh}
+
+    @pytest.mark.asyncio
+    async def test_cancelled_preview_leaves_nothing_to_hand_back(self, plugin, fake_romm_api):
+        """A cancel landing after the unit loop stages no delta (#1202), so the
+        read has nothing to restore — the panel comes back to an idle page."""
+        self._preview_setup(plugin, fake_romm_api)
+        orch = plugin._sync_service._orchestrator
+        box = plugin._sync_service._box
+        orig_fetch = orch._fetch_preview_unit
+
+        async def fetch_then_cancel(unit, *args, **kwargs):
+            await orig_fetch(unit, *args, **kwargs)
+            box.request_cancel()
+
+        orch._fetch_preview_unit = fetch_then_cancel
+
+        result = await plugin.sync_preview()
+
+        assert result["success"] is False
+        assert await plugin.get_pending_preview() == {"success": True, "preview": None}
 
 
 # ── Tests for uncovered helper methods in library_sync.py ──────────

--- a/tests/services/library/test_sync_orchestrator.py
+++ b/tests/services/library/test_sync_orchestrator.py
@@ -34,7 +34,6 @@ import pytest
 from adapters.persistence import (
     PersistenceAdapter,
 )
-from domain.preview_delta import PreviewDelta
 from domain.sync_diff import BIND_ROM_ID_KEY
 from domain.sync_stage import SyncStage
 from domain.sync_state import SyncState
@@ -563,8 +562,8 @@ class TestSyncApplyDelta:
     """
 
     def _setup_pending_delta(self, plugin, preview_id="test-preview-123"):
-        """Helper to populate _pending_delta with valid data."""
-        plugin._sync_service._pending_delta = PreviewDelta(
+        """Helper to stage a valid pending delta through the box's own verb."""
+        plugin._sync_service._box.stage_preview(
             preview_id=preview_id,
             created_at=plugin._sync_service._orchestrator._clock.time(),
             platforms_count=1,
@@ -709,7 +708,7 @@ class TestSyncCancelPreview:
 
     @pytest.mark.asyncio
     async def test_clears_pending_delta(self, plugin):
-        plugin._sync_service._pending_delta = PreviewDelta(
+        plugin._sync_service._box.stage_preview(
             preview_id="some-id",
             created_at=plugin._sync_service._orchestrator._clock.time(),
             platforms_count=0,

--- a/tests/services/library/test_sync_orchestrator.py
+++ b/tests/services/library/test_sync_orchestrator.py
@@ -245,8 +245,6 @@ class TestSyncPreview:
         assert plugin._sync_service._pending_delta is not None
         assert plugin._sync_service._pending_delta.preview_id == result["preview_id"]
         assert plugin._sync_service._pending_delta.created_at == plugin._sync_service._orchestrator._clock.time()
-        assert plugin._sync_service._pending_delta.platforms_count == 1
-        assert plugin._sync_service._pending_delta.total_roms == 1
 
     @pytest.mark.asyncio
     async def test_does_not_write_metadata(self, plugin, fake_romm_api):
@@ -566,8 +564,6 @@ class TestSyncApplyDelta:
         plugin._sync_service._box.stage_preview(
             preview_id=preview_id,
             created_at=plugin._sync_service._orchestrator._clock.time(),
-            platforms_count=1,
-            total_roms=3,
             answer={"success": True, "preview_id": preview_id},
         )
 
@@ -711,8 +707,6 @@ class TestSyncCancelPreview:
         plugin._sync_service._box.stage_preview(
             preview_id="some-id",
             created_at=plugin._sync_service._orchestrator._clock.time(),
-            platforms_count=0,
-            total_roms=0,
             answer={"success": True, "preview_id": "some-id"},
         )
         result = await plugin.sync_cancel_preview()

--- a/tests/services/library/test_sync_orchestrator.py
+++ b/tests/services/library/test_sync_orchestrator.py
@@ -256,6 +256,9 @@ class TestSyncPreview:
         assert frames[-1]["stage"] == "done"
         assert frames[-1]["message"] == "Preview ready"
         assert frames[-1]["running"] is False
+        # The lifecycle flag rides the get_sync_status answer alone — an event
+        # carrying it would make the two look interchangeable, which they are not.
+        assert "inFlight" not in frames[-1]
         # ...and the run id it named is gone from what the next mount reads.
         assert frames[-1]["runId"] != ""
         status = plugin._sync_service.get_sync_status()
@@ -1026,12 +1029,52 @@ class TestGetSyncStatus:
             "totalSteps": 2,
         }
         plugin._sync_service._sync_progress = snapshot
+        plugin._sync_service._box.try_begin_run("run-live")
 
         status = plugin._sync_service.get_sync_status()
 
-        assert status == snapshot
+        assert status == {**snapshot, "inFlight": True}
         assert status["running"] is True
         assert status["stage"] == "applying"
+
+    def test_in_flight_is_the_lifecycle_not_a_reading_of_the_frame(self, plugin):
+        """The two answer different questions and are allowed to disagree.
+
+        A cancel drain is the standing example: ``_finish_sync`` writes the
+        CANCELLED frame — ``running: False`` — while the run still owns the slot,
+        so a frontend inferring "no run" from the frame would retract a run that
+        is still winding down. It reads ``inFlight`` instead.
+        """
+        box = plugin._sync_service._box
+        box.try_begin_run("run-1")
+        box.request_cancel("run-1")
+        plugin._sync_service._sync_progress = {
+            "running": False,
+            "stage": "cancelled",
+            "message": "Sync cancelled",
+            "runId": "run-1",
+        }
+
+        status = plugin._sync_service.get_sync_status()
+
+        assert status["running"] is False
+        assert status["inFlight"] is True
+
+    def test_in_flight_is_false_once_the_run_is_finished(self, plugin):
+        """And the panel's licence to retract: the run is over, said plainly.
+
+        Without this the reset above makes a finished run and one that never
+        started the same answer, so a lost terminal frame would leave every later
+        mount believing a run is live with nothing on the page to escape it.
+        """
+        box = plugin._sync_service._box
+        box.try_begin_run("run-1")
+        box.finish_run("run-1")
+
+        status = plugin._sync_service.get_sync_status()
+
+        assert status["inFlight"] is False
+        assert status["running"] is False
 
     @pytest.mark.asyncio
     async def test_emit_progress_sub_stage_rides_event_and_status(self, plugin):

--- a/tests/services/library/test_sync_orchestrator.py
+++ b/tests/services/library/test_sync_orchestrator.py
@@ -756,6 +756,35 @@ class TestGetPendingPreview:
         assert await plugin.get_pending_preview() == {"success": True, "preview": None}
 
     @pytest.mark.asyncio
+    async def test_withholds_the_snapshot_while_a_run_is_in_flight(self, plugin, fake_romm_api):
+        """A panel that remounts mid-run must not be handed a card to render over
+        the run's own progress rows. The snapshot is withheld, not discarded —
+        the frontend's own store guard can be wrong about a live run exactly
+        when it matters (an apply refused with ``sync_in_progress`` retracts the
+        optimistic running flag while the backend keeps the delta), so the
+        backend is the one that has to be right.
+        """
+        self._preview_setup(plugin, fake_romm_api)
+        await plugin.sync_preview()
+        box = plugin._sync_service._box
+        assert box.try_begin_run("run-1") is True
+
+        assert await plugin.get_pending_preview() == {"success": True, "preview": None}
+        assert box.pending_delta is not None
+
+    @pytest.mark.asyncio
+    async def test_hands_the_snapshot_back_once_the_run_is_over(self, plugin, fake_romm_api):
+        self._preview_setup(plugin, fake_romm_api)
+        fresh = await plugin.sync_preview()
+        box = plugin._sync_service._box
+        box.try_begin_run("run-1")
+        assert await plugin.get_pending_preview() == {"success": True, "preview": None}
+
+        box.finish_run("run-1")
+
+        assert await plugin.get_pending_preview() == {"success": True, "preview": fresh}
+
+    @pytest.mark.asyncio
     async def test_hands_back_the_exact_answer_sync_preview_returned(self, plugin, fake_romm_api):
         """The restored card must be what the user was shown — the same payload,
         not a second assembly of it that can drift from the first."""

--- a/tests/services/library/test_terminal_frame_contract.py
+++ b/tests/services/library/test_terminal_frame_contract.py
@@ -25,11 +25,21 @@ three of which exist today:
 Where the enforcement ends, stated plainly because the invariant register cites
 this file: the scan reads call sites and dict literals, so a frame assembled by
 a helper it cannot follow, or emitted through an aliased callable, is outside it.
-Two such indirections exist today and are inert rather than holes — the
-parameterized snapshot inside ``emit_progress`` itself (its ``running`` and
-``stage`` are its parameters, and every caller of it IS scanned) and the
-fetcher's late-bound proxy in ``services/library/service.py``, which forwards
-whatever its own — scanned — callers passed it.
+Three such indirections exist today and all are inert rather than holes:
+
+* the parameterized snapshot inside ``emit_progress`` itself (its ``running``
+  and ``stage`` are its parameters, and every caller of it IS scanned);
+* the fetcher's late-bound proxy in ``services/library/service.py``, which
+  forwards whatever its own — scanned — callers passed it;
+* ``finish_run``'s ``self.sync_progress = _default_progress()`` in
+  ``services/library/_state.py``. This one is a write to the very attribute
+  ``_snapshot_write_sites`` watches, and it is invisible only because the value
+  is a call rather than a dict literal. **Leave it that way.** It is not a frame:
+  nothing emits it, so nothing reaches the panel from it — it returns the
+  snapshot ``get_sync_status`` answers with to the idle default once a run is
+  over. Spelled as a literal it would read ``running: False`` with a non-terminal
+  stage and this scan would flag it, which would be a false positive: the rule is
+  about frames the panel is SENT, and no reader ever sees this one as an event.
 
 :class:`TestScanScope` pins the rest of the scope so it cannot shrink unnoticed:
 that the scan still reaches every module producing frames today, that no producer

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -888,6 +888,10 @@ _MIGRATION_BLOCKED_WHITELIST: set[str] = {
     "get_sync_status",
     "get_sync_stats",
     "get_session_budget_status",
+    # Read-only pending-preview query (plus the lazy drop of an expired
+    # snapshot) — it starts no run and touches no RetroDECK path, and the panel
+    # asks for it on every mount, so a pending migration must not refuse it.
+    "get_pending_preview",
     "get_rom_by_steam_app_id",
     "get_download_queue",
     "get_installed_rom",


### PR DESCRIPTION
Compute a sync preview, step into a submenu, come back: the card was gone and there was no way to apply what had just been computed — while the backend went on holding that preview for another half hour. The panel's card lived in component state, and the unmount threw it away.

The backend now hands it back. It stores the **exact answer `sync_preview` returned** and returns that same object on request, so a restored card cannot differ from the one you saw; there is no second assembly that could drift. The answer carries `expires_at`, an absolute wall-clock deadline rather than a countdown — both sides share a clock, and an absolute deadline stays right across a suspend, where a locally counted-down number quietly gains time.

A new callable asks for it. "Nothing pending" is a success answer carrying `preview: null`, not a failure shape — there is nothing wrong with having no preview.

The staged preview's whole lifetime moves onto `LibrarySyncStateBox` as verbs, so nothing outside `_state.py` assigns the field, and the thirty minutes live in exactly one place: the deadline the card counts down to and the verdict that rejects a stale apply now come from the same constant. While a run is in flight the preview is **withheld rather than discarded** — the apply deliberately keeps a preview it refuses, so withholding it means it is still there when the run ends.

On mount the panel asks and restores. Which answer wins is decided by when its information was issued rather than when it arrives: a dismissal outranks a read already open, the read asked for last wins whichever answers first, and a read only ever fills — never clears — because "nothing pending" conflates nothing staged, aged out, and withheld during a run, and so is no evidence that a preview in hand is gone.

The countdown sits on the card next to Apply. At zero the card **stays where it is**, replaces the countdown with an expired notice and drops Apply, so nothing moves under your finger and the card goes away only when you dismiss it. An older backend that sends no deadline yields no countdown and behaves exactly as before.

Two fields on the staged snapshot turned out to be write-only — a docstring claimed they were persisted into the sync stats, and nothing has ever read them; the apply path recomputes both from the work queue. They are gone.

Closes #1751. That issue asked for `MainPage.tsx` to be decomposed, starting by moving its stateless helpers out. The premise was examined and rejected — the helpers were already outside the component, no gate measures the file, and the work the issue was really pointing at was unresolved ownership of state and reads, which the six changes under it did instead. This is the last of them.

**Found on device, and fixed here.** Three things went wrong in real use, and none of them was caused by this branch — all three reproduce on `main`. They are fixed here because without them the feature does not deliver what it promises.

Coming back to the page during a preview showed the idle buttons for a second or two before the progress reappeared; and after cancelling one preview and starting another, coming back mid-run showed a green "Preview ready" belonging to the previous one. Both are one write: the panel asks the backend for the run's state on mount and adopted that answer even when it was **older** than what the panel already knew. The backend never cleared its stored progress when a run ended, so it kept answering with the last run's terminal frame — and the window between pressing Sync and the backend's first frame of the new run is seconds wide, because a full Steam shortcut scan happens in between.

The backend now clears that snapshot when a run ends, after the terminal frame has gone out, and reports whether a run is in flight alongside the frame. That second part matters more than it looks: the panel previously had to *infer* the run's state from a frame's contents, and an inference cannot distinguish "no run" from "no news". Now an idle answer is evidence, so the panel can stand its ground during the start window and still be corrected when a terminal frame is genuinely lost. Inferring it instead would wedge the panel on "a run is live" with no way back — no start controls, a Cancel that cannot cancel a run the backend has forgotten, and four unrelated actions disabled — until the plugin is reloaded.

The third was the feature's own promise failing: if the preview **finished** while you were back on the page, the card never appeared — only the "Preview ready" line — and it took another visit to see it. The result was being delivered to the panel instance that started it, which the navigation had already discarded. The pending preview now lives in a module store like the download and sync-stats state, so the departing instance writes where the arriving one reads, and a preview that becomes ready while you are watching is fetched rather than waited for.

A run in flight now owns the panel body: a preview held during a run is **kept and hidden**, not dropped, and its card appears the moment the run ends. And the controls that start a preview are never rendered while a preview is running or a result is standing — that is the rule the report reduced to, and it is pinned as a test in both remount cases.
